### PR TITLE
Defibrillates Split-Personality

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -1,5 +1,3 @@
-//SKYRAT EDIT REMOVAL BEGIN
-/*
 #define OWNER 0
 #define STRANGER 1
 
@@ -237,5 +235,3 @@
 
 #undef OWNER
 #undef STRANGER
-*/
-// SKYRAT EDIT REMOVAL END

--- a/code/modules/spells/spell_types/personality_commune.dm
+++ b/code/modules/spells/spell_types/personality_commune.dm
@@ -1,5 +1,3 @@
-//SKYRAT EDIT REMOVAL BEGIN
-/*
 /obj/effect/proc_holder/spell/targeted/personality_commune
 	name = "Personality Commune"
 	desc = "Sends thoughts to your alternate consciousness."
@@ -32,5 +30,3 @@
 		if(!isobserver(ded))
 			continue
 		to_chat(ded, "[FOLLOW_LINK(ded, user)] <span class='boldnotice'>[user] [name]:</span> <span class='notice'>\"[msg]\" to</span> <span class='name'>[trauma]</span>")
-*/
-//SKYRATS EDIT REMOVAL END


### PR DESCRIPTION
## About The Pull Request

Returns Split-Personality to the list of possible traumas.

## Why It's Good For The Game

I agree that it wasn't very fun on the old base, but its been updated here so that you can actually talk with your other half, which I think could lead a lot of good RP. I have seen people who wished they could have it before for that reason, but at the moment there isn't any way at all to spawn it in the code. We already removed the random brain trauma event, so there is isn't a random chance you are going to get it during ERP or anything, given that the list of stuff which can cause it is already pretty low. I just think that its cool enough to bring back, at least in some form. Given that this is the most simple way to do it, I am starting here. I really just want to know what other people have to think about it returning as well.

## Changelog
:cl:
add: Re-added split-personality
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->