### PR TITLE
[NON-MODULAR] Adds a crafting recipe for the double emergency oxygen tank

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -1030,6 +1030,22 @@
 	result = /obj/item/pickaxe/improvised
 	category = CAT_MISC
 
+// Skryat addition start
+/datum/crafting_recipe/doubletank
+	name = "Double emergency oxygen tank"
+	reqs = list(
+		/obj/item/tank/internals/emergency_oxygen/engi = 2,
+		/obj/item/stack/sticky_tape = 1,
+	)
+	result = /obj/item/tank/internals/emergency_oxygen/double/empty
+	category = CAT_MISC
+// Skyrat addition end
+
+/datum/crafting_recipe/New()
+	if(!(result in reqs))
+		blacklist += result
+
+
 /datum/crafting_recipe/underwater_basket
 	name = "Underwater Basket (Bamboo)"
 	reqs = list(

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -1041,11 +1041,6 @@
 	category = CAT_MISC
 // Skyrat addition end
 
-/datum/crafting_recipe/New()
-	if(!(result in reqs))
-		blacklist += result
-
-
 /datum/crafting_recipe/underwater_basket
 	name = "Underwater Basket (Bamboo)"
 	reqs = list(


### PR DESCRIPTION
## About The Pull Request

A simple crafting recipe addition. Two engi tanks and sticky tape makes a double engi tank.

## Why It's Good For The Game

The double emergency tank is nice, it gives about 40 minutes of air. To my knowledge it is only attainable through maintenance spawn as of now.

## Changelog
:cl:
add: Adds a crafting recipe for the double emergency oxygen tank.
/:cl:
