### PR TITLE
changes available scientist slots from 5 to 4

### DIFF
--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -38,7 +38,7 @@ Geneticist=2,2
 Virologist=1,1
 Psychologist=1,1
 
-Scientist=5,3
+Scientist=4,3
 Roboticist=2,2
 
 Warden=1,1


### PR DESCRIPTION
exactly what it says on the tin.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

one single number change in config/jobs.txt :^)

## Why It's Good For The Game

Medical has five job slots for MD. Why? Because it usually takes five doctors to manage the steady flow of injured and dead generated by the local traitors, changelings, assault ops, or otherwise.

Engineering has five job slots for engineer. Why? Because it usually takes five engineers to manage the steady flow of holes poked in the station by the same guys.

By contrast, here is a list of _everything_ available for scientists to do in science, with the number of people that can do the things per shift parenthesized:

- Desk + research (1)
- Xenobio (max 2, [if they can cooperate](https://tgstation13.org/wiki/Byond_the_impossible) or if one is teaching the other)
- Nanites (takes about 1hr 20m out of a full 2+ hour shift - requires an average of 2/3 of a job slot per shift)
- Parts run (_should_ 👀 take about 30m to finish from roundstart, assuming mining does their job - average of 1/4 of a job slot per shift)
- Toxins (takes about 20m - average of 1/6 of a job slot per shift)

Left out cytology because it's incomplete and no one does it except as a single-shift curiosity.
Total scientists required: average just over 4, assuming there's no RD. Currently, if science is fully staffed (1 rd, 5 sci, 2 robo, 2 gene), the best case scenario is that the map is one that has three genetics consoles and one scientist transfers there.

## Changelog
:cl:
tweak: Removed a scientist job slot, because science doesn't currently have enough work for all of them to do
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
