### PR TITLE
makes it so the chapdrobe pharaoh outfit actually has it in stock

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -375,9 +375,9 @@
 					/obj/item/clothing/suit/chaplainsuit/monkrobeeast = 1,
 					/obj/item/clothing/head/beanie/rasta = 1,
 					//SKYRAT EDIT ADDITION BEGIN
-					/obj/item/clothing/suit/nemes,
-					/obj/item/clothing/head/nemes,
-					/obj/item/clothing/head/pharaoh)
+					/obj/item/clothing/suit/nemes = 1,
+					/obj/item/clothing/head/nemes = 1,
+					/obj/item/clothing/head/pharaoh = 1)
 					//SKYRAT EDIT ADDITION END
 	contraband = list(/obj/item/toy/plush/ratplush = 1,
 					/obj/item/toy/plush/narplush = 1,


### PR DESCRIPTION
## About The Pull Request

Makes it so the chapdrobe pharaoh outfit actually has it in stock. Not sure how I missed this when I PR'd it.

## Why It's Good For The Game

Uhhhh, bug fix.

## Changelog
:cl:
fix: Makes it so the chapdrobe pharaoh outfit actually has it in stock.
/:cl:
