### PR TITLE
Slightly buffs monkey recycler

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -31,7 +31,8 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 /obj/machinery/monkey_recycler/RefreshParts()	//Ranges from 0.2 to 0.8 per monkey recycled
 	cube_production = 0
 	for(var/obj/item/stock_parts/manipulator/B in component_parts)
-		cube_production += B.rating * 0.1
+		//cube_production += B.rating * 0.1 //ORIGINAL
+		cube_production += B.rating * 0.2 //SKYRAT EDIT CHANGE - buffs to allow 1.2 cubes per monkey at T4
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 		cube_production += M.rating * 0.1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs monkey recycler from 0.1 to 0.2 cubes per monkey per manipulator tier. 
Old values (assuming tier parity):
T1 - 0.2
T2 - 0.4
T3 - 0.6
T4 - 0.8

New values:
T1 - 0.3
T2 - 0.6
T3 - 0.9
T4 - 1.2


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows you to eventually be self sufficient on monkeys, you don't have to wait the whole time for industrial greys or trek to botany or whatever every ten minutes. It's not *too* much of a return though so you won't exactly stack up huge piles of monkey cubes

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Gives the monkey recycler more cubes per monkey per manipulator tier
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
