### PR TITLE
Biomeat in Biogen, Fast Food Craft

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -1,6 +1,7 @@
 /datum/crafting_recipe/food
 	var/real_parts
 	category = CAT_FOOD
+	time = 5 // Skyrat Change, default crafting time is 30 deciseconds, food is crafted much more often and in large numbers.
 
 /datum/crafting_recipe/food/New()
 	real_parts = parts.Copy()

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -66,6 +66,16 @@
 	build_path = /obj/item/food/monkeycube
 	category = list("initial","Food")
 
+//SKYRAT EDIT ADDITION BEGIN
+/datum/design/biomeat
+	name = "Meat Product"
+	id = "meatp"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 125) //Monkey Cube is more efficient, but this is easier on the chef.
+	build_path = /obj/item/food/meat/slab/meatproduct
+	category = list("initial","Food")
+//SKYRAT EDIT ADDITION END
+
 /datum/design/ez_nut   //easy nut :)
 	name = "25u E-Z Nutrient"
 	id = "ez_nut"


### PR DESCRIPTION
## About The Pull Request

Food crafting now takes 5 deciseconds, instead of 30.
Meat Product can be produced in the biogen.

## Why It's Good For The Game

Right now, the chef is going through hell because of the food rework on TG, in addition to some QoL features missing.

These changes are to put it a bit more in-line with oldbase chef, and to make it easier to "cook" crafted meals.

## Changelog
:cl:
tweak: Food crafting now takes 5 deciseconds, instead of 30.
add: Meat Product can be produced in the biogen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
