### PR TITLE
Reverts the space nerf PR and adds some light story to space ruins with plushies included

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/DJstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation.dmm
@@ -85,8 +85,8 @@
 /area/ruin/space/djstation)
 "as" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/suit/space/syndicate/orange,
+/obj/item/clothing/head/helmet/space/syndicate/orange,
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plating,
 /area/ruin/space/djstation)
@@ -267,6 +267,7 @@
 /area/ruin/space/djstation)
 "aV" = (
 /obj/structure/closet,
+/obj/item/toy/plush/slimeplushie,
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/djstation)
 "aW" = (

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -1116,7 +1116,7 @@
 	},
 /area/ruin/space/derelict/singularity_engine)
 "eY" = (
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/syndicate/black/engie,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "eZ" = (
@@ -1186,7 +1186,7 @@
 	},
 /area/ruin/space/derelict/singularity_engine)
 "fk" = (
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/syndicate/black/engie,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "fl" = (
@@ -3470,7 +3470,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/syndicate/black/red,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/se_solar)
 "oc" = (
@@ -3499,7 +3499,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/se_solar)
 "oh" = (
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/syndicate/black/red,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/se_solar)
 "oi" = (
@@ -3631,7 +3631,7 @@
 	},
 /area/template_noop)
 "CZ" = (
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/syndicate/black/green,
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged2"
 	},
@@ -3796,7 +3796,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/ai_upload)
 "Ob" = (
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/syndicate/black/green,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/ai_upload)
 "Oj" = (

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -253,9 +253,8 @@
 /area/ruin/space/has_grav/abandonedzoo)
 "aT" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/hardsuit/medical,
 /obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/clothing/head/helmet/space/eva,
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aU" = (

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -1691,6 +1691,11 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost)
+"YE" = (
+/obj/structure/alien/weeds/creature,
+/obj/item/toy/plush/narplush,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/derelictoutpost)
 
 (1,1,1) = {"
 aa
@@ -2789,7 +2794,7 @@ bn
 cj
 cj
 bF
-bl
+YE
 dl
 bF
 bl

--- a/_maps/RandomRuins/SpaceRuins/bus.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bus.dmm
@@ -100,6 +100,10 @@
 /obj/structure/fluff/bus/passable/seat/driver,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/food/grown/citrus/orange,
+/obj/item/paperslip{
+	pixel_x = -2;
+	pixel_y = 17
+	},
 /turf/open/floor/plasteel/airless/dark{
 	icon_state = "bus"
 	},
@@ -250,8 +254,8 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered/no_grav)
 "aR" = (
-/obj/item/storage/toolbox/mechanical,
 /obj/effect/decal/cleanable/oil,
+/obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered/no_grav)
 "aS" = (
@@ -312,6 +316,54 @@
 "bb" = (
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plating/asteroid/airless,
+/area/ruin/unpowered/no_grav)
+"bL" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1;
+	pixel_x = 2;
+	pixel_y = 23
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1;
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/unpowered/no_grav)
+"pX" = (
+/obj/item/paperplane{
+	dir = 8;
+	pixel_x = -11;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/unpowered/no_grav)
+"tu" = (
+/obj/structure/fluff/bus/passable,
+/obj/item/paper/crumpled/muddy{
+	pixel_x = -6
+	},
+/turf/open/floor/plasteel/airless/dark{
+	icon_state = "bus"
+	},
+/area/ruin/unpowered/no_grav)
+"UF" = (
+/obj/item/rollingpaper{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/structure/fluff/bus/passable/seat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/airless/dark{
+	icon_state = "bus"
+	},
+/area/ruin/unpowered/no_grav)
+"VH" = (
+/obj/structure/fluff/bus/passable,
+/obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
+/turf/open/floor/plasteel/airless/dark{
+	icon_state = "bus"
+	},
 /area/ruin/unpowered/no_grav)
 "XA" = (
 /obj/structure/fluff/bus/passable/seat,
@@ -377,7 +429,7 @@ ad
 aP
 aj
 aU
-az
+VH
 aI
 ad
 ad
@@ -393,10 +445,10 @@ ab
 ad
 al
 ad
-ad
+pX
 ad
 aj
-am
+UF
 aZ
 aK
 ad
@@ -437,7 +489,7 @@ aI
 ad
 aj
 aU
-az
+tu
 aJ
 ad
 ad
@@ -459,7 +511,7 @@ aj
 aW
 aE
 aM
-ad
+bL
 ad
 "}
 (8,1,1) = {"
@@ -594,7 +646,7 @@ aj
 as
 aE
 aM
-ad
+bL
 ad
 aP
 ad

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -943,7 +943,7 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/secure/weapon,
-/obj/item/gun/energy/disabler,
+/obj/item/gun/ballistic/shotgun/sc_pump,
 /turf/open/floor/plasteel/airless/dark,
 /area/shuttle/caravan/freighter2)
 "iX" = (
@@ -951,6 +951,8 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/secure/gear,
+/obj/effect/spawner/lootdrop/space/cashmoney,
 /turf/open/floor/plasteel/airless/dark,
 /area/shuttle/caravan/freighter2)
 "iY" = (
@@ -1031,7 +1033,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/secure/weapon,
-/obj/item/gun/energy/laser/retro,
+/obj/item/gun/ballistic/automatic/pistol/aps,
 /turf/open/floor/plasteel/airless/dark,
 /area/shuttle/caravan/freighter2)
 "js" = (
@@ -1292,6 +1294,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter3)
+"wy" = (
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/unpowered)
 "GL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
@@ -2801,7 +2807,7 @@ bt
 bt
 bt
 dD
-dD
+wy
 bt
 dD
 dD

--- a/_maps/RandomRuins/SpaceRuins/clownplanet.dmm
+++ b/_maps/RandomRuins/SpaceRuins/clownplanet.dmm
@@ -376,6 +376,10 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating/asteroid,
 /area/ruin/powered/clownplanet)
+"es" = (
+/obj/item/bot_assembly/honkbot,
+/turf/open/floor/mineral/bananium,
+/area/ruin/powered/clownplanet)
 
 (1,1,1) = {"
 aa
@@ -622,7 +626,7 @@ ak
 aj
 aU
 at
-av
+es
 at
 ay
 av

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1897,7 +1897,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/awaymission/bmpship/fore)
 "xA" = (
-/turf/closed/mineral/random/no_caves,
+/turf/closed/mineral/random,
 /area/awaymission/bmpship)
 "ya" = (
 /obj/machinery/door/poddoor/shutters{

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1695,6 +1695,7 @@
 "gA" = (
 /obj/effect/decal/remains/human,
 /obj/structure/cable,
+/obj/effect/gibspawner/human,
 /turf/open/floor/plasteel,
 /area/awaymission/bmpship/aft)
 "gD" = (
@@ -1704,7 +1705,7 @@
 /area/awaymission/bmpship/aft)
 "gE" = (
 /obj/effect/decal/remains/human,
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/syndicate/green/dark,
 /obj/effect/gibspawner/generic,
 /turf/open/floor/plating/asteroid/airless,
 /area/awaymission/bmpship)
@@ -1763,7 +1764,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/bmpship/aft)
 "gQ" = (
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/syndicate/green/dark,
 /turf/open/floor/plating/asteroid/airless,
 /area/awaymission/bmpship)
 "gR" = (
@@ -1801,6 +1802,7 @@
 /area/awaymission/bmpship/midship)
 "hb" = (
 /obj/effect/decal/remains/human,
+/obj/effect/gibspawner/human,
 /turf/open/floor/plasteel,
 /area/awaymission/bmpship/aft)
 "hc" = (
@@ -1895,7 +1897,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/awaymission/bmpship/fore)
 "xA" = (
-/turf/closed/mineral/random,
+/turf/closed/mineral/random/no_caves,
 /area/awaymission/bmpship)
 "ya" = (
 /obj/machinery/door/poddoor/shutters{

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -150,6 +150,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/space/cashmoney,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage/storage)
 "aH" = (
@@ -1745,7 +1746,9 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
-/obj/effect/spawner/lootdrop/space/fancytool,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/deepstorage/armory)
 "ey" = (

--- a/_maps/RandomRuins/SpaceRuins/emptyshell.dmm
+++ b/_maps/RandomRuins/SpaceRuins/emptyshell.dmm
@@ -17,7 +17,7 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "f" = (
-/obj/item/ammo_box/magazine/sniper_rounds,
+/obj/effect/spawner/lootdrop/space/syndiecosmetic,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "g" = (
@@ -51,6 +51,10 @@
 	lootcount = 4;
 	name = "4maintenance loot spawner"
 	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"H" = (
+/obj/item/shard,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 
@@ -266,7 +270,7 @@ c
 c
 d
 d
-d
+H
 d
 d
 d

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -1,40 +1,27 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ai" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"dS" = (
-/obj/machinery/light{
+"aK" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/structure/bed,
-/obj/effect/decal/remains/human,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"eH" = (
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/gasthelizard)
-"eS" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"gz" = (
+"bo" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/light,
-/obj/structure/table,
-/obj/item/gps/spaceruin,
+/obj/machinery/atmospherics/components/unary/outlet_injector,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"cy" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
-"gR" = (
-/turf/closed/wall,
-/area/ruin/space/has_grav/gasthelizard)
-"gV" = (
+"dl" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/dropper,
@@ -43,7 +30,7 @@
 /obj/item/razor,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"ho" = (
+"gD" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -51,174 +38,47 @@
 	dir = 1
 	},
 /obj/structure/bed,
-/obj/effect/decal/remains/human,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/item/toy/plush/lizardplushie,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"hs" = (
-/obj/structure/table/reinforced,
-/obj/item/surgicaldrill,
-/obj/item/hemostat,
-/obj/item/scalpel,
-/obj/item/surgical_drapes,
-/obj/item/retractor,
-/obj/item/cautery,
-/obj/item/circular_saw,
-/obj/machinery/light,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"jE" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"ke" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/drone,
-/obj/item/melee/baton/cattleprod,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"kr" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"kE" = (
-/obj/structure/chair/office,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"ld" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/reagent_containers/syringe/lethal,
-/obj/item/reagent_containers/syringe/lethal/choral,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"lg" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"ll" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"lB" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"mp" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"oD" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"oR" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
-"oV" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"pb" = (
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"rv" = (
-/obj/machinery/gibber,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"ry" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"rW" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 5
+	dir = 8
 	},
+/obj/item/paper/crumpled,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"rY" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+"gS" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
-"sv" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
+"iS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"kN" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Worn-out APC";
+	pixel_x = 1;
+	pixel_y = 23
+	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/turf/open/floor/plasteel/airless/dark,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
-"sZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"uz" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/stack/sheet/animalhide/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"uH" = (
-/obj/machinery/door/airlock/security,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"vP" = (
+"lb" = (
 /obj/item/reagent_containers/glass/bottle/morphine{
 	pixel_x = -4;
 	pixel_y = 1
@@ -240,96 +100,93 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"wC" = (
+"nw" = (
+/turf/template_noop,
+/area/template_noop)
+"oM" = (
 /obj/structure/table,
-/obj/item/storage/box/prisoner,
+/obj/item/paper_bin,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
-"xw" = (
+"oZ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"pM" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"pW" = (
+/obj/structure/table/reinforced,
+/obj/item/surgicaldrill,
+/obj/item/hemostat,
+/obj/item/scalpel,
+/obj/item/surgical_drapes,
+/obj/item/retractor,
+/obj/item/cautery,
+/obj/item/circular_saw,
 /obj/machinery/light,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"Bx" = (
+"qZ" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"rG" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"BP" = (
-/obj/machinery/door/window/brigdoor/northleft,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"BQ" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"DH" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"Eh" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Worn-out APC";
-	pixel_x = 1;
-	pixel_y = 23
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"FX" = (
+"sh" = (
+/obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
-"Hn" = (
+"sA" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
-"JZ" = (
-/obj/structure/table/reinforced,
-/obj/item/kitchen/knife/butcher,
-/obj/item/restraints/handcuffs,
-/obj/item/reagent_containers/spray/pepper,
+"vk" = (
+/obj/structure/chair/office,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"vn" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/stack/sheet/animalhide/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"KC" = (
+"wy" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/gasthelizard)
+"wR" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
-"MX" = (
-/obj/structure/table,
-/obj/item/pen/red,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"Na" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"No" = (
+"xg" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -343,27 +200,50 @@
 	},
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"Oj" = (
+"xj" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"xQ" = (
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"zN" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
-"ON" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/gasthelizard)
-"OY" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/gasthelizard)
-"SE" = (
+"Ce" = (
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"Tb" = (
+"CR" = (
+/obj/structure/table/reinforced,
+/obj/item/kitchen/knife/butcher,
+/obj/item/restraints/handcuffs,
+/obj/item/reagent_containers/spray/pepper,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"Dj" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"Dk" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"DP" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/drone,
+/obj/item/melee/baton/cattleprod,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"Eh" = (
+/obj/machinery/gibber,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"EI" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -372,17 +252,90 @@
 	},
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"WB" = (
-/obj/structure/window/reinforced{
-	dir = 4
+"Fx" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/machinery/light{
+	dir = 1
 	},
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"Gg" = (
+/obj/structure/table,
+/obj/item/pen/red,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"Ha" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"WD" = (
+"Ht" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"HJ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed,
+/obj/effect/decal/remains/human,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"Il" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/table,
+/obj/item/gps/spaceruin,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"IE" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"JR" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"NL" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"PN" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -390,25 +343,56 @@
 	dir = 1
 	},
 /obj/structure/bed,
+/obj/effect/decal/remains/human,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/obj/item/paper/crumpled,
+/obj/item/toy/plush/lizardplushie,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"XX" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
+"Qf" = (
+/obj/machinery/door/airlock/security,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"Qh" = (
+/obj/machinery/door/window/brigdoor/northleft,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
 	},
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
-"YN" = (
+"Ra" = (
+/obj/structure/table,
+/obj/item/storage/box/prisoner,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"Rk" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"RL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"RW" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/reagent_containers/syringe/lethal,
+/obj/item/reagent_containers/syringe/lethal/choral,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"Se" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -421,308 +405,324 @@
 	},
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
+"Ts" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"UN" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/gasthelizard)
+"Xz" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/gasthelizard)
+"ZZ" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
 
 (1,1,1) = {"
-FX
-FX
-FX
-FX
-FX
-FX
-FX
-FX
-oR
-FX
-FX
-FX
-FX
-FX
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+sh
+nw
+nw
+nw
+nw
+nw
 "}
 (2,1,1) = {"
-FX
-FX
-FX
-oR
-oR
-oR
-oR
-FX
-oR
-oR
-oR
-FX
-FX
-FX
+nw
+nw
+nw
+sh
+sh
+sh
+sh
+nw
+sh
+sh
+sh
+nw
+nw
+nw
 "}
 (3,1,1) = {"
-FX
-FX
-FX
-oR
-oR
-gR
-gR
-gR
-gR
-gR
-gR
-gR
-oR
-FX
+nw
+nw
+nw
+sh
+sh
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+sh
+nw
 "}
 (4,1,1) = {"
-FX
-oR
-oR
-oR
-oR
-gR
-KC
-lB
-oV
-ke
-ai
-gR
-oR
-oR
+nw
+sh
+sh
+sh
+sh
+Xz
+wR
+Dj
+Rk
+DP
+ZZ
+Xz
+sh
+sh
 "}
 (5,1,1) = {"
-oR
-FX
-gR
-gR
-gR
-gR
-Eh
-BQ
-Na
-pb
-xw
-gR
-gR
-gR
+sh
+nw
+Xz
+Xz
+Xz
+Xz
+kN
+pM
+sA
+xQ
+Dk
+Xz
+Xz
+Xz
 "}
 (6,1,1) = {"
-FX
-oR
-gR
-dS
-Bx
-rY
-Hn
-pb
-pb
-pb
-pb
-ON
-eH
-OY
+nw
+sh
+Xz
+HJ
+iS
+NL
+IE
+xQ
+xQ
+xQ
+xQ
+UN
+wy
+aK
 "}
 (7,1,1) = {"
-oR
-oR
-gR
-Tb
-WB
-BP
-eS
-pb
-pb
-pb
-oD
-gR
-gR
-gR
+sh
+sh
+Xz
+EI
+bo
+Qh
+xj
+xQ
+xQ
+xQ
+Ts
+Xz
+Xz
+Xz
 "}
 (8,1,1) = {"
-FX
-oR
-gR
-ho
-jE
-rY
-Hn
-pb
-pb
-MX
-gR
-gR
-oR
-oR
+nw
+sh
+Xz
+PN
+rG
+NL
+IE
+xQ
+xQ
+Gg
+Xz
+Xz
+sh
+sh
 "}
 (9,1,1) = {"
-oR
-oR
-gR
-Tb
-WB
-BP
-eS
-pb
-kE
-DH
-gR
-oR
-oR
-FX
+sh
+sh
+Xz
+EI
+bo
+Qh
+xj
+xQ
+vk
+oM
+Xz
+sh
+sh
+nw
 "}
 (10,1,1) = {"
-FX
-FX
-gR
-WD
-jE
-rY
-Hn
-pb
-pb
-wC
-gR
-oR
-FX
-FX
+nw
+nw
+Xz
+gD
+rG
+NL
+IE
+xQ
+xQ
+Ra
+Xz
+sh
+nw
+nw
 "}
 (11,1,1) = {"
-oR
-oR
-gR
-rW
-YN
-BP
-eS
-pb
-pb
-gz
-gR
-oR
-FX
-FX
+sh
+sh
+Xz
+oZ
+Se
+Qh
+xj
+xQ
+xQ
+Il
+Xz
+sh
+nw
+nw
 "}
 (12,1,1) = {"
-oR
-FX
-gR
-No
-jE
-rY
-Hn
-pb
-pb
-ll
-gR
-oR
-FX
-FX
+sh
+nw
+Xz
+xg
+rG
+NL
+IE
+xQ
+xQ
+cy
+Xz
+sh
+nw
+nw
 "}
 (13,1,1) = {"
-FX
-oR
-gR
-sZ
-kr
-BP
-XX
-pb
-pb
-Oj
-gR
-oR
-FX
-FX
+nw
+sh
+Xz
+RL
+Ha
+Qh
+gS
+xQ
+xQ
+zN
+Xz
+sh
+nw
+nw
 "}
 (14,1,1) = {"
-FX
-oR
-gR
-gR
-gR
-gR
-gR
-gR
-uH
-gR
-gR
-oR
-FX
-FX
+nw
+sh
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Qf
+Xz
+Xz
+sh
+nw
+nw
 "}
 (15,1,1) = {"
-FX
-oR
-oR
-gR
-uz
-SE
-mp
-rv
-SE
-hs
-gR
-FX
-FX
-FX
+nw
+sh
+sh
+Xz
+vn
+Ce
+qZ
+Eh
+Ce
+pW
+Xz
+nw
+nw
+nw
 "}
 (16,1,1) = {"
-FX
-oR
-oR
-gR
-sv
-SE
-SE
-SE
-SE
-lg
-gR
-FX
-FX
-FX
+nw
+sh
+sh
+Xz
+Fx
+Ce
+Ce
+Ce
+Ce
+Ht
+Xz
+nw
+nw
+nw
 "}
 (17,1,1) = {"
-FX
-FX
-oR
-gR
-ry
-SE
-JZ
-ld
-vP
-gV
-gR
-oR
-oR
-FX
+nw
+nw
+sh
+Xz
+JR
+Ce
+CR
+RW
+lb
+dl
+Xz
+sh
+sh
+nw
 "}
 (18,1,1) = {"
-FX
-FX
-oR
-gR
-gR
-gR
-gR
-gR
-gR
-gR
-gR
-oR
-FX
-FX
+nw
+nw
+sh
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+sh
+nw
+nw
 "}
 (19,1,1) = {"
-FX
-FX
-FX
-FX
-oR
-oR
-FX
-FX
-oR
-oR
-oR
-FX
-FX
-FX
+nw
+nw
+nw
+nw
+sh
+sh
+nw
+nw
+sh
+sh
+sh
+nw
+nw
+nw
 "}

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -1,125 +1,152 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/template_noop,
-/area/template_noop)
-"b" = (
+"ai" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"dS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed,
+/obj/effect/decal/remains/human,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"eH" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/gasthelizard)
+"eS" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"gz" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/table,
+/obj/item/gps/spaceruin,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"gR" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/gasthelizard)
+"gV" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/item/razor,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"ho" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed,
+/obj/effect/decal/remains/human,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/toy/plush/lizardplushie,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"hs" = (
+/obj/structure/table/reinforced,
+/obj/item/surgicaldrill,
+/obj/item/hemostat,
+/obj/item/scalpel,
+/obj/item/surgical_drapes,
+/obj/item/retractor,
+/obj/item/cautery,
+/obj/item/circular_saw,
+/obj/machinery/light,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"jE" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"ke" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/drone,
+/obj/item/melee/baton/cattleprod,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"kr" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"kE" = (
+/obj/structure/chair/office,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"ld" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/reagent_containers/syringe/lethal,
+/obj/item/reagent_containers/syringe/lethal/choral,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"lg" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"ll" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"lB" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"mp" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"oD" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"oR" = (
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
-"c" = (
-/turf/closed/wall,
-/area/ruin/space/has_grav/gasthelizard)
-"d" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/bed,
-/obj/effect/decal/remains/human,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"e" = (
-/obj/structure/window/reinforced{
+"oV" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"pb" = (
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"rv" = (
+/obj/machinery/gibber,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"f" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/bed,
-/obj/effect/decal/remains/human,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"g" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/bed,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"h" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"i" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"j" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/outlet_injector,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"k" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"l" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"m" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/stack/sheet/animalhide/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"n" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"o" = (
+"ry" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/food/meat/slab/human/mutant/lizard,
 /obj/item/food/meat/slab/human/mutant/lizard,
@@ -131,7 +158,19 @@
 /obj/item/food/meat/slab/human/mutant/lizard,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"p" = (
+"rW" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"rY" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
@@ -144,124 +183,42 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
-"q" = (
-/obj/machinery/door/window/brigdoor/northleft,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"r" = (
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"s" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"t" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Worn-out APC";
-	pixel_x = 1;
-	pixel_y = 23
-	},
+"sv" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"u" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"v" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"w" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"x" = (
-/obj/structure/kitchenspike,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"y" = (
-/obj/structure/table/reinforced,
-/obj/item/kitchen/knife/butcher,
-/obj/item/restraints/handcuffs,
-/obj/item/reagent_containers/spray/pepper,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"z" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+"sZ" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"A" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"B" = (
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"C" = (
-/obj/machinery/gibber,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"D" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/reagent_containers/syringe/lethal,
-/obj/item/reagent_containers/syringe/lethal/choral,
+"uz" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/stack/sheet/animalhide/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"E" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"F" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"G" = (
-/obj/structure/chair/office,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"H" = (
+"uH" = (
 /obj/machinery/door/airlock/security,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"I" = (
+"vP" = (
 /obj/item/reagent_containers/glass/bottle/morphine{
 	pixel_x = -4;
 	pixel_y = 1
@@ -283,396 +240,489 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"J" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/drone,
-/obj/item/melee/baton/cattleprod,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"K" = (
-/obj/structure/table,
-/obj/item/pen/red,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"L" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"M" = (
+"wC" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
-"N" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+"xw" = (
 /obj/machinery/light,
-/obj/structure/table,
-/obj/item/gps/spaceruin,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
-"O" = (
-/obj/machinery/portable_atmospherics/scrubber,
+"Bx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"BP" = (
+/obj/machinery/door/window/brigdoor/northleft,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"BQ" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"DH" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"Eh" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Worn-out APC";
+	pixel_x = 1;
+	pixel_y = 23
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"FX" = (
+/turf/template_noop,
+/area/template_noop)
+"Hn" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"JZ" = (
+/obj/structure/table/reinforced,
+/obj/item/kitchen/knife/butcher,
+/obj/item/restraints/handcuffs,
+/obj/item/reagent_containers/spray/pepper,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"KC" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"MX" = (
+/obj/structure/table,
+/obj/item/pen/red,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"Na" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"No" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed,
+/obj/effect/decal/remains/human,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"Oj" = (
+/obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/gasthelizard)
-"P" = (
-/obj/structure/table/reinforced,
-/obj/item/surgicaldrill,
-/obj/item/hemostat,
-/obj/item/scalpel,
-/obj/item/surgical_drapes,
-/obj/item/retractor,
-/obj/item/cautery,
-/obj/item/circular_saw,
-/obj/machinery/light,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"Q" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"R" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/bottle/mutagen,
-/obj/item/reagent_containers/glass/bottle/mutagen,
-/obj/item/razor,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"S" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"T" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"U" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/gasthelizard)
-"V" = (
+"ON" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/gasthelizard)
-"W" = (
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/gasthelizard)
-"Z" = (
+"OY" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/gasthelizard)
+"SE" = (
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"Tb" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"WB" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"WD" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/item/paper/crumpled,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"XX" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/gasthelizard)
+"YN" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
 
 (1,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-b
-a
-a
-a
-a
-a
+FX
+FX
+FX
+FX
+FX
+FX
+FX
+FX
+oR
+FX
+FX
+FX
+FX
+FX
 "}
 (2,1,1) = {"
-a
-a
-a
-b
-b
-b
-b
-a
-b
-b
-b
-a
-a
-a
+FX
+FX
+FX
+oR
+oR
+oR
+oR
+FX
+oR
+oR
+oR
+FX
+FX
+FX
 "}
 (3,1,1) = {"
-a
-a
-a
-b
-b
-c
-c
-c
-c
-c
-c
-c
-b
-a
+FX
+FX
+FX
+oR
+oR
+gR
+gR
+gR
+gR
+gR
+gR
+gR
+oR
+FX
 "}
 (4,1,1) = {"
-a
-b
-b
-b
-b
-c
-s
-z
-E
-J
-S
-c
-b
-b
+FX
+oR
+oR
+oR
+oR
+gR
+KC
+lB
+oV
+ke
+ai
+gR
+oR
+oR
 "}
 (5,1,1) = {"
-b
-a
-c
-c
-c
-c
-t
-A
-F
-B
-T
-c
-c
-c
+oR
+FX
+gR
+gR
+gR
+gR
+Eh
+BQ
+Na
+pb
+xw
+gR
+gR
+gR
 "}
 (6,1,1) = {"
-a
-b
-c
-d
-i
-p
-u
-B
-B
-B
-B
-V
-W
-Z
+FX
+oR
+gR
+dS
+Bx
+rY
+Hn
+pb
+pb
+pb
+pb
+ON
+eH
+OY
 "}
 (7,1,1) = {"
-b
-b
-c
-e
-j
-q
-v
-B
-B
-B
-U
-c
-c
-c
+oR
+oR
+gR
+Tb
+WB
+BP
+eS
+pb
+pb
+pb
+oD
+gR
+gR
+gR
 "}
 (8,1,1) = {"
-a
-b
-c
-f
-k
-p
-u
-B
-B
-K
-c
-c
-b
-b
+FX
+oR
+gR
+ho
+jE
+rY
+Hn
+pb
+pb
+MX
+gR
+gR
+oR
+oR
 "}
 (9,1,1) = {"
-b
-b
-c
-e
-j
-q
-v
-B
-G
-L
-c
-b
-b
-a
+oR
+oR
+gR
+Tb
+WB
+BP
+eS
+pb
+kE
+DH
+gR
+oR
+oR
+FX
 "}
 (10,1,1) = {"
-a
-a
-c
-g
-k
-p
-u
-B
-B
-M
-c
-b
-a
-a
+FX
+FX
+gR
+WD
+jE
+rY
+Hn
+pb
+pb
+wC
+gR
+oR
+FX
+FX
 "}
 (11,1,1) = {"
-b
-b
-c
-e
-j
-q
-v
-B
-B
-N
-c
-b
-a
-a
+oR
+oR
+gR
+rW
+YN
+BP
+eS
+pb
+pb
+gz
+gR
+oR
+FX
+FX
 "}
 (12,1,1) = {"
-b
-a
-c
-f
-k
-p
-u
-B
-B
-O
-c
-b
-a
-a
+oR
+FX
+gR
+No
+jE
+rY
+Hn
+pb
+pb
+ll
+gR
+oR
+FX
+FX
 "}
 (13,1,1) = {"
-a
-b
-c
-h
-l
-q
-w
-B
-B
-O
-c
-b
-a
-a
+FX
+oR
+gR
+sZ
+kr
+BP
+XX
+pb
+pb
+Oj
+gR
+oR
+FX
+FX
 "}
 (14,1,1) = {"
-a
-b
-c
-c
-c
-c
-c
-c
-H
-c
-c
-b
-a
-a
+FX
+oR
+gR
+gR
+gR
+gR
+gR
+gR
+uH
+gR
+gR
+oR
+FX
+FX
 "}
 (15,1,1) = {"
-a
-b
-b
-c
-m
-r
-x
-C
-r
-P
-c
-a
-a
-a
+FX
+oR
+oR
+gR
+uz
+SE
+mp
+rv
+SE
+hs
+gR
+FX
+FX
+FX
 "}
 (16,1,1) = {"
-a
-b
-b
-c
-n
-r
-r
-r
-r
-Q
-c
-a
-a
-a
+FX
+oR
+oR
+gR
+sv
+SE
+SE
+SE
+SE
+lg
+gR
+FX
+FX
+FX
 "}
 (17,1,1) = {"
-a
-a
-b
-c
-o
-r
-y
-D
-I
-R
-c
-b
-b
-a
+FX
+FX
+oR
+gR
+ry
+SE
+JZ
+ld
+vP
+gV
+gR
+oR
+oR
+FX
 "}
 (18,1,1) = {"
-a
-a
-b
-c
-c
-c
-c
-c
-c
-c
-c
-b
-a
-a
+FX
+FX
+oR
+gR
+gR
+gR
+gR
+gR
+gR
+gR
+gR
+oR
+FX
+FX
 "}
 (19,1,1) = {"
-a
-a
-a
-a
-b
-b
-a
-a
-b
-b
-b
-a
-a
-a
+FX
+FX
+FX
+FX
+oR
+oR
+FX
+FX
+oR
+oR
+oR
+FX
+FX
+FX
 "}

--- a/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
@@ -98,6 +98,19 @@
 	},
 /turf/open/floor/grass,
 /area/ruin/space/has_grav)
+"D" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/item/clothing/mask/gondola,
+/turf/open/floor/grass,
+/area/ruin/space/has_grav)
+"F" = (
+/obj/item/toy/plush/snakeplushie,
+/turf/open/floor/grass,
+/area/ruin/space/has_grav)
+"Y" = (
+/obj/item/clothing/under/costume/gondola,
+/turf/open/floor/grass,
+/area/ruin/space/has_grav)
 
 (1,1,1) = {"
 a
@@ -384,7 +397,7 @@ d
 d
 d
 d
-d
+Y
 j
 d
 d
@@ -713,7 +726,7 @@ b
 d
 f
 n
-d
+F
 d
 d
 d
@@ -1183,7 +1196,7 @@ d
 e
 g
 d
-i
+D
 d
 d
 d

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -876,11 +876,11 @@
 "cI" = (
 /obj/structure/safe/floor,
 /obj/item/tank/internals/oxygen/red,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/suit/space/eva,
 /obj/item/reagent_containers/food/drinks/bottle/rum,
 /obj/item/reagent_containers/food/drinks/bottle/rum,
 /obj/item/folder/syndicate/mining,
+/obj/item/clothing/suit/space/hardsuit/syndi,
+/obj/item/clothing/mask/gas/syndicate,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/onehalf/bridge)
 "cJ" = (

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -462,6 +462,7 @@
 /obj/structure/mirror{
 	pixel_x = 32
 	},
+/obj/item/bikehorn/rubberducky,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ruin/space/has_grav/hotel/guestroom/room_4)
 "bT" = (
@@ -580,6 +581,7 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
 "cj" = (
 /obj/structure/table/wood,
+/obj/item/toy/plush/beeplushie,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
 "ck" = (
@@ -1057,6 +1059,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/toy/crayon/spraycan,
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/hotel/workroom)
 "dE" = (
@@ -1319,6 +1322,7 @@
 "eC" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
+/obj/item/clothing/head/ushanka,
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/hotel/workroom)
 "eD" = (
@@ -1659,6 +1663,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/mirror/magic/lesser,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel)
 "fJ" = (
@@ -1702,6 +1707,9 @@
 	dir = 4;
 	pixel_x = -12;
 	pixel_y = 2
+	},
+/mob/living/simple_animal/hostile/retaliate/goat{
+	name = "Gete"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/hotel/bar)
@@ -1918,6 +1926,7 @@
 	dir = 1;
 	layer = 2.9
 	},
+/obj/item/paper_bin,
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/hotel/dock)
 "gv" = (
@@ -1930,7 +1939,9 @@
 	layer = 2.9
 	},
 /obj/item/gps/spaceruin{
-	name = "hotel gps"
+	name = "hotel gps";
+	pixel_x = 3;
+	pixel_y = 3
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/hotel/dock)
@@ -2040,6 +2051,10 @@
 /area/ruin/space/has_grav/hotel/dock)
 "gP" = (
 /obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = -7;
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/hotel/dock)
 "gQ" = (
@@ -2106,6 +2121,9 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
+	},
+/obj/item/candle/infinite{
+	pixel_y = 10
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/bar)
@@ -2237,6 +2255,7 @@
 /area/ruin/space/has_grav/hotel/dock)
 "hs" = (
 /obj/structure/table/wood,
+/obj/item/newspaper,
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/hotel/dock)
 "ht" = (
@@ -2319,7 +2338,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/hotel/workroom)
 "hB" = (
-/obj/structure/mirror{
+/obj/structure/mirror/magic/lesser{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark,
@@ -2392,6 +2411,7 @@
 "hM" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced,
+/obj/item/paper_bin,
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/hotel/dock)
 "hN" = (
@@ -2956,6 +2976,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/spawner/lootdrop/maint_drugs,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "jt" = (
@@ -3126,6 +3147,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/item/paper/crumpled/bloody,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/hotel/security)
 "jN" = (
@@ -3485,6 +3507,7 @@
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/bot_assembly/secbot,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/security)
 "kM" = (
@@ -4468,6 +4491,7 @@
 "mM" = (
 /obj/machinery/light,
 /obj/structure/table,
+/obj/item/reagent_containers/spray/spraytan,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)
 "mN" = (
@@ -4495,6 +4519,14 @@
 /obj/effect/baseturf_helper/space,
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel/pool)
+"se" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/space/has_grav/hotel/dock)
 "sN" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -4503,6 +4535,39 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/power)
+"Gy" = (
+/obj/structure/table,
+/obj/item/reagent_containers/spray/spraytan,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/hotel/pool)
+"Ie" = (
+/obj/structure/table,
+/obj/item/food/cherrycupcake/blue,
+/obj/item/food/cherrycupcake{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/space/has_grav/hotel/bar)
+"Mf" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/paperplane,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/hotel/security)
+"QZ" = (
+/obj/item/food/canned/peaches/maint,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel)
 
 (1,1,1) = {"
 aa
@@ -5218,7 +5283,7 @@ ab
 aa
 af
 am
-aw
+QZ
 aw
 aw
 aw
@@ -5867,7 +5932,7 @@ fi
 fx
 fx
 gb
-gp
+Ie
 gD
 gV
 fx
@@ -6095,7 +6160,7 @@ kn
 kO
 le
 jG
-jM
+Mf
 kn
 kn
 kO
@@ -7085,7 +7150,7 @@ lj
 kD
 kD
 jR
-ll
+Gy
 jQ
 ac
 ac
@@ -7761,7 +7826,7 @@ gv
 gP
 hc
 hc
-gP
+se
 hN
 fu
 in
@@ -7983,7 +8048,7 @@ jR
 jR
 jR
 kU
-ll
+Gy
 lt
 ll
 jR

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -1663,7 +1663,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/mirror/magic/lesser,
+/obj/structure/mirror,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel)
 "fJ" = (

--- a/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -323,6 +323,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/storage/belt/military,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/turretedoutpost)
 "aX" = (
@@ -358,6 +359,27 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/turretedoutpost)
+"eH" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/shield/riot,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/turretedoutpost)
+"lI" = (
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/obj/item/toy/plush/nukeplushie,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/turretedoutpost)
 "tK" = (
@@ -512,7 +534,7 @@ ad
 at
 az
 aG
-aG
+eH
 az
 aX
 ad
@@ -772,7 +794,7 @@ ad
 al
 ad
 aK
-aP
+lI
 aP
 aP
 ad

--- a/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
+++ b/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
@@ -85,6 +85,10 @@
 /obj/item/clothing/glasses/sunglasses/big{
 	name = "aesthetic sunglasses"
 	},
+/obj/item/toy/plush/pkplush{
+	pixel_x = 4;
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel/vaporwave,
 /area/ruin/space/has_grav/powered/aesthetic)
 "t" = (

--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
@@ -39,8 +39,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/whiteship/box)
 "hT" = (
-/obj/structure/frame/computer{
-	anchored = 1;
+/obj/machinery/computer/operating{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
@@ -153,8 +152,7 @@
 /area/ruin/space/has_grav/whiteship/box)
 "sX" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/suit/space/hardsuit/medical,
 /obj/item/clothing/mask/breath,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
@@ -163,6 +161,10 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"ya" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/whiteship/box)
 "zY" = (
 /obj/machinery/door/poddoor{
@@ -204,6 +206,11 @@
 	charge = 100;
 	maxcharge = 15000
 	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"DK" = (
+/obj/structure/table,
+/obj/item/toy/plush/carpplushie,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
 "Gj" = (
@@ -287,6 +294,10 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"VS" = (
+/obj/item/bot_assembly/floorbot,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/whiteship/box)
 "Xp" = (
 /obj/structure/shuttle/engine/propulsion/left{
@@ -677,7 +688,7 @@ kK
 nH
 kK
 az
-Vt
+VS
 Vt
 az
 kK
@@ -691,7 +702,7 @@ az
 kK
 az
 Vt
-Vt
+ya
 az
 kK
 nH
@@ -701,7 +712,7 @@ nH
 nH
 kK
 az
-Vt
+ya
 bN
 kK
 pv
@@ -1053,7 +1064,7 @@ pv
 pv
 gc
 Ay
-gc
+DK
 pv
 pv
 pv

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -139,7 +139,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/suit_storage_unit/cmo,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
 "ar" = (
@@ -1934,7 +1934,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/suit_storage_unit/cmo,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/medbay)
 "dq" = (

--- a/_maps/shuttles/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship_cere.dmm
@@ -403,6 +403,20 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
+"vh" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/mask/cigarette,
+/obj/item/storage/fancy/cigarettes{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/lighter/greyscale{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/abandoned)
 "We" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -495,7 +509,7 @@ aG
 aJ
 ab
 aP
-aU
+vh
 aS
 ab
 ab

--- a/_maps/shuttles/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship_pubby.dmm
@@ -37,8 +37,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/table/glass,
 /obj/item/gun/medbeam,
+/obj/structure/table/abductor,
 /turf/open/floor/plating/abductor,
 /area/shuttle/abandoned)
 "i" = (
@@ -53,7 +53,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/table/glass,
+/obj/structure/table/abductor,
 /obj/machinery/recharger,
 /obj/item/gun/energy/laser/retro,
 /turf/open/floor/plating/abductor,
@@ -71,6 +71,7 @@
 /turf/open/floor/plating/abductor,
 /area/shuttle/abandoned)
 "m" = (
+/obj/item/gps/spaceruin,
 /turf/open/floor/plating/abductor,
 /area/shuttle/abandoned)
 "n" = (
@@ -100,11 +101,10 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/structure/table/glass,
+/obj/structure/table/abductor,
 /obj/item/tank/internals/oxygen,
 /obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/suit/space/hardsuit/engine/elite,
 /turf/open/floor/plating/abductor,
 /area/shuttle/abandoned)
 "q" = (
@@ -118,7 +118,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/structure/table/glass,
+/obj/structure/table/abductor,
 /obj/item/clothing/shoes/magboots,
 /turf/open/floor/plating/abductor,
 /area/shuttle/abandoned)

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -81,7 +81,8 @@
 	retreat_distance = 5
 	minimum_distance = 5
 	projectiletype = /obj/projectile/beam/laser
-	loot = list(/obj/effect/mob_spawn/human/corpse/pirate/ranged)
+	loot = list(/obj/effect/mob_spawn/human/corpse/pirate/ranged,
+			/obj/item/gun/energy/laser)
 
 /mob/living/simple_animal/hostile/pirate/ranged/space
 	name = "Space Pirate Gunner"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Rebalances all previously changed space loot from ruins as well as migrates plushies and some ruins gain a small bit of implied story
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
due to[ PR 981 ](https://github.com/Skyrat-SS13/Skyrat-tg/pull/981)space has become an entirely tedious and barely rewarding place with no place to even upgrade your things, no hardsuits or rewards for beating large combat oriented ruins such as the trade route, the only place to even aquire a weapon in space to fight the more combat oriented ruins currently is at the crashed ship by beating a turret to death in which you get a no-pin cannon. and as per some requests some more light story elements were added to the ruins, and of course the plushies that many love, and if the random spawn is ported ill update this with such. however the main point of this pr is to fix the loot changes that were overnerfed during pr 981 of october
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
🆑/
add: replaces all of the eva suits across every ruin with their previous two piece color counterpart in the derelict or their previous hardsuit equivalent
balance: makes pirates drop their weapons again to allow the trade route to be completed without additional aid from foreign firepower
add: re-adds all previous ballistic weapons to the trade route
add: plushies have migrated across the space ruins making one of each plushie have its home in a selected ruin fitting its theme
add: adds blood and a paper to the gas ruin
add: adds a honkbot to the clown champion planet -HONK-
add: gives the gondola asteroid a suit and mask (no more slaughtering gondolas for a costume.... unless?)
add: gives the receptionists at the space hotel some coffee and tea aswell as a paper and pen to check people into the hotel with
add: makes the hotel a little more romantic with some candles for its tables
add: due to complaints the hotel security is reinforced with a secbot assembly, seems the hotel doesn't cover the full cost of a bot
add: adds spraytan for thoose in the hotel wishing to get darker skin without bathing in the stars radiation
add: re-adds the turreted outposts chest rig and shield
add: re-adds the wt-rifle to deep storage's armory with its previous mags
add: syndicates deserve bedsheets too, gives some sheets to the turreted outposts and a plushie for the softies among them
add: gives the whiteship_box a floorbot
add: makes ceres whiteship fir its previous abductor theme with some tables and a returned suit
add: makes the space bus more modern with some cigarettes and paper strewn about, damn kids even rusted away a good toolbox into an old one
add: the previous occupants of the crashed_ship gained one new appropriately placed gibbed human
add: replaces a useless snipermag in the emptyshell with an equally but slightly less so useless syndicate cosmetic loot drop
add: adds a lesser magic mirror to the space hotel for those wishing for some more rp potential with it
add: the space hotel has become the space goatel without people as a new goat joins the kitchen, welcome gete to the party and dont feed him too much trash or corprate will get mad again
remove: removes all previous loot changes by pull request 281 regarding non-pool items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
