### PR TITLE
Removes teleporter species change, increases rads

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -76,9 +76,9 @@
 			use_power(5000)
 			if(!calibrated && prob(30 - ((accuracy) * 10))) //oh dear a problem
 				if(ishuman(M))//don't remove people from the round randomly you jerks
+					var/mob/living/carbon/human/human = M
 					//SKYRAT EDIT REMOVAL BEGIN
 					/*
-					var/mob/living/carbon/human/human = M
 					if(!(human.mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL|MOB_UNDEAD|MOB_SPIRIT)))
 						if(human.dna && human.dna.species.id != "fly")
 							to_chat(M, "<span class='hear'>You hear a buzzing in your ears.</span>")

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -76,14 +76,21 @@
 			use_power(5000)
 			if(!calibrated && prob(30 - ((accuracy) * 10))) //oh dear a problem
 				if(ishuman(M))//don't remove people from the round randomly you jerks
+					//SKYRAT EDIT REMOVAL BEGIN
+					/*
 					var/mob/living/carbon/human/human = M
 					if(!(human.mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL|MOB_UNDEAD|MOB_SPIRIT)))
 						if(human.dna && human.dna.species.id != "fly")
 							to_chat(M, "<span class='hear'>You hear a buzzing in your ears.</span>")
 							human.set_species(/datum/species/fly)
 							log_game("[human] ([key_name(human)]) was turned into a fly person")
+					*/
+					//SKYRAT EDIT REMOVAL END
 
-					human.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0)
+					//SKYRAT EDIT CHANGE BEGIN
+					//human.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0) - SKYRAT EDIT - ORIGINAL
+					human.apply_effect((rand(420 - accuracy * 40, 780 - accuracy * 60)), EFFECT_IRRADIATE, 0) //SKYRAT EDIT - heavy rads to compensate
+					//SKYRAT EDIT CHANGE END
 			calibrated = FALSE
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reject fly, return to monke
Copies changes from oldbase https://github.com/Skyrat-SS13/Skyrat13/pull/2736

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Species change is not fun, and a pain in the ass to deal with. Increases rads to compensate

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
removal: Removed the chance to be turned into a flyperson when using the teleporter uncalibrated
balance: Greatly increases rads to compensate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
