### PR TITLE
Makes command immune to FAMILIES

### DIFF
--- a/code/game/gamemodes/gang/gang_things.dm
+++ b/code/game/gamemodes/gang/gang_things.dm
@@ -12,9 +12,9 @@
 
 /obj/item/gang_induction_package/attack_self(mob/living/user)
 	..()
-	if(HAS_TRAIT(user, TRAIT_MINDSHIELD))
+	/*if(HAS_TRAIT(user, TRAIT_MINDSHIELD))
 		to_chat(user, "You attended a seminar on not signing up for a gang and are not interested.")
-		return
+		return*/
 	if(user.mind.has_antag_datum(/datum/antagonist/ert/families))
 		to_chat(user, "As a police officer, you can't join this family. However, you pretend to accept it to keep your cover up.")
 		for(var/threads in team_to_use.free_clothes)

--- a/modular_skyrat/modules/antagonists/code/gamemodes.dm
+++ b/modular_skyrat/modules/antagonists/code/gamemodes.dm
@@ -13,6 +13,9 @@
 /datum/game_mode/heretics
 	protected_jobs = list("Prisoner", "Blueshield", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
 
+/datum/game_mode/gang
+	protected_jobs = list("Prisoner", "Blueshield", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster") //i hate whoever just copy pasted this a bunch of times
+
 /datum/dynamic_ruleset/roundstart/traitor
 	protected_roles = list("Prisoner", "Blueshield", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
 

--- a/modular_skyrat/modules/antagonists/code/gang_things.dm
+++ b/modular_skyrat/modules/antagonists/code/gang_things.dm
@@ -1,0 +1,10 @@
+/obj/item/gang_induction_package/attack_self(mob/living/user)
+	if(user.mind.assigned_role in GLOB.command_positions)
+		to_chat(user, "Joining a gang would hurt profits, wouldn't it? Central wouldn't be happy.")
+		user.emote("shake")
+		return
+	if(HAS_TRAIT(user, TRAIT_MINDSHIELD) || (user.mind.assigned_role in GLOB.security_positions))
+		to_chat(user, "You attended a seminar on not signing up for a gang and are not interested.")
+		user.emote("shake")
+		return
+	..()

--- a/modular_skyrat/modules/antagonists/code/gang_things.dm
+++ b/modular_skyrat/modules/antagonists/code/gang_things.dm
@@ -3,7 +3,11 @@
 		to_chat(user, "Joining a gang would hurt profits, wouldn't it? Central wouldn't be happy.")
 		user.emote("shake")
 		return
-	if(HAS_TRAIT(user, TRAIT_MINDSHIELD) || (user.mind.assigned_role in GLOB.security_positions))
+	if(user.mind.assigned_role == "Blueshield")
+		to_chat(user, "It'd be a terrible idea. What about the Heads of Staff?")
+		user.emote("shake")
+		return
+	if(HAS_TRAIT(user, TRAIT_MINDSHIELD))
 		to_chat(user, "You attended a seminar on not signing up for a gang and are not interested.")
 		user.emote("shake")
 		return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3380,6 +3380,7 @@
 #include "modular_skyrat\modules\ambitions\code\antag_datums.dm"
 #include "modular_skyrat\modules\ambitions\code\mind.dm"
 #include "modular_skyrat\modules\antagonists\code\gamemodes.dm"
+#include "modular_skyrat\modules\antagonists\code\gang_things.dm"
 #include "modular_skyrat\modules\antagonists\code\modules\uplink\uplink_items.dm"
 #include "modular_skyrat\modules\autotransfer\code\autotransfer.dm"
 #include "modular_skyrat\modules\autotransfer\code\autotransfer_config.dm"


### PR DESCRIPTION
Heads of Command cannot spawn as family leaders or join families. This PR also hardcodes Security to be unable to join them at all, even if they lose their mindshield.
:cl: GuppyLaxx
add: Added immunity from Families to Heads of Staff (And sec)
/:cl:
