### PR TITLE
Remove gun safeties from bows

### DIFF
--- a/modular_skyrat/modules/gunsafety/code/gun_safety.dm
+++ b/modular_skyrat/modules/gunsafety/code/gun_safety.dm
@@ -48,6 +48,9 @@
 /obj/item/gun/ballistic
 	has_gun_safety = TRUE
 
+/obj/item/gun/ballistic/bow
+	has_gun_safety = FALSE
+
 /obj/item/gun/energy
 	has_gun_safety = TRUE
 


### PR DESCRIPTION
## About The Pull Request
Does as it says on the tin.

## Why It's Good For The Game
While there are bows with safeties, I don't think the ones ingame are deadly recurve ones needing that.

## Changelog
:cl: Avunia Takiya
fix: After several questions of "why" and especially "how", NT has decided to remove mandatory safeties on primitive bow weapons.
/:cl: