### PR TITLE
Makes it so when you lie down it makes you lie down in the direction you're facing

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1295,7 +1295,7 @@
 /// Special carbon interaction on lying down, to transform its sprite by a rotation.
 /mob/living/carbon/proc/lying_angle_on_lying_down(new_lying_angle)
 	if(!new_lying_angle)
-		//SKYRAT EDIT ADDITION BEGIN - SOUNDS
+		//SKYRAT EDIT ADDITION BEGIN
 		if(dir == WEST)
 			set_lying_angle(270)
 			return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1295,6 +1295,14 @@
 /// Special carbon interaction on lying down, to transform its sprite by a rotation.
 /mob/living/carbon/proc/lying_angle_on_lying_down(new_lying_angle)
 	if(!new_lying_angle)
+		//SKYRAT EDIT ADDITION BEGIN - SOUNDS
+		if(dir == WEST)
+			set_lying_angle(270)
+			return
+		else if(dir == EAST)
+			set_lying_angle(90)
+			return
+		//SKYRAT EDIT END
 		set_lying_angle(pick(90, 270))
 	else
 		set_lying_angle(new_lying_angle)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If you are facing down you lie down left, if you are facing right you lie down right

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Imagine you want to lay down on a bed with someone. So, you hit rest. Oh shit, wrong direction! Time to get back up and hit rest again. Nope, its the wrong direction again. Time to get back up again. Hit rest again. GOD DAMN IT WHY IS IT THE WRONG FUCKING DIRECTION AGAIN JUST GIVE ME THE CORRECT DIRECTION HOW MANY TRIES COULD THIS POSSIBLY TAKE.

Okay, maybe you don't rage this hard, but it's still annoying to do this.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: You now lie down in the direction you are facing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
