### PR TITLE
[Ready] [Not Modular] Expansive Smuggling

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -322,18 +322,28 @@
 	STR.set_holdable(null, list(/obj/item/storage/backpack/satchel/flat)) //muh recursive backpacks)
 
 /obj/item/storage/backpack/satchel/flat/PopulateContents()
-	var/datum/supply_pack/costumes_toys/randomised/contraband/C = new
+	//SKYRAT EDIT CHANGE BEGIN
+	/*
+	/datum/supply_pack/costumes_toys/randomised/contraband/C = new
 	for(var/i in 1 to 2)
 		var/ctype = pick(C.contains)
 		new ctype(src)
 
 	qdel(C)
+	*/
+	var/contraband_list = list(/obj/item/storage/bag/ammo=4, /obj/item/storage/belt/utility/syndicate=1, /obj/item/storage/toolbox/syndicate=7, /obj/item/card/id/syndicate=6, /obj/item/storage/secure/briefcase/syndie=3, /obj/item/stack/telecrystal=2, /obj/item/storage/belt/military=12, /obj/item/storage/pill_bottle/aranesp=11, /obj/item/storage/pill_bottle/happy=12, /obj/item/storage/pill_bottle/stimulant=9, /obj/item/storage/pill_bottle/lsd=10, /obj/item/storage/fancy/cigarettes/cigpack_syndicate=8, /obj/item/storage/fancy/cigarettes/cigpack_shadyjims=10, /obj/item/reagent_containers/food/drinks/bottle/absinthe=12, /obj/item/storage/box/fireworks/dangerous=11, /obj/item/food/grown/cannabis/white=9, /obj/item/food/grown/cannabis=13, /obj/item/food/grown/cannabis/rainbow=8, /obj/item/food/grown/mushroom/libertycap=11, /obj/item/clothing/mask/gas/syndicate=10, /obj/item/vending_refill/donksoft=13, /obj/item/ammo_box/foambox/riot=11, /obj/item/soap/syndie=7)
+	for(var/i in 1 to 3)
+		var/contraband_type = pickweight(contraband_list)
+		contraband_list -= contraband_type
+		new contraband_type(src)
+
+	//SKYRAT EDIT CHANGE END
 
 /obj/item/storage/backpack/satchel/flat/with_tools/PopulateContents()
 	new /obj/item/stack/tile/plasteel(src)
 	new /obj/item/crowbar(src)
 
-	..()
+//	..() SKYRAT EDIT REMOVAL
 
 /obj/item/storage/backpack/satchel/flat/empty/PopulateContents()
 	return


### PR DESCRIPTION
## About The Pull Request

Changes and expands the Smugglers Satchels at round spawn to have 3 items (As opposed to 2) And to pull from a different pool of loot.

Changes:
>Removed Dope necklace + Tacticool turtleneck. Smugglers have valued these as not worth smuggling. (Also removes posters)
>Added a variety of new items, Including Liberty caps, Syndicate toolboxes, Syndicate soap, Chest rigs, and doctorable ID's, And those ever-rare Telecrystals in single packs
>Stuffed another item into satchels
>Makes sure that no item repeats. No buyer wants to sample the same thing twice.

## Why It's Good For The Game

Makes placing and finding smuggler satchels better for syndicate members

## Changelog
:cl:
tweak: Smugglers have decided to stuff caches a bit more.
tweak: Smugglers have decided to venture into more lucrative caches.
code: Removes super call from with_tools variant of smuggler satchels.
/:cl:
