### PR TITLE
Shotguns! Prisoner PDAs! Bears (not really)! Oh my!

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -25277,28 +25277,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"bcQ" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/prisoner,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "bcR" = (
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
@@ -54221,18 +54199,6 @@
 "cbE" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/warden)
-"cbF" = (
-/obj/structure/closet/secure_closet/warden,
-/obj/item/clothing/under/rank/security/warden/grey,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -105880,6 +105846,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"eBp" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/bodybags{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/prisoner,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/storage/box/pdas{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "eBZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -113674,6 +113666,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"vrJ" = (
+/obj/structure/closet/secure_closet/warden,
+/obj/item/clothing/under/rank/security/warden/grey,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/gun/ballistic/shotgun/automatic/dual_tube,
+/turf/open/floor/plasteel,
+/area/security/warden)
 "vwn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
@@ -167488,7 +167493,7 @@ bTh
 bVn
 bXL
 bZT
-cbF
+vrJ
 bFP
 bav
 chb
@@ -168230,7 +168235,7 @@ aMi
 pff
 aZo
 niD
-bcQ
+eBp
 aFm
 aaa
 bhe

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -3595,11 +3595,6 @@
 "ahP" = (
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"ahQ" = (
-/obj/structure/closet/secure_closet/warden,
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "ahR" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/warden,
@@ -19644,19 +19639,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"aTp" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/storage/box/prisoner{
-	pixel_y = 8
-	},
-/obj/item/storage/box/prisoner,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aTq" = (
 /obj/structure/table,
 /obj/item/storage/box/hug{
@@ -50297,6 +50279,23 @@
 "hjZ" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
+"hkX" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/storage/box/prisoner{
+	pixel_y = 8
+	},
+/obj/item/storage/box/prisoner,
+/obj/machinery/light,
+/obj/item/storage/box/pdas{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hnE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -51049,6 +51048,12 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"jxv" = (
+/obj/structure/closet/secure_closet/warden,
+/obj/structure/cable,
+/obj/item/gun/ballistic/shotgun/automatic/dual_tube,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "jxy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple{
@@ -80802,7 +80807,7 @@ abz
 aaJ
 aLF
 arS
-aTp
+hkX
 aai
 boP
 boP
@@ -85432,7 +85437,7 @@ aaZ
 aeW
 agQ
 ahv
-ahQ
+jxv
 aiI
 aiH
 ajB

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -69512,29 +69512,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
-"cgB" = (
-/obj/structure/closet/secure_closet/warden,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/security/warden";
-	dir = 8;
-	name = "Brig Control APC";
-	pixel_x = -26
-	},
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/security/warden)
 "cgC" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -88933,6 +88910,30 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/chemistry)
+"glB" = (
+/obj/structure/closet/secure_closet/warden,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/security/warden";
+	dir = 8;
+	name = "Brig Control APC";
+	pixel_x = -26
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable,
+/obj/item/gun/ballistic/shotgun/automatic/dual_tube,
+/turf/open/floor/plasteel/dark,
+/area/security/warden)
 "gmS" = (
 /obj/structure/sign/poster/official/help_others,
 /turf/closed/wall/r_wall/rust,
@@ -88944,6 +88945,23 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
+/area/security/prison)
+"gsm" = (
+/obj/structure/rack,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/item/storage/box/pdas{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "gwd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -90417,19 +90435,6 @@
 "qDo" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"qFC" = (
-/obj/structure/rack,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "qGP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -102864,7 +102869,7 @@ bVx
 aav
 bmQ
 cCu
-qFC
+gsm
 aau
 fVr
 gZw
@@ -111603,7 +111608,7 @@ aef
 ani
 anm
 aeg
-cgB
+glB
 aEz
 cBn
 ahr

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1297,18 +1297,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"adf" = (
-/obj/structure/table,
-/obj/item/storage/box/prisoner{
-	pixel_y = 8
-	},
-/obj/item/storage/box/prisoner,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "adg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -11141,15 +11129,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"azE" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/closet/secure_closet/warden,
-/obj/item/gun/energy/laser,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/warden)
 "azG" = (
 /obj/machinery/computer/bank_machine,
 /obj/effect/turf_decal/bot_white,
@@ -74846,6 +74825,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"rqN" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/closet/secure_closet/warden,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/item/gun/ballistic/shotgun/automatic/dual_tube,
+/turf/open/floor/plasteel,
+/area/security/warden)
 "rqO" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -79577,6 +79565,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"xQZ" = (
+/obj/structure/table,
+/obj/item/storage/box/prisoner{
+	pixel_y = 8
+	},
+/obj/item/storage/box/prisoner,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/storage/box/pdas{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xRq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -105044,7 +105048,7 @@ abL
 acf
 acy
 xSF
-adf
+xQZ
 adV
 aaw
 hyP
@@ -106863,7 +106867,7 @@ ast
 avY
 awZ
 ayz
-azE
+rqN
 aCh
 aFR
 dnM


### PR DESCRIPTION

## About The Pull Request

Gives the warden the much-needed firepower of a shotgun back - but with the Cycler Shotgun, for when you need to go from code blue to code red but don't want to unload your gun.

Also gives each permabrig PDA's located with the IDs.

## Why It's Good For The Game

Warden has allways had a shotgun. Even though TG removed the Shortie, we still have the Original wardens weapon of choice - The Cycler. And now it's back.

## Changelog
:cl:
add: Added the Cycler Shotgun to the wardens locker, to suppliment the loss of the Shortened Combat Shotgun.
add: Added PDA's to Perma, alongside the IDs.
/:cl:
