### PR TITLE
Teleporter changes [NON-MODUALR]

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -95,7 +95,7 @@
 							qdel(BP) //WHEEEEE LOST TO SPACE N' TIME
 							dismembered++
 					//SKYRAT EDIT CHANGE END
-					//human.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0) - SKYRAT EDIT REMOVAL
+					human.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0)
 			calibrated = FALSE
 	return
 

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -88,16 +88,14 @@
 					var/dismembered = 0
 					to_chat(human, "<span class='danger'>Your limbs lose molecular cohesion as you teleport!</span>")
 					for(var/obj/item/bodypart/BP in human.bodyparts)
-						if(dismembered <= 2) //Remove two body parts.
+						if(dismembered <= 2) //Remove 3 body parts.
 							if(BP.name == "chest" || BP.name == "head")
 								continue
 							BP.dismember()
 							qdel(BP) //WHEEEEE LOST TO SPACE N' TIME
 							dismembered++
-
 					//SKYRAT EDIT CHANGE END
-					//human.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0) - ORIGINAL
-					human.apply_effect((rand(780 - accuracy * 40, 1040 - accuracy * 60)), EFFECT_IRRADIATE, 0) //SKYRAT EDIT CHANGE
+					//human.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0) - SKYRAT EDIT REMOVAL
 			calibrated = FALSE
 	return
 

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -83,21 +83,26 @@
 							to_chat(M, "<span class='hear'>You hear a buzzing in your ears.</span>")
 							human.set_species(/datum/species/fly)
 							log_game("[human] ([key_name(human)]) was turned into a fly person")
+					human.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0)
 					*/ //SKYRAT EDIT REMOVAL END
 					//SKRYAT EDIT CHANGE BEGIN
-					var/dismembered = 0
 					to_chat(human, "<span class='danger'>Your limbs lose molecular cohesion as you teleport!</span>")
+					var/list/bodyparts_dismember = list()
+					var/rad_mod = 0
 					for(var/obj/item/bodypart/BP in human.bodyparts)
-						if(dismembered < 2) //Remove 2 body parts.
-							if(BP.body_zone == BODY_ZONE_CHEST || BP.body_zone== BODY_ZONE_HEAD)
-								continue
-							BP.dismember()
-							qdel(BP) //WHEEEEE LOST TO SPACE N' TIME
-							dismembered++
-						else
+						if(BP.body_zone == BODY_ZONE_CHEST || BP.body_zone== BODY_ZONE_HEAD)
+							continue
+						bodyparts_dismember.Add(BP)
+					for(var/i in 1 to 2) //Removing two bodyparts.
+						var/obj/item/bodypart/BP = pick(bodyparts_dismember)
+						if(!istype(BP))
+							rad_mod += 300 //Bad snowflake, take more rads!
 							break
+						BP.dismember()
+						bodyparts_dismember.Remove(BP) //GC optimisation
+						qdel(BP)
+					human.apply_effect((rand(480 + rad_mod - accuracy * 40, 880 + rad_mod - accuracy * 60)), EFFECT_IRRADIATE, 0)
 					//SKYRAT EDIT CHANGE END
-					human.apply_effect((rand(480 - accuracy * 40, 880 - accuracy * 60)), EFFECT_IRRADIATE, 0)
 			calibrated = FALSE
 	return
 

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -88,14 +88,14 @@
 					var/dismembered = 0
 					to_chat(human, "<span class='danger'>Your limbs lose molecular cohesion as you teleport!</span>")
 					for(var/obj/item/bodypart/BP in human.bodyparts)
-						if(dismembered <= 2) //Remove 3 body parts.
+						if(dismembered <= 1) //Remove 3 body parts.
 							if(BP.name == "chest" || BP.name == "head")
 								continue
 							BP.dismember()
 							qdel(BP) //WHEEEEE LOST TO SPACE N' TIME
 							dismembered++
 					//SKYRAT EDIT CHANGE END
-					human.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0)
+					human.apply_effect((rand(480 - accuracy * 40, 880 - accuracy * 60)), EFFECT_IRRADIATE, 0)
 			calibrated = FALSE
 	return
 

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -77,13 +77,27 @@
 			if(!calibrated && prob(30 - ((accuracy) * 10))) //oh dear a problem
 				if(ishuman(M))//don't remove people from the round randomly you jerks
 					var/mob/living/carbon/human/human = M
+					/* - SKRYAT EDIT CHANGE ORIGINAL
 					if(!(human.mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL|MOB_UNDEAD|MOB_SPIRIT)))
 						if(human.dna && human.dna.species.id != "fly")
 							to_chat(M, "<span class='hear'>You hear a buzzing in your ears.</span>")
 							human.set_species(/datum/species/fly)
 							log_game("[human] ([key_name(human)]) was turned into a fly person")
+					*/ //SKYRAT EDIT REMOVAL END
+					//SKRYAT EDIT CHANGE BEGIN
+					var/dismembered = 0
+					to_chat(human, "<span class='danger'>Your limbs lose molecular cohesion as you teleport!</span>")
+					for(var/obj/item/bodypart/BP in human.bodyparts)
+						if(dismembered <= 2) //Remove two body parts.
+							if(BP.name == "chest" || BP.name == "head")
+								continue
+							BP.dismember()
+							qdel(BP) //WHEEEEE LOST TO SPACE N' TIME
+							dismembered++
 
-					human.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0)
+					//SKYRAT EDIT CHANGE END
+					//human.apply_effect((rand(120 - accuracy * 40, 180 - accuracy * 60)), EFFECT_IRRADIATE, 0) - ORIGINAL
+					human.apply_effect((rand(780 - accuracy * 40, 1040 - accuracy * 60)), EFFECT_IRRADIATE, 0) //SKYRAT EDIT CHANGE
 			calibrated = FALSE
 	return
 

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -88,12 +88,14 @@
 					var/dismembered = 0
 					to_chat(human, "<span class='danger'>Your limbs lose molecular cohesion as you teleport!</span>")
 					for(var/obj/item/bodypart/BP in human.bodyparts)
-						if(dismembered <= 1) //Remove 3 body parts.
-							if(BP.name == "chest" || BP.name == "head")
+						if(dismembered < 2) //Remove 2 body parts.
+							if(BP.body_zone == BODY_ZONE_CHEST || BP.body_zone== BODY_ZONE_HEAD)
 								continue
 							BP.dismember()
 							qdel(BP) //WHEEEEE LOST TO SPACE N' TIME
 							dismembered++
+						else
+							break
 					//SKYRAT EDIT CHANGE END
 					human.apply_effect((rand(480 - accuracy * 40, 880 - accuracy * 60)), EFFECT_IRRADIATE, 0)
 			calibrated = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Let's not go easy on dumb people that use an uncalibrated teleporter;
You'll lose 2 limbs, and you'll also receive a a lot of radiation.

## Why It's Good For The Game

Muh character.

## Changelog
:cl:
balance: Teleproters no longer change species, but are FAR more deadly when used uncalibrated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
