### PR TITLE
Revert "Makes it so assistants (and others with the no_dresscode var) have their loadout equipped first"

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -468,10 +468,6 @@ SUBSYSTEM_DEF(job)
 	to_chat(M, "<b>You are the [rank].</b>")
 	var/list/packed_items //SKYRAT CHANGE ADDITION - CUSTOMIZATION
 	if(job)
-		//SKYRAT EDIT ADDITION BEGIN - CUSTOMIZATION
-		if (job.no_dresscode && job.loadout && M.client)
-			packed_items = M.client.prefs.equip_preference_loadout(living_mob,FALSE,job)
-		//SKYRAT EDIT ADDITION END
 		var/new_mob = job.equip(living_mob, null, null, joined_late , null, M.client)//silicons override this proc to return a mob
 		if(ismob(new_mob))
 			living_mob = new_mob
@@ -504,7 +500,7 @@ SUBSYSTEM_DEF(job)
 	if(job && living_mob)
 		job.after_spawn(living_mob, M, joined_late) // note: this happens before the mob has a key! M will always have a client, H might not.
 		//SKYRAT CHANGE ADDITION BEGIN - CUSTOMIZATION
-		if(!job.no_dresscode && job.loadout)
+		if(job.loadout)
 			if(M.client)
 				packed_items = M.client.prefs.equip_preference_loadout(living_mob, FALSE, job)
 		if(packed_items)


### PR DESCRIPTION
Reverts Skyrat-SS13/Skyrat-tg#2404

loadouts :b:roke 
![obraz](https://user-images.githubusercontent.com/6381979/103465717-c5fdfc80-4d3e-11eb-912c-843cb45fc41f.png)


on a late join, PDA is gone.