### PR TITLE
Prohibits the HoP from opening blueshield slots.

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -34,7 +34,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		"Chief Engineer",
 		"Research Director",
 		"Chief Medical Officer",
-		"Blueshield"	//SKYRAT EDIT: Blueshield slots should never be above 1.
+		"Blueshield",	//SKYRAT EDIT: Blueshield slots should never be above 1.
 		"Prisoner")
 
 	//The scaling factor of max total positions in relation to the total amount of people on board the station in %

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -34,6 +34,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		"Chief Engineer",
 		"Research Director",
 		"Chief Medical Officer",
+		"Blueshield"	//SKYRAT EDIT: Blueshield slots should never be above 1.
 		"Prisoner")
 
 	//The scaling factor of max total positions in relation to the total amount of people on board the station in %


### PR DESCRIPTION
## About The Pull Request
Tested and working. Makes it so you cannot add modify slots through the ID console.

## Why It's Good For The Game
Blueshield have a high power level, some would argue too high, some would argue enough.
![image](https://user-images.githubusercontent.com/53862927/105655583-34565a80-5eb8-11eb-9aa3-21835f2d1a58.png)
If you have two blueshields, what are antags gong to do?
Also redshield bad.

## Changelog
:cl:
fix: You can no longer open additional blueshield slots.
/:cl:
