### PR TITLE
Increased minimal population for the spider infestation event.

### DIFF
--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -17,7 +17,7 @@
 
 /datum/round_event/spider_infestation/start()
 	create_midwife_eggs(spawncount)
-
+	
 /proc/create_midwife_eggs(amount)
 	var/list/spawn_locs = list()
 	for(var/x in GLOB.xeno_spawn)

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/spider_infestation
 	weight = 10
 	max_occurrences = 1
-	min_players = 20
+	//min_players = 20 - SKYRAT EDIT - moved to modular_skyrat/master_files
 
 /datum/round_event/spider_infestation
 	announceWhen = 400
@@ -17,7 +17,7 @@
 
 /datum/round_event/spider_infestation/start()
 	create_midwife_eggs(spawncount)
-	
+
 /proc/create_midwife_eggs(amount)
 	var/list/spawn_locs = list()
 	for(var/x in GLOB.xeno_spawn)

--- a/modular_skyrat/master_files/code/modules/events/spider_infestation.dm
+++ b/modular_skyrat/master_files/code/modules/events/spider_infestation.dm
@@ -1,0 +1,1 @@
+min_players = 60

--- a/modular_skyrat/master_files/code/modules/events/spider_infestation.dm
+++ b/modular_skyrat/master_files/code/modules/events/spider_infestation.dm
@@ -1,1 +1,2 @@
-min_players = 60
+/datum/round_event_control/spider_infestation
+	min_players = 60

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3334,6 +3334,7 @@
 #include "modular_skyrat\master_files\code\game\objects\structures\trash_pile.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\anthro_clothes.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\non_anthro_clothes.dm"
+#include "modular_skyrat\master_files\code\modules\events\spider_infestation.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\emote_popup.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\carbon_say.dm"
 #include "modular_skyrat\master_files\code\modules\power\lighting.dm"


### PR DESCRIPTION
## Why It's Good For The Game
Spiders can multiply at an incredible rate and easily overwhelm smaller crews.

## Changelog
:cl:
tweak: minimal population for the spider infestation increased from 20 to 60
/:cl:

