### PR TITLE
Powersinks can no longer be purchased via Traitor Uplink

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1510,6 +1510,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/sbeacondrop
 	cost = 10
 
+/* SKYRAT CHANGE, REMOVAL
 /datum/uplink_item/device_tools/powersink
 	name = "Power Sink"
 	desc = "When screwed to wiring attached to a power grid and activated, this large device lights up and places excessive \
@@ -1517,6 +1518,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			traditional bags and boxes. Caution: Will explode if the powernet contains sufficient amounts of energy."
 	item = /obj/item/powersink
 	cost = 10
+/*
 
 /datum/uplink_item/device_tools/rad_laser
 	name = "Radioactive Microlaser"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1518,7 +1518,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			traditional bags and boxes. Caution: Will explode if the powernet contains sufficient amounts of energy."
 	item = /obj/item/powersink
 	cost = 10
-/*
+*/
 
 /datum/uplink_item/device_tools/rad_laser
 	name = "Radioactive Microlaser"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes powersinks from the uplink.

## Why It's Good For The Game

Powersinks are one of those items that just completely halt a round and are never used to further a goal or an objective that is actually meaningful. When they are purchased, they are consistently placed in meta locations or their own custom locations, usually in locations that are absolutely absurd and require EVA equipment not typically issued to crew. Even with a population of 80, there are only a few people willing and able to actually locate a powersink and even fewer able to actually search in locations it's usually in.

With the extremely low price of 10TC (Traitors are given 30TC in total!), it absolutely does too much to damage a round and arguably does more damage to the round of the 18TC Syndicate Bomb, which actually has a highly likelihood of being discovered due to the ticking sound effect. and affects a smaller area of the station. The seriously low price can actually allow a total of 3 purchases per traitor, assuming that it isn't on sale, which can unironically be enough to halt the round for a significant period of time.

I think if an antagonist wishes to use this item, they should contact admins instead and do a TC trade like some people do when they ask for special antag types like wizard, or ask for special items. In moderation, the power sink is fine but I think people have abused this uplink item way too much to remain an actual uplink item. The rebase was a chance to prove everyone wrong when it was added back in rotation but I don't think anyone was proved wrong.

You can see the PR in oldbase here: https://github.com/Skyrat-SS13/Skyrat13/pull/1777

## Changelog
:cl: BurgerBB
del:  Removes power sinks from the uplink.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
