### PR TITLE
Teleporter now has safety features, unless emagged.

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -74,7 +74,7 @@
 	if (ismovable(M))
 		if(do_teleport(M, com.target, channel = TELEPORT_CHANNEL_BLUESPACE))
 			use_power(5000)
-			if(!calibrated && prob(30 - ((accuracy) * 10))) //oh dear a problem
+			if(!calibrated) //oh dear a problem SKYRAT CHANGE: 100% chance to delimb if uncalibrated.
 				if(ishuman(M))//don't remove people from the round randomly you jerks
 					var/mob/living/carbon/human/human = M
 					/* - SKRYAT EDIT CHANGE ORIGINAL
@@ -104,7 +104,27 @@
 					human.apply_effect((rand(480 + rad_mod - accuracy * 40, 880 + rad_mod - accuracy * 60)), EFFECT_IRRADIATE, 0)
 					//SKYRAT EDIT CHANGE END
 			calibrated = FALSE
+			//SKYRAT CHANGE START, remove target, unless emagged.
+			if(!(obj_flags & EMAGGED)) //If we're emagged, don't uncalibrate.
+				if(power_station)
+					power_station.engaged = FALSE
+					if(power_station.teleporter_console)
+						power_station.teleporter_console.target = null
+						power_station.teleporter_console.update_icon()
+					power_station.update_icon()
+				update_icon()
+			//END OF SKYRAT CHANGE
+
 	return
+
+//SKYRAT CHANGE, emagged teleporter.
+/obj/machinery/teleport/hub/emag_act(mob/user)
+	if(obj_flags & EMAGGED)
+		return
+	obj_flags |= EMAGGED
+	playsound(src, "sparks", 75, TRUE, SILENCED_SOUND_EXTRARANGE)
+	to_chat(user, "<span class='notice'>You use the cryptographic sequencer on [src] to short the calibration safeties!</span>")
+//Skyrat change end.
 
 /obj/machinery/teleport/hub/update_icon_state()
 	if(panel_open)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Using a teleporter will shut off the teleporter and clear the teleporter location, on top of uncalibrating it as a safety precaution.
Emagging a teleporter hub will revert it to this previous behavior.
Delimb chance is now 100% when you enter it while emagged and uncalibrated.

## Why It's Good For The Game

On the Skyrat-Citadel code, stepping into an uncalibrated teleporter would no longer uncalibrate it. The captain was free to set it to some location, like the Hotel, and wouldn't require any user input. This was acceptable.

On the current rebase, it now uncalibrates after every time you use it. On top of that, if you enter a teleporter while it's uncalibrated, it has a chance to delimb you unless upgraded. These two features combined is dumb as hell and punishes players who are used to the previous rebase as well as new players who are unfamiliar with how a teleporter works. It bandaid fixes powergamers using it to swarm a location, which barely happens on Skyrat. The change I added is significantly better and makes more sense realisticly.

Implementation in this PR is a sane middle ground that prevents swarms of people teleporting in at once while removing the RNG punishment for doing so, while giving antags the option to punish via an emag charge.

## Changelog
:cl: BurgerBB
add: Teleporter Hubs now shut off and clear their target after each use as a safety measure. Teleporter Hubs can now be emagged to overload safety features, reverting to previous teleporter Hub behaviors.
tweak: Teleporter uncalibration delimb chance is now always 100%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
