### PR TITLE
Adds Surplus Rifles to the Supply Console

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -623,6 +623,14 @@
                     /obj/item/gun/ballistic/rifle/boltaction)
     crate_name = "surplus armoury crate"
 
+/datum/supply_pack/security/armory/mosin_ammo
+    name = "Surplus Ammo Crate"
+    desc = "Contains two budget 7.62 ammo boxes. Perfect for cheap warfare, or when the shuttle vote is too democratic."
+    cost = CARGO_CRATE_VALUE * 12
+	contains = list(/obj/item/storage/toolbox/ammo,
+	                /obj/item/storage/toolbox/ammo)
+    crate_name = "surplus ammo crate"
+
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -614,6 +614,15 @@
 
 /datum/supply_pack/security/armory/mafia //SKYRAT EDIT ADDITION
 
+/datum/supply_pack/security/armory/mosin
+    name = "Surplus Armoury Crate"
+    desc = "Contains three budget Mosin-Nagants, chambered in 7.62. Perfect for cheap warfare, or when the shuttle vote is too democratic."
+    cost = CARGO_CRATE_VALUE * 15
+    contains = list(/obj/item/gun/ballistic/rifle/boltaction,
+                    /obj/item/gun/ballistic/rifle/boltaction,
+                    /obj/item/gun/ballistic/rifle/boltaction)
+    crate_name = "surplus armoury crate"
+
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -623,14 +623,6 @@
                     /obj/item/gun/ballistic/rifle/boltaction)
     crate_name = "surplus armoury crate"
 
-/datum/supply_pack/security/armory/mosin_ammo
-    name = "Surplus Ammo Crate"
-    desc = "Contains two budget 7.62 ammo boxes. Perfect for cheap warfare, or when the shuttle vote is too democratic."
-    cost = CARGO_CRATE_VALUE * 12
-	contains = list(/obj/item/storage/toolbox/ammo,
-	                /obj/item/storage/toolbox/ammo)
-    crate_name = "surplus ammo crate"
-
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."


### PR DESCRIPTION

## About The Pull Request

Adds Mosin-Nagants to the armoury tab of the supply console for budget warfare or dealing with certain threats.

## Why It's Good For The Game

Let's be honest here. /TG/'s done nothing but nerf security. First it was buckshot and slugs, now it's our printed guns. These budget weapons should help tip the odds a little, and also means security has to interact with cargo more, which is an upside for the maintainers.

## Changelog
:cl:
add: Surplus armoury crate.
/:cl:

