### PR TITLE
[Non-Modular] Directional meteor waves

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -23,16 +23,27 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 //Meteor spawning global procs
 ///////////////////////////////
 
-/proc/spawn_meteors(number = 10, list/meteortypes, dir) // SKYRAT EDIT - Directional Meteors
+/* SKYRAT EDIT ORIGINAL
+/proc/spawn_meteors(number = 10, list/meteortypes)
 	for(var/i = 0; i < number; i++)
-		spawn_meteor(meteortypes, dir) // SKYRAT EDIT - Directional Meteors
+		spawn_meteor(meteortypes)
+*/
 
-/proc/spawn_meteor(list/meteortypes, dir) // SKYRAT EDIT - Directional Meteors
+// SKYRAT EDIT CHANGE - Directional Meteors
+/proc/spawn_meteors(number = 10, list/meteortypes, dir)
+	for(var/i = 0; i < number; i++)
+		spawn_meteor(meteortypes, dir)
+// SKYRAT EDIT END
+
+
+// proc/spawn_meteor(list/meteortypes) // ORIGINAL
+/proc/spawn_meteor(list/meteortypes, dir) // SKYRAT EDIT CHANGE - Directional Meteors
 	var/turf/pickedstart
 	var/turf/pickedgoal
 	var/max_i = 10//number of tries to spawn meteor.
 	while(!isspaceturf(pickedstart))
-		var/startSide = dir || pick(GLOB.cardinals) // SKYRAT EDIT - Directional Meteors
+		//var/startSide = pick(GLOB.cardinals) // ORIGINAL
+		var/startSide = dir || pick(GLOB.cardinals) // SKYRAT EDIT CHANGE - Directional Meteors
 		var/startZ = pick(SSmapping.levels_by_trait(ZTRAIT_STATION))
 		pickedstart = spaceDebrisStartLoc(startSide, startZ)
 		pickedgoal = spaceDebrisFinishLoc(startSide, startZ)

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 
 /proc/spawn_meteors(number = 10, list/meteortypes, dir) // SKYRAT EDIT - Directional Meteors
 	for(var/i = 0; i < number; i++)
-		spawn_meteor(meteortypes, dir)
+		spawn_meteor(meteortypes, dir) // SKYRAT EDIT - Directional Meteors
 
 /proc/spawn_meteor(list/meteortypes, dir) // SKYRAT EDIT - Directional Meteors
 	var/turf/pickedstart

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -23,16 +23,16 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 //Meteor spawning global procs
 ///////////////////////////////
 
-/proc/spawn_meteors(number = 10, list/meteortypes)
+/proc/spawn_meteors(number = 10, list/meteortypes, dir) // SKYRAT EDIT - Directional Meteors
 	for(var/i = 0; i < number; i++)
-		spawn_meteor(meteortypes)
+		spawn_meteor(meteortypes, dir)
 
-/proc/spawn_meteor(list/meteortypes)
+/proc/spawn_meteor(list/meteortypes, dir) // SKYRAT EDIT - Directional Meteors
 	var/turf/pickedstart
 	var/turf/pickedgoal
 	var/max_i = 10//number of tries to spawn meteor.
 	while(!isspaceturf(pickedstart))
-		var/startSide = pick(GLOB.cardinals)
+		var/startSide = dir || pick(GLOB.cardinals) // SKYRAT EDIT - Directional Meteors
 		var/startZ = pick(SSmapping.levels_by_trait(ZTRAIT_STATION))
 		pickedstart = spaceDebrisStartLoc(startSide, startZ)
 		pickedgoal = spaceDebrisFinishLoc(startSide, startZ)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -854,7 +854,7 @@
 	name = "Shield Generator Satellite"
 	desc = "Protect the very existence of this station with these Anti-Meteor defenses. Contains three Shield Generator Satellites."
 	cost = CARGO_CRATE_VALUE * 6
-	special = TRUE
+	// special = TRUE 			// SKYRAT EDIT - Shield sats always available
 	access_view = ACCESS_HEADS
 	contains = list(
 					/obj/machinery/satellite/meteor_shield,
@@ -868,7 +868,7 @@
 	name = "Shield System Control Board"
 	desc = "A control system for the Shield Generator Satellite system."
 	cost = CARGO_CRATE_VALUE * 10
-	special = TRUE
+	// special = TRUE 			// SKYRAT EDIT - Shield sats always available
 	access_view = ACCESS_HEADS
 	contains = list(/obj/item/circuitboard/computer/sat_control)
 	crate_name= "shield control board crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -853,8 +853,8 @@
 /datum/supply_pack/engineering/shield_sat
 	name = "Shield Generator Satellite"
 	desc = "Protect the very existence of this station with these Anti-Meteor defenses. Contains three Shield Generator Satellites."
-	cost = CARGO_CRATE_VALUE * 6
-	// special = TRUE 			// SKYRAT EDIT - Shield sats always available
+	cost = CARGO_CRATE_VALUE * 50 	// SKYRAT EDIT - 10k for shield sat crate
+	// special = TRUE 				// SKYRAT EDIT - Shield sats always available
 	access_view = ACCESS_HEADS
 	contains = list(
 					/obj/machinery/satellite/meteor_shield,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -853,8 +853,9 @@
 /datum/supply_pack/engineering/shield_sat
 	name = "Shield Generator Satellite"
 	desc = "Protect the very existence of this station with these Anti-Meteor defenses. Contains three Shield Generator Satellites."
-	cost = CARGO_CRATE_VALUE * 50 	// SKYRAT EDIT - 10k for shield sat crate
-	// special = TRUE 				// SKYRAT EDIT - Shield sats always available
+	// cost = CARGO_CRATE_VALUE * 6	// SKYRAT EDIT ORIGINAL
+	// special = TRUE				// SKYRAT EDIT REMOVAL - Always available shield sats
+	cost = CARGO_CRATE_VALUE * 30 	// SKYRAT EDIT - 6k for shield sat crate
 	access_view = ACCESS_HEADS
 	contains = list(
 					/obj/machinery/satellite/meteor_shield,
@@ -868,7 +869,7 @@
 	name = "Shield System Control Board"
 	desc = "A control system for the Shield Generator Satellite system."
 	cost = CARGO_CRATE_VALUE * 10
-	// special = TRUE 			// SKYRAT EDIT - Shield sats always available
+	// special = TRUE 			// SKYRAT EDIT REMOVAL - Shield sats always available
 	access_view = ACCESS_HEADS
 	contains = list(/obj/item/circuitboard/computer/sat_control)
 	crate_name= "shield control board crate"

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -14,7 +14,7 @@
 	announceWhen	= 1
 	var/list/wave_type
 	var/wave_name = "normal"
-	var/direction // SKYRAT EDIT - Directional Meteors
+	var/direction // SKYRAT EDIT ADDITION - Directional Meteors
 
 /datum/round_event/meteor_wave/New()
 	..()
@@ -22,7 +22,7 @@
 		determine_wave_type()
 
 /datum/round_event/meteor_wave/proc/determine_wave_type()
-	direction = pick(GLOB.cardinals) // SKYRAT EDIT - Directional Meteors
+	direction = pick(GLOB.cardinals) // SKYRAT EDIT ADDITION - Directional Meteors
 	if(!wave_name)
 		wave_name = pickweight(list(
 			"normal" = 50,
@@ -49,12 +49,13 @@
 			kill()
 
 /datum/round_event/meteor_wave/announce(fake)
-	//priority_announce("Meteors have been detected on collision course with the station.", "Meteor Alert", 'sound/ai/meteors.ogg') //ORIGINAL
-	priority_announce(generateMeteorString(startWhen,direction), "Meteor Alert", 'sound/ai/meteors.ogg') // SKYRAT EDIT - Directional Meteors
+	//priority_announce("Meteors have been detected on collision course with the station.", "Meteor Alert", 'sound/ai/meteors.ogg') // ORIGINAL
+	priority_announce(generateMeteorString(startWhen,direction), "Meteor Alert", 'sound/ai/meteors.ogg') // SKYRAT EDIT CHANGE - Directional Meteors
 
 /datum/round_event/meteor_wave/tick()
 	if(ISMULTIPLE(activeFor, 3))
-		spawn_meteors(5, wave_type, direction) //meteor list types defined in gamemode/meteor/meteors.dm
+		//spawn_meteors(5, wave_type) //meteor list types defined in gamemode/meteor/meteors.dm // ORIGINAL
+		spawn_meteors(5, wave_type, direction) // SKYRAT EDIT CHANGE - Directional Meteors
 
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -14,7 +14,7 @@
 	announceWhen	= 1
 	var/list/wave_type
 	var/wave_name = "normal"
-	var/direction // SKYRAT EDIT - DIRECTION
+	var/direction // SKYRAT EDIT - Directional Meteors
 
 /datum/round_event/meteor_wave/New()
 	..()
@@ -22,7 +22,7 @@
 		determine_wave_type()
 
 /datum/round_event/meteor_wave/proc/determine_wave_type()
-	direction = pick(GLOB.cardinals)
+	direction = pick(GLOB.cardinals) // SKYRAT EDIT - Directional Meteors
 	if(!wave_name)
 		wave_name = pickweight(list(
 			"normal" = 50,
@@ -93,4 +93,4 @@
 		if(WEST)
 			directionstring = " towards port"
 	return "Meteors have been detected on a collision course with the station[directionstring]. Estimated time until impact: [round((startWhen * SSevents.wait) / 10, 0.1)] seconds."
-// SKYRAT EDIT END
+// SKYRAT EDIT ADDITION END

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -14,6 +14,7 @@
 	announceWhen	= 1
 	var/list/wave_type
 	var/wave_name = "normal"
+	var/direction // SKYRAT EDIT - DIRECTION
 
 /datum/round_event/meteor_wave/New()
 	..()
@@ -21,6 +22,7 @@
 		determine_wave_type()
 
 /datum/round_event/meteor_wave/proc/determine_wave_type()
+	direction = pick(GLOB.cardinals)
 	if(!wave_name)
 		wave_name = pickweight(list(
 			"normal" = 50,
@@ -48,11 +50,11 @@
 
 /datum/round_event/meteor_wave/announce(fake)
 	//priority_announce("Meteors have been detected on collision course with the station.", "Meteor Alert", 'sound/ai/meteors.ogg') //ORIGINAL
-	priority_announce("Meteors have been detected on collision course with the station. Estimated time until impact: [round((startWhen * SSevents.wait) / 10, 0.1)] seconds.", "Meteor Alert", 'sound/ai/meteors.ogg') //ORIGINAL
+	priority_announce(generateMeteorString(startWhen,direction), "Meteor Alert", 'sound/ai/meteors.ogg') // SKYRAT EDIT - Directional Meteors
 
 /datum/round_event/meteor_wave/tick()
 	if(ISMULTIPLE(activeFor, 3))
-		spawn_meteors(5, wave_type) //meteor list types defined in gamemode/meteor/meteors.dm
+		spawn_meteors(5, wave_type, direction) //meteor list types defined in gamemode/meteor/meteors.dm
 
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"
@@ -77,3 +79,18 @@
 
 /datum/round_event/meteor_wave/catastrophic
 	wave_name = "catastrophic"
+
+// SKYRAT EDIT ADDITION BEGIN - Directional Meteor Waves
+/proc/generateMeteorString(startWhen,direction)
+	var/directionstring
+	switch(direction)
+		if(NORTH)
+			directionstring = " towards the fore"
+		if(SOUTH)
+			directionstring = " towards the aft"
+		if(EAST)
+			directionstring = " towards starboard"
+		if(WEST)
+			directionstring = " towards port"
+	return "Meteors have been detected on a collision course with the station[directionstring]. Estimated time until impact: [round((startWhen * SSevents.wait) / 10, 0.1)] seconds."
+// SKYRAT EDIT END

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -12,14 +12,16 @@
 		You can order the satellites and control systems at cargo.
 		"}
 
-
+/* SKYRAT EDIT - Shield Sats always available
 /datum/station_goal/station_shield/on_report()
+
 	//Unlock
 	var/datum/supply_pack/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shield_sat]
 	P.special_enabled = TRUE
 
 	P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shield_sat_control]
 	P.special_enabled = TRUE
+*/
 
 /datum/station_goal/station_shield/check_completion()
 	if(..())

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -12,7 +12,7 @@
 		You can order the satellites and control systems at cargo.
 		"}
 
-/* SKYRAT EDIT - Shield Sats always available
+/* SKYRAT EDIT REMOVAL - Shield Sats always available
 /datum/station_goal/station_shield/on_report()
 
 	//Unlock


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just like how it was on the old codebase, meteor waves now have a specified direction they spawn the asteroids in.

Additionally, meteor shield sat crates are always available at cargo.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This allows engineers to know where the threat is coming from to prepare, and allows them to actually buy shield sats again when the station goal isn't there.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The cost of meteor shield sat crates has been increased to 10k
tweak: Meteor shield sat crates are available to purchase from cargo at all times now.
tweak: The meteor wave event only barrages the station from a certain cardinal direction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
