### PR TITLE
[MODULAR][MY-FIRST-PR] Ports the Janitor Arm Implant

### DIFF
--- a/modular_skyrat/modules/implants/code/organs/augments_arms.dm
+++ b/modular_skyrat/modules/implants/code/organs/augments_arms.dm
@@ -54,3 +54,18 @@
 	desc = "An optimized, highly advanced stripped-down multitool able to interface with electronics far better than its standard counterpart."
 	icon = 'icons/obj/items_cyborg.dmi'
 	icon_state = "multitool_cyborg"
+
+/obj/item/organ/cyberimp/arm/janitor
+	name = "janitorial tools implant"
+	desc = "A set of janitorial tools on the user's arm."
+	contents = newlist(/obj/item/lightreplacer, /obj/item/holosign_creator, /obj/item/soap/nanotrasen, /obj/item/reagent_containers/spray/cyborg_drying, /obj/item/mop/advanced, /obj/item/paint/paint_remover, /obj/item/reagent_containers/glass/beaker/large, /obj/item/reagent_containers/spray/cleaner) //Beaker if for refilling sprays
+
+/obj/item/organ/cyberimp/arm/janitor/emag_act()
+	. = ..()
+	if(obj_flags & EMAGGED)
+		return
+	obj_flags |= EMAGGED
+	to_chat(usr, "<span class='notice'>You unlock [src]'s integrated deluxe cleaning supplies!</span>")
+	items_list += new /obj/item/soap/syndie(src) //We add not replace.
+	items_list += new /obj/item/reagent_containers/spray/cyborg_lube(src)
+	return TRUE

--- a/modular_skyrat/modules/implants/code/research/designs/medical_designs.dm
+++ b/modular_skyrat/modules/implants/code/research/designs/medical_designs.dm
@@ -74,3 +74,15 @@
 	build_path = /obj/item/organ/cyberimp/chest/scanner
 	category = list("Misc", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
+/datum/design/cyberimp_janitor
+	name = "Janitor Arm Implant"
+	desc = "A set of janitor tools fitted into an arm implant, designed to be installed on subject's arm."
+	id = "ci-janitor"
+	build_type = PROTOLATHE | MECHFAB
+	materials = list (/datum/material/iron = 3500, /datum/material/glass = 1500, /datum/material/silver = 1500)
+	construction_time = 200
+	build_path = /obj/item/organ/cyberimp/arm/janitor
+	category = list("Misc", "Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SERVICE
+

--- a/modular_skyrat/modules/implants/code/research/techweb/medical_nodes.dm
+++ b/modular_skyrat/modules/implants/code/research/techweb/medical_nodes.dm
@@ -1,5 +1,5 @@
 /datum/techweb_node/cyber_implants
-	design_ids = list("ci-nutriment", "ci-scanner", "ci-breather", "ci-gloweyes", "ci-welding", "ci-medhud", "ci-sechud", "ci-diaghud", "ci-botany")
+	design_ids = list("ci-nutriment", "ci-scanner", "ci-breather", "ci-gloweyes", "ci-welding", "ci-medhud", "ci-sechud", "ci-diaghud", "ci-botany", "ci-janitor")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/adv_cyber_implants


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What it says in the title. This is a port of the janitor arm implant from old base. It is almost a direct copy and paste. Material cost, tools, and emag function are carried over.

My only changes from that are putting it on the already modularized medical research node, alongside the botany implant. This prevents having to modularize more tech nodes or create new ones, which would be well outside the scope of this PR.

I have also added the ability to print the implant from the service lathe. This is mainly to give the rare traitor janitor the chance to get and emag the implant prior to installation, since chances are they won't get to hold it before it's installed if they go to medical or robotics for it. It is not prevented from printing at those locations however.

I am aware of a potential upcoming major implant overhaul from upstream that includes a janitorial arm implant. I am sending this one in anyway, because I believe this carries more skyrat flavor and it's ready to go, modular and everything.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A fun novelty arm implant from the oldbase. It retains it's non-lethal emag mode for the enterprising traitor as well.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Added some lines to three files.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
