### PR TITLE
Comments out wisdom cow, brain trauma events, add timer to meteor event, changes event weights

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -1,9 +1,8 @@
-//SKYRAT EDIT REMOVAL BEGIN - EVENTS
-/*
 /datum/round_event_control/brain_trauma
 	name = "Spontaneous Brain Trauma"
 	typepath = /datum/round_event/brain_trauma
 	weight = 25
+	max_occurrences = 0 //SKYRAT EDIT ADDITION - EVENTS
 
 /datum/round_event/brain_trauma
 	fakeable = FALSE
@@ -36,5 +35,3 @@
 	))
 
 	H.gain_trauma_type(trauma_type, resistance)
-*/
-//SKYRAT EDIT REMOVAL END

--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -1,3 +1,5 @@
+//SKYRAT EDIT REMOVAL BEGIN - EVENTS
+/*
 /datum/round_event_control/brain_trauma
 	name = "Spontaneous Brain Trauma"
 	typepath = /datum/round_event/brain_trauma
@@ -34,3 +36,5 @@
 	))
 
 	H.gain_trauma_type(trauma_type, resistance)
+*/
+//SKYRAT EDIT REMOVAL END

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -15,12 +15,6 @@
 	var/list/wave_type
 	var/wave_name = "normal"
 
-//SKYRAT EDIT ADDITION - EVENTS
-/datum/round_event/meteor_wave/setup()
-	startWhen = rand(90, 180) // Apparently it is by 2 seconds, so 90 is actually 180 seconds, and 180 is 360 seconds. So this is 3-6 minutes
-	endWhen = startWhen + 60
-//SKYRAT EDIT ADDITION END
-
 /datum/round_event/meteor_wave/New()
 	..()
 	if(!wave_type)

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -15,6 +15,12 @@
 	var/list/wave_type
 	var/wave_name = "normal"
 
+//SKYRAT EDIT ADDITION - EVENTS
+/datum/round_event/meteor_wave/setup()
+	startWhen = rand(90, 180) // Apparently it is by 2 seconds, so 90 is actually 180 seconds, and 180 is 360 seconds. So this is 3-6 minutes
+	endWhen = startWhen + 60
+//SKYRAT EDIT ADDITION END
+
 /datum/round_event/meteor_wave/New()
 	..()
 	if(!wave_type)
@@ -47,7 +53,8 @@
 			kill()
 
 /datum/round_event/meteor_wave/announce(fake)
-	priority_announce("Meteors have been detected on collision course with the station.", "Meteor Alert", 'sound/ai/meteors.ogg')
+	//priority_announce("Meteors have been detected on collision course with the station.", "Meteor Alert", 'sound/ai/meteors.ogg') //ORIGINAL
+	priority_announce("Meteors have been detected on collision course with the station. Estimated time until impact: [round((startWhen * SSevents.wait) / 10, 0.1)] seconds.", "Meteor Alert", 'sound/ai/meteors.ogg') //ORIGINAL
 
 /datum/round_event/meteor_wave/tick()
 	if(ISMULTIPLE(activeFor, 3))
@@ -56,7 +63,8 @@
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
-	weight = 5
+	//weight = 5 //ORIGINAL
+	weight = 2 //SKYRAT EDIT CHANGE - EVENTS
 	min_players = 20
 	max_occurrences = 3
 	earliest_start = 35 MINUTES
@@ -67,7 +75,8 @@
 /datum/round_event_control/meteor_wave/catastrophic
 	name = "Meteor Wave: Catastrophic"
 	typepath = /datum/round_event/meteor_wave/catastrophic
-	weight = 7
+	//weight = 7 //ORIGINAL
+	weight = 2 //SKYRAT EDIT CHANGE - EVENTS
 	min_players = 25
 	max_occurrences = 3
 	earliest_start = 45 MINUTES

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -1,7 +1,8 @@
 /datum/round_event_control/pirates
 	name = "Space Pirates"
 	typepath = /datum/round_event/pirates
-	weight = 8
+	//weight = 8 //ORIGINAL
+	weight = 2 //SKYRAT EDIT CHANGE - EVENTS
 	max_occurrences = 1
 	min_players = 10
 	earliest_start = 30 MINUTES

--- a/code/modules/events/wisdomcow.dm
+++ b/code/modules/events/wisdomcow.dm
@@ -1,3 +1,5 @@
+//SKYRAT EDIT REMOVAL BEGIN - EVENTS
+/*
 /datum/round_event_control/wisdomcow
 	name = "Wisdom cow"
 	typepath = /datum/round_event/wisdomcow
@@ -11,4 +13,5 @@
 	var/turf/targetloc = get_random_station_turf()
 	new /mob/living/simple_animal/cow/wisdom(targetloc)
 	do_smoke(1, targetloc)
-
+*/
+//SKYRAT EDIT REMOVAL END

--- a/code/modules/events/wisdomcow.dm
+++ b/code/modules/events/wisdomcow.dm
@@ -1,9 +1,8 @@
-//SKYRAT EDIT REMOVAL BEGIN - EVENTS
-/*
 /datum/round_event_control/wisdomcow
 	name = "Wisdom cow"
 	typepath = /datum/round_event/wisdomcow
-	max_occurrences = 1
+	//max_occurrences = 1 //ORIGINAL
+	max_occurrences = 0 //SKYRAT EDIT CHANGE - EVENTS
 	weight = 20
 
 /datum/round_event/wisdomcow/announce(fake)
@@ -13,5 +12,4 @@
 	var/turf/targetloc = get_random_station_turf()
 	new /mob/living/simple_animal/cow/wisdom(targetloc)
 	do_smoke(1, targetloc)
-*/
-//SKYRAT EDIT REMOVAL END
+

--- a/modular_skyrat/modules/events/code/modules/events/meteor_wave.dm
+++ b/modular_skyrat/modules/events/code/modules/events/meteor_wave.dm
@@ -1,0 +1,3 @@
+/datum/round_event/meteor_wave/setup()
+	startWhen = rand(90, 180) // Apparently it is by 2 seconds, so 90 is actually 180 seconds, and 180 is 360 seconds. So this is 3-6 minutes
+	endWhen = startWhen + 60

--- a/modular_skyrat/modules/events/readme.md
+++ b/modular_skyrat/modules/events/readme.md
@@ -1,0 +1,32 @@
+https://github.com/Skyrat-SS13/Skyrat-tg/pulls
+
+## Title: Events
+
+MODULE ID: EVENT
+
+### Description:
+
+Changes to the existing TG events, aswell our own events
+
+### TG Proc Changes:
+- OVERRIDE: modular_skyrat/modules/events/code/modules/events/meteor_wave.dm > /datum/round_event/meteor_wave/setup()
+- code/modules/events/meteor_wave.dm > /datum/round_event/meteor_wave/announce()
+
+### Defines:
+
+- code/modules/events/brain_trauma.dm > /datum/round_event_control/brain_trauma > max_occurences = 0
+- code/modules/events/wisdomcow.dm  > /datum/round_event_control/wisdomcow > max_occurences = 0
+- code/modules/events/pirates.dm > /datum/round_event_control/pirates > weight = 2
+- code/modules/events/meteor_wave.dm > /datum/round_event/meteor_wave/threatening > weight = 2
+- code/modules/events/meteor_wave.dm > /datum/round_event/meteor_wave/catastrophic > weight = 2
+
+### Master file additions
+
+- N/A
+
+### Included files that are not contained in this module:
+
+- N/A
+
+### Credits:
+Azarak

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3406,6 +3406,7 @@
 #include "modular_skyrat\modules\emotes\code\dna_screams.dm"
 #include "modular_skyrat\modules\emotes\code\emotes.dm"
 #include "modular_skyrat\modules\emotes\code\silicon_emotes.dm"
+#include "modular_skyrat\modules\events\code\modules\events\meteor_wave.dm"
 #include "modular_skyrat\modules\gunpoint\code\datum\gunpoint\gunpoint.dm"
 #include "modular_skyrat\modules\gunpoint\code\datum\gunpoint\gunpoint_datum.dm"
 #include "modular_skyrat\modules\gunpoint\code\datum\gunpoint\gunpoint_radial.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Wisdom cow is really silly. Brain trauma event is quite common and contributes very little to the round. Meteors were too common for how destructive they are, not a good fit for our long rounds. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tweaked some event weights: namely: space pirates, meteors
add: Added a timer to meteors before they arrive, the ETA is alerted to the crew
del: Removed brain trauma and wisdom cow events
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
