### PR TITLE
[Not Modular] [2-Line] Slightly increases the RIPLEY MKII mechspeed to oldbase levels.

### DIFF
--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -62,8 +62,8 @@
 	name = "\improper APLU MK-II \"Ripley\""
 	icon_state = "ripleymkii"
 	fast_pressure_step_in = 2 //step_in while in low pressure conditions
-	slow_pressure_step_in = 4 //step_in while in normal pressure conditions
-	movedelay = 4
+	slow_pressure_step_in = 3 //step_in while in normal pressure conditions //SKYRAT EDIT - Movedelay is now 3, from 4.
+	movedelay = 3 //SKYRAT EDIT - Movedelay is now 3, from 4.
 	max_temperature = 30000
 	max_integrity = 250
 	armor = list(MELEE = 40, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 60, BIO = 0, RAD = 70, FIRE = 100, ACID = 100)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Decreases the RIPLEY movedelay to 3, from 4.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is the value from the oldbase. The RIPLEY MKII is just the default RIPLEY from the oldbase, and theres no reason it should be this slow. Theres making a tradeoff for an upgrade, and then theres making the installation a downgrade.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Balance: The RIPLEY MKII is ever-so-slightly faster in atmosphere.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
