### PR TITLE
[Non-Modular (?)] HOS with the Big Iron on his Hip

### DIFF
--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -46,7 +46,7 @@
 	gloves = /obj/item/clothing/gloves/color/black
 	head = /obj/item/clothing/head/hos/beret
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
-	suit_store = /obj/item/gun/energy/e_gun
+	suit_store = /obj/item/gun/ballistic/revolver/mateba
 	r_pocket = /obj/item/assembly/flash/handheld
 	l_pocket = /obj/item/restraints/handcuffs
 	backpack_contents = list(/obj/item/melee/baton/loaded=1, /obj/item/modular_computer/tablet/preset/advanced/command=1)

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -58,7 +58,7 @@
 
 	implants = list(/obj/item/implant/mindshield)
 
-	chameleon_extras = list(/obj/item/gun/energy/e_gun/hos, /obj/item/stamp/hos)
+	chameleon_extras = list(/obj/item/gun/ballistic/revolver/mateba, /obj/item/stamp/hos)
 
 /datum/outfit/job/hos/hardsuit
 	name = "Head of Security (Hardsuit)"


### PR DESCRIPTION
## About The Pull Request

Replaces the HOS's roundstart energy carbine with the Unica-6 revolver.

## Why It's Good For The Game

Look, gonna be honest. Security is boned in the ballistic departments, especially now that we have no slugs nor buckshot. We really need some sort of cure to the DE-sword wielding maniacs that pop up occasionally, space dragons and of course, traitors with big irons of their own. This is probably gonna get pissed on but worth a shot.

Also a big iron fits the HOS much more aesthetically rather than an energy weapon. I could try re-do the PR w/ a replacement of the multiphase gun but this is the first attempt.

## Changelog
:cl:
add: Unica-6 Revolver to HOS spawn.
remove: Energy carbine to HOS spawn.
