### PR TITLE
Body part wreching(dislocation) [SEMI-MODULAR]

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -162,10 +162,11 @@
 		var/datum/wound/W = i
 		if(W.try_handling(user))
 			return TRUE
+
 	//SKYRAT EDIT ADDITION BEGIN - MEDICAL
 	if((pulledby == user) && (pulledby.grab_state >= GRAB_AGGRESSIVE) && (user.a_intent == INTENT_HARM))
 		var/obj/item/bodypart/part = get_bodypart(user.zone_selected)
-		if(istype(part))
+		if(istype(part) || zone_selected == BODY_ZONE_PRECISE_GROIN)
 			part.get_wrenched(user, src)
 			return TRUE
 	//SKYRAT EDIT END

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -166,7 +166,7 @@
 	//SKYRAT EDIT ADDITION BEGIN - MEDICAL
 	if((pulledby == user) && (pulledby.grab_state >= GRAB_AGGRESSIVE) && (user.a_intent == INTENT_HARM))
 		var/obj/item/bodypart/part = get_bodypart(user.zone_selected)
-		if(istype(part) || zone_selected == BODY_ZONE_PRECISE_GROIN)
+		if(istype(part))
 			part.get_wrenched(user, src)
 			return TRUE
 	//SKYRAT EDIT END

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -162,7 +162,13 @@
 		var/datum/wound/W = i
 		if(W.try_handling(user))
 			return TRUE
-
+	//SKYRAT EDIT ADDITION BEGIN - MEDICAL
+	if((pulledby == user) && (pulledby.grab_state >= GRAB_AGGRESSIVE) && (user.a_intent == INTENT_HARM))
+		var/obj/item/bodypart/part = get_bodypart(user.zone_selected)
+		if(istype(part))
+			part.get_wrenched(user, src)
+			return TRUE
+	//SKYRAT EDIT END
 	return FALSE
 
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -53,6 +53,7 @@
 	only_forced_audio = TRUE
 	vary = TRUE
 
+/* - SKYRAT EDIT REMOVAL - EMOTES
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/user)
 	if(!ishuman(user))
 		return
@@ -68,7 +69,7 @@
 			return pick('sound/voice/human/malescream_1.ogg', 'sound/voice/human/malescream_2.ogg', 'sound/voice/human/malescream_3.ogg', 'sound/voice/human/malescream_4.ogg', 'sound/voice/human/malescream_5.ogg', 'sound/voice/human/malescream_6.ogg')
 	else if(ismoth(H))
 		return 'sound/voice/moth/scream_moth.ogg'
-
+*/
 
 /datum/emote/living/carbon/human/pale
 	key = "pale"

--- a/modular_skyrat/modules/medical/code/_wounds.dm
+++ b/modular_skyrat/modules/medical/code/_wounds.dm
@@ -1,0 +1,26 @@
+/datum/wound/blunt/moderate/hips
+	name = "Hip Dislocation"
+	desc = "Patient's thighbone has been forced out of it's socket, causing painful and ineffective locomotion."
+	treat_text = "Recommended application of bonesetter to the groin, though manual relocation by applying an aggressive grab to the patient and helpfully interacting with their groin may suffice."
+	examine_desc = "seems to be sitting at a weird angle"
+	occur_text = "pops loudly"
+	severity = WOUND_SEVERITY_MODERATE
+	viable_zones = list(BODY_ZONE_PRECISE_GROIN)
+
+/datum/wound/blunt/moderate/jaw
+	name = "Jaw Dislocation"
+	desc = "Patient has a dislocated jaw, causing pain and discomfort."
+	treat_text = "Recommended application of bonesetter to the head, though forcing the jaw back in place by applying an aggressive grab to the patient and helpfully interacting with their head may suffice."
+	examine_desc = "is red and swollen"
+	occur_text = "snaps audibly"
+	severity = WOUND_SEVERITY_MODERATE
+	viable_zones = list(BODY_ZONE_HEAD)
+
+/datum/wound/blunt/moderate/ribcage
+	name = "Rib Dislocation"
+	desc = "Patient has dislocated ribs, causing extreme pain and labored breathing."
+	treat_text = "Recommended application of bonesetter to the chest, though massaging cartilage by applying an aggressive grab to the laid down patient and helpfully interacting with their chest may suffice."
+	examine_desc = "is red and swollen"
+	occur_text = "pops loudly"
+	severity = WOUND_SEVERITY_MODERATE
+	viable_zones = list(BODY_ZONE_CHEST)

--- a/modular_skyrat/modules/medical/code/wreching.dm
+++ b/modular_skyrat/modules/medical/code/wreching.dm
@@ -1,0 +1,60 @@
+/obj/item/bodypart/proc/get_wrenched(mob/living/carbon/user, mob/living/carbon/victim, silent = FALSE)
+	. = FALSE
+	if(!owner || !user)
+		return
+	if(!victim)
+		victim = owner
+
+	var/bio_state = victim.get_biological_state()
+
+	if(!bio_state)
+		return
+
+	for(var/datum/wound/W in wounds)
+		if(bio_state & BIO_JUST_BONE)
+			if(W.wound_type in WOUND_BLUNT)
+				return
+		else if(bio_state & BIO_JUST_FLESH)
+			if(W.wound_type in WOUND_SLASH)
+				return
+
+	var/time = 4 SECONDS
+	var/time_mod = 1
+	var/prob_mod = 20
+	if(time_mod)
+		time *= time_mod
+
+	if(INTERACTING_WITH(user, victim))
+		return
+
+	if(!silent)
+		user.visible_message("<span class='danger'>[user] starts wrenching [victim]'s [name]!</span>", "<span class='danger'>You start wrenching [victim]'s [name]!</span>", ignored_mobs=victim)
+		to_chat(victim, "<span class='userdanger'>[user] starts wrenching your [name]!</span>")
+
+	if(!do_after(user, time, target=victim))
+		return
+
+	if(prob(30 + prob_mod))
+		user.visible_message("<span class='danger'>[user] dislocates [victim]'s [name] with a sickening crack!</span>", "<span class='danger'>You dislocate [victim]'s [name] with a sickening crack!</span>", ignored_mobs=victim)
+		to_chat(victim, "<span class='userdanger'>[user] dislocates your [name] with a sickening crack!</span>")
+		victim.emote("scream")
+		var/datum/wound/W
+		if(status)
+			if(body_zone == BODY_ZONE_HEAD)
+				W = new /datum/wound/blunt/moderate/jaw()
+			else if(body_zone == BODY_ZONE_PRECISE_GROIN)
+				W = new /datum/wound/blunt/moderate/hips()
+			else if(body_zone == BODY_ZONE_CHEST)
+					W = new /datum/wound/blunt/moderate/ribcage()
+			else
+				W = new /datum/wound/blunt/moderate()
+		if(istype(W))
+			W.apply_wound(src, FALSE)
+		receive_damage(brute=15)
+	else
+		user.visible_message("<span class='danger'>[user] wrenches [victim]'s [name] around painfully!</span>", "<span class='danger'>You wrench [victim]'s [name] around painfully!</span>", ignored_mobs=victim)
+		to_chat(victim, "<span class='userdanger'>[user] wrenches your [name] around painfully!</span>")
+		receive_damage(brute=7)
+		get_wrenched(user, victim, TRUE)
+	return TRUE
+

--- a/modular_skyrat/modules/medical/code/wreching.dm
+++ b/modular_skyrat/modules/medical/code/wreching.dm
@@ -45,7 +45,7 @@
 			else if(body_zone == BODY_ZONE_PRECISE_GROIN)
 				W = new /datum/wound/blunt/moderate/hips()
 			else if(body_zone == BODY_ZONE_CHEST)
-					W = new /datum/wound/blunt/moderate/ribcage()
+				W = new /datum/wound/blunt/moderate/ribcage()
 			else
 				W = new /datum/wound/blunt/moderate()
 		if(istype(W))

--- a/modular_skyrat/modules/medical/readme.md
+++ b/modular_skyrat/modules/medical/readme.md
@@ -1,0 +1,28 @@
+https://github.com/Skyrat-SS13/Skyrat-tg/pull/
+
+## Title: Medical Module
+
+MODULE ID: MEDICAL
+
+### Description:
+
+A module that has generalised medical proceedures that we have added.
+
+### TG Proc Changes:
+
+- /mob/living/carbon/attack_hand(mob/living/carbon/human/user)
+
+### Defines:
+
+- N/A
+
+### Master file additions
+
+- N/A
+
+### Included files that are not contained in this module:
+
+- N/A
+
+### Credits:
+Gandalf2k15 - porting & refactoring

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3509,6 +3509,8 @@
 #include "modular_skyrat\modules\inflatables\code\inflatable.dm"
 #include "modular_skyrat\modules\jukebox\code\controllers\subsystem\jukeboxes.dm"
 #include "modular_skyrat\modules\jukebox\code\controllers\subsystem\game\machinery\dance_machine.dm"
+#include "modular_skyrat\modules\medical\code\_wounds.dm"
+#include "modular_skyrat\modules\medical\code\wreching.dm"
 #include "modular_skyrat\modules\mentor\code\_globalvars.dm"
 #include "modular_skyrat\modules\mentor\code\client_procs.dm"
 #include "modular_skyrat\modules\mentor\code\config.dm"


### PR DESCRIPTION
## About The Pull Request

Allows people to dislocate other people's arms, legs, etc. This causes a moderate wound to occur, simple dislocation. Synthliz needs to have synth wounds enabled. 

Also fixes the issue with two screams being played when someone screams.

## Why It's Good For The Game

Good for torture RP and other such things.

## Changelog
:cl:
add: The ability to dislocate people's things.
fix: Double screams.
/:cl:
