### PR TITLE
Allow blind and/or deaf characters to see/hear emotes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -79,9 +79,9 @@
 			M.show_message("[FOLLOW_LINK(M, user)] [dchatmsg]")
 
 	if(emote_type == EMOTE_AUDIBLE)
-		user.audible_message(msg, audible_message_flags = EMOTE_MESSAGE)
+		user.audible_message(msg, deaf_message = "<b>[user]</b> [msg]", audible_message_flags = EMOTE_MESSAGE)
 	else
-		user.visible_message(msg, visible_message_flags = EMOTE_MESSAGE)
+		user.visible_message(msg, blind_message = "<b>[user]</b> [msg]", visible_message_flags = EMOTE_MESSAGE)
 
 /// For handling emote cooldown, return true to allow the emote to happen
 /datum/emote/proc/check_cooldown(mob/user, intentional)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -79,9 +79,13 @@
 			M.show_message("[FOLLOW_LINK(M, user)] [dchatmsg]")
 
 	if(emote_type == EMOTE_AUDIBLE)
-		user.audible_message(msg, deaf_message = "<b>[user]</b> [msg]", audible_message_flags = EMOTE_MESSAGE)
+		//SKYRAT EDIT CHANGE BEGIN
+		//user.audible_message(msg, audible_message_flags = EMOTE_MESSAGE) - SKYRAT EDIT - ORIGINAL
+		user.audible_message(msg, deaf_message = "You see how <b>[user]</b> [msg]", audible_message_flags = EMOTE_MESSAGE)
 	else
-		user.visible_message(msg, blind_message = "<b>[user]</b> [msg]", visible_message_flags = EMOTE_MESSAGE)
+		//user.visible_message(msg, visible_message_flags = EMOTE_MESSAGE) - SKYRAT EDIT - ORIGINAL
+		user.visible_message(msg, blind_message = "You hear how <b>[user]</b> [msg]", visible_message_flags = EMOTE_MESSAGE)
+		//SKYRAT EDIT CHANGE END
 
 /// For handling emote cooldown, return true to allow the emote to happen
 /datum/emote/proc/check_cooldown(mob/user, intentional)


### PR DESCRIPTION
## About The Pull Request
Does what it says on the tin.

Examples:
When you're blind and someone does a visible emote (default emote)
![image](https://user-images.githubusercontent.com/6952402/103590294-c1c41180-4eed-11eb-8c2b-7a5541a61f5d.png)
When you're deaf and someone does an audible emote
![image](https://user-images.githubusercontent.com/6952402/103590307-cb4d7980-4eed-11eb-9350-8b3745907301.png)

## Changelog
:cl:
tweak: Blind characters can now "hear" all emotes
tweak: Deaf characters can now "see" all emotes
/:cl:
