### PR TITLE
fixes firearm availability from partisan shuttle

### DIFF
--- a/modular_skyrat/modules/ruins/maps/space/prisonshuttle.dmm
+++ b/modular_skyrat/modules/ruins/maps/space/prisonshuttle.dmm
@@ -87,10 +87,9 @@
 	name = "Unexplored Location"
 	})
 "ku" = (
-/obj/machinery/porta_turret/syndicate{
+/obj/machinery/porta_turret/syndicate/energy{
 	dir = 8;
-	pixel_x = 32;
-	pixel_y = 4
+	pixel_x = 32
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -279,7 +278,7 @@
 	name = "Unexplored Location"
 	})
 "ED" = (
-/mob/living/simple_animal/hostile/russian/ranged,
+/mob/living/simple_animal/hostile/russian,
 /turf/open/floor/plasteel/white/corner,
 /area/ruin/space/has_grav/powered{
 	name = "Unexplored Location"
@@ -388,10 +387,9 @@
 	name = "Unexplored Location"
 	})
 "Nw" = (
-/obj/machinery/porta_turret/syndicate{
+/obj/machinery/porta_turret/syndicate/energy{
 	dir = 4;
-	pixel_x = -32;
-	pixel_y = 4
+	pixel_x = -32
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -416,10 +414,9 @@
 	name = "Unexplored Location"
 	})
 "Rg" = (
-/obj/machinery/porta_turret/syndicate{
+/obj/machinery/porta_turret/syndicate/energy{
 	dir = 10;
-	pixel_x = 32;
-	pixel_y = 4
+	pixel_x = 32
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -475,16 +472,15 @@
 	name = "Unexplored Location"
 	})
 "Vy" = (
-/mob/living/simple_animal/hostile/russian/ranged/trooper,
+/mob/living/simple_animal/hostile/russian/ranged/officer,
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/powered{
 	name = "Unexplored Location"
 	})
 "Wt" = (
-/obj/machinery/porta_turret/syndicate{
+/obj/machinery/porta_turret/syndicate/energy{
 	dir = 6;
-	pixel_x = -32;
-	pixel_y = 4
+	pixel_x = -32
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -506,7 +502,7 @@
 	name = "Unexplored Location"
 	})
 "XQ" = (
-/mob/living/simple_animal/hostile/russian/ranged/mosin,
+/mob/living/simple_animal/hostile/russian,
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},


### PR DESCRIPTION
## About The Pull Request

swaps around russian simplemob enemy types and makes sure none of them drop ranged weapons like before

## Why It's Good For The Game

no more unintended shitload of firearms from one space ruin

## Changelog
:cl:
fix: enemy types and vars on partisan shuttle changed around to prevent loads of guns coming into circulation by accident
/:cl: