### PR TITLE
Balances BZ and Miasma effects.

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -286,11 +286,12 @@
 		var/bz_pp = breath.get_breath_partial_pressure(breath_gases[/datum/gas/bz][MOLES])
 		if(bz_pp > BZ_trip_balls_min)
 			H.hallucination += 10
+			H.druggy += 5 //SKYRAT CHANGE.
 			H.reagents.add_reagent(/datum/reagent/bz_metabolites,5)
 			if(prob(33))
 				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3, 150)
 
-		else if(bz_pp > 0.01)
+		else if(bz_pp > 0.1) //SKYRAT CHANGE.
 			H.hallucination += 5
 			H.reagents.add_reagent(/datum/reagent/bz_metabolites,1)
 
@@ -390,7 +391,7 @@
 			var/miasma_pp = breath.get_breath_partial_pressure(breath_gases[/datum/gas/miasma][MOLES])
 
 			//Miasma sickness
-			if(prob(0.5 * miasma_pp))
+			if(miasma_pp >= 0.25 && prob(0.5 * miasma_pp)) //SKYRAT CHANGE
 				var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(min(round(max(miasma_pp/2, 1), 1), 6), min(round(max(miasma_pp, 1), 1), 8))
 				//tl;dr the first argument chooses the smaller of miasma_pp/2 or 6(typical max virus symptoms), the second chooses the smaller of miasma_pp or 8(max virus symptom level) //
 				miasma_disease.name = "Unknown"//^each argument has a minimum of 1 and rounds to the nearest value. Feel free to change the pp scaling I couldn't decide on good numbers for it.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

BZ now requires at least 0.1 moles instead of 0.01 to trigger BZ effects.
You now gain a druggy effect if you inhale too much BZ (1 mole).
Miasma now requires at least 0.25 moles instead of 0 moles to trigger a chance to trigger a disease per breath.


## Why It's Good For The Game

Similar tweaks existed on old skyrat and were absolutely needed. They're now needed even more considering Ice Box atmos or lavaland atmos has a chance to contain either BZ or miasma.

## Changelog
:cl: BurgerBB
balance: BZ now requires at least 0.1 moles instead of 0.01 to trigger BZ effects.
balance: You now gain a druggy effect if you inhale too much BZ (1 mole).
balance: Miasma now requires at least 0.25 moles instead of 0 moles to trigger a chance to trigger a disease.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
