### PR TITLE
[NON-MODULAR] Can't use direct radio implements if you can't use items (cant radio while cuffed, stunned)

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -386,6 +386,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 /mob/living/proc/radio(message, list/message_mods = list(), list/spans, language)
 	//SKYRAT EDIT ADDITION BEGIN
 	if(!(mobility_flags & MOBILITY_USE)) // if can't use items, you can't press the button
+		to_chat(src, "<span class='warning'>You can't use the radio now!</span>")
 		return TRUE //Means other procs wont continue
 	//SKYRAT EDIT END
 	var/obj/item/implant/radio/imp = locate() in src

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -385,9 +385,9 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 /mob/living/proc/radio(message, list/message_mods = list(), list/spans, language)
 	//SKYRAT EDIT ADDITION BEGIN
-	if(!(mobility_flags & MOBILITY_USE)) // if can't use items, you can't press the button
-		to_chat(src, "<span class='warning'>You can't use the radio now!</span>")
-		return TRUE //Means other procs wont continue
+	if((message_mods[MODE_HEADSET] || message_mods[RADIO_EXTENSION]) && !(mobility_flags & MOBILITY_USE)) // If can't use items, you can't press the button
+		to_chat(src, "<span class='warning'>You can't use the radio right now!</span>")
+		return ITALICS | REDUCE_RANGE
 	//SKYRAT EDIT END
 	var/obj/item/implant/radio/imp = locate() in src
 	if(imp && imp.radio.on)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -384,6 +384,10 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return message
 
 /mob/living/proc/radio(message, list/message_mods = list(), list/spans, language)
+	//SKYRAT EDIT ADDITION BEGIN
+	if(!(mobility_flags & MOBILITY_USE)) // if can't use items, you can't press the button
+		return TRUE //Means other procs wont continue
+	//SKYRAT EDIT END
 	var/obj/item/implant/radio/imp = locate() in src
 	if(imp && imp.radio.on)
 		if(message_mods[MODE_HEADSET])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Disencourages validhunting and prevents callouts from being so easy. no longer you need to strip people of their headset if they're cuffed.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: You no longer can use direct radio implements if you cant use items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
