### PR TITLE
Lowers stasis bed surgery efficiency by 5%

### DIFF
--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -3,7 +3,8 @@
 	if(locate(/obj/structure/table/optable, T))
 		return 1
 	else if(locate(/obj/machinery/stasis, T))
-		return 0.9
+		//return 0.9 //ORIGINAL
+		return 0.8 //SKYRAT EDIT CHANGE - drops success chance on stasis beds by 10%. Use a damn operating table
 	else if(locate(/obj/structure/table, T))
 		return 0.8
 	else if(locate(/obj/structure/bed, T))

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -4,7 +4,7 @@
 		return 1
 	else if(locate(/obj/machinery/stasis, T))
 		//return 0.9 //ORIGINAL
-		return 0.85 //SKYRAT EDIT CHANGE - drops success chance on stasis beds by 10%. Use a damn operating table
+		return 0.85 //SKYRAT EDIT CHANGE - drops success chance on stasis beds by 5%. Use a damn operating table
 	else if(locate(/obj/structure/table, T))
 		return 0.8
 	else if(locate(/obj/structure/bed, T))

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -4,7 +4,7 @@
 		return 1
 	else if(locate(/obj/machinery/stasis, T))
 		//return 0.9 //ORIGINAL
-		return 0.8 //SKYRAT EDIT CHANGE - drops success chance on stasis beds by 10%. Use a damn operating table
+		return 0.85 //SKYRAT EDIT CHANGE - drops success chance on stasis beds by 10%. Use a damn operating table
 	else if(locate(/obj/structure/table, T))
 		return 0.8
 	else if(locate(/obj/structure/bed, T))


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

Nobody uses the damn operating tables, stasis beds are too strong. This just leads to 4 brain surgeries in one big open room in medical which is pretty LRP. Stasis beds need a little more tuning than just this, but it's a start.

## Changelog
:cl:
balance: lowers stasis bed efficiency by 5%
/:cl:
