### PR TITLE
Fixes Duplicate TC from Ambitions Module 

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -261,9 +261,9 @@
 	killer.add_malf_picker()
 
 /datum/antagonist/traitor/proc/equip(silent = FALSE)
-	if(traitor_kind == TRAITOR_HUMAN && !/var/has_been_antag_geared)
+	if(traitor_kind == TRAITOR_HUMAN && !has_been_antag_geared)
 		owner.equip_traitor(employer, silent, src)
-		/var/has_been_antag_geared = TRUE
+		has_been_antag_geared = TRUE
 
 //TODO Collate
 /datum/antagonist/traitor/roundend_report()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -17,8 +17,6 @@
 	var/should_equip = TRUE
 	var/traitor_kind = TRAITOR_HUMAN //Set on initial assignment
 	var/datum/contractor_hub/contractor_hub
-	///A check to see if they have already been given there gear
-	var/has_been_antag_geared = FALSE //SKYRAT EDIT
 
 /datum/antagonist/traitor/on_gain()
 	if(owner.current && isAI(owner.current))
@@ -259,12 +257,11 @@
 	killer.set_syndie_radio()
 	to_chat(killer, "Your radio has been upgraded! Use :t to speak on an encrypted channel with Syndicate Agents!")
 	killer.add_malf_picker()
-//Skyrat Edit
+
 /datum/antagonist/traitor/proc/equip(silent = FALSE)
-	if(traitor_kind == TRAITOR_HUMAN && !has_been_antag_geared) //if(traitor_kind == TRAITOR_HUMAN) //Skyrat Edit, This was orgional
+	if(traitor_kind == TRAITOR_HUMAN)
 		owner.equip_traitor(employer, silent, src)
-		has_been_antag_geared = TRUE //Added
-//End Skyrat Edit
+
 
 //TODO Collate
 /datum/antagonist/traitor/roundend_report()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -17,6 +17,8 @@
 	var/should_equip = TRUE
 	var/traitor_kind = TRAITOR_HUMAN //Set on initial assignment
 	var/datum/contractor_hub/contractor_hub
+	///A check to see if they have already been given there gear
+	var/has_been_antag_geared = FALSE
 
 /datum/antagonist/traitor/on_gain()
 	if(owner.current && isAI(owner.current))
@@ -259,8 +261,9 @@
 	killer.add_malf_picker()
 
 /datum/antagonist/traitor/proc/equip(silent = FALSE)
-	if(traitor_kind == TRAITOR_HUMAN)
+	if(traitor_kind == TRAITOR_HUMAN && !/var/has_been_antag_geared)
 		owner.equip_traitor(employer, silent, src)
+		/var/has_been_antag_geared = TRUE
 
 //TODO Collate
 /datum/antagonist/traitor/roundend_report()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -18,7 +18,7 @@
 	var/traitor_kind = TRAITOR_HUMAN //Set on initial assignment
 	var/datum/contractor_hub/contractor_hub
 	///A check to see if they have already been given there gear
-	var/has_been_antag_geared = FALSE
+	var/has_been_antag_geared = FALSE //SKYRAT EDIT
 
 /datum/antagonist/traitor/on_gain()
 	if(owner.current && isAI(owner.current))
@@ -259,11 +259,12 @@
 	killer.set_syndie_radio()
 	to_chat(killer, "Your radio has been upgraded! Use :t to speak on an encrypted channel with Syndicate Agents!")
 	killer.add_malf_picker()
-
+//Skyrat Edit
 /datum/antagonist/traitor/proc/equip(silent = FALSE)
-	if(traitor_kind == TRAITOR_HUMAN && !has_been_antag_geared)
+	if(traitor_kind == TRAITOR_HUMAN && !has_been_antag_geared) //if(traitor_kind == TRAITOR_HUMAN) //Skyrat Edit, This was orgional
 		owner.equip_traitor(employer, silent, src)
-		has_been_antag_geared = TRUE
+		has_been_antag_geared = TRUE //Added
+//End Skyrat Edit
 
 //TODO Collate
 /datum/antagonist/traitor/roundend_report()

--- a/modular_skyrat/modules/ambitions/code/antag_datums.dm
+++ b/modular_skyrat/modules/ambitions/code/antag_datums.dm
@@ -1,6 +1,8 @@
 /datum/antagonist
 	///Whether the antagonist uses ambitions
 	var/uses_ambitions = FALSE
+	///A check to see if they have already been given there gear
+	var/has_been_antag_geared = FALSE
 
 ///This gets called after our ambitions are submitted, or the antag datum is given to someone with filled ambitions
 /datum/antagonist/proc/ambitions_add()
@@ -15,7 +17,11 @@
 
 /datum/antagonist/traitor/ambitions_add()
 	if(traitor_kind == TRAITOR_HUMAN && should_equip)
-		equip()
+		if(!has_been_antag_geared)
+			equip()
+			has_been_antag_geared = TRUE
+		else
+			message_admins("[usr.ckey] has already had there Trator items given, Not Giving Items")
 
 /datum/antagonist/changeling
 	uses_ambitions = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bug with the Ambitions module.
If a Antag as submitted and approved ambitions. then they drop there PDA, Then change objectives. give_antag is called again giving them another pda and bunch of TC.

Added check to that function to check if they have already been given the antag gear, and if so. just do nothing.
I think this works, but Needs checking by Azarak
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Miss Fox
fix: Fixes to Ambitions module causing duplicate TC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
