### PR TITLE
[NON-MODULAR] Admin Antag Removal removes Changeling powers properly

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -220,6 +220,10 @@ GLOBAL_LIST_EMPTY(antagonists)
 	message_admins("[key_name_admin(user)] has removed [name] antagonist status from [key_name_admin(owner)].")
 	log_admin("[key_name(user)] has removed [name] antagonist status from [key_name(owner)].")
 	on_removal()
+	//SKYRAT EDIT ADDITION BEGIN - AMBITIONS
+	if(uses_ambitions && owner.my_ambitions.submitted)
+		ambitions_removal()
+	//SKYRAT EDIT ADDITION END
 
 //gamemode/proc/is_mode_antag(antagonist/A) => TRUE/FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Just a small oversight.
Fixes the issue where if you remove the Changeling antagonist from a player as an admin, none of their powers were removed. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix / Oversight
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Foxtrot (Funce)
fix: Admin-Removing Changeling Status will no longer let the player keep all the powers. Sorry folks!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
