### PR TITLE
Exempt active testmerges from becoming stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,4 +17,4 @@ jobs:
         days-before-stale: 14
         days-before-close: 14
         stale-pr-label: 'Stale'
-        exempt-pr-labels: 'RED LABEL,Upstream PR Merged,Fix'
+        exempt-pr-labels: 'RED LABEL,Upstream PR Merged,Fix,Test Merged'


### PR DESCRIPTION
They really shouldnt become stale while active.
Also lets hope actions/stale isn't bugged for labels with spaces or i'm gonna throw a fit.