### PR TITLE
Fixes eye lights not working on module change

### DIFF
--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/update_icons.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/update_icons.dm
@@ -1,9 +1,9 @@
 /mob/living/silicon/robot/update_icons()
+	icon = (module.cyborg_icon_override ? module.cyborg_icon_override : initial(icon))
 	. = ..()
 	update_dogborg_icons()
 
 /mob/living/silicon/robot/proc/update_dogborg_icons()
-	icon = (module.cyborg_icon_override ? module.cyborg_icon_override : initial(icon))
 	var/extra_overlay
 	for(var/i in held_items)
 		var/obj/item/O = i


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does half of #1430 
Now the eyelights work.
@KathrinBailey Does this count as a hacktober one as well? It was tricky to track down, and I can do the other half of the #1430 if necessary to elevate this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Funce (Foxtrot)
fix: Borg Eyelights properly work on module change again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
