### PR TITLE
Automatically flag Severe+ intensity ambitions for admin review

### DIFF
--- a/modular_skyrat/modules/ambitions/code/ambition.dm
+++ b/modular_skyrat/modules/ambitions/code/ambition.dm
@@ -316,7 +316,7 @@
 			if("submit")
 				submit()
 				log_action("SUBMIT: Submitted their ambitions", FALSE)
-				if(intensity >= AMBITION_INTENSITY_MEDIUM)
+				if(intensity >= AMBITION_INTENSITY_SEVERE)
 					admin_review_requested = TRUE
 					GLOB.ambitions_to_review[src] = 0
 					message_admins("<span class='adminhelp'>[ADMIN_TPMONTY(usr)] has submitted high-intensity ambitions, which have been automatically flagged for review.(<a href='?src=[REF(src)];admin_pref=show_ambitions'>VIEW</a>)</span>")

--- a/modular_skyrat/modules/ambitions/code/ambition.dm
+++ b/modular_skyrat/modules/ambitions/code/ambition.dm
@@ -70,8 +70,9 @@
 		dat += "<BR><center><b>You've requested admin approval, ambitions will automatically be submitted after approval.</b></center>"
 	else if(!submitted)
 		submit_link = "href='?src=[REF(src)];pref=submit'"
+		dat += "<BR><b><font color='#FF0000'>Your current ambitions or edits have not been submitted yet.</font></b>"
 	else
-		dat += "<BR><center><b>You've already submitted your ambitions, but feel free to edit them.</b></center>"
+		dat += "<BR><center><b>You've already submitted your ambitions, but feel free to edit them. Editing will require you to re-submit afterwards.</b></center>"
 	dat += "<center><a [submit_link]>Submit</a> <a href='?src=[REF(src)];pref=template'>Choose template</a> <a [review_link]>Request admin review (optional)</a></center>"
 	dat += "<HR>"
 	if(changed_after_approval)
@@ -110,6 +111,7 @@
 	dat += "<BR>"
 	dat += "<h3>Intensity:</h3>"
 	dat += "<i>Set the estimated intensity of your ambitions, this helps the admins gauge on how chaotic a round may be. Please set it accordingly.</i>"
+	dat += "<BR><i>Submitting ambitions with an intensity of 'Medium' or higher will automatically request an admin review.</i>"
 	if(intensity == 0)
 		dat += "<BR><center><font color='#CCCCFF'><b>Please set your intensity!</b></font></center>"
 	dat += "<table>"
@@ -314,7 +316,12 @@
 			if("submit")
 				submit()
 				log_action("SUBMIT: Submitted their ambitions", FALSE)
-				message_admins("<span class='adminhelp'>[ADMIN_TPMONTY(usr)] has submitted their ambitions. (<a href='?src=[REF(src)];admin_pref=show_ambitions'>VIEW</a>)</span>")
+				if(intensity >= AMBITION_INTENSITY_MEDIUM)
+					admin_review_requested = TRUE
+					GLOB.ambitions_to_review[src] = 0
+					message_admins("<span class='adminhelp'>[ADMIN_TPMONTY(usr)] has submitted high-intensity ambitions, which have been automatically flagged for review.(<a href='?src=[REF(src)];admin_pref=show_ambitions'>VIEW</a>)</span>")
+				else
+					message_admins("<span class='adminhelp'>[ADMIN_TPMONTY(usr)] has submitted their ambitions. (<a href='?src=[REF(src)];admin_pref=show_ambitions'>VIEW</a>)</span>")
 			if("spice")
 				var/new_intensity = text2num(href_list["amount"])
 				if(intensity == new_intensity)
@@ -329,16 +336,19 @@
 						string = "Medium"
 					if(AMBITION_INTENSITY_SEVERE)
 						string = "Severe"
+						//message_admins("<span class='adminhelp'>[ADMIN_TPMONTY(usr)] has set their ambition intensity to [string]. (<a href='?src=[REF(src)];admin_pref=show_ambitions'>VIEW</a>)</span>")
 					if(AMBITION_INTENSITY_EXTREME)
 						string = "Extreme"
+						//message_admins("<span class='adminhelp'>[ADMIN_TPMONTY(usr)] has set their ambition intensity to [string]. (<a href='?src=[REF(src)];admin_pref=show_ambitions'>VIEW</a>)</span>")
 				log_action("INTENSITY: set to [string]")
-				if(submitted)
+				/*if(submitted)
 					GLOB.total_intensity -= intensity
 					if(intensity)
 						GLOB.intensity_counts["[intensity]"] -= 1
 					GLOB.total_intensity += new_intensity
 					if(new_intensity)
-						GLOB.intensity_counts["[new_intensity]"] += 1
+						GLOB.intensity_counts["[new_intensity]"] += 1*/
+				un_submit()
 				intensity = new_intensity
 			if("edit_admin_note")
 				var/msg = input(usr, "Set your note to admins!", "Note to admins", note_to_admins) as message|null
@@ -350,11 +360,13 @@
 				if(msg)
 					narrative = strip_html_simple(msg, MAX_FLAVOR_LEN, TRUE)
 					log_action("NARRATIVE - change: [narrative]")
+					un_submit()
 			if("remove_objective")
 				var/index = text2num(href_list["index"])
 				if(length(objectives) < index)
 					return
 				log_action("OBJ - removed: [objectives[index]]")
+				un_submit()
 				objectives.Remove(objectives[index])
 			if("edit_objective")
 				var/index = text2num(href_list["index"])
@@ -366,6 +378,7 @@
 					if(length(objectives) < index)
 						return
 					objectives[index] = strip_html_simple(msg, MAX_FLAVOR_LEN, TRUE)
+					un_submit()
 					log_action("OBJ - edit: [old_obj] TO-> [objectives[index]]")
 			if("add_objective")
 				var/msg = input(usr, "Add new objective:", "Objectives", "") as message|null
@@ -373,6 +386,7 @@
 					var/new_obj = strip_html_simple(msg, MAX_FLAVOR_LEN, TRUE)
 					objectives += new_obj
 					log_action("OBJ - add: [new_obj]")
+					un_submit()
 
 		ShowPanel(usr)
 		return TRUE
@@ -395,6 +409,13 @@
 	my_mind.ambition_submit()
 	GLOB.total_intensity += intensity
 	GLOB.intensity_counts["[intensity]"] += 1
+
+/datum/ambitions/proc/un_submit()
+	if(!submitted)
+		return
+	submitted = FALSE
+	GLOB.total_intensity -= intensity
+	GLOB.intensity_counts["[intensity]"] -= 1
 
 /mob/proc/view_ambitions()
 	set name = "View Ambitions"

--- a/modular_skyrat/modules/ambitions/code/ambition.dm
+++ b/modular_skyrat/modules/ambitions/code/ambition.dm
@@ -341,13 +341,6 @@
 						string = "Extreme"
 						//message_admins("<span class='adminhelp'>[ADMIN_TPMONTY(usr)] has set their ambition intensity to [string]. (<a href='?src=[REF(src)];admin_pref=show_ambitions'>VIEW</a>)</span>")
 				log_action("INTENSITY: set to [string]")
-				/*if(submitted)
-					GLOB.total_intensity -= intensity
-					if(intensity)
-						GLOB.intensity_counts["[intensity]"] -= 1
-					GLOB.total_intensity += new_intensity
-					if(new_intensity)
-						GLOB.intensity_counts["[new_intensity]"] += 1*/
 				un_submit()
 				intensity = new_intensity
 			if("edit_admin_note")

--- a/modular_skyrat/modules/ambitions/code/ambition.dm
+++ b/modular_skyrat/modules/ambitions/code/ambition.dm
@@ -336,10 +336,8 @@
 						string = "Medium"
 					if(AMBITION_INTENSITY_SEVERE)
 						string = "Severe"
-						//message_admins("<span class='adminhelp'>[ADMIN_TPMONTY(usr)] has set their ambition intensity to [string]. (<a href='?src=[REF(src)];admin_pref=show_ambitions'>VIEW</a>)</span>")
 					if(AMBITION_INTENSITY_EXTREME)
 						string = "Extreme"
-						//message_admins("<span class='adminhelp'>[ADMIN_TPMONTY(usr)] has set their ambition intensity to [string]. (<a href='?src=[REF(src)];admin_pref=show_ambitions'>VIEW</a>)</span>")
 				log_action("INTENSITY: set to [string]")
 				un_submit()
 				intensity = new_intensity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Submitted ambitions of Severe intensity or higher are automatically flagged for review and notify admins now.
Editing your ambitions 'un-submits' them now too, so admins will be notified again if high intensity ambitions are changed and submitted.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Yes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Submitting traitor ambitions of intensity 'Severe' or higher automatically flags them for admin review.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
