### PR TITLE
Fix a couple typos in modular hairstyles

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/hair.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/hair.dm
@@ -23,7 +23,7 @@
 
 /datum/sprite_accessory/hair/skyrat/ziegler
 	name = "Ziegler"
-	icon_state = "hair_Ziegler"
+	icon_state = "hair_ziegler"
 
 /datum/sprite_accessory/hair/skyrat/hightight
 	name = "Hightight"
@@ -131,7 +131,7 @@
 
 /datum/sprite_accessory/hair/skyrat/rows1
 	name = "Rows 1"
-	icon_state = "hair_rows"
+	icon_state = "hair_rows1"
 
 /datum/sprite_accessory/hair/skyrat/rows2
 	name = "Rows 2"
@@ -167,7 +167,7 @@
 
 /datum/sprite_accessory/hair/skyrat/shorthair4
 	name = "Short Hair 4"
-	icon_state = "hair_dave"
+	icon_state = "hair_shorthair4"
 
 /datum/sprite_accessory/hair/skyrat/shortovereyealt
 	name = "Short Over Eye ALT"
@@ -193,19 +193,19 @@
 	name = "Simple Ponytail"
 	icon_state = "hair_simple_ponytail"
 
-/datum/sprite_accessory/hair/loose_slicked
+/datum/sprite_accessory/hair/skyrat/loose_slicked
 	name = "Loose Slicked"
 	icon_state = "hair_loose_slicked"
 
-/datum/sprite_accessory/hair/diagonal_bangs
+/datum/sprite_accessory/hair/skyrat/diagonal_bangs
 	name = "Diagonal Bangs"
 	icon_state = "hair_diagonal_bangs"
 
-/datum/sprite_accessory/hair/gloomy_medium
+/datum/sprite_accessory/hair/skyrat/gloomy_medium
 	name = "Medium Gloomy Bangs"
 	icon_state = "hair_gloomy_medium"
 
-/datum/sprite_accessory/hair/gloomy_long
+/datum/sprite_accessory/hair/skyrat/gloomy_long
 	name = "Long Gloomy Bangs"
 	icon_state = "hair_gloomy_long"
 


### PR DESCRIPTION
## About The Pull Request
As title, fixes some typos in the modular hairstyle, lowercased one, and made one note be a duplicate of another.

## Changelog
:cl: Avunia Takiya
fix: According to newest trends, errors are not a valid hairstyle anymore, so we've adapted accordingly and turned any error hairstyle into a regular mess of hairs!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
