### PR TITLE
High impact bottom-end simulation [Thermodynamics] [Gluons] [Semi-Modular]

### DIFF
--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -3,3 +3,4 @@
 #define TRAIT_NORUNNING				"norunning"		// You walk!
 #define TRAIT_EXCITABLE				"wagwag" //Will wag when patted!
 #define TRAIT_OXYIMMUNE				"oxyimmune"		// Immune to oxygen damage, ideally give this to all non-breathing species or bad stuff will happen
+#define TRAIT_IRONASS				"ironass"

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -252,7 +252,7 @@
 			return
 	//SKYRAT EDIT ADDITION BEGIN - EMOTES
 	if(zone_selected == BODY_ZONE_PRECISE_GROIN && target.dir == src.dir)
-		if(!HAS_TRAIT(target, TRAIT_IRONASS))
+		if(HAS_TRAIT(target, TRAIT_IRONASS))
 			var/obj/item/bodypart/affecting = src.get_bodypart("[(src.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
 			if(affecting?.receive_damage(2))
 				src.update_damage_overlays()
@@ -260,13 +260,15 @@
 			"<span class='danger'>You tried slapping [target]'s ass, but it felt like metal, ouch!</span>",\
 			"You hear a sore sounding slap.")
 			playsound(target.loc, 'sound/effects/snap.ogg', 50, TRUE, -1)
+			to_chat(target, "<span class='danger'>[src] tried slapping your ass, but it was deflected!")
 			return
 		else
 			do_ass_slap_animation(target)
 			playsound(target.loc, 'sound/weapons/slap.ogg', 50, TRUE, -1)
-			visible_message("<span class='danger'>\The [src] slaps [src == target ? "[src.p_their()] own" : "\the [target]'s"] ass!</span>",\
-				"<span class='notice'>[src] slaps your ass! </span>",\
-				"You hear a slap.", "<span class='notice'>You slap [src == target ? "your own" : "\the [target]'s"] ass! </span>")
+			visible_message("<span class='danger'>[src] slaps [target] right on the ass!</span>",\
+				"<span class='notice'>You slap [src] on the ass, how satisfying.</span>",\
+				"You hear a slap.")
+			to_chat(target, "<span class='danger'>[src] slaps your ass!")
 			return
 	//SKYRAT EDIT END
 	do_attack_animation(target, ATTACK_EFFECT_DISARM)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -250,6 +250,25 @@
 			"You hear a slap.")
 			target.dna?.species?.stop_wagging_tail(target)
 			return
+	//SKYRAT EDIT ADDITION BEGIN - EMOTES
+	if(zone_selected == BODY_ZONE_PRECISE_GROIN && target.dir == src.dir)
+		if(!HAS_TRAIT(target, TRAIT_IRONASS))
+			var/obj/item/bodypart/affecting = src.get_bodypart("[(src.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
+			if(affecting?.receive_damage(2))
+				src.update_damage_overlays()
+			visible_message("<span class='danger'>[src] tried slapping [target]'s ass, however it was much harder than expected!</span>",
+			"<span class='danger'>You tried slapping [target]'s ass, but it felt like metal, ouch!</span>",\
+			"You hear a sore sounding slap.")
+			playsound(target.loc, 'sound/effects/snap.ogg', 50, TRUE, -1)
+			return
+		else
+			do_ass_slap_animation(target)
+			playsound(target.loc, 'sound/weapons/slap.ogg', 50, TRUE, -1)
+			visible_message("<span class='danger'>\The [src] slaps [src == target ? "[src.p_their()] own" : "\the [target]'s"] ass!</span>",\
+				"<span class='notice'>[src] slaps your ass! </span>",\
+				"You hear a slap.", "<span class='notice'>You slap [src == target ? "your own" : "\the [target]'s"] ass! </span>")
+			return
+	//SKYRAT EDIT END
 	do_attack_animation(target, ATTACK_EFFECT_DISARM)
 	playsound(target, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
 	if (ishuman(target))
@@ -423,6 +442,7 @@
 		Paralyze(60)
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)
+	var/nosound = FALSE //SKYRAT EDIT ADDITION - EMOTES
 	if(on_fire)
 		to_chat(M, "<span class='warning'>You can't put [p_them()] out with just your bare hands!</span>")
 		return
@@ -441,6 +461,7 @@
 
 	//SKYRAT EDIT ADDITION BEGIN - EMOTES
 	else if(M.zone_selected == BODY_ZONE_PRECISE_MOUTH)
+		nosound = TRUE
 		M.visible_message("<span class='notice'>[M] boops [src]'s nose.", \
 					"<span class='notice'>You boop [src] on the nose.</span>")
 		playsound(src, 'modular_skyrat/modules/emotes/sound/emotes/Nose_boop.ogg', 50, 0)
@@ -497,7 +518,8 @@
 	if(body_position != STANDING_UP && !resting && !buckled && !HAS_TRAIT(src, TRAIT_FLOORED))
 		get_up(TRUE)
 
-	playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
+	if(!nosound) //SKYRAT EDIT ADDITION - EMOTES
+		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
 
 	// Shake animation
 	if (incapacitated())

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -4,6 +4,15 @@
 	desc = "Head patting makes your tail wag! You're very excitable! WAG WAG."
 	gain_text = "<span class='notice'>You crave for some headpats!</span>"
 	lose_text = "<span class='notice'>You no longer care for headpats all that much.</span>"
-	medical_record_text = "Patient seems to get excited easily ."
+	medical_record_text = "Patient seems to get excited easily."
 	value = 0
 	mob_trait = TRAIT_EXCITABLE
+
+/datum/quirk/ironass
+	name = "Iron Ass"
+	desc = "Your ass is incredibly firm, so firm infact that anyone slapping it will suffer grave injuries."
+	gain_text = "<span class='notice'>Your ass feels solid!</span>"
+	lose_text = "<span class='notice'>Your ass doesn't feel so solid anymore.</span>"
+	medical_record_text = "Patient's ass seems incredibly solid."
+	value = 0
+	mob_trait = TRAIT_IRONASS

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -477,3 +477,15 @@
 	if(H.dna.species.id == "moth")
 		sound = 'modular_skyrat/modules/emotes/sound/emotes/mothlaugh.ogg'
 	playsound(user, sound, 50, 1, -1)
+
+/mob/living/proc/do_ass_slap_animation(atom/slapped)
+	do_attack_animation(slapped, no_effect=TRUE)
+	var/image/gloveimg = image('icons/effects/effects.dmi', slapped, "slapglove", slapped.layer + 0.1)
+	gloveimg.pixel_y = 0 // should line up with head
+	gloveimg.pixel_x = 0
+	flick_overlay(gloveimg, GLOB.clients, 10)
+
+	// And animate the attack!
+	animate(gloveimg, alpha = 175, transform = matrix() * 0.75, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3)
+	animate(time = 1)
+	animate(alpha = 0, time = 3, easing = CIRCULAR_EASING|EASE_OUT)

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -481,11 +481,11 @@
 /mob/living/proc/do_ass_slap_animation(atom/slapped)
 	do_attack_animation(slapped, no_effect=TRUE)
 	var/image/gloveimg = image('icons/effects/effects.dmi', slapped, "slapglove", slapped.layer + 0.1)
-	gloveimg.pixel_y = 0 // should line up with head
+	gloveimg.pixel_y = -5
 	gloveimg.pixel_x = 0
 	flick_overlay(gloveimg, GLOB.clients, 10)
 
 	// And animate the attack!
-	animate(gloveimg, alpha = 175, transform = matrix() * 0.75, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3)
+	animate(gloveimg, alpha = 175, transform = matrix() * 0.75, pixel_x = 0, pixel_y = -5, pixel_z = 0, time = 3)
 	animate(time = 1)
 	animate(alpha = 0, time = 3, easing = CIRCULAR_EASING|EASE_OUT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds rear impact simulation, with realistic physics and thermodynamic properties. Scientific experimentation number 3443.

This also includes some gluon prevention systems which render impacts to the bottom useless, and in some cases, can cause damage to the offending article.

## Why It's Good For The Game

Science has always been lacking, so it's about time we started adding onto it.

## Changelog
:cl:
add: You may now apply force to the bottom.
add: A trait that prevents applying force to the bottom.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
