### PR TITLE
[NON-MODULAR] Renames pepperspray to "Assistant Away!"

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -198,7 +198,7 @@
 
 //pepperspray
 /obj/item/reagent_containers/spray/pepper
-	name = "pepperspray"
+	name = "Assistant Away!"
 	desc = "Manufactured by UhangInc, used to blind and down an opponent quickly."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "pepperspray"


### PR DESCRIPTION
## About The Pull Request

exactly what it says on the tin

## Why It's Good For The Game

Pepperspray is just assistant repellant, it's never used for anything else so why not make it emphasize on that.

## Changelog
:cl:
tweak: Pepperspray is now "Assistant Away!"
/:cl: