### PR TITLE
Fix firealarm alert level indicator

### DIFF
--- a/code/__DEFINES/~skyrat_defines/security_alerts.dm
+++ b/code/__DEFINES/~skyrat_defines/security_alerts.dm
@@ -1,9 +1,9 @@
 //Security levels
-#define SEC_LEVEL_GREEN		1
-#define SEC_LEVEL_BLUE		2
-#define SEC_LEVEL_VIOLET	3
-#define SEC_LEVEL_ORANGE	4
-#define SEC_LEVEL_AMBER		5
-#define SEC_LEVEL_RED		6
-#define SEC_LEVEL_DELTA		7
-#define SEC_LEVEL_GAMMA		8 //Oh shit bois
+#define SEC_LEVEL_GREEN		0
+#define SEC_LEVEL_BLUE		1
+#define SEC_LEVEL_VIOLET	2
+#define SEC_LEVEL_ORANGE	3
+#define SEC_LEVEL_AMBER		4
+#define SEC_LEVEL_RED		5
+#define SEC_LEVEL_DELTA		6
+#define SEC_LEVEL_GAMMA		7 //Oh shit bois

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -883,7 +883,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!check_rights(R_ADMIN))
 		return
 
-	var/level = input("Select security level to change to","Set Security Level") as null|anything in list("green","blue","violet","amber","red","delta","gamma")
+	var/level = input("Select security level to change to","Set Security Level") as null|anything in list("green","blue","violet","orange","amber","red","delta","gamma")
 	if(level)
 		set_security_level(level)
 

--- a/modular_skyrat/modules/alerts/code/set_security_level.dm
+++ b/modular_skyrat/modules/alerts/code/set_security_level.dm
@@ -3,7 +3,7 @@ GLOBAL_VAR_INIT(gamma_looping, FALSE) //This is so we know if the gamma sound ef
 #define GAMMA_LOOP_LENGTH 1236 //2.06 minutes in deciseconds
 
 /proc/set_security_level(level)
-	level = seclevel2num(level) || level
+	level = isnum(level) ? level : seclevel2num(level)
 
 	//Will not be announced if you try to set to the same level as it already is
 	if(level >= SEC_LEVEL_GREEN && level <= SEC_LEVEL_GAMMA && level != GLOB.security_level)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Zero-indexes the security levels again, so the firealarm lights work properly again.
Also fixed the set_security_level proc to not raise an exception when given a `0` as input (green_alert)
And added orange alert level (engineering) to admins' selection of security levels.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People can see the alert level by checking the light again, no more violet on blue, and blue on green.
Also we're in coder territory here, indexes start from 0 >:(
And admins probably also want some of that orange alert 👉👈
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed firealarm lights.
refactor: set_security_level doesn't crap itself with 0s anymore
admin: Gave admins the ability to set security level to orange
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
