### PR TITLE
[Not modular] 'Dangerous' SM setups can now be used to farm anom cores

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1087,15 +1087,23 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 /obj/machinery/power/supermatter_crystal/proc/supermatter_anomaly_gen(turf/anomalycenter, type = FLUX_ANOMALY, anomalyrange = 5)
 	var/turf/L = pick(orange(anomalyrange, anomalycenter))
+	// BEGIN SKYRAT CHANGE - High Energy Anomaly Core Generation
+	var/drops_core = FALSE
+	// Every 334 EER above POWER_PENALTY_THRESHOLD adds 10% chance for the anomalies to leave behind a core when neutralized
+	var/chance_bonus = clamp((10 * (power - POWER_PENALTY_THRESHOLD) / 334), 0, 95)
+	if(prob(5 + round(chance_bonus))) // 5% base chance to drop a core
+		drops_core = TRUE
+
 	if(L)
 		switch(type)
 			if(FLUX_ANOMALY)
-				var/obj/effect/anomaly/flux/A = new(L, 300, FALSE)
+				var/obj/effect/anomaly/flux/A = new(L, 300, drops_core)
 				A.explosive = FALSE
 			if(GRAVITATIONAL_ANOMALY)
-				new /obj/effect/anomaly/grav(L, 250, FALSE)
+				new /obj/effect/anomaly/grav(L, 250, drops_core)
 			if(PYRO_ANOMALY)
-				new /obj/effect/anomaly/pyro(L, 200, FALSE)
+				new /obj/effect/anomaly/pyro(L, 200, drops_core)
+	// END SKYRAT CHANGE
 
 /obj/machinery/power/supermatter_crystal/proc/supermatter_zap(atom/zapstart = src, range = 5, zap_str = 4000, zap_flags = ZAP_SUPERMATTER_FLAGS, list/targets_hit = list())
 	if(QDELETED(zapstart))

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1085,6 +1085,20 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				continue //You can't pull someone nailed to the deck
 		step_towards(P,center)
 
+/* - SKYRAT EDIT CHANGE - QOL - ORIGINAL
+/obj/machinery/power/supermatter_crystal/proc/supermatter_anomaly_gen(turf/anomalycenter, type = FLUX_ANOMALY, anomalyrange = 5)
+	var/turf/L = pick(orange(anomalyrange, anomalycenter))
+	if(L)
+		switch(type)
+			if(FLUX_ANOMALY)
+				var/obj/effect/anomaly/flux/A = new(L, 300, FALSE)
+				A.explosive = FALSE
+			if(GRAVITATIONAL_ANOMALY)
+				new /obj/effect/anomaly/grav(L, 250, FALSE)
+			if(PYRO_ANOMALY)
+				new /obj/effect/anomaly/pyro(L, 200, FALSE)
+*/
+
 /obj/machinery/power/supermatter_crystal/proc/supermatter_anomaly_gen(turf/anomalycenter, type = FLUX_ANOMALY, anomalyrange = 5)
 	var/turf/L = pick(orange(anomalyrange, anomalycenter))
 	// BEGIN SKYRAT CHANGE - High Energy Anomaly Core Generation


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Anomalies generated by the Supermatter (this happens at low integrity, or at very high EER) now have a 5% base chance to drop an anomaly core.

This chance increases by 10% for ever 334 EER above 5,000 (the threshold at which anomalies and lightning bolts spawn).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Encourages engineers to make creative SM setups to get these anomaly cores.
- Encourages cooperation between engineering and science, to provide them the anomaly cores they need.
- It requires active participation to make these cores. If you don't neutralize them, the pyros will mess things up bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Anomalies generated by a Supermatter now have a chance to drop cores. This chance scales with EER above 5,000.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
