### PR TITLE
Ports echoes, makes thrown items always do sound, with volume being a difference if a force is present

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -44,7 +44,8 @@
 		if(get_dist(M, turf_source) <= maxdistance)
 			M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, channel, pressure_affected, S)
 
-/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, channel = 0, pressure_affected = TRUE, sound/S, distance_multiplier = 1)
+///mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, channel = 0, pressure_affected = TRUE, sound/S, distance_multiplier = 1) //ORIGINAL
+/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, channel = 0, pressure_affected = TRUE, sound/S, distance_multiplier = 1 ,envwet = -10000, envdry = 0) //SKYRAT EDIT CHANGE - SOUND ECHO
 	if(!client || !can_hear())
 		return
 
@@ -54,6 +55,7 @@
 	S.wait = 0 //No queue
 	S.channel = channel || SSsounds.random_available_channel()
 	S.volume = vol
+	S.environment = 7 //SKYRAT CHANGE ADDITION - SOUND ECHO
 
 	if(vary)
 		if(frequency)
@@ -83,6 +85,8 @@
 					pressure_factor = max((pressure - SOUND_MINIMUM_PRESSURE)/(ONE_ATMOSPHERE - SOUND_MINIMUM_PRESSURE), 0)
 			else //space
 				pressure_factor = 0
+
+			S.echo = list(envdry, null, envwet, null, null, null, null, null, null, null, null, null, null, 1, 1, 1, null, null) //SKYRAT CHANGE ADDITION - SOUND ECHO
 
 			if(distance <= 1)
 				pressure_factor = max(pressure_factor, 0.15) //touching the source of the sound

--- a/modular_skyrat/master_files/code/game/objects/items.dm
+++ b/modular_skyrat/master_files/code/game/objects/items.dm
@@ -1,4 +1,3 @@
 /obj/item/after_throw()
 	. = ..()
-	if(throwforce)
-		playsound(loc, 'sound/weapons/punchmiss.ogg', 50, TRUE, -1)
+	playsound(loc, 'sound/weapons/punchmiss.ogg', 50, TRUE, -1)

--- a/modular_skyrat/master_files/code/game/objects/items.dm
+++ b/modular_skyrat/master_files/code/game/objects/items.dm
@@ -1,3 +1,3 @@
 /obj/item/after_throw()
 	. = ..()
-	playsound(loc, 'sound/weapons/punchmiss.ogg', 50, TRUE, -1)
+	playsound(loc, 'sound/weapons/punchmiss.ogg', (throwforce ? 50 : 25), TRUE, -1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Sound echoes are a thing now
tweak: Tweaked throws to always play a sound, with it being louder if an object has a force
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
