### PR TITLE
[Non-Modular] Rebalances previous SM anom PR

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1105,8 +1105,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/turf/L = pick(orange(anomalyrange, anomalycenter))
 	// BEGIN SKYRAT CHANGE - High Energy Anomaly Core Generation
 	var/drops_core = FALSE
-	// Every 250 EER above POWER_PENALTY_THRESHOLD adds 10% chance for the anomalies to leave behind a core when neutralized
-	var/chance_bonus = clamp((10 * (power - POWER_PENALTY_THRESHOLD) / 250), 0, 95)
+	// Every 334 EER above POWER_PENALTY_THRESHOLD adds 10% chance for the anomalies to leave behind a core when neutralized
+	var/chance_bonus = clamp((10 * (power - POWER_PENALTY_THRESHOLD) / 334), 0, 95)
 	if(prob(25 + round(chance_bonus))) // 25% base chance to drop a core
 		drops_core = TRUE
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1105,9 +1105,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/turf/L = pick(orange(anomalyrange, anomalycenter))
 	// BEGIN SKYRAT CHANGE - High Energy Anomaly Core Generation
 	var/drops_core = FALSE
-	// Every 334 EER above POWER_PENALTY_THRESHOLD adds 10% chance for the anomalies to leave behind a core when neutralized
-	var/chance_bonus = clamp((10 * (power - POWER_PENALTY_THRESHOLD) / 334), 0, 95)
-	if(prob(5 + round(chance_bonus))) // 5% base chance to drop a core
+	// Every 250 EER above POWER_PENALTY_THRESHOLD adds 10% chance for the anomalies to leave behind a core when neutralized
+	var/chance_bonus = clamp((10 * (power - POWER_PENALTY_THRESHOLD) / 250), 0, 95)
+	if(prob(25 + round(chance_bonus))) // 25% base chance to drop a core
 		drops_core = TRUE
 
 	if(L)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I previously re-enabled the SM spawning core-dropping anomalies but gave it a low chance to do so. This PR rebalances the base drop rate.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I've seen people run high EER supermatters a few times now to spawn the anoms, and did it myself a few times too, and the drop rate was *way* too low. Especially compared to the danger involved, /tg/ anomalies are pretty lethal turns out. At the current numbers and with some testing, it seemed a lot more fair to do.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Increased the base chance for a supermatter to spawn anomaly-core dropping anomalies to 25%. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
