### PR TITLE
The Nuke Disk can no longer trigger the lone ops event.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -629,8 +629,8 @@ This is here to make the tiles around the station mininuke change when it's arme
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 30, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/fake = FALSE
-	var/turf/lastlocation
-	var/last_disk_move
+	//var/turf/lastlocation SKYRAT CHANGE
+	//var/last_disk_move SKYRAT CHANGE
 
 /obj/item/disk/nuclear/Initialize()
 	. = ..()
@@ -638,13 +638,14 @@ This is here to make the tiles around the station mininuke change when it's arme
 
 	if(!fake)
 		AddElement(/datum/element/point_of_interest)
-		last_disk_move = world.time
-		START_PROCESSING(SSobj, src)
+		//last_disk_move = world.time SKYRAT CHANGE
+		//START_PROCESSING(SSobj, src) SKYRAT CHANGE
 
 /obj/item/disk/nuclear/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/stationloving, !fake)
 
+/* SKYRAT CHANGE. No more nuke disk processing
 /obj/item/disk/nuclear/process()
 	if(fake)
 		STOP_PROCESSING(SSobj, src)
@@ -679,6 +680,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 			if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
 				message_admins("[src] is on the move (currently in [ADMIN_VERBOSEJMP(newturf)]). The weight of Lone Operative is now [loneop.weight].")
 			log_game("[src] being on the move has reduced the weight of the Lone Operative event to [loneop.weight].")
+*/
 
 /obj/item/disk/nuclear/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevents the nuke disk from triggering the lone ops event due to disk idling.

## Why It's Good For The Game

In order to understand why this needs removal, you must first understand why lone ops occurs. Lone Ops occurs when the nuke disk is stationary for more than 500 seconds and a dice roll occurs that increases the chance by 1 percent every 1000 seconds. This dice roll occurs every process tick, which I think is every second. It then adds a weight to nuke ops occurring in the event processor. It's a lot of pointless RNG but once ever so often, it does trigger pretty frequently if the disk is stationary because of permutations.

As per antag policy, antags and crewmembers are expected to avoid metagaming and powergaming when interacting with eachother. They are usually expected to roleplay first as well. If a crewmember shuts down an antag's gimmick because they're an antag, they're going to get a bwoink. Likewise, if an antag shuts down a crewmember's enjoyment via round removal, they're also going to get a bwoink unless they deserve something for round removal. It isn't baby-proofing fo the sake of RP but rather a gentleman's agreement saying that both sides will avoid powergaming for the sake of having more fun. If we didn't have these rules in place, antag would be permitted to mass kill everyone because they _could_ be doing stuff to stop them and robotics would be permitted to make an army of Gygaxes because antags _could_ be planning on going loud this round.

However, for some reason, lone ops is except from the policies that I described. **A ghost role that has the power to end a round entirely and shut down the existing antag's gimmicks as well is except from these policies as long as they turn on combat indicator and do everything to secure the disk and nuke the station.** Ghost roles should absolutely not have this power considering that **there is literally nothing stopping the ghost role, other than guilt, from using the information they gained as ghost to complete their objective.** There is a feature that literally informs ghosts that the nuke disk is stationary and the operative spawn is a result of that disk being stationary. No other ghost role benefits this much from extra information.

All in all, the existence of lone ops is absolutely inconsistent. Nuke ops is not in rotation, but lone ops is? Wizard isn't in rotation, but lone ops is? Mid round ninjas are disabled, but lone ops is?

## Changelog
:cl: BurgerBB
del: Disables Lone Ops from spawning due to immobile nuke disk. Admins can still spawn this antagonist if they wish.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
