### PR TITLE
Updates Skyrat Cargo Packs to TG Format, Adds Mini-E-Gun Goodie

### DIFF
--- a/modular_skyrat/modules/cargo/code/goodies.dm
+++ b/modular_skyrat/modules/cargo/code/goodies.dm
@@ -1,11 +1,69 @@
 //////////////////////////////////////////////////////////////////////////////
+//////////////////////// Emergency Race Stuff ////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/goody/airsuppliesnitrogen
+	name = "Emergency Air Supplies (Nitrogen)"
+	desc = "A vox breathing mask and nitrogen tank."
+	cost = PAYCHECK_MEDIUM
+	contains = list(/obj/item/tank/internals/nitrogen/belt,
+                    /obj/item/clothing/mask/breath/vox)
+
+/datum/supply_pack/goody/airsuppliesoxygen
+	name = "Emergency Air Supplies (Oxygen)"
+	desc = "A breathing mask and emergency oxygen tank."
+	cost = PAYCHECK_MEDIUM
+	contains = list(/obj/item/tank/internals/emergency_oxygen,
+                    /obj/item/clothing/mask/breath)
+
+/datum/supply_pack/goody/airsuppliesplasma
+	name = "Emergency Air Supplies (Plasma)"
+	desc = "A breathing mask and plasmaman plasma tank."
+	cost = PAYCHECK_MEDIUM
+	contains = list(/obj/item/tank/internals/plasmaman/belt,
+                    /obj/item/clothing/mask/breath)
+
+//////////////////////////////////////////////////////////////////////////////
+///////////////////////////// Misc Stuff /////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/goody/crayons
+	name = "Box of Crayons"
+	desc = "Colorful!"
+	cost = PAYCHECK_MEDIUM * 2
+	contains = list(/obj/item/storage/crayons)
+
+/datum/supply_pack/goody/diamondring
+	name = "Diamond Ring"
+	desc = "Show them your love is like a diamond: unbreakable and everlasting. No refunds."
+	cost = PAYCHECK_MEDIUM * 50
+	contains = list(/obj/item/storage/fancy/ringbox/diamond)
+	crate_name = "diamond ring crate"
+
+/datum/supply_pack/goody/paperbin
+	name = "Paper Bin"
+	desc = "Pushing paperwork is always easier when you have paper to push!"
+	cost = PAYCHECK_MEDIUM * 4
+	contains = list(/obj/item/paper_bin)
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Weapons or Ammo /////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/goody/minienergygun
+	name = "Mini Energy Gun"
+	desc = "For when you want a little extra insurance. Not very strong, but a decent deterrent." //20 Damage a hit, maximum of 120 damage before recharge.
+	cost = PAYCHECK_HARD * 8
+	contains = list(/obj/item/gun/energy/e_gun/mini)
+
+//////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Carpet Packs ////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/goody/carpet
 	name = "Classic Carpet Single-Pack"
 	desc = "Plasteel floor tiles getting on your nerves? This 50 units stack of extra soft carpet will tie any room together."
-	cost = 200
+	cost = PAYCHECK_MEDIUM * 3
 	contains = list(/obj/item/stack/tile/carpet/fifty)
 
 /datum/supply_pack/goody/carpet/black
@@ -15,7 +73,7 @@
 /datum/supply_pack/goody/carpet/premium
 	name = "Royal Black Carpet Single-Pack"
 	desc = "Exotic carpets for all your decorating needs. This 50 unit stack of extra soft carpet will tie any room together."
-	cost = 250
+	cost = PAYCHECK_MEDIUM * 3.5
 	contains = list(/obj/item/stack/tile/carpet/royalblack/fifty)
 
 /datum/supply_pack/goody/carpet/premium/royalblue
@@ -45,47 +103,3 @@
 /datum/supply_pack/goody/carpet/premium/blue
 	name = "Blue Carpet Single-Pack"
 	contains = list(/obj/item/stack/tile/carpet/blue/fifty)
-
-//////////////////////////////////////////////////////////////////////////////
-//////////////////////////// Other Stuff /////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////
-
-/datum/supply_pack/goody/crayons
-	name = "Box of Crayons"
-	desc = "Colorful!"
-	cost = 100
-	contains = list(/obj/item/storage/crayons)
-
-/datum/supply_pack/goody/diamondring
-	name = "Diamond Ring"
-	desc = "Show them your love is like a diamond: unbreakable and everlasting. No refunds."
-	cost = 5000
-	contains = list(/obj/item/storage/fancy/ringbox/diamond)
-	crate_name = "diamond ring crate"
-
-/datum/supply_pack/goody/airsuppliesnitrogen
-	name = "Emergency Air Supplies (Nitrogen)"
-	desc = "A vox breathing mask and nitrogen tank."
-	cost = 125
-	contains = list(/obj/item/tank/internals/nitrogen/belt,
-                    /obj/item/clothing/mask/breath/vox)
-
-/datum/supply_pack/goody/airsuppliesoxygen
-	name = "Emergency Air Supplies (Oxygen)"
-	desc = "A breathing mask and emergency oxygen tank."
-	cost = 125
-	contains = list(/obj/item/tank/internals/emergency_oxygen,
-                    /obj/item/clothing/mask/breath)
-
-/datum/supply_pack/goody/airsuppliesplasma
-	name = "Emergency Air Supplies (Plasma)"
-	desc = "A breathing mask and plasmaman plasma tank."
-	cost = 125
-	contains = list(/obj/item/tank/internals/plasmaman/belt,
-                    /obj/item/clothing/mask/breath)
-
-/datum/supply_pack/goody/paperbin
-	name = "Pushing paperwork is always easier when you have paper to push!"
-	desc = "Paper Package"
-	cost = 100
-	contains = list(/obj/item/paper_bin)

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -1,3 +1,5 @@
+/// Cost of the crate. DO NOT GO ANY LOWER THAN X1.4 the "CARGO_CRATE_VALUE" value if using regular crates, or infinite profit will be possible!
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////// Livestock ///////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
@@ -5,21 +7,21 @@
 /datum/supply_pack/critter/doublecrab
 	name = "Crab Crate"
 	desc = "Contains two crabs. Get your crab on!"
-	cost = 1000
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/mob/living/simple_animal/crab,
                     /mob/living/simple_animal/crab)
 	crate_name = "look sir free crabs"
 
 /datum/supply_pack/critter/mouse
 	name = "Mouse Crate"
-	desc = "Good for snakes and lizards of all ages. Contains twelve feeder mice." //Skyrat change, changed number for consistency
-	cost = 2000
+	desc = "Good for snakes and lizards of all ages. Contains six feeder mice."
+	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/mob/living/simple_animal/mouse,)
 	crate_name = "mouse crate"
 
 /datum/supply_pack/critter/mouse/generate()
 	. = ..()
-	for(var/i in 1 to 11)
+	for(var/i in 1 to 5)
 		new /mob/living/simple_animal/mouse(.)
 
 //////////////////////////////////////////////////////////////////////////////
@@ -30,7 +32,7 @@
 	name = "Anesthetics Crate"
 	desc = "Contains two of the following: Morphine bottles, syringes, breath masks, and anesthetic tanks. Requires Medical Access to open."
 	access = ACCESS_MEDICAL
-	cost = 3500
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/reagent_containers/glass/bottle/morphine,
                     /obj/item/reagent_containers/glass/bottle/morphine,
                     /obj/item/reagent_containers/syringe,
@@ -44,7 +46,7 @@
 /datum/supply_pack/medical/bodybags
 	name = "Bodybags"
 	desc = "For when the bodies hit the floor. Contains 4 boxes of bodybags."
-	cost = 1200
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/storage/box/bodybags,
 					/obj/item/storage/box/bodybags,
 					/obj/item/storage/box/bodybags,
@@ -54,7 +56,7 @@
 /datum/supply_pack/medical/firstaidmixed
 	name = "Mixed Medical Kits"
 	desc = "Contains one of each medical kits for dealing with a variety of injured crewmembers."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/storage/firstaid/toxin,
 					/obj/item/storage/firstaid/o2,
 					/obj/item/storage/firstaid/brute,
@@ -65,7 +67,7 @@
 /datum/supply_pack/medical/medipens
 	name = "Epinephrine Medipens"
 	desc = "Contains two boxes of epinephrine medipens. Each box contains seven pens."
-	cost = 1300
+	cost = CARGO_CRATE_VALUE * 4.5
 	contains = list(/obj/item/storage/box/medipens,
                     /obj/item/storage/box/medipens)
 	crate_name = "medipen crate"
@@ -77,7 +79,7 @@
 /datum/supply_pack/misc/coloredsheets
 	name = "Bedsheet Crate"
 	desc = "Give your night life a splash of color with this crate filled with bedsheets! Contains a total of nine different-colored sheets."
-	cost = 1250
+	cost = CARGO_CRATE_VALUE * 2.5
 	contains = list(/obj/item/bedsheet/blue,
 					/obj/item/bedsheet/green,
 					/obj/item/bedsheet/orange,
@@ -92,7 +94,7 @@
 /datum/supply_pack/misc/candles
 	name = "Candle Crate"
 	desc = "Set up a romantic dinner or host a séance with these extra candles and crayons."
-	cost = 850
+	cost = CARGO_CRATE_VALUE * 1.5
 	contains = list(/obj/item/storage/fancy/candle_box,
 					/obj/item/storage/fancy/candle_box,
 					/obj/item/storage/box/matches)
@@ -103,22 +105,22 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/organic/combomeal
-    name = "Burger Combo Crate"
-    desc = "We value our customers at the Greasy Griddle, so much so that we're willing to deliver -just for you.- Contains two combo meals, consisting of a Burger, Fries, and pack of chicken nuggets!"
-    cost = 3200
-    contains = list(/obj/item/food/burger/cheese,
+	name = "Burger Combo Crate"
+	desc = "We value our customers at the Greasy Griddle, so much so that we're willing to deliver -just for you.- Contains two combo meals, consisting of a Burger, Fries, and pack of chicken nuggets!"
+	cost = CARGO_CRATE_VALUE * 5
+	contains = list(/obj/item/food/burger/cheese,
                     /obj/item/food/burger/cheese,
 					/obj/item/food/fries,
                     /obj/item/food/fries,
                     /obj/item/storage/fancy/nugget_box,
                     /obj/item/storage/fancy/nugget_box)
-    crate_name = "combo meal w/toy"
-    crate_type = /obj/structure/closet/crate/wooden
+	crate_name = "combo meal w/toy"
+	crate_type = /obj/structure/closet/crate/wooden
 
 /datum/supply_pack/organic/fiestatortilla
 	name = "Fiesta Crate"
 	desc = "Spice up the kitchen with this fiesta themed food order! Contains 8 tortilla based food items and some hot-sauce."
-	cost = 2750
+	cost = CARGO_CRATE_VALUE * 4.5
 	contains = list(/obj/item/food/taco,
 					/obj/item/food/taco,
 					/obj/item/food/taco/plain,
@@ -132,8 +134,8 @@
 
 /datum/supply_pack/organic/fakemeat
 	name = "Meat Crate 'Synthetic'"
-	desc = "Run outta meat already? Keep the lizards content with this freezer filled with cruelty-free and chemically compounded meat! Contains 12 slabs of meat product, and 4 slabs of *carp*." //Skyrat change, adds "and" for grammatical correctness
-	cost = 1200 // Buying 3 food crates nets you 9 meat for 900 points, plus like, 6 bags of rice, flour, and egg boxes. This is 12 for 500, but you -only- get meat and carp.
+	desc = "Run outta meat already? Keep the lizards content with this freezer filled with cruelty-free and chemically compounded meat! Contains 12 slabs of meat product, and 4 slabs of *carp*."
+	cost = CARGO_CRATE_VALUE * 2.25
 	contains = list(/obj/item/food/meat/slab/meatproduct,
                     /obj/item/food/meat/slab/meatproduct,
                     /obj/item/food/meat/slab/meatproduct,
@@ -156,7 +158,7 @@
 /datum/supply_pack/organic/mixedboxes
 	name = "Mixed Ingredient Boxes"
 	desc = "Get overwhelmed with inspiration by ordering these boxes of surprise ingredients! Get four boxes filled with an assortment of products!"
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/storage/box/ingredients/wildcard,
 					/obj/item/storage/box/ingredients/wildcard,
 					/obj/item/storage/box/ingredients/wildcard,
@@ -169,10 +171,10 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/service/buildabar
-    name = "Build a Bar Crate"
-    desc = "Looking to set up your own little safe haven? Get a jump-start on it with this handy kit. Contains circuitboards for bar equipment, some parts, and some basic bartending supplies. (Glass not included)"
-    cost = 2700
-    contains = list(/obj/item/storage/box/drinkingglasses,
+	name = "Build a Bar Crate"
+	desc = "Looking to set up your own little safe haven? Get a jump-start on it with this handy kit. Contains circuitboards for bar equipment, some parts, and some basic bartending supplies. (Glass not included)"
+	cost = CARGO_CRATE_VALUE * 4
+	contains = list(/obj/item/storage/box/drinkingglasses,
 					/obj/item/storage/box/drinkingglasses,
                     /obj/item/storage/part_replacer/cargo,
 					/obj/item/stack/sheet/metal/ten,
@@ -185,12 +187,12 @@
 					/obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
 					/obj/item/circuitboard/machine/chem_dispenser/drinks,
 					/obj/item/circuitboard/machine/dish_drive)
-    crate_name = "build a bar crate"
+	crate_name = "build a bar crate"
 
 /datum/supply_pack/service/janitor/janpimp
 	name = "Custodial Cruiser"
 	desc = "Clown steal your ride? Assistant lock it in the dorms? Order a new one and get back to cleaning in style!"
-	cost = 3000
+	cost = CARGO_CRATE_VALUE * 4
 	access = ACCESS_JANITOR
 	contains = list(/obj/vehicle/ridden/janicart,
 					/obj/item/key/janitor)
@@ -200,7 +202,7 @@
 /datum/supply_pack/service/lamplight
 	name = "Emergency Lighting Crate"
 	desc = "Dealing with brownouts? Lights out across the station? Brighten things up with a pack of four lamps and flashlights."
-	cost = 2000
+	cost = CARGO_CRATE_VALUE * 1.75
 	contains = list(/obj/item/flashlight/lamp,
 					/obj/item/flashlight/lamp,
 					/obj/item/flashlight/lamp/green,
@@ -212,24 +214,13 @@
 	crate_name = "emergency lighting crate"
 
 //////////////////////////////////////////////////////////////////////////////
-////////////////////////////// Science ///////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////
-
-/datum/supply_pack/science/monkey
-	name = "Monkey Cube Crate"
-	desc = "Stop monkeying around! Contains seven monkey cubes. Just add water!"
-	cost = 1500
-	contains = list (/obj/item/storage/box/monkeycubes)
-	crate_name = "monkey cube crate"
-
-//////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Materials & Sheets //////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/materials/rawlumber
 	name = "20 Towercap Logs"
 	desc = "Set up a cookout or a classy beachside bonfire with these terrific towercaps!"
-	cost = 1300 // Because TG has elasticity, this isn't particularly profitable long-term to resell back as planks, but it -is- cheaper than planks themselves.
+	cost = CARGO_CRATE_VALUE * 3.5
 	contains = list(/obj/item/grown/log)
 	crate_name = "lumber crate"
 


### PR DESCRIPTION
## About The Pull Request

Updated all of the (current) skyrat crates to the new TG price format. (I hate it. I'm bad at math.)

- Added Mini Energy Gun as a Goodie.
- Removed Monkey Cube Crate (Duplicate)

## Why It's Good For The Game

Consistency, I guess? Also, the mini-e-gun is like. Much more of a self defense weapons than shotguns.

## Changelog
:cl:
add: Mini-E-Gun Goodie Pack
fix: The one paper bin pack being named weird.
del: Duplicate Monkey Cube Crate
tweak: Update Cargo Packs CARGO_CRATE_VALUE and PAYCHECK formats.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
