### PR TITLE
Added SQL logging to atoms

### DIFF
--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -10,6 +10,21 @@
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
 --
+-- Table Structure for table 'game_log'
+--
+-- Skyrat edit to enable SQL logging of all messages.
+
+CREATE TABLE `game_log` (
+  `ID` int(11) NOT NULL,
+  `datetime` datetime NOT NULL,
+  `round_id` int(11) NOT NULL,
+  `ckey` varchar(32) COLLATE utf8_bin NOT NULL,
+  `loc` varchar(60) COLLATE utf8_bin NOT NULL,
+  `type` varchar(10) COLLATE utf8_bin NOT NULL,
+  `message` varchar(1000) COLLATE utf8_bin NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
 -- Table structure for table `admin`
 --
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1320,9 +1320,20 @@
 	return
 
 /// Generic logging helper
-/atom/proc/log_message(message, message_type, color=null, log_globally=TRUE)
+/atom/proc/log_message(message, message_type, color=null, log_globally=TRUE, log_SQL=TRUE)
 	if(!log_globally)
 		return
+	// SQL Logging for all incomming messages into the helper if enabled via the log_SQL var.
+	if(log_SQL)
+		//Build SQL Query to insert log into the DB, and catch errors
+		var/datum/db_query/query_sql_log_messages = SSdbcore.NewQuery({"
+			INSERT INTO [format_table_name("game_log")] (datetime, round_id, ckey, loc, type, message)
+			VALUES (:time, :round_id, :ckey, :loc, :type, :message)
+		"}, list("time" = SQLtime(), "round_id" = "[GLOB.round_id]", "ckey" = key_name(src), "loc" = loc_name(src), type = message_type, "message" = message))
+		if(!query_sql_log_messages.warn_execute())
+			qdel(query_sql_log_messages)
+			return
+		qdel(query_sql_log_messages)
 
 	var/log_text = "[key_name(src)] [message] [loc_name(src)]"
 	switch(message_type)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1319,7 +1319,7 @@
 /atom/proc/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	return
 
-/// Generic logging helper
+/// Generic logging helper //Skyrat Edit
 /atom/proc/log_message(message, message_type, color=null, log_globally=TRUE, log_SQL=TRUE)
 	if(!log_globally)
 		return
@@ -1334,7 +1334,7 @@
 			qdel(query_sql_log_messages)
 			return
 		qdel(query_sql_log_messages)
-
+//end Skyrat Edit
 	var/log_text = "[key_name(src)] [message] [loc_name(src)]"
 	switch(message_type)
 		if(LOG_ATTACK)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Modifies Atoms.dm to add SQL logging for the message handler.
This allows SQL logging for all actions (Say,PDA,Attack,Admin,dsay etc) to allow for future work on an admin interface for log handling.

I only want this test murged for a round, both to see if it causes any performance impact on the server and to then collect the table and work on the web interface.

The system also has a flag "sql_LOG" that can be changed to disable the SQL logging without removing the code.
Could also be added so its a dynamic config option that can be enable/disabled mid-round in case of issues

Requires adding a table with the following structure to the database.
```sql
CREATE TABLE `game_log` (
  `ID` int(11) NOT NULL,
  `datetime` datetime NOT NULL,
  `round_id` int(11) NOT NULL,
  `ckey` varchar(60) COLLATE utf8_bin NOT NULL,
  `loc` varchar(60) COLLATE utf8_bin NOT NULL,
  `type` varchar(10) COLLATE utf8_bin NOT NULL,
  `message` varchar(1000) COLLATE utf8_bin NOT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
````
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's been a major request from nearly all the staff that the logging be improved. currently to search over past round you have to open each rounds file for each of the actions you want (If you wanted to check what "MrBadAtRp" was doing in a round, you have to open game.log, pda.log and attack.log then search and filter out everything you wanted)
With this PR it adds the ability to in future make a web interface were you can search all the logs from all the rounds at once.
Allowing you to see inline attack logs from multiple people at once, or see everyone talking in one area of the station.
Would also allow augmenting tickets and bans with log entries, so making the PC's job easier as well.

Here is some examples that can be done with SQL Querys to the log.
Example 1: Showing all actions in area
![image](https://user-images.githubusercontent.com/4310446/97502480-7c2a1c00-1973-11eb-803f-7e54264521b8.png)

Example 2: Getting logs from two players at once, inline so you can much more easily see who attacked first.
![image](https://user-images.githubusercontent.com/4310446/97502555-9d8b0800-1973-11eb-8177-ef08b15ce0bc.png)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added SQL Logging to Atoms.dm
Update: SQL Schema and comments on atoms.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
