### PR TITLE
[TM FIRST] Wounds are applied easier on damaged bodyparts

### DIFF
--- a/code/__DEFINES/~skyrat_defines/medical_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/medical_defines.dm
@@ -1,3 +1,8 @@
+//Deterministic bonus for bodypart wounding:
+#define DAMAGED_BODYPART_BONUS_WOUNDING_BONUS 30 //After this threshold we dont get any wounding bonuses form damaged bodyparts
+#define DAMAGED_BODYPART_BONUS_WOUNDING_THRESHOLD 0.5 //How much extra % of wounding dmg we'll have if a bodypart is damaged enough
+#define DAMAGED_BODYPART_BONUS_WOUNDING_COEFF 15 //This is multiplied by the sustained damage %. Keep in mind the % limit //Currently: 15/0.5=7.5
+
 #define GAUZE_STAIN_BLOOD 1
 #define GAUZE_STAIN_PUS 2
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -306,10 +306,13 @@
 	// now we have our wounding_type and are ready to carry on with wounds and dealing the actual damage
 	if(owner && wounding_dmg >= WOUND_MINIMUM_DAMAGE && wound_bonus != CANT_WOUND)
 		//SKYRAT EDIT ADDITION - MEDICAL
-		//This makes it so the more damaged bodyparts are, the more likely they are to get wounds, at most 50% more likely, at 50% limb health
-		//However, this bonus isn't applied when the object doesn't pass the initial wound threshold
-		var/damaged_percent = (brute_dam + burn_dam)/max_damage
-		wounding_dmg = min(wounding_dmg*(1+damaged_percent), wounding_dmg*1.5)
+		//This makes it so the more damaged bodyparts are, the more likely they are to get wounds
+		//However, this bonus isn't applied when the object doesn't pass the initial wound threshold, nor is it when it already has enough wounding dmg
+		if(wounding_dmg < DAMAGED_BODYPART_BONUS_WOUNDING_BONUS)
+			var/damaged_percent = (brute_dam + burn_dam)/max_damage
+			if(damaged_percent > DAMAGED_BODYPART_BONUS_WOUNDING_THRESHOLD)
+				damaged_percent = DAMAGED_BODYPART_BONUS_WOUNDING_THRESHOLD
+			wounding_dmg = min(DAMAGED_BODYPART_BONUS_WOUNDING_BONUS, wounding_dmg+(damaged_percent*DAMAGED_BODYPART_BONUS_WOUNDING_COEFF))
 
 		if(current_gauze)
 			current_gauze.take_damage()

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -306,6 +306,11 @@
 	// now we have our wounding_type and are ready to carry on with wounds and dealing the actual damage
 	if(owner && wounding_dmg >= WOUND_MINIMUM_DAMAGE && wound_bonus != CANT_WOUND)
 		//SKYRAT EDIT ADDITION - MEDICAL
+		//This makes it so the more damaged bodyparts are, the more likely they are to get wounds, at most 50% more likely, at 50% limb health
+		//However, this bonus isn't applied when the object doesn't pass the initial wound threshold
+		var/damaged_percent = (brute_dam + burn_dam)/max_damage
+		wounding_dmg = min(wounding_dmg*(1+damaged_percent), wounding_dmg*1.5)
+
 		if(current_gauze)
 			current_gauze.take_damage()
 		if(current_splint)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is a flat bonus relative to the wound lost % of HP. capping at 50% damage, providing 7.5 wound bonus.
This bonus does not apply to delimb rolls, HOWEVER it'll make mangling easier, which in turn can also make delimbing easier

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Wounds as of now are too hard to apply, especially with things that cant quite brush the threshold with its base values, despite hammering a person or shanking them super thoroughly. This helps those cases

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Damaged bodyparts are now more likely to recieve wounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
