### PR TITLE
[Modular] Mob layer shifting verbs

### DIFF
--- a/modular_skyrat/modules/layer_shift/code/modules/mob/mob_movement.dm
+++ b/modular_skyrat/modules/layer_shift/code/modules/mob/mob_movement.dm
@@ -1,0 +1,36 @@
+#define MOB_LAYER_SHIFT_INCREMENT	0.01
+#define MOB_LAYER_SHIFT_MIN 		3.95
+//#define MOB_LAYER 				4   // This is a byond standard define
+#define MOB_LAYER_SHIFT_MAX   		4.05
+
+/mob/verb/layershift_up()
+	set name = "Shift Layer Upwards"
+	set category = "IC"
+
+	if(incapacitated() || (layer == LYING_MOB_LAYER))
+		to_chat(src, "<span class='warning'>You can't do that right now!</span>")
+		return
+
+	if(layer >= MOB_LAYER_SHIFT_MAX)
+		to_chat(src, "<span class='warning'>You cannot increase your layer priority any further.</span>")
+		return
+
+	layer += MOB_LAYER_SHIFT_INCREMENT
+	var/layer_priority = (layer - MOB_LAYER) * 100 // Just for text feedback
+	to_chat(src, "<span class='notice'>Your layer priority is now [layer_priority].</span>")
+
+/mob/verb/layershift_down()
+	set name = "Shift Layer Downwards"
+	set category = "IC"
+
+	if(incapacitated() || (layer == LYING_MOB_LAYER))
+		to_chat(src, "<span class='warning'>You can't do that right now!</span>")
+		return
+
+	if(layer <= MOB_LAYER_SHIFT_MIN)
+		to_chat(src, "<span class='warning'>You cannot decrease your layer priority any further.</span>")
+		return
+	
+	layer -= MOB_LAYER_SHIFT_INCREMENT
+	var/layer_priority = (layer - MOB_LAYER) * 100 // Just for text feedback
+	to_chat(src, "<span class='notice'>Your layer priority is now [layer_priority].</span>")

--- a/modular_skyrat/modules/layer_shift/code/modules/mob/mob_movement.dm
+++ b/modular_skyrat/modules/layer_shift/code/modules/mob/mob_movement.dm
@@ -7,7 +7,7 @@
 	set name = "Shift Layer Upwards"
 	set category = "IC"
 
-	if(incapacitated() || body_position == LYING_DOWN))
+	if(incapacitated() || body_position == LYING_DOWN)
 		to_chat(src, "<span class='warning'>You can't do that right now!</span>")
 		return
 
@@ -23,7 +23,7 @@
 	set name = "Shift Layer Downwards"
 	set category = "IC"
 
-	if(incapacitated() || body_position == LYING_DOWN))
+	if(incapacitated() || body_position == LYING_DOWN)
 		to_chat(src, "<span class='warning'>You can't do that right now!</span>")
 		return
 

--- a/modular_skyrat/modules/layer_shift/code/modules/mob/mob_movement.dm
+++ b/modular_skyrat/modules/layer_shift/code/modules/mob/mob_movement.dm
@@ -3,11 +3,11 @@
 //#define MOB_LAYER 				4   // This is a byond standard define
 #define MOB_LAYER_SHIFT_MAX   		4.05
 
-/mob/verb/layershift_up()
+/mob/living/verb/layershift_up()
 	set name = "Shift Layer Upwards"
 	set category = "IC"
 
-	if(incapacitated() || (layer == LYING_MOB_LAYER))
+	if(incapacitated() || body_position == LYING_DOWN))
 		to_chat(src, "<span class='warning'>You can't do that right now!</span>")
 		return
 
@@ -19,11 +19,11 @@
 	var/layer_priority = (layer - MOB_LAYER) * 100 // Just for text feedback
 	to_chat(src, "<span class='notice'>Your layer priority is now [layer_priority].</span>")
 
-/mob/verb/layershift_down()
+/mob/living/verb/layershift_down()
 	set name = "Shift Layer Downwards"
 	set category = "IC"
 
-	if(incapacitated() || (layer == LYING_MOB_LAYER))
+	if(incapacitated() || body_position == LYING_DOWN))
 		to_chat(src, "<span class='warning'>You can't do that right now!</span>")
 		return
 

--- a/modular_skyrat/modules/layer_shift/readme.md
+++ b/modular_skyrat/modules/layer_shift/readme.md
@@ -1,0 +1,19 @@
+## Title: Pixel shifting for RP positioning
+
+MODULE ID: LAYER_SHIFT
+
+### Description:
+
+This module adds 2 verbs that lets mobs shift their layer var ever so slightly to complement pixel-shifting, in order to maintain IC hierarchy of who should be showing up above one another sprite-wise.
+
+### TG Proc Changes:
+
+### Defines:
+
+### Included files:
+
+N/A
+
+### Credits:
+
+Ranged66 - Coding

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3573,6 +3573,7 @@
 #include "modular_skyrat\modules\inflatables\code\inflatable.dm"
 #include "modular_skyrat\modules\jukebox\code\controllers\subsystem\jukeboxes.dm"
 #include "modular_skyrat\modules\jukebox\code\controllers\subsystem\game\machinery\dance_machine.dm"
+#include "modular_skyrat\modules\layer_shift\code\modules\mob\mob_movement.dm"
 #include "modular_skyrat\modules\mentor\code\_globalvars.dm"
 #include "modular_skyrat\modules\mentor\code\client_procs.dm"
 #include "modular_skyrat\modules\mentor\code\config.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds two verbs to the IC tab which allow you to slightly increment your mob's 'layer' var. Useful for situations where you want a certain pixelshifted character to be drawn above or below the others.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

yes

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added two verbs to the IC tab that change your mob's 'layer' (sprite background/foreground priority) slightly. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
