### PR TITLE
Fix various issues with borg resting

### DIFF
--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot.dm
@@ -1,12 +1,27 @@
 /mob/living/silicon/robot
 	var/robot_resting = FALSE
+	var/robot_rest_style = ROBOT_REST_NORMAL
 	var/dogborg = FALSE
 
 /mob/living/silicon/robot/Moved(atom/OldLoc, Dir, Forced = FALSE)
 	. = ..()
 	if(robot_resting)
 		robot_resting = FALSE
+		on_standing_up()
 		update_icons()
+
+/mob/living/silicon/robot/toggle_resting()
+	robot_lay_down()
+
+/mob/living/silicon/robot/on_lying_down(new_lying_angle)
+	if(layer == initial(layer)) //to avoid things like hiding larvas.
+		layer = LYING_MOB_LAYER //so mob lying always appear behind standing mobs
+	density = FALSE // We lose density and stop bumping passable dense things.
+
+/mob/living/silicon/robot/on_standing_up()
+	if(layer == LYING_MOB_LAYER)
+		layer = initial(layer)
+	density = initial(density) // We were prone before, so we become dense and things can bump into us again.
 
 /mob/living/silicon/robot/proc/rest_style()
 	set name = "Switch Rest Style"
@@ -14,14 +29,17 @@
 	set desc = "Select your resting pose."
 	if(!dogborg)
 		to_chat(src, "<span class='warning'>You can't do that!</span>")
+		return
 	var/choice = alert(src, "Select resting pose", "", "Resting", "Sitting", "Belly up")
 	switch(choice)
 		if("Resting")
-			robot_resting = ROBOT_REST_NORMAL
+			robot_rest_style = ROBOT_REST_NORMAL
 		if("Sitting")
-			robot_resting = ROBOT_REST_SITTING
+			robot_rest_style = ROBOT_REST_SITTING
 		if("Belly up")
-			robot_resting = ROBOT_REST_BELLY_UP
+			robot_rest_style = ROBOT_REST_BELLY_UP
+	robot_resting = robot_rest_style
+	on_lying_down()
 	update_icons()
 
 /mob/living/silicon/robot/proc/robot_lay_down()
@@ -29,15 +47,18 @@
 	set category = "Robot Commands"
 	if(!dogborg)
 		to_chat(src, "<span class='warning'>You can't do that!</span>")
+		return
 	if(stat != CONSCIOUS) //Make sure we don't enable movement when not concious
 		return
 	if(robot_resting)
 		to_chat(src, "<span class='notice'>You are now getting up.</span>")
 		robot_resting = FALSE
 		mobility_flags = MOBILITY_FLAGS_DEFAULT
+		on_standing_up()
 	else
 		to_chat(src, "<span class='notice'>You are now laying down.</span>")
-		robot_resting = ROBOT_REST_NORMAL
+		robot_resting = robot_rest_style
+		on_lying_down()
 	update_icons()
 
 /mob/living/silicon/robot/update_resting()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #1430
Second Half of fixing that issue (several months later don't hurt me)

Makes the Dogborg rest style persist.
Links the rest hotkey to the dogborg lie down. This will also fix normal borgs doing human flopdowns.
Density while lying down has been added because "Lockers aren't very sexy to stack with"

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfixes and QoL
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Foxtrot (Funce)
fix: Borg rest hotkey has been fixed.
fix: Dogborg rest style is now persistent until the next choosing of rest style.
tweak: You no longer trip over borgs that are lying down.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
