### PR TITLE
Admin Control Click spawn is no longer selfish.

### DIFF
--- a/modular_skyrat/modules/icspawning/code/_onclick/observer.dm
+++ b/modular_skyrat/modules/icspawning/code/_onclick/observer.dm
@@ -36,26 +36,26 @@
 				return
 
 
-		var/turf/current_turf = get_turf(src)
-		var/mob/living/carbon/human/spawned_player = new(src)
+		var/turf/current_turf = get_turf(user)
+		var/mob/living/carbon/human/spawned_player = new(user)
 
 		if (character_option == "Selected Character")
-			spawned_player.name = src.name
-			spawned_player.real_name = src.real_name
+			spawned_player.name = user.name
+			spawned_player.real_name = user.real_name
 
 			var/mob/living/carbon/human/H = spawned_player
-			client?.prefs.copy_to(H)
+			user.client?.prefs.copy_to(H)
 			H.dna.update_dna_identity()
 
-		QDEL_IN(src, 1)
+		QDEL_IN(user, 1)
 
 		if (teleport_option == "Bluespace")
 			playsound(spawned_player, 'sound/magic/Disable_Tech.ogg', 100, 1)
 
-		if(mind && isliving(spawned_player))
-			mind.transfer_to(spawned_player, 1) // second argument to force key move to new mob
+		if(user.mind && isliving(spawned_player))
+			user.mind.transfer_to(spawned_player, 1) // second argument to force key move to new mob
 		else
-			spawned_player.ckey = key
+			spawned_player.ckey = user.key
 
 		if(give_return != "No")
 			spawned_player.mind.AddSpell(new /obj/effect/proc_holder/spell/self/return_back, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bugfix cried out for by Inferno.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Easy spawning players for testing purposes is more helpful than you think.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Foxtrot (Funce)
admin: Control Click fast admin spawn can now work on players other than yourself. Functionality Restored!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
