### PR TITLE
Emote spam + Fixes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -25,6 +25,9 @@
 	var/vary = FALSE	//used for the honk borg emote
 	var/only_forced_audio = FALSE //can only code call this event instead of the player.
 	var/cooldown = 0.8 SECONDS
+	//SKYRAT EDIT ADDITION BEGIN - EMOTES
+	var/sound_volume = 25 //Emote volume
+	//SKYRAT EDIT ADDITION END
 
 /datum/emote/New()
 	if (ispath(mob_type_allowed_typecache))
@@ -63,7 +66,10 @@
 
 	var/tmp_sound = get_sound(user)
 	if(tmp_sound && (!only_forced_audio || !intentional))
-		playsound(user, tmp_sound, 50, vary)
+		//SKYRAT EDIT CHANGE BEGIN
+		//playsound(user, tmp_sound, 50, vary) - SKYRAT EDIT - ORIGINAL
+		playsound(user, tmp_sound, sound_volume, vary)
+		//SKYRAT EDIT CHANGE END
 
 	for(var/mob/M in GLOB.dead_mob_list)
 		if(!M.client || isnewplayer(M))
@@ -81,11 +87,15 @@
 /datum/emote/proc/check_cooldown(mob/user, intentional)
 	if(!intentional)
 		return TRUE
-	if(user.emotes_used && user.emotes_used[src] + cooldown > world.time)
+	//SKYRAT EDIT CHANGE BEGIN - EMOTES - GLOBAL COOLDOWN
+	//if(user.emotes_used && user.emotes_used[src] + cooldown > world.time) - SKYRAT EDIT - ORIGINAL
+	if(user.nextsoundemote > world.time)
 		return FALSE
-	if(!user.emotes_used)
-		user.emotes_used = list()
-	user.emotes_used[src] = world.time
+	//if(!user.emotes_used)
+	//	user.emotes_used = list()
+	//user.emotes_used[src] = world.time - SKYRAT EDIT - ORIGINAL
+	user.nextsoundemote = world.time + cooldown
+	//SKYRAT EDIT CHANGE END
 	return TRUE
 
 /datum/emote/proc/get_sound(mob/living/user)

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -84,6 +84,8 @@
 	mob_type_allowed_typecache = list(/mob/living/carbon/monkey)
 	emote_type = EMOTE_AUDIBLE
 
+//SKYRAT EDIT REMOVAL BEGIN - EMOTES - begone with the annoying screech
+/*
 /datum/emote/living/carbon/screech/get_sound(mob/living/user)
 	return pick('sound/creatures/monkey/monkey_screech_1.ogg',
 				'sound/creatures/monkey/monkey_screech_2.ogg',
@@ -92,6 +94,9 @@
 				'sound/creatures/monkey/monkey_screech_5.ogg',
 				'sound/creatures/monkey/monkey_screech_6.ogg',
 				'sound/creatures/monkey/monkey_screech_7.ogg')
+*/
+//SKYRAT EDIT REMOVAL END
+
 /datum/emote/living/carbon/screech/roar
 	key = "roar"
 	key_third_person = "roars"

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -15,6 +15,8 @@
 	key = "blink_r"
 	message = "blinks rapidly."
 
+//SKYRAT EDIT REMOVAL BEGIN - EMOTES - (Moved to modular_skyrat/modules/emotes/code/emotes.dm as /datum/emote/living/clap)
+/*
 /datum/emote/living/carbon/clap
 	key = "clap"
 	key_third_person = "claps"
@@ -33,6 +35,8 @@
 							'sound/misc/clap2.ogg',
 							'sound/misc/clap3.ogg',
 							'sound/misc/clap4.ogg')
+*/
+//SKYRAT EDIT REMOVAL END
 
 /datum/emote/living/carbon/crack
 	key = "crack"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -119,6 +119,8 @@
 	hands_use_check = TRUE
 	var/wing_time = 20
 
+//SKYRAT EDIT REMOVAL BEGIN - EMOTES - Not working due to modified mutant code, will be fixed later
+/*
 /datum/emote/living/flap/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
 	if(. && ishuman(user))
@@ -131,6 +133,8 @@
 			else
 				H.OpenWings()
 			addtimer(CALLBACK(H, open ? /mob/living/carbon/human.proc/OpenWings : /mob/living/carbon/human.proc/CloseWings), wing_time)
+*/
+//SKYRAT EDIT REMOVAL END
 
 /datum/emote/living/flap/aflap
 	key = "aflap"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -5,7 +5,6 @@
 	var/nextsoundemote = 1 //Time at which the next emote can be played
 
 //GLOBAL cooldown pool that is shared with all emotes instead of each seperately
-/* UNITTEST CHECK -- DO NOT MERGE WITH THIS
 /datum/emote/check_cooldown(mob/user, intentional)
 	if(!intentional)
 		return TRUE
@@ -13,7 +12,6 @@
 		return FALSE
 	user.nextsoundemote = world.time + cooldown
 	return TRUE
-*/
 
 //Disables the custom emote blacklist from TG that normally applies to slimes.
 /datum/emote/living/custom

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -56,15 +56,10 @@
 		var/mob/living/carbon/human/H = user
 		var/datum/species/userspecies = H.dna.species
 
-		if(user.gender == FEMALE && length(userspecies.femalescreamsounds))
-			return pick(userspecies.femalescreamsounds)
-		if(user.gender == MALE && length(userspecies.screamsounds))
+		if(user.gender == MALE || !length(userspecies.femalescreamsounds))
 			return pick(userspecies.screamsounds)
-		if(length(userspecies.screamsounds) && length(userspecies.femalescreamsounds))
-			var/list/tempScreams = list()
-			tempScreams += userspecies.screamsounds
-			tempScreams += userspecies.femalescreamsounds
-			return pick(tempScreams)
+		else
+			return pick(userspecies.femalescreamsounds)
 	return
 
 /datum/emote/living/scream/can_run_emote(mob/living/user, status_check, intentional)
@@ -81,20 +76,14 @@
 	if(isvox(user))
 		return 'modular_skyrat/modules/emotes/sound/emotes/voxcough.ogg'
 	if(iscarbon(user))
-		if(user.gender == FEMALE)
-			return pick('modular_skyrat/modules/emotes/sound/emotes/female/female_cough_1.ogg',
-						'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_2.ogg',
-						'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_3.ogg')
 		if(user.gender == MALE)
 			return pick('modular_skyrat/modules/emotes/sound/emotes/male/male_cough_1.ogg',
 						'modular_skyrat/modules/emotes/sound/emotes/male/male_cough_2.ogg',
 						'modular_skyrat/modules/emotes/sound/emotes/male/male_cough_3.ogg')
-	return pick('modular_skyrat/modules/emotes/sound/emotes/male/male_cough_1.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/male/male_cough_2.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/male/male_cough_3.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_1.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_2.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_3.ogg')
+		return pick('modular_skyrat/modules/emotes/sound/emotes/female/female_cough_1.ogg',
+					'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_2.ogg',
+					'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_3.ogg')
+	return
 
 /datum/emote/living/sneeze
 	vary = TRUE
@@ -103,12 +92,10 @@
 	if(isvox(user))
 		return 'modular_skyrat/modules/emotes/sound/emotes/voxsneeze.ogg'
 	if(iscarbon(user))
-		if(user.gender == FEMALE)
-			return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sneeze.ogg'
 		if(user.gender == MALE)
 			return 'modular_skyrat/modules/emotes/sound/emotes/male/male_sneeze.ogg'
-	return pick('modular_skyrat/modules/emotes/sound/emotes/male/male_sneeze.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/female_sneeze.ogg')
+		return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sneeze.ogg'
+	return
 
 /datum/emote/living/peep
 	key = "peep"
@@ -247,35 +234,23 @@
 
 /datum/emote/living/sigh/get_sound(mob/living/user)
 	if(iscarbon(user))
-		if(user.gender == FEMALE)
-			return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sigh.ogg'
 		if(user.gender == MALE)
 			return 'modular_skyrat/modules/emotes/sound/emotes/male/male_sigh.ogg'
-	return pick('modular_skyrat/modules/emotes/sound/emotes/male/male_sigh.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/female_sigh.ogg')
+		return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sigh.ogg'
+	return
 
 /datum/emote/living/sniff
 	vary = TRUE
 
 /datum/emote/living/sniff/get_sound(mob/living/user)
 	if(iscarbon(user))
-		if(user.gender == FEMALE)
-			return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sniff.ogg'
 		if(user.gender == MALE)
 			return 'modular_skyrat/modules/emotes/sound/emotes/male/male_sniff.ogg'
-	return pick('modular_skyrat/modules/emotes/sound/emotes/male/male_sniff.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/female_sniff.ogg')
-
+		return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sniff.ogg'
+	return
 
 /datum/emote/living/gasp/get_sound(mob/living/user)
 	if(iscarbon(user))
-		if(user.gender == FEMALE)
-			return pick('modular_skyrat/modules/emotes/sound/emotes/female/gasp_f1.ogg',
-						'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f2.ogg',
-						'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f3.ogg',
-						'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f4.ogg',
-						'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f5.ogg',
-						'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f6.ogg')
 		if(user.gender == MALE)
 			return pick('modular_skyrat/modules/emotes/sound/emotes/male/gasp_m1.ogg',
 						'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m2.ogg',
@@ -283,19 +258,13 @@
 						'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m4.ogg',
 						'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m5.ogg',
 						'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m6.ogg')
-	return pick('modular_skyrat/modules/emotes/sound/emotes/male/gasp_m1.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m2.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m3.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m4.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m5.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m6.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f1.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f2.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f3.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f4.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f5.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f6.ogg')
-
+		return pick('modular_skyrat/modules/emotes/sound/emotes/female/gasp_f1.ogg',
+					'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f2.ogg',
+					'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f3.ogg',
+					'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f4.ogg',
+					'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f5.ogg',
+					'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f6.ogg')
+	return
 
 /datum/emote/living/snore
 	vary = TRUE
@@ -306,12 +275,10 @@
 
 /datum/emote/living/burp/get_sound(mob/living/user)
 	if(iscarbon(user))
-		if(user.gender == FEMALE)
-			return 'modular_skyrat/modules/emotes/sound/emotes/female/burp_f.ogg'
 		if(user.gender == MALE)
 			return 'modular_skyrat/modules/emotes/sound/emotes/male/burp_m.ogg'
-	return pick('modular_skyrat/modules/emotes/sound/emotes/male/burp_m.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/burp_f.ogg')
+		return 'modular_skyrat/modules/emotes/sound/emotes/female/burp_f.ogg'
+	return
 
 /datum/emote/living/clap
 	key = "clap"
@@ -366,16 +333,12 @@
 	if(ismoth(user))
 		return 'modular_skyrat/modules/emotes/sound/emotes/mothlaugh.ogg'
 	if(iscarbon(user))
-		if(user.gender == FEMALE)
-			return pick('modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg',
-						'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg')
 		if(user.gender == MALE)
 			return pick('sound/voice/human/manlaugh1.ogg',
 						'sound/voice/human/manlaugh2.ogg')
-	return pick('sound/voice/human/manlaugh1.ogg',
-				'sound/voice/human/manlaugh2.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg')
+		return pick('modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg',
+					'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg')
+	return
 
 /datum/emote/living/headtilt
 	key = "tilt"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -7,6 +7,7 @@
 //Disables the custom emote blacklist from TG that normally applies to slimes.
 /datum/emote/living/custom
 	mob_type_blacklist_typecache = list(/mob/living/brain)
+
 /datum/emote/living/quill
 	key = "quill"
 	key_third_person = "quills"
@@ -141,6 +142,7 @@
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/snap3.ogg'
 	cooldown = EMOTE_DELAY
+
 /datum/emote/living/awoo
 	key = "awoo"
 	key_third_person = "awoos"
@@ -306,37 +308,42 @@
 	key_third_person = "claps"
 	message = "claps."
 	emote_type = EMOTE_AUDIBLE
+	muzzle_ignore = TRUE
 	hands_use_check = TRUE
 	vary = TRUE
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
 	cooldown = EMOTE_DELAY
 
+/datum/emote/living/clap/get_sound(mob/living/user)
+	return pick('modular_skyrat/modules/emotes/sound/emotes/clap1.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/clap2.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/clap3.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/clap4.ogg')
 
-/datum/emote/living/clap/run_emote(mob/living/user, params)
-	if(!(. = ..()))
-		return
-	if(user.nextsoundemote >= world.time)
-		return
-	user.nextsoundemote = world.time + EMOTE_DELAY
-	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/clap1.ogg','modular_skyrat/modules/emotes/sound/emotes/clap2.ogg','modular_skyrat/modules/emotes/sound/emotes/clap3.ogg','modular_skyrat/modules/emotes/sound/emotes/clap4.ogg')
-	playsound(user, sound, 50, vary)
+/datum/emote/living/clap/can_run_emote(mob/living/carbon/user, status_check = TRUE , intentional)
+	if(user.usable_hands < 2)
+		return FALSE
+	return ..()
 
 /datum/emote/living/clap1
 	key = "clap1"
 	key_third_person = "claps once"
 	message = "claps once."
 	emote_type = EMOTE_AUDIBLE
+	muzzle_ignore = TRUE
+	hands_use_check = TRUE
 	vary = TRUE
+	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
 	cooldown = EMOTE_DELAY
 
-/datum/emote/living/clap1/run_emote(mob/living/user, params)
-	if(!(. = ..()))
-		return
-	if(user.nextsoundemote >= world.time)
-		return
-	user.nextsoundemote = world.time + EMOTE_DELAY
-	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/claponce1.ogg', 'modular_skyrat/modules/emotes/sound/emotes/claponce2.ogg')
-	playsound(user, sound, 50, vary)
+/datum/emote/living/clap1/get_sound(mob/living/user)
+	return pick('modular_skyrat/modules/emotes/sound/emotes/claponce1.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/claponce2.ogg')
+
+/datum/emote/living/clap1/can_run_emote(mob/living/carbon/user, status_check = TRUE , intentional)
+	if(user.usable_hands < 2)
+		return FALSE
+	return ..()
 
 /datum/emote/living/laugh
 	key = "laugh"
@@ -440,7 +447,8 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/hoot.ogg'
-	cooldown = 1.4 SECONDS
+	cooldown = EMOTE_DELAY
+
 /datum/emote/living/growl
 	key = "growl"
 	key_third_person = "growls"
@@ -494,8 +502,8 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/long_awoo.ogg'
-	cooldown = EMOTE_DELAY
-	cooldown = 2.5 SECONDS
+	cooldown = 3 SECONDS
+
 /datum/emote/living/rattle
 	key = "rattle"
 	key_third_person = "rattles"
@@ -513,7 +521,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/cackle_yeen.ogg'
-	cooldown = 1.2 SECONDS
+	cooldown = EMOTE_DELAY
 
 /mob/living/proc/do_ass_slap_animation(atom/slapped)
 	do_attack_animation(slapped, no_effect=TRUE)

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -1,17 +1,11 @@
 
-#define EMOTE_DELAY 2 SECONDS //To prevent spam emotes.
+#define EMOTE_DELAY 15 SECONDS //To prevent spam emotes.
 
 /mob
 	var/nextsoundemote = 1 //Time at which the next emote can be played
 
-//GLOBAL cooldown pool that is shared with all emotes instead of each seperately
-/datum/emote/check_cooldown(mob/user, intentional)
-	if(!intentional)
-		return TRUE
-	if(user.nextsoundemote > world.time)
-		return FALSE
-	user.nextsoundemote = world.time + cooldown
-	return TRUE
+/datum/emote
+	cooldown = EMOTE_DELAY
 
 //Disables the custom emote blacklist from TG that normally applies to slimes.
 /datum/emote/living/custom
@@ -26,12 +20,10 @@
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/voxrustle.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/scream
 	message = "screams!"
 	mob_type_blacklist_typecache = list(/mob/living/simple_animal/slime, /mob/living/brain)
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/scream/run_emote(mob/living/user, params)
 	if(!(. = ..()))
@@ -85,9 +77,6 @@
 		R.cell.use(200)
 	return ..()
 
-/datum/emote/living/cough
-	cooldown = EMOTE_DELAY
-
 /datum/emote/living/cough/get_sound(mob/living/user)
 	if(isvox(user))
 		return 'modular_skyrat/modules/emotes/sound/emotes/voxcough.ogg'
@@ -109,7 +98,6 @@
 
 /datum/emote/living/sneeze
 	vary = TRUE
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/sneeze/get_sound(mob/living/user)
 	if(isvox(user))
@@ -129,7 +117,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/peep_once.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/peep2
 	key = "peep2"
@@ -138,7 +125,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/peep.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/snap
 	key = "snap"
@@ -149,7 +135,6 @@
 	hands_use_check = TRUE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/snap.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/snap2
 	key = "snap2"
@@ -160,7 +145,6 @@
 	hands_use_check = TRUE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/snap2.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/snap3
 	key = "snap3"
@@ -171,7 +155,6 @@
 	hands_use_check = TRUE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/snap3.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/awoo
 	key = "awoo"
@@ -188,7 +171,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/nya.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/weh
 	key = "weh"
@@ -197,7 +179,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/weh.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/dab
 	key = "dab"
@@ -205,7 +186,6 @@
 	message = "suddenly hits a dab!"
 	emote_type = EMOTE_AUDIBLE
 	hands_use_check = TRUE
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/mothsqueak
 	key = "msqueak"
@@ -214,7 +194,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/mothsqueak.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/merp
 	key = "merp"
@@ -223,7 +202,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/merp.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/bark
 	key = "bark"
@@ -232,7 +210,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/bark2.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/squish
 	key = "squish"
@@ -241,7 +218,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/slime_squish.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/meow
 	key = "meow"
@@ -250,7 +226,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/meow.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/hiss
 	key = "hiss"
@@ -260,7 +235,6 @@
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/hiss.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/chitter
 	key = "chitter"
@@ -270,7 +244,6 @@
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/mothchitter.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/sigh/get_sound(mob/living/user)
 	if(iscarbon(user))
@@ -327,11 +300,9 @@
 /datum/emote/living/snore
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/snore.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/burp
 	vary = TRUE
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/burp/get_sound(mob/living/user)
 	if(iscarbon(user))
