### PR TITLE
adds flash darks to the bepis minor rewards

### DIFF
--- a/code/modules/research/bepis.dm
+++ b/code/modules/research/bepis.dm
@@ -37,6 +37,7 @@
 		//To add a new minor reward, add it here.
 		/obj/item/stack/circuit_stack/full,
 		/obj/item/pen/survival,
+		/obj/item/flashlight/flashdark,
 		/obj/item/circuitboard/machine/sleeper/party,
 		/obj/item/toy/sprayoncan,
 	)

--- a/code/modules/research/bepis.dm
+++ b/code/modules/research/bepis.dm
@@ -37,7 +37,7 @@
 		//To add a new minor reward, add it here.
 		/obj/item/stack/circuit_stack/full,
 		/obj/item/pen/survival,
-		/obj/item/flashlight/flashdark,
+		/obj/item/flashlight/flashdark,//SKYRAT EDIT
 		/obj/item/circuitboard/machine/sleeper/party,
 		/obj/item/toy/sprayoncan,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds another gimmick item to the minor rewards that we had there on the old code. flash darks being anti flash lights that project darkness where ever you shine them

## Why It's Good For The Game

adds in more diversity to the bepis minor rewards 

## Changelog
:cl:
add: Added flash darks to the B.E.P.I.S. minor rewards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
