### PR TITLE
[NON-MODULAR] Porting audible emotes from oldbase.

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -29,9 +29,9 @@
 #define MODE_WHISPER "whisper"
 #define MODE_WHISPER_CRIT "whispercrit"
 
-//SKYRAT custom verb EDIT
+//SKYRAT custom verb
 #define MODE_CUSTOM_SAY "custom_say"
-//SKYRAT EDIT
+//SKYRAT custom sayverb end.
 
 #define MODE_DEPARTMENT "department"
 #define MODE_KEY_DEPARTMENT "h"

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -29,6 +29,10 @@
 #define MODE_WHISPER "whisper"
 #define MODE_WHISPER_CRIT "whispercrit"
 
+//SKYRAT custom verb EDIT
+#define MODE_CUSTOM_SAY "custom_say"
+//SKYRAT EDIT
+
 #define MODE_DEPARTMENT "department"
 #define MODE_KEY_DEPARTMENT "h"
 #define MODE_TOKEN_DEPARTMENT ":h"

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -76,7 +76,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 /atom/movable/proc/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
 	return ""
 
-/atom/movable/proc/say_mod(input, message_mods)
+/atom/movable/proc/say_mod(input, message_mods) //SKYRAT custom sayverb old code: /atom/movable/proc/say_mod(input, list/message_mods = list())
 	var/ending = copytext_char(input, -1)
 	if(copytext_char(input, -2) == "!!")
 		return verb_yell
@@ -98,30 +98,31 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 	var/spanned = attach_spans(input, spans)
 	return "[say_mod(input, message_mods)][spanned ? ", \"[spanned]\"" : ""]"
-// SKYRAT custom verb edit. [spanned ? ", \"[spanned]\"" : ""]"
+//SKYRAT custom verb edit. [spanned ? ", \"[spanned]\"" : ""]"
 
-// SKYRAT custom sayverb
+//SKYRAT custom sayverb
 /atom/movable/proc/quoteless_say_quote(input, list/spans = list(speech_span), message_mods)
 	if((input[1] == "!") && (length_char(input) > 1))
 		return ""
 	var/pos = findtext(input, "*")
 	return pos? copytext(input, pos + 1) : input
+//SKYRAT custom sayverb end.
 
 /atom/movable/proc/lang_treat(atom/movable/speaker, datum/language/language, raw_message, list/spans, list/message_mods = list(), no_quote = FALSE)
 	if(has_language(language))
 		var/atom/movable/AM = speaker.GetSource()
 		if(AM) //Basically means "if the speaker is virtual"
-			return no_quote ? AM.quoteless_say_quote(raw_message, spans, message_mods) : AM.say_quote(raw_message, spans, message_mods)
+			return no_quote ? AM.quoteless_say_quote(raw_message, spans, message_mods) : AM.say_quote(raw_message, spans, message_mods) //SKYRAT custom sayverb old code: return no_quote ? raw_message : AM.say_quote(raw_message, spans, message_mods)
 		else
-			return no_quote ? speaker.quoteless_say_quote(raw_message, spans, message_mods) : speaker.say_quote(raw_message, spans, message_mods)
+			return no_quote ? speaker.quoteless_say_quote(raw_message, spans, message_mods) : speaker.say_quote(raw_message, spans, message_mods) //SKYRAT custom sayverb old code: return no_quote ? raw_message : speaker.say_quote(raw_message, spans, message_mods)
 	else if(language)
 		var/atom/movable/AM = speaker.GetSource()
 		var/datum/language/D = GLOB.language_datum_instances[language]
 		raw_message = D.scramble(raw_message)
 		if(AM)
-			return no_quote ? AM.quoteless_say_quote(raw_message, spans, message_mods) : AM.say_quote(raw_message, spans, message_mods)
+			return no_quote ? AM.quoteless_say_quote(raw_message, spans, message_mods) : AM.say_quote(raw_message, spans, message_mods) //SKYRAT custom sayverb old code: return no_quote ? raw_message : AM.say_quote(raw_message, spans, message_mods)
 		else
-			return no_quote ? speaker.quoteless_say_quote(raw_message, spans, message_mods) : speaker.say_quote(raw_message, spans, message_mods)
+			return no_quote ? speaker.quoteless_say_quote(raw_message, spans, message_mods) : speaker.say_quote(raw_message, spans, message_mods) //SKYRAT custom sayverb old code: return no_quote ? raw_message : speaker.say_quote(raw_message, spans, message_mods)
 	else
 		return "makes a strange sound."
 
@@ -137,6 +138,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		return returntext
 	return "[copytext_char("[freq]", 1, 4)].[copytext_char("[freq]", 4, 5)]"
 
+//SKYRAT custom sayverb
 /atom/movable/proc/attach_spans(input, list/spans)
 	if((input[1] == "!") && (length(input) > 2))
 		return
@@ -147,6 +149,11 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		return "[message_spans_start(spans)][input]</span>"
 	else
 		return
+//SKYRAT custom sayverb end.
+/* Old code:
+/proc/attach_spans(input, list/spans)
+	return "[message_spans_start(spans)][input]</span>"
+*/
 
 /proc/message_spans_start(list/spans)
 	var/output = "<span class='"

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -97,23 +97,31 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		spans |= SPAN_YELL
 
 	var/spanned = attach_spans(input, spans)
-	return "[say_mod(input, message_mods)], \"[spanned]\""
+	return "[say_mod(input, message_mods)][spanned ? ", \"[spanned]\"" : ""]"
+// SKYRAT custom verb edit. [spanned ? ", \"[spanned]\"" : ""]"
+
+// SKYRAT custom sayverb
+/atom/movable/proc/quoteless_say_quote(input, list/spans = list(speech_span), message_mods)
+	if((input[1] == "!") && (length_char(input) > 1))
+		return ""
+	var/pos = findtext(input, "*")
+	return pos? copytext(input, pos + 1) : input
 
 /atom/movable/proc/lang_treat(atom/movable/speaker, datum/language/language, raw_message, list/spans, list/message_mods = list(), no_quote = FALSE)
 	if(has_language(language))
 		var/atom/movable/AM = speaker.GetSource()
 		if(AM) //Basically means "if the speaker is virtual"
-			return no_quote ? raw_message : AM.say_quote(raw_message, spans, message_mods)
+			return no_quote ? AM.quoteless_say_quote(raw_message, spans, message_mods) : AM.say_quote(raw_message, spans, message_mods)
 		else
-			return no_quote ? raw_message : speaker.say_quote(raw_message, spans, message_mods)
+			return no_quote ? speaker.quoteless_say_quote(raw_message, spans, message_mods) : speaker.say_quote(raw_message, spans, message_mods)
 	else if(language)
 		var/atom/movable/AM = speaker.GetSource()
 		var/datum/language/D = GLOB.language_datum_instances[language]
 		raw_message = D.scramble(raw_message)
 		if(AM)
-			return no_quote ? raw_message : AM.say_quote(raw_message, spans, message_mods)
+			return no_quote ? AM.quoteless_say_quote(raw_message, spans, message_mods) : AM.say_quote(raw_message, spans, message_mods)
 		else
-			return no_quote ? raw_message : speaker.say_quote(raw_message, spans, message_mods)
+			return no_quote ? speaker.quoteless_say_quote(raw_message, spans, message_mods) : speaker.say_quote(raw_message, spans, message_mods)
 	else
 		return "makes a strange sound."
 
@@ -129,8 +137,16 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		return returntext
 	return "[copytext_char("[freq]", 1, 4)].[copytext_char("[freq]", 4, 5)]"
 
-/proc/attach_spans(input, list/spans)
-	return "[message_spans_start(spans)][input]</span>"
+/atom/movable/proc/attach_spans(input, list/spans)
+	if((input[1] == "!") && (length(input) > 2))
+		return
+	var/customsayverb = findtext(input, "*")
+	if(customsayverb)
+		input = capitalize(copytext(input, customsayverb + length(input[customsayverb])))
+	if(input)
+		return "[message_spans_start(spans)][input]</span>"
+	else
+		return
 
 /proc/message_spans_start(list/spans)
 	var/output = "<span class='"

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -76,7 +76,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 /atom/movable/proc/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
 	return ""
 
-/atom/movable/proc/say_mod(input, list/message_mods = list())
+/atom/movable/proc/say_mod(input, message_mods)
 	var/ending = copytext_char(input, -1)
 	if(copytext_char(input, -2) == "!!")
 		return verb_yell

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -429,7 +429,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			return ITALICS | REDUCE_RANGE
 
 	return 0
-// SKYRAT EDIT START
+//SKYRAT custom sayverb
 /mob/living/say_mod(input, message_mods)
 	if(message_mods == MODE_WHISPER_CRIT)
 		return ..()
@@ -458,8 +458,15 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			. = "gibbers"
 	else
 		. = ..()
-//SKYRAT EDIT END
-/* ORIGINAL CODE
+
+/proc/uncostumize_say(input, message_mods)
+	. = input
+	if(message_mods == MODE_CUSTOM_SAY)
+		var/customsayverb = findtext(input, "*")
+		return lowertext(copytext_char(input, 1, customsayverb))
+
+//SKYRAT custom sayverb end.
+/* original code:
 /mob/living/say_mod(input, list/message_mods = list())
 	if(message_mods[WHISPER_MODE] == MODE_WHISPER)
 		. = verb_whisper
@@ -480,12 +487,6 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	else
 		. = ..()
 */
-
-/proc/uncostumize_say(input, message_mods)
-	. = input
-	if(message_mods == MODE_CUSTOM_SAY)
-		var/customsayverb = findtext(input, "*")
-		return lowertext(copytext_char(input, 1, customsayverb))
 
 /mob/living/whisper(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	if(!message)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -429,7 +429,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			return ITALICS | REDUCE_RANGE
 
 	return 0
-
+// SKYRAT EDIT START
 /mob/living/say_mod(input, message_mods)
 	if(message_mods == MODE_WHISPER_CRIT)
 		return ..()
@@ -458,6 +458,28 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			. = "gibbers"
 	else
 		. = ..()
+//SKYRAT EDIT END
+/* ORIGINAL CODE
+/mob/living/say_mod(input, list/message_mods = list())
+	if(message_mods[WHISPER_MODE] == MODE_WHISPER)
+		. = verb_whisper
+	else if(message_mods[WHISPER_MODE] == MODE_WHISPER_CRIT)
+		. = "[verb_whisper] in [p_their()] last breath"
+	else if(message_mods[MODE_SING])
+		. = verb_sing
+	else if(stuttering)
+		if(HAS_TRAIT(src, TRAIT_SIGN_LANG))
+			. = "shakily signs"
+		else
+			. = "stammers"
+	else if(derpspeech)
+		if(HAS_TRAIT(src, TRAIT_SIGN_LANG))
+			. = "incoherently signs"
+		else
+			. = "gibbers"
+	else
+		. = ..()
+*/
 
 /proc/uncostumize_say(input, message_mods)
 	. = input

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -430,7 +430,16 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 
 	return 0
 
-/mob/living/say_mod(input, list/message_mods = list())
+/mob/living/say_mod(input, message_mods)
+	if(message_mods == MODE_WHISPER_CRIT)
+		return ..()
+	if((input[1] == "!") && (length_char(input) > 1))
+		message_mods = MODE_CUSTOM_SAY
+		return copytext_char(input, 3)
+	var/customsayverb = findtext(input, "*")
+	if(customsayverb)
+		message_mods = MODE_CUSTOM_SAY
+		return lowertext(copytext_char(input, 1, customsayverb))
 	if(message_mods[WHISPER_MODE] == MODE_WHISPER)
 		. = verb_whisper
 	else if(message_mods[WHISPER_MODE] == MODE_WHISPER_CRIT)
@@ -449,6 +458,12 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			. = "gibbers"
 	else
 		. = ..()
+
+/proc/uncostumize_say(input, message_mods)
+	. = input
+	if(message_mods == MODE_CUSTOM_SAY)
+		var/customsayverb = findtext(input, "*")
+		return lowertext(copytext_char(input, 1, customsayverb))
 
 /mob/living/whisper(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	if(!message)

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -157,4 +157,3 @@
 		if(!message)
 			return
 	return message
-

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -14,6 +14,28 @@
 	if(message)
 		say(message)
 
+//SKYRAT custom sayverb EDIT
+
+/mob/say_mod(input, message_mods)
+	if(message_mods == MODE_WHISPER_CRIT)
+		return ..()
+	if((input[1] == "!") && (length_char(input) > 1))
+		message_mods = MODE_CUSTOM_SAY
+		return copytext_char(input, 3)
+	var/customsayverb = findtext(input, "*")
+	if(customsayverb)
+		message_mods = MODE_CUSTOM_SAY
+		return lowertext(copytext_char(input, 1, customsayverb))
+	return ..()
+
+/proc/uncostumize_say(input, list/message_mods = list())
+	. = input
+	if(message_mods == MODE_CUSTOM_SAY)
+		var/customsayverb = findtext(input, "*")
+		return lowertext(copytext_char(input, 1, customsayverb))
+
+//SKYRAT EDIT END
+
 ///Whisper verb
 /mob/verb/whisper_verb(message as text)
 	set name = "Whisper"
@@ -157,3 +179,4 @@
 		if(!message)
 			return
 	return message
+

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -14,28 +14,6 @@
 	if(message)
 		say(message)
 
-//SKYRAT custom sayverb EDIT
-
-/mob/say_mod(input, message_mods)
-	if(message_mods == MODE_WHISPER_CRIT)
-		return ..()
-	if((input[1] == "!") && (length_char(input) > 1))
-		message_mods = MODE_CUSTOM_SAY
-		return copytext_char(input, 3)
-	var/customsayverb = findtext(input, "*")
-	if(customsayverb)
-		message_mods = MODE_CUSTOM_SAY
-		return lowertext(copytext_char(input, 1, customsayverb))
-	return ..()
-
-/proc/uncostumize_say(input, list/message_mods = list())
-	. = input
-	if(message_mods == MODE_CUSTOM_SAY)
-		var/customsayverb = findtext(input, "*")
-		return lowertext(copytext_char(input, 1, customsayverb))
-
-//SKYRAT EDIT END
-
 ///Whisper verb
 /mob/verb/whisper_verb(message as text)
 	set name = "Whisper"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It allows you to use audible emotes for speech with a ! prefix. Like ';! cheers "Hello crew!"'.
Works without radio and with whisper command, too.

## Why It's Good For The Game

This code is ported from our very own oldbase. One of my own most awaited features to return.

## Changelog
:cl:
add: Audible emotes! Prefix your messages like ;! scoffs "I did ++not++ forget the nuke disk."
/:cl:
