### PR TITLE
Makes two mood messages first person

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -138,7 +138,7 @@
 	timeout = 3 MINUTES
 
 /datum/mood_event/religiously_comforted
-	description = "<span class='nicegreen'>You are comforted by the presence of a holy person.</span>\n"
+	description = "<span class='nicegreen'>I feel comforted by the presence of a holy person.</span>\n"
 	mood_change = 3
 	timeout = 5 MINUTES
 

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -138,7 +138,8 @@
 	timeout = 3 MINUTES
 
 /datum/mood_event/religiously_comforted
-	description = "<span class='nicegreen'>I feel comforted by the presence of a holy person.</span>\n"
+	//description = "<span class='nicegreen'>You are comforted by the presence of a holy person.</span>\n" //SKYRAT CHANGE - ORIGINAL
+	description = "<span class='nicegreen'>I feel comforted by the presence of a holy person.</span>\n" //SKYRAT CHANGE
 	mood_change = 3
 	timeout = 5 MINUTES
 

--- a/code/datums/mood_events/needs_events.dm
+++ b/code/datums/mood_events/needs_events.dm
@@ -54,7 +54,7 @@
 	mood_change = -8
 
 /datum/mood_event/disgust/bad_smell
-	description = "<span class='warning'>You smell something horribly decayed inside this room.</span>\n"
+	description = "<span class='warning'>I can smell something horribly decayed inside this room.</span>\n"
 	mood_change = -6
 
 /datum/mood_event/disgust/nauseating_stench

--- a/code/datums/mood_events/needs_events.dm
+++ b/code/datums/mood_events/needs_events.dm
@@ -54,7 +54,8 @@
 	mood_change = -8
 
 /datum/mood_event/disgust/bad_smell
-	description = "<span class='warning'>I can smell something horribly decayed inside this room.</span>\n"
+	//description = "<span class='warning'>You smell something horribly decayed inside this room.</span>\n" //SKYRAT CHANGE - ORIGINAL
+	description = "<span class='warning'>I can smell something horribly decayed inside this room.</span>\n" //SKYRAT CHANGE
 	mood_change = -6
 
 /datum/mood_event/disgust/nauseating_stench


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Consistency

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Makes mood messages consistently first person
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
