### PR TITLE
[Modular] Adds a bunch of new cargo packs for medical and engineering

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -75,7 +75,7 @@
 /datum/supply_pack/medical/hardsuit_medical
 	name = "Medical Hardsuit Crate"
 	desc = "Contains a single hardsuit, built to standard medical specifications."
-	cost = CARGO_CRATE_VALUE * 10
+	cost = CARGO_CRATE_VALUE * 13
 	access = ACCESS_MEDICAL
 	contains = list(/obj/item/clothing/suit/space/hardsuit/medical)
 	crate_name = "medical hardsuit crate"
@@ -154,7 +154,7 @@
 	desc = "Contains a single hardsuit, built to standard engineering specifications."
 	access_view = ACCESS_ENGINE_EQUIP
 	contains = list(/obj/item/clothing/suit/space/hardsuit/engine)
-	cost = CARGO_CRATE_VALUE * 10
+	cost = CARGO_CRATE_VALUE * 13
 	crate_name = "engineering hardsuit crate"
 
 /datum/supply_pack/engineering/hardsuit_atmospherics
@@ -162,7 +162,7 @@
 	desc = "Contains a single hardsuit, built to standard atmospherics suit specifications."
 	access_view = ACCESS_ENGINE_EQUIP
 	contains = list(/obj/item/clothing/suit/space/hardsuit/engine/atmos)
-	cost = CARGO_CRATE_VALUE * 13
+	cost = CARGO_CRATE_VALUE * 16
 	crate_name = "atmospherics hardsuit crate"
 
 /datum/supply_pack/engineering/engi_inducers

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -88,7 +88,7 @@
 	contains = list(/obj/item/defibrillator/compact/combat/loaded/nanotrasen)
 	crate_name = "advanced defibrillator crate"
 
-/datum/supply_pack/medical/advanced_defib
+/datum/supply_pack/medical/medigun
 	name = "Experimental Medical Beam Crate"
 	desc = "Contains a single experimental NT-tech Medical Beam Gun, a highly experimental device capable of sending temporary healing nanites across a short distance."
 	cost = CARGO_CRATE_VALUE * 50
@@ -157,7 +157,7 @@
 	cost = CARGO_CRATE_VALUE * 10
 	crate_name = "engineering hardsuit crate"
 
-/datum/supply_pack/engineering/hardsuit_atmospherings
+/datum/supply_pack/engineering/hardsuit_atmospherics
 	name = "Atmospherics Hardsuit Crate"
 	desc = "Contains a single hardsuit, built to standard atmospherics suit specifications."
 	access_view = ACCESS_ENGINE_EQUIP

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -72,6 +72,108 @@
                     /obj/item/storage/box/medipens)
 	crate_name = "medipen crate"
 
+/datum/supply_pack/medical/hardsuit_medical
+	name = "Medical Hardsuit Crate"
+	desc = "Contains a single hardsuit, built to standard medical specifications."
+	cost = CARGO_CRATE_VALUE * 10
+	access = ACCESS_MEDICAL
+	contains = list(/obj/item/clothing/suit/space/hardsuit/medical)
+	crate_name = "medical hardsuit crate"
+
+/datum/supply_pack/medical/advanced_defib
+	name = "Advanced Defibrillator Crate"
+	desc = "Contains a single high-tech NT defibrillator, capable of self-charging and applying reviving shocks through thick clothing materials."
+	cost = CARGO_CRATE_VALUE * 25
+	access = ACCESS_CMO
+	contains = list(/obj/item/defibrillator/compact/combat/loaded/nanotrasen)
+	crate_name = "advanced defibrillator crate"
+
+/datum/supply_pack/medical/advanced_defib
+	name = "Experimental Medical Beam Crate"
+	desc = "Contains a single experimental NT-tech Medical Beam Gun, a highly experimenal device capable of sending temporary healing nanites across a short distance."
+	cost = CARGO_CRATE_VALUE * 50
+	access = ACCESS_CMO
+	contains = list(/obj/item/gun/medbeam)
+	crate_name = "medical beam gun crate"
+
+//////////////////////////////////////////////////////////////////////////////
+///////////////////////////// Engineering ////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/engineering/industrial_rcd
+	name = "Industrial RCD Crate"
+	desc = "Manufactured at a high-tech NT production facility, this pack contains 2 industrial RCDs with expanded matter reserves and upgraded deconstructors."
+	access_view = ACCESS_ENGINE_EQUIP
+	contains = list(/obj/item/construction/rcd/combat,
+					/obj/item/construction/rcd/combat)
+	cost = CARGO_CRATE_VALUE * 40
+	crate_name = "industrial RCD crate"
+
+/datum/supply_pack/engineering/experimental_rcd
+	name = "Experimental RCD Crate"
+	desc = "Contains a single highly advanced RCD, capable of projecting its improved construction nanites at an increased range."
+	access = ACCESS_CE
+	access_view = ACCESS_ENGINE_EQUIP
+	contains = list(/obj/item/construction/rcd/arcd)
+	cost = CARGO_CRATE_VALUE * 50
+	crate_name = "experimental RCD crate"
+
+/datum/supply_pack/engineering/material_pouches
+	name = "Material Pouches Crate"
+	desc = "Contains three material pouches."
+	access_view = ACCESS_ENGINE_EQUIP
+	contains = list(/obj/item/storage/bag/material,
+					/obj/item/storage/bag/material,
+					/obj/item/storage/bag/material)
+	cost = CARGO_CRATE_VALUE * 15
+	crate_name = "material pouches crate"
+
+/datum/supply_pack/engineering/material_pouches
+	name = "Double extended emergency tank Crate"
+	desc = "Contains four double extended-capacity emergency tanks."
+	access_view = ACCESS_ENGINE_EQUIP
+	contains = list(/obj/item/tank/internals/emergency_oxygen/double,
+					/obj/item/tank/internals/emergency_oxygen/double,
+					/obj/item/tank/internals/emergency_oxygen/double,
+					/obj/item/tank/internals/emergency_oxygen/double)
+	cost = CARGO_CRATE_VALUE * 15
+	crate_name = "double extended emergency tank crate"
+
+/datum/supply_pack/engineering/advanced_extinguisher
+	name = "Advanced Foam Extinguisher Crate"
+	desc = "Contains advanced fire extinguishers which use foam as extinguishing agent."
+	access_view = ACCESS_ENGINE_EQUIP
+	contains = list(/obj/item/extinguisher/advanced,
+					/obj/item/extinguisher/advanced,
+					/obj/item/extinguisher/advanced)
+	cost = CARGO_CRATE_VALUE * 18
+	crate_name = "advanced extinguisher crate"
+
+/datum/supply_pack/engineering/hardsuit_engineering
+	name = "Engineering Hardsuit Crate"
+	desc = "Contains a single hardsuit, built to standard engineering specifications."
+	access_view = ACCESS_ENGINE_EQUIP
+	contains = list(/obj/item/clothing/suit/space/hardsuit/engine)
+	cost = CARGO_CRATE_VALUE * 10
+	crate_name = "engineering hardsuit crate"
+
+/datum/supply_pack/engineering/hardsuit_atmospherings
+	name = "Atmospherics Hardsuit Crate"
+	desc = "Contains a single hardsuit, built to standard atmospherics suit specifications."
+	access_view = ACCESS_ENGINE_EQUIP
+	contains = list(/obj/item/clothing/suit/space/hardsuit/engine/atmos)
+	cost = CARGO_CRATE_VALUE * 13
+	crate_name = "atmospherics hardsuit crate"
+
+/datum/supply_pack/engineering/engi_inducers
+	name = "NT-150 Industrial Power Inducers Crate"
+	desc = "An improveed model over the NT-75 EPI, the NT-150 charges at double the rate and contains an improved powercell. Contains two engineering-spec Inducers."
+	cost = CARGO_CRATE_VALUE * 6
+	contains = list(/obj/item/inducer,
+					/obj/item/inducer)
+	crate_name = "engineering inducer crate"
+	crate_type = /obj/structure/closet/crate/engineering/electrical
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Misc Crates /////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -91,10 +91,22 @@
 /datum/supply_pack/medical/medigun
 	name = "Experimental Medical Beam Crate"
 	desc = "Contains a single experimental NT-tech Medical Beam Gun, a highly experimental device capable of sending temporary healing nanites across a short distance."
-	cost = CARGO_CRATE_VALUE * 50
+	cost = CARGO_CRATE_VALUE * 75
 	access = ACCESS_CMO
 	contains = list(/obj/item/gun/medbeam)
 	crate_name = "medical beam gun crate"
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Security ////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/security/hardsuit_security
+	name = "Security Hardsuit Crate"
+	desc = "Contains a single armored up hardsuit, built to standard security specifications."
+	cost = CARGO_CRATE_VALUE * 16
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/clothing/suit/space/hardsuit/security)
+	crate_name = "security hardsuit crate"
 
 //////////////////////////////////////////////////////////////////////////////
 ///////////////////////////// Engineering ////////////////////////////////////

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -90,7 +90,7 @@
 
 /datum/supply_pack/medical/advanced_defib
 	name = "Experimental Medical Beam Crate"
-	desc = "Contains a single experimental NT-tech Medical Beam Gun, a highly experimenal device capable of sending temporary healing nanites across a short distance."
+	desc = "Contains a single experimental NT-tech Medical Beam Gun, a highly experimental device capable of sending temporary healing nanites across a short distance."
 	cost = CARGO_CRATE_VALUE * 50
 	access = ACCESS_CMO
 	contains = list(/obj/item/gun/medbeam)
@@ -167,7 +167,7 @@
 
 /datum/supply_pack/engineering/engi_inducers
 	name = "NT-150 Industrial Power Inducers Crate"
-	desc = "An improveed model over the NT-75 EPI, the NT-150 charges at double the rate and contains an improved powercell. Contains two engineering-spec Inducers."
+	desc = "An improved model over the NT-75 EPI, the NT-150 charges at double the rate and contains an improved powercell. Contains two engineering-spec Inducers."
 	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/obj/item/inducer,
 					/obj/item/inducer)

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -128,7 +128,7 @@
 	cost = CARGO_CRATE_VALUE * 15
 	crate_name = "material pouches crate"
 
-/datum/supply_pack/engineering/material_pouches
+/datum/supply_pack/engineering/doublecap_tanks
 	name = "Double extended emergency tank Crate"
 	desc = "Contains four double extended-capacity emergency tanks."
 	access_view = ACCESS_ENGINE_EQUIP

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -221,7 +221,7 @@
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/meow.ogg'
 
 /datum/emote/living/hiss
-	key = "hiss"
+	key = "hiss1"
 	key_third_person = "hisses"
 	message = "hisses!"
 	emote_type = EMOTE_AUDIBLE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Contains the following packs (contents, (cost total)):
**Engineering**
2x Industrial RCD (8k)
1x Advanced RCD (10k)
3x Material Pouches (3k)
4x double-cap emergency O2 tanks (3k)
3x advanced fire extinguishers (3.6k)
1x engineering hardsuit (2.6k)
1x atmospherics hardsuit (3.2k)
3x engineering inducers (1.2k)

**Medical**
1x medical hardsuit (2.6k)
1x NanoTrasen Defib (5k)
1x Medical Beam Gun (15k)

**Security**
1x security hardsuit (3.2k)

this PR also bugfixes the *hiss emote by turning it into *hiss1 so it doesn't conflict with xenos, because I accidentally pushed the fix to this branch so this is where it goes now

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This adds a bunch of missing, limited supply, and a few normally unobtainable items to cargo crates for (what I believe; feel free to discuss) are balanced prices, incentivizing more use of the cargo bounties by the medical and engineering departments in order to get these new items.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a bunch new cargo crates for engineering and medical.
fix: *hiss is now *hiss1 so it actually works again and doesn't conflict with xeno hiss.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