@@ -351,7 +322,6 @@
 	hands_use_check = TRUE
 	vary = TRUE
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/clap/get_sound(mob/living/user)
 	return pick('modular_skyrat/modules/emotes/sound/emotes/clap1.ogg',
@@ -373,7 +343,6 @@
 	hands_use_check = TRUE
 	vary = TRUE
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/clap1/get_sound(mob/living/user)
 	return pick('modular_skyrat/modules/emotes/sound/emotes/claponce1.ogg',
@@ -392,7 +361,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/laugh/get_sound(mob/living/user)
 	if(ismoth(user))
@@ -414,14 +382,12 @@
 	key_third_person = "tilts"
 	message = "tilts their head."
 	message_AI = "tilts the image on their display."
-	cooldown = EMOTE_DELAY
 
 /datum/emote/beep
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/twobeep.ogg'
-	mob_type_allowed_typecache = list(/mob/living)
-	cooldown = EMOTE_DELAY
+	mob_type_allowed_typecache = list(/mob/living) //Beep already exists on brains and silicons
 
 // Avian revolution
 /datum/emote/living/bawk
@@ -431,7 +397,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/bawk.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/caw
 	key = "caw"
@@ -440,7 +405,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/caw.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/caw2
 	key = "caw2"
@@ -449,14 +413,12 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/caw2.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/whistle
 	key = "whistle"
 	key_third_person = "whistles"
 	message = "whistles."
 	emote_type = EMOTE_AUDIBLE
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/blep
 	key = "blep"
@@ -464,7 +426,6 @@
 	message = "bleps their tongue out. Blep."
 	message_AI = "shows an image of a random blepping animal. Blep."
 	message_robot = "bleps their robo-tongue out. Blep."
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/bork
 	key = "bork"
@@ -473,7 +434,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/bork.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/hoot
 	key = "hoot"
@@ -482,7 +442,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/hoot.ogg'
-	cooldown = EMOTE_DELAY
+	//cooldown = 2 SECONDS -- Removed as the current global cooldown is larger
 
 /datum/emote/living/growl
 	key = "growl"
@@ -492,7 +452,6 @@
 	muzzle_ignore = TRUE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/growl.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/woof
 	key = "woof"
@@ -501,7 +460,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/woof.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/baa
 	key = "baa"
@@ -510,7 +468,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/baa.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/baa2
 	key = "baa2"
@@ -519,7 +476,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/baa2.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/wurble
 	key = "wurble"
@@ -528,7 +484,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/wurble.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/awoo2
 	key = "awoo2"
@@ -537,7 +492,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/long_awoo.ogg'
-	cooldown = 3 SECONDS
+	//cooldown = 3 SECONDS -- Removed as the current global cooldown is larger
 
 /datum/emote/living/rattle
 	key = "rattle"
@@ -547,7 +502,6 @@
 	muzzle_ignore = TRUE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/rattle.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/living/cackle
 	key = "cackle"
@@ -556,11 +510,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/cackle_yeen.ogg'
-	cooldown = EMOTE_DELAY
-
-// No more monkey screeching ear rape
-/datum/emote/living/carbon/screech/get_sound(mob/living/user)
-	return
 
 /mob/living/proc/do_ass_slap_animation(atom/slapped)
 	do_attack_animation(slapped, no_effect=TRUE)

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -309,6 +309,7 @@
 	hands_use_check = TRUE
 	vary = TRUE
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
+	cooldown = EMOTE_DELAY
 
 
 /datum/emote/living/clap/run_emote(mob/living/user, params)
@@ -326,6 +327,7 @@
 	message = "claps once."
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/clap1/run_emote(mob/living/user, params)
 	if(!(. = ..()))
@@ -344,6 +346,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/laugh/run_emote(mob/living/user, params)
 	if(!(. = ..()))

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -24,6 +24,7 @@
 /datum/emote/living/scream
 	message = "screams!"
 	mob_type_blacklist_typecache = list(/mob/living/simple_animal/slime, /mob/living/brain)
+	vary = TRUE
 
 /datum/emote/living/scream/run_emote(mob/living/user, params)
 	if(!(. = ..()))
@@ -32,7 +33,7 @@
 		if(ishuman(user))
 			user.adjustOxyLoss(5)
 		var/sound = get_sound(user, TRUE)
-		playsound(user.loc, sound, 50, 1, 4, 1.2)
+		playsound(user.loc, sound, sound_volume, vary, 4, 1.2)
 
 /datum/emote/living/scream/select_message_type(mob/user, intentional)
 	if(!intentional && isanimal(user))

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -5,6 +5,7 @@
 	var/nextsoundemote = 1 //Time at which the next emote can be played
 
 //GLOBAL cooldown pool that is shared with all emotes instead of each seperately
+/* UNITTEST CHECK -- DO NOT MERGE WITH THIS
 /datum/emote/check_cooldown(mob/user, intentional)
 	if(!intentional)
 		return TRUE
@@ -12,6 +13,7 @@
 		return FALSE
 	user.nextsoundemote = world.time + cooldown
 	return TRUE
+*/
 
 //Disables the custom emote blacklist from TG that normally applies to slimes.
 /datum/emote/living/custom

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -82,11 +82,11 @@
 	if(user.nextsoundemote >= world.time)
 		return
 	user.nextsoundemote = world.time + EMOTE_DELAY
-	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/male/male_sneeze.ogg')
+	var/sound = 'modular_skyrat/modules/emotes/sound/emotes/male/male_sneeze.ogg'
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			sound = pick('modular_skyrat/modules/emotes/sound/emotes/female/female_sneeze.ogg')
+			sound = 'modular_skyrat/modules/emotes/sound/emotes/female/female_sneeze.ogg'
 	if(isvox(user))
 		sound = 'modular_skyrat/modules/emotes/sound/emotes/voxsneeze.ogg'
 	playsound(user, sound, 50, 1, -1)
@@ -199,7 +199,7 @@
 	message = "barks!"
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
-	sound = pick(list('modular_skyrat/modules/emotes/sound/voice/bark1.ogg', 'modular_skyrat/modules/emotes/sound/voice/bark2.ogg'))
+	sound = 'modular_skyrat/modules/emotes/sound/voice/bark2.ogg'
 	cooldown = EMOTE_DELAY
 
 /datum/emote/living/squish
@@ -285,7 +285,7 @@
 	if(user.nextsoundemote >= world.time)
 		return
 	user.nextsoundemote = world.time + EMOTE_DELAY
-	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/snore.ogg')
+	var/sound = 'modular_skyrat/modules/emotes/sound/emotes/snore.ogg'
 	playsound(user, sound, 50, 1, -1)
 
 /datum/emote/living/burp/run_emote(mob/living/user, params)
@@ -294,11 +294,11 @@
 	if(user.nextsoundemote >= world.time)
 		return
 	user.nextsoundemote = world.time + EMOTE_DELAY
-	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/male/burp_m.ogg')
+	var/sound = 'modular_skyrat/modules/emotes/sound/emotes/male/burp_m.ogg'
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			sound = pick('modular_skyrat/modules/emotes/sound/emotes/female/burp_f.ogg')
+			sound = 'modular_skyrat/modules/emotes/sound/emotes/female/burp_f.ogg'
 	playsound(user, sound, 50, 1, -1)
 
 /datum/emote/living/clap
@@ -352,11 +352,11 @@
 		return
 	user.nextsoundemote = world.time + EMOTE_DELAY
 	var/mob/living/carbon/H = user
-	var/sound = pick(list('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg'))
+	var/sound = pick('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg')
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			sound = pick(list('modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg', 'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg'))
+			sound = pick('modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg', 'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg')
 	if(H.dna.species.id == "moth")
 		sound = 'modular_skyrat/modules/emotes/sound/emotes/mothlaugh.ogg'
 	playsound(user, sound, 50, vary)

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -33,7 +33,7 @@
 	mob_type_blacklist_typecache = list(/mob/living/simple_animal/slime, /mob/living/brain)
 	cooldown = EMOTE_DELAY
 
-/datum/emote/living/scream/run_emote(mob/user, params)
+/datum/emote/living/scream/run_emote(mob/living/user, params)
 	if(!(. = ..()))
 		return
 	if(!user.is_muzzled() && !(user.mind && user.mind.miming))
@@ -49,7 +49,7 @@
 		return "makes a very loud noise."
 	. = ..()
 
-/datum/emote/living/scream/get_sound(mob/user, override = FALSE)
+/datum/emote/living/scream/get_sound(mob/living/user, override = FALSE)
 	if(!override)
 		return
 	if(iscyborg(user))
@@ -70,7 +70,7 @@
 		return 'sound/voice/hiss6.ogg'
 	return
 
-/datum/emote/living/scream/can_run_emote(mob/user, status_check, intentional)
+/datum/emote/living/scream/can_run_emote(mob/living/user, status_check, intentional)
 	. = ..()
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/R = user

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -58,50 +58,69 @@
 		return 'modular_skyrat/modules/emotes/sound/voice/scream_monkey.ogg'
 	if(istype(user, /mob/living/simple_animal/hostile/gorilla))
 		return 'sound/creatures/gorilla.ogg'
+	if(isalien(user))
+		return 'sound/voice/hiss6.ogg'
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		var/datum/species/userspecies = H.dna.species
-		if(H)
-			if(H.gender == FEMALE && length(userspecies.femalescreamsounds))
-				return pick(userspecies.femalescreamsounds)
-			else
-				return pick(userspecies.screamsounds)
-	if(isalien(user))
-		return 'sound/voice/hiss6.ogg'
+
+		if(user.gender == FEMALE && length(userspecies.femalescreamsounds))
+			return pick(userspecies.femalescreamsounds)
+		if(user.gender == MALE && length(userspecies.screamsounds))
+			return pick(userspecies.screamsounds)
+		if(length(userspecies.screamsounds) && length(userspecies.femalescreamsounds))
+			var/list/tempScreams = list()
+			tempScreams += userspecies.screamsounds
+			tempScreams += userspecies.femalescreamsounds
+			return pick(tempScreams)
 	return
 
 /datum/emote/living/scream/can_run_emote(mob/living/user, status_check, intentional)
-	. = ..()
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/R = user
+
 		if(R.cell?.charge < 200)
 			to_chat(R, "<span class='warning'>Scream module deactivated. Please recharge.</span>")
 			return FALSE
 		R.cell.use(200)
+	return ..()
 
 /datum/emote/living/cough
 	cooldown = EMOTE_DELAY
 
 /datum/emote/living/cough/get_sound(mob/living/user)
-	if(iscarbon(user) && user.gender == FEMALE)
-		return pick('modular_skyrat/modules/emotes/sound/emotes/female/female_cough_1.ogg',
-					'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_2.ogg',
-					'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_3.ogg')
 	if(isvox(user))
 		return 'modular_skyrat/modules/emotes/sound/emotes/voxcough.ogg'
+	if(iscarbon(user))
+		if(user.gender == FEMALE)
+			return pick('modular_skyrat/modules/emotes/sound/emotes/female/female_cough_1.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_2.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_3.ogg')
+		if(user.gender == MALE)
+			return pick('modular_skyrat/modules/emotes/sound/emotes/male/male_cough_1.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/male/male_cough_2.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/male/male_cough_3.ogg')
 	return pick('modular_skyrat/modules/emotes/sound/emotes/male/male_cough_1.ogg',
 				'modular_skyrat/modules/emotes/sound/emotes/male/male_cough_2.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/male/male_cough_3.ogg')
+				'modular_skyrat/modules/emotes/sound/emotes/male/male_cough_3.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_1.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_2.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_3.ogg')
 
 /datum/emote/living/sneeze
+	vary = TRUE
 	cooldown = EMOTE_DELAY
 
 /datum/emote/living/sneeze/get_sound(mob/living/user)
-	if(iscarbon(user) && user.gender == FEMALE)
-		return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sneeze.ogg'
 	if(isvox(user))
 		return 'modular_skyrat/modules/emotes/sound/emotes/voxsneeze.ogg'
-	return 'modular_skyrat/modules/emotes/sound/emotes/male/male_sneeze.ogg'
+	if(iscarbon(user))
+		if(user.gender == FEMALE)
+			return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sneeze.ogg'
+		if(user.gender == MALE)
+			return 'modular_skyrat/modules/emotes/sound/emotes/male/male_sneeze.ogg'
+	return pick('modular_skyrat/modules/emotes/sound/emotes/male/male_sneeze.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/female_sneeze.ogg')
 
 /datum/emote/living/peep
 	key = "peep"
@@ -254,31 +273,55 @@
 	cooldown = EMOTE_DELAY
 
 /datum/emote/living/sigh/get_sound(mob/living/user)
-	if(iscarbon(user) && user.gender == FEMALE)
-		return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sigh.ogg'
-	return 'modular_skyrat/modules/emotes/sound/emotes/male/male_sigh.ogg'
+	if(iscarbon(user))
+		if(user.gender == FEMALE)
+			return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sigh.ogg'
+		if(user.gender == MALE)
+			return 'modular_skyrat/modules/emotes/sound/emotes/male/male_sigh.ogg'
+	return pick('modular_skyrat/modules/emotes/sound/emotes/male/male_sigh.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/female_sigh.ogg')
 
+/datum/emote/living/sniff
+	vary = TRUE
 
 /datum/emote/living/sniff/get_sound(mob/living/user)
-	if(iscarbon(user) && user.gender == FEMALE)
-		return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sniff.ogg'
-	return 'modular_skyrat/modules/emotes/sound/emotes/male/male_sniff.ogg'
+	if(iscarbon(user))
+		if(user.gender == FEMALE)
+			return 'modular_skyrat/modules/emotes/sound/emotes/female/female_sniff.ogg'
+		if(user.gender == MALE)
+			return 'modular_skyrat/modules/emotes/sound/emotes/male/male_sniff.ogg'
+	return pick('modular_skyrat/modules/emotes/sound/emotes/male/male_sniff.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/female_sniff.ogg')
 
 
 /datum/emote/living/gasp/get_sound(mob/living/user)
-	if(iscarbon(user) && user.gender == FEMALE)
-		return pick('modular_skyrat/modules/emotes/sound/emotes/female/gasp_f1.ogg',
-					'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f2.ogg',
-					'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f3.ogg',
-					'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f4.ogg',
-					'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f5.ogg',
-					'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f6.ogg')
+	if(iscarbon(user))
+		if(user.gender == FEMALE)
+			return pick('modular_skyrat/modules/emotes/sound/emotes/female/gasp_f1.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f2.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f3.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f4.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f5.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f6.ogg')
+		if(user.gender == MALE)
+			return pick('modular_skyrat/modules/emotes/sound/emotes/male/gasp_m1.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m2.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m3.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m4.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m5.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m6.ogg')
 	return pick('modular_skyrat/modules/emotes/sound/emotes/male/gasp_m1.ogg',
 				'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m2.ogg',
 				'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m3.ogg',
 				'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m4.ogg',
 				'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m5.ogg',
-				'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m6.ogg')
+				'modular_skyrat/modules/emotes/sound/emotes/male/gasp_m6.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f1.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f2.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f3.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f4.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f5.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/gasp_f6.ogg')
 
 
 /datum/emote/living/snore
@@ -286,25 +329,18 @@
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/snore.ogg'
 	cooldown = EMOTE_DELAY
 
-/*
-/datum/emote/living/burp/run_emote(mob/living/user, params)
-	if(!(. = ..()))
-		return
-	var/sound = 'modular_skyrat/modules/emotes/sound/emotes/male/burp_m.ogg'
-	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		if(C.gender == FEMALE)
-			sound = 'modular_skyrat/modules/emotes/sound/emotes/female/burp_f.ogg'
-	playsound(user, sound, 50, 1, -1)
-*/
 /datum/emote/living/burp
 	vary = TRUE
 	cooldown = EMOTE_DELAY
 
 /datum/emote/living/burp/get_sound(mob/living/user)
-	if(iscarbon(user) && user.gender == FEMALE)
-		return 'modular_skyrat/modules/emotes/sound/emotes/female/burp_f.ogg'
-	return 'modular_skyrat/modules/emotes/sound/emotes/male/burp_m.ogg'
+	if(iscarbon(user))
+		if(user.gender == FEMALE)
+			return 'modular_skyrat/modules/emotes/sound/emotes/female/burp_f.ogg'
+		if(user.gender == MALE)
+			return 'modular_skyrat/modules/emotes/sound/emotes/male/burp_m.ogg'
+	return pick('modular_skyrat/modules/emotes/sound/emotes/male/burp_m.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/burp_f.ogg')
 
 /datum/emote/living/clap
 	key = "clap"
@@ -359,15 +395,19 @@
 	cooldown = EMOTE_DELAY
 
 /datum/emote/living/laugh/get_sound(mob/living/user)
-	var/mob/living/carbon/H = user
-	if(iscarbon(user) && H.gender == FEMALE)
-		//var/mob/living/carbon/C = user
-		return pick('modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg',
-					'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg')
-	if(H.dna.species.id == "moth")
+	if(ismoth(user))
 		return 'modular_skyrat/modules/emotes/sound/emotes/mothlaugh.ogg'
+	if(iscarbon(user))
+		if(user.gender == FEMALE)
+			return pick('modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg',
+						'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg')
+		if(user.gender == MALE)
+			return pick('sound/voice/human/manlaugh1.ogg',
+						'sound/voice/human/manlaugh2.ogg')
 	return pick('sound/voice/human/manlaugh1.ogg',
-				'sound/voice/human/manlaugh2.ogg')
+				'sound/voice/human/manlaugh2.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg',
+				'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg')
 
 /datum/emote/living/headtilt
 	key = "tilt"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -1,3 +1,12 @@
+
+#define EMOTE_DELAY 2 SECONDS //To prevent spam emotes.
+
+/mob
+	var/nextsoundemote = 1
+
+//Disables the custom emote blacklist from TG that normally applies to slimes.
+/datum/emote/living/custom
+	mob_type_blacklist_typecache = list(/mob/living/brain)
 /datum/emote/living/quill
 	key = "quill"
 	key_third_person = "quills"
@@ -7,6 +16,7 @@
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/voxrustle.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/scream/run_emote(mob/living/user, params) //I can't not port this shit, come on.
 	if(user.nextsoundemote >= world.time || user.stat != CONSCIOUS)
@@ -14,7 +24,7 @@
 	var/sound
 	var/miming = user.mind ? user.mind.miming : 0
 	if(!user.is_muzzled() && !miming)
-		user.nextsoundemote = world.time + 7
+		user.nextsoundemote = world.time + EMOTE_DELAY
 		if(issilicon(user))
 			sound = 'modular_skyrat/modules/emotes/sound/voice/scream_silicon.ogg'
 			if(iscyborg(user))
@@ -56,7 +66,7 @@
 		return
 	if(user.nextsoundemote >= world.time)
 		return
-	user.nextsoundemote = world.time + 7
+	user.nextsoundemote = world.time + EMOTE_DELAY
 	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/male/male_cough_1.ogg','modular_skyrat/modules/emotes/sound/emotes/male/male_cough_2.ogg','modular_skyrat/modules/emotes/sound/emotes/male/male_cough_3.ogg')
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
@@ -71,7 +81,7 @@
 		return
 	if(user.nextsoundemote >= world.time)
 		return
-	user.nextsoundemote = world.time + 7
+	user.nextsoundemote = world.time + EMOTE_DELAY
 	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/male/male_sneeze.ogg')
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
@@ -88,6 +98,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/peep_once.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/peep2
 	key = "peep2"
@@ -96,13 +107,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/peep.ogg'
-
-/mob
-	var/nextsoundemote = 1
-
-//Disables the custom emote blacklist from TG that normally applies to slimes.
-/datum/emote/living/custom
-	mob_type_blacklist_typecache = list(/mob/living/brain)
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/snap
 	key = "snap"
@@ -113,6 +118,7 @@
 	hands_use_check = TRUE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/snap.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/snap2
 	key = "snap2"
@@ -123,6 +129,7 @@
 	hands_use_check = TRUE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/snap2.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/snap3
 	key = "snap3"
@@ -133,7 +140,7 @@
 	hands_use_check = TRUE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/snap3.ogg'
-
+	cooldown = EMOTE_DELAY
 /datum/emote/living/awoo
 	key = "awoo"
 	key_third_person = "awoos"
@@ -149,6 +156,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/nya.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/weh
 	key = "weh"
@@ -157,6 +165,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/weh.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/dab
 	key = "dab"
@@ -164,6 +173,7 @@
 	message = "suddenly hits a dab!"
 	emote_type = EMOTE_AUDIBLE
 	hands_use_check = TRUE
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/mothsqueak
 	key = "msqueak"
@@ -172,6 +182,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/mothsqueak.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/merp
 	key = "merp"
@@ -180,6 +191,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/merp.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/bark
 	key = "bark"
@@ -187,15 +199,8 @@
 	message = "barks!"
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
-
-/datum/emote/living/bark/run_emote(mob/living/user, params)
-	if(!(. = ..()))
-		return
-	if(user.nextsoundemote >= world.time)
-		return
-	user.nextsoundemote = world.time + 7
-	var/sound = pick('modular_skyrat/modules/emotes/sound/voice/bark1.ogg', 'modular_skyrat/modules/emotes/sound/voice/bark2.ogg')
-	playsound(user, sound, 50, vary)
+	sound = pick(list('modular_skyrat/modules/emotes/sound/voice/bark1.ogg', 'modular_skyrat/modules/emotes/sound/voice/bark2.ogg'))
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/squish
 	key = "squish"
@@ -204,6 +209,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/slime_squish.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/meow
 	key = "meow"
@@ -212,6 +218,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/meow.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/hiss
 	key = "hiss"
@@ -221,6 +228,7 @@
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/hiss.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/chitter
 	key = "chitter"
@@ -230,18 +238,19 @@
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/mothchitter.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/living/sigh/run_emote(mob/living/user, params)
 	if(!(. = ..()))
 		return
 	if(user.nextsoundemote >= world.time)
 		return
-	user.nextsoundemote = world.time + 7
-	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/male/male_sigh.ogg')
+	user.nextsoundemote = world.time + EMOTE_DELAY
+	var/sound = 'modular_skyrat/modules/emotes/sound/emotes/male/male_sigh.ogg'
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			sound = pick('modular_skyrat/modules/emotes/sound/emotes/female/female_sigh.ogg')
+			sound = 'modular_skyrat/modules/emotes/sound/emotes/female/female_sigh.ogg'
 	playsound(user, sound, 50, 1, -1)
 
 /datum/emote/living/sniff/run_emote(mob/living/user, params)
@@ -249,12 +258,12 @@
 		return
 	if(user.nextsoundemote >= world.time)
 		return
-	user.nextsoundemote = world.time + 7
-	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/male/male_sniff.ogg')
+	user.nextsoundemote = world.time + EMOTE_DELAY
+	var/sound = 'modular_skyrat/modules/emotes/sound/emotes/male/male_sniff.ogg'
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			sound = pick('modular_skyrat/modules/emotes/sound/emotes/female/female_sniff.ogg')
+			sound = 'modular_skyrat/modules/emotes/sound/emotes/female/female_sniff.ogg'
 	playsound(user, sound, 50, 1, -1)
 
 /datum/emote/living/gasp/run_emote(mob/living/user, params)
@@ -262,7 +271,7 @@
 		return
 	if(user.nextsoundemote >= world.time)
 		return
-	user.nextsoundemote = world.time + 7
+	user.nextsoundemote = world.time + EMOTE_DELAY
 	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/male/gasp_m1.ogg','modular_skyrat/modules/emotes/sound/emotes/male/gasp_m2.ogg','modular_skyrat/modules/emotes/sound/emotes/male/gasp_m3.ogg','modular_skyrat/modules/emotes/sound/emotes/male/gasp_m4.ogg','modular_skyrat/modules/emotes/sound/emotes/male/gasp_m5.ogg','modular_skyrat/modules/emotes/sound/emotes/male/gasp_m6.ogg')
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
@@ -275,7 +284,7 @@
 		return
 	if(user.nextsoundemote >= world.time)
 		return
-	user.nextsoundemote = world.time + 7
+	user.nextsoundemote = world.time + EMOTE_DELAY
 	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/snore.ogg')
 	playsound(user, sound, 50, 1, -1)
 
@@ -284,7 +293,7 @@
 		return
 	if(user.nextsoundemote >= world.time)
 		return
-	user.nextsoundemote = world.time + 7
+	user.nextsoundemote = world.time + EMOTE_DELAY
 	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/male/burp_m.ogg')
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
@@ -301,12 +310,13 @@
 	vary = TRUE
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
 
+
 /datum/emote/living/clap/run_emote(mob/living/user, params)
 	if(!(. = ..()))
 		return
 	if(user.nextsoundemote >= world.time)
 		return
-	user.nextsoundemote = world.time + 7
+	user.nextsoundemote = world.time + EMOTE_DELAY
 	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/clap1.ogg','modular_skyrat/modules/emotes/sound/emotes/clap2.ogg','modular_skyrat/modules/emotes/sound/emotes/clap3.ogg','modular_skyrat/modules/emotes/sound/emotes/clap4.ogg')
 	playsound(user, sound, 50, vary)
 
@@ -322,7 +332,7 @@
 		return
 	if(user.nextsoundemote >= world.time)
 		return
-	user.nextsoundemote = world.time + 7
+	user.nextsoundemote = world.time + EMOTE_DELAY
 	var/sound = pick('modular_skyrat/modules/emotes/sound/emotes/claponce1.ogg', 'modular_skyrat/modules/emotes/sound/emotes/claponce2.ogg')
 	playsound(user, sound, 50, vary)
 
@@ -340,16 +350,167 @@
 		return
 	if(user.nextsoundemote >= world.time)
 		return
-	user.nextsoundemote = world.time + 7
+	user.nextsoundemote = world.time + EMOTE_DELAY
 	var/mob/living/carbon/H = user
-	var/sound = pick('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg')
+	var/sound = pick(list('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg'))
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			sound = pick('modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg', 'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg')
+			sound = pick(list('modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg', 'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg'))
 	if(H.dna.species.id == "moth")
 		sound = 'modular_skyrat/modules/emotes/sound/emotes/mothlaugh.ogg'
 	playsound(user, sound, 50, vary)
+
+/datum/emote/living/headtilt
+	key = "tilt"
+	key_third_person = "tilts"
+	message = "tilts their head."
+	message_AI = "tilts the image on their display."
+	cooldown = EMOTE_DELAY
+
+/datum/emote/living/beeps
+	key = "beeps"
+	key_third_person = "beeps"
+	message = "beeps."
+	message_param = "beeps at %t."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/emotes/twobeep.ogg'
+	cooldown = EMOTE_DELAY
+
+// Avian revolution
+/datum/emote/living/bawk
+	key = "bawk"
+	key_third_person = "bawks"
+	message = "bawks like a chicken."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/voice/bawk.ogg'
+	cooldown = EMOTE_DELAY
+
+/datum/emote/living/caw
+	key = "caw"
+	key_third_person = "caws"
+	message = "caws!"
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/voice/caw.ogg'
+	cooldown = EMOTE_DELAY
+
+/datum/emote/living/caw2
+	key = "caw2"
+	key_third_person = "caws twice"
+	message = "caws twice!"
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/voice/caw2.ogg'
+	cooldown = EMOTE_DELAY
+
+/datum/emote/living/whistle
+	key = "whistle"
+	key_third_person = "whistles"
+	message = "whistles."
+	emote_type = EMOTE_AUDIBLE
+	cooldown = EMOTE_DELAY
+
+/datum/emote/living/blep
+	key = "blep"
+	key_third_person = "bleps"
+	message = "bleps their tongue out. Blep."
+	message_AI = "shows an image of a random blepping animal. Blep."
+	message_robot = "bleps their robo-tongue out. Blep."
+	cooldown = EMOTE_DELAY
+
+/datum/emote/living/bork
+	key = "bork"
+	key_third_person = "borks"
+	message = "lets out a bork."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/voice/bork.ogg'
+	cooldown = EMOTE_DELAY
+
+/datum/emote/living/hoot
+	key = "hoot"
+	key_third_person = "hoots"
+	message = "hoots!"
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/voice/hoot.ogg'
+	cooldown = 1.4 SECONDS
+/datum/emote/living/growl
+	key = "growl"
+	key_third_person = "growls"
+	message = "lets out a growl."
+	emote_type = EMOTE_AUDIBLE
+	muzzle_ignore = TRUE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/voice/growl.ogg'
+	cooldown = EMOTE_DELAY
+
+/datum/emote/living/woof
+	key = "woof"
+	key_third_person = "woofs"
+	message = "lets out a woof."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/voice/woof.ogg'
+	cooldown = EMOTE_DELAY
+
+/datum/emote/living/baa
+	key = "baa"
+	key_third_person = "baas"
+	message = "lets out a baa."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/voice/baa.ogg'
+	cooldown = EMOTE_DELAY
+
+/datum/emote/living/baa2
+	key = "baa2"
+	key_third_person = "baas"
+	message = "bleats."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/voice/baa2.ogg'
+	cooldown = EMOTE_DELAY
+
+/datum/emote/living/wurble
+	key = "wurble"
+	key_third_person = "wurbles"
+	message = "lets out a wurble."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/voice/wurble.ogg'
+	cooldown = EMOTE_DELAY
+
+/datum/emote/living/awoo2
+	key = "awoo2"
+	key_third_person = "awoos"
+	message = "lets out an awoo!"
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/voice/long_awoo.ogg'
+	cooldown = EMOTE_DELAY
+	cooldown = 2.5 SECONDS
+/datum/emote/living/rattle
+	key = "rattle"
+	key_third_person = "rattles"
+	message = "rattles!"
+	emote_type = EMOTE_AUDIBLE
+	muzzle_ignore = TRUE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/voice/rattle.ogg'
+	cooldown = EMOTE_DELAY
+
+/datum/emote/living/cackle
+	key = "cackle"
+	key_third_person = "cackles"
+	message = "cackles hysterically!"
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/voice/cackle_yeen.ogg'
+	cooldown = 1.2 SECONDS
 
 /mob/living/proc/do_ass_slap_animation(atom/slapped)
 	do_attack_animation(slapped, no_effect=TRUE)
@@ -362,141 +523,3 @@
 	animate(gloveimg, alpha = 175, transform = matrix() * 0.75, pixel_x = 0, pixel_y = -5, pixel_z = 0, time = 3)
 	animate(time = 1)
 	animate(alpha = 0, time = 3, easing = CIRCULAR_EASING|EASE_OUT)
-
-/datum/emote/living/headtilt
-	key = "tilt"
-	key_third_person = "tilts"
-	message = "tilts their head."
-	message_AI = "tilts the image on their display."
-
-/datum/emote/living/beeps
-	key = "beeps"
-	key_third_person = "beeps"
-	message = "beeps."
-	message_param = "beeps at %t."
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/emotes/twobeep.ogg'
-
-// Avian revolution
-/datum/emote/living/bawk
-	key = "bawk"
-	key_third_person = "bawks"
-	message = "bawks like a chicken."
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/bawk.ogg'
-
-/datum/emote/living/caw
-	key = "caw"
-	key_third_person = "caws"
-	message = "caws!"
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/caw.ogg'
-
-/datum/emote/living/caw2
-	key = "caw2"
-	key_third_person = "caws twice"
-	message = "caws twice!"
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/caw2.ogg'
-
-/datum/emote/living/whistle
-	key = "whistle"
-	key_third_person = "whistles"
-	message = "whistles."
-	emote_type = EMOTE_AUDIBLE
-
-/datum/emote/living/blep
-	key = "blep"
-	key_third_person = "bleps"
-	message = "bleps their tongue out. Blep."
-	message_AI = "shows an image of a random blepping animal. Blep."
-	message_robot = "bleps their robo-tongue out. Blep."
-
-/datum/emote/living/bork
-	key = "bork"
-	key_third_person = "borks"
-	message = "lets out a bork."
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/bork.ogg'
-
-/datum/emote/living/hoot
-	key = "hoot"
-	key_third_person = "hoots"
-	message = "hoots!"
-	emote_type = EMOTE_AUDIBLE
-	cooldown = 1.4 SECONDS
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/hoot.ogg'
-
-/datum/emote/living/growl
-	key = "growl"
-	key_third_person = "growls"
-	message = "lets out a growl."
-	emote_type = EMOTE_AUDIBLE
-	muzzle_ignore = TRUE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/growl.ogg'
-
-/datum/emote/living/woof
-	key = "woof"
-	key_third_person = "woofs"
-	message = "lets out a woof."
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/woof.ogg'
-
-/datum/emote/living/baa
-	key = "baa"
-	key_third_person = "baas"
-	message = "lets out a baa."
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/baa.ogg'
-
-/datum/emote/living/baa2
-	key = "baa2"
-	key_third_person = "baas"
-	message = "bleats."
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/baa2.ogg'
-
-/datum/emote/living/wurble
-	key = "wurble"
-	key_third_person = "wurbles"
-	message = "lets out a wurble."
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/wurble.ogg'
-
-/datum/emote/living/awoo2
-	key = "awoo2"
-	key_third_person = "awoos"
-	message = "lets out an awoo!"
-	emote_type = EMOTE_AUDIBLE
-	cooldown = 2.5 SECONDS
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/long_awoo.ogg'
-
-/datum/emote/living/rattle
-	key = "rattle"
-	key_third_person = "rattles"
-	message = "rattles!"
-	emote_type = EMOTE_AUDIBLE
-	muzzle_ignore = TRUE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/rattle.ogg'
-
-/datum/emote/living/cackle
-	key = "cackle"
-	key_third_person = "cackles"
-	message = "cackles hysterically!"
-	emote_type = EMOTE_AUDIBLE
-	cooldown = 1.2 SECONDS
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/cackle_yeen.ogg'

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -376,14 +376,11 @@
 	message_AI = "tilts the image on their display."
 	cooldown = EMOTE_DELAY
 
-/datum/emote/living/beeps
-	key = "beeps"
-	key_third_person = "beeps"
-	message = "beeps."
-	message_param = "beeps at %t."
+/datum/emote/beep
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/twobeep.ogg'
+	mob_type_allowed_typecache = list(/mob/living)
 	cooldown = EMOTE_DELAY
 
 // Avian revolution

--- a/modular_skyrat/modules/emotes/code/silicon_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/silicon_emotes.dm
@@ -1,11 +1,3 @@
-/datum/emote/silicon/check_cooldown(mob/user, intentional)
-	if(!intentional)
-		return TRUE
-	if(user.nextsoundemote > world.time)
-		return FALSE
-	user.nextsoundemote = world.time + cooldown
-	return TRUE
-
 /datum/emote/silicon/dwoop
 	key = "dwoop"
 	key_third_person = "dwoops"

--- a/modular_skyrat/modules/emotes/code/silicon_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/silicon_emotes.dm
@@ -4,15 +4,31 @@
 	message = "chirps happily!"
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/dwoop.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/silicon/yes
 	key = "yes"
 	message = "emits an affirmative blip."
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/synth_yes.ogg'
+	cooldown = EMOTE_DELAY
 
 /datum/emote/silicon/no
 	key = "no"
 	message = "emits a negative blip."
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/synth_no.ogg'
+	cooldown = EMOTE_DELAY
+
+//Let's also at least add a longer cooldown to the longer/louder/more irritating ones
+/datum/emote/silicon/buzz
+	cooldown = EMOTE_DELAY
+
+/datum/emote/silicon/buzz2
+	cooldown = EMOTE_DELAY
+
+/datum/emote/silicon/sad
+	cooldown = EMOTE_DELAY
+
+/datum/emote/silicon/warn
+	cooldown = EMOTE_DELAY

--- a/modular_skyrat/modules/emotes/code/silicon_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/silicon_emotes.dm
@@ -1,3 +1,11 @@
+/datum/emote/silicon/check_cooldown(mob/user, intentional)
+	if(!intentional)
+		return TRUE
+	if(user.nextsoundemote > world.time)
+		return FALSE
+	user.nextsoundemote = world.time + cooldown
+	return TRUE
+
 /datum/emote/silicon/dwoop
 	key = "dwoop"
 	key_third_person = "dwoops"

--- a/modular_skyrat/modules/emotes/code/silicon_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/silicon_emotes.dm
@@ -4,31 +4,15 @@
 	message = "chirps happily!"
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/dwoop.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/silicon/yes
 	key = "yes"
 	message = "emits an affirmative blip."
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/synth_yes.ogg'
-	cooldown = EMOTE_DELAY
 
 /datum/emote/silicon/no
 	key = "no"
 	message = "emits a negative blip."
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/synth_no.ogg'
-	cooldown = EMOTE_DELAY
-
-//Let's also at least add a longer cooldown to the longer/louder/more irritating ones
-/datum/emote/silicon/buzz
-	cooldown = EMOTE_DELAY
-
-/datum/emote/silicon/buzz2
-	cooldown = EMOTE_DELAY
-
-/datum/emote/silicon/sad
-	cooldown = EMOTE_DELAY
-
-/datum/emote/silicon/warn
-	cooldown = EMOTE_DELAY

--- a/modular_skyrat/modules/emotes/readme.md
+++ b/modular_skyrat/modules/emotes/readme.md
@@ -10,20 +10,30 @@ MODULE ID: EMOTES
 
 Adds all the emotes we once had on the oldbase, and shoves them right into here.
 
-Also adds some new emotes, and adjusted sound files.
+Adds some new emotes, and adjusted sound files.
+
+Pretty much anything that changes emotes is in here
 
 ### TG Proc Changes:
 
-- Skyrat-tg\code\modules\mob\living\carbon\carbon_defense.dm > /mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)
+File Location | Changed TG Proc
+------------- | ---------------
+code/datums/emotes.dm | `/datum/emote/proc/check_cooldown(mob/user, intentional)`
+code/datums/emotes.dm | `/datum/emote/proc/run_emote(mob/user, params, type_override, intentional = FALSE)`
+code/modules/mob/living/carbon/carbon_defense.dm | `/mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)`
 
 ### TG File Changes:
 
-- code\modules\mob\living\emote.dm
-- code\modules\mob\living\carbon\emote.dm
+- code/datums/emotes.dm
+- code/modules/mob/living/emote.dm
+- code/modules/mob/living/carbon/emote.dm
 
 ### Defines:
 
-- #define TRAIT_EXCITABLE	"wagwag"
+File Location | Defines
+------------- | -------
+code/__DEFINES/~skyrat_defines/traits.dm 		| `#define TRAIT_EXCITABLE	"wagwag"`
+modular_skyrat/modules/emotes/code/emotes.dm 	| `#define EMOTE_DELAY`
 
 ### Master file additions
 

--- a/modular_skyrat/modules/emotes/readme.md
+++ b/modular_skyrat/modules/emotes/readme.md
@@ -1,5 +1,6 @@
 https://github.com/Skyrat-SS13/Skyrat-tg/pull/892
 https://github.com/Skyrat-SS13/Skyrat-tg/pull/1925
+https://github.com/Skyrat-SS13/Skyrat-tg/pull/2320
 
 ## Title: All the emotes.
 
@@ -9,7 +10,7 @@ MODULE ID: EMOTES
 
 Adds all the emotes we once had on the oldbase, and shoves them right into here.
 
-Edit (Avunia): Also adds some new emotes, and adjusted sound files.
+Also adds some new emotes, and adjusted sound files.
 
 ### TG Proc Changes:
 
@@ -18,6 +19,7 @@ Edit (Avunia): Also adds some new emotes, and adjusted sound files.
 ### TG File Changes:
 
 - code\modules\mob\living\emote.dm
+- code\modules\mob\living\carbon\emote.dm
 
 ### Defines:
 
@@ -32,7 +34,9 @@ Edit (Avunia): Also adds some new emotes, and adjusted sound files.
 - N/A
 
 ### Credits:
-Gandalf2k15 - porting and refactoring
-
-Avunia Takiya - refactoring code and adjusting existing sound files, adding more emotes
-VOREstation - a couple of the soundfiles and emote texts
+- Gandalf2k15 - porting and refactoring
+- Avunia Takiya
+  - refactoring code
+  - adjusting existing sound files
+  - adding more emotes
+- VOREstation - a couple of the soundfiles and emote texts


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevents most of our emotes from being spammed by giving them a 15 second delay, for most, as requested.
Decreases emote volume to 25% from 50.
Adds a variable to control emote sound volume.
Makes emote cooldowns per player rather than per player per emote.
Refactors a lot of the emote datums to use `get_sound` instead of `run_emote`

## Changelog
:cl: Gandalf2k15, Avunia
tweak: You can no longer spam certain emotes.
tweak: You can't clap without hands anymore
tweak: You can clap without a mouth again
tweak: Emotes now have a global cooldown instead per emote
tweak: Emote volume reduced from 50% to 25%
tweak: Emote cooldown increased to 15 seconds
refactor: Uncooked the spaghetti that *scream was, among others
refactor: Emotes can now have variable volume adjustments in the code
/:cl:
