### PR TITLE
Nerfs Powersinks

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -18,9 +18,9 @@
 	throw_speed = 1
 	throw_range = 2
 	custom_materials = list(/datum/material/iron=750)
-	var/drain_rate = 2000000	// amount of power to drain per tick
+	var/drain_rate = 300000	// amount of power to drain per tick //SKYRAT CHANGE
 	var/power_drained = 0 		// has drained this much power
-	var/max_power = 6e8		// maximum power that can be drained before exploding
+	var/max_power = 3e7		// maximum power that can be drained before exploding //SKYRAT CHANGE
 	var/mode = 0		// 0 = off, 1=clamped (off), 2=operating
 	var/admins_warned = FALSE // stop spam, only warn the admins once that we are about to boom
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1516,7 +1516,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			load on the grid, causing a station-wide blackout. The sink is large and cannot be stored in most \
 			traditional bags and boxes. Caution: Will explode if the powernet contains sufficient amounts of energy."
 	item = /obj/item/powersink
-	cost = 10
+	cost = 16 //SKYRAT CHANGE, CAN ONLY BUY ONE PER PERSON (WITH 30TC)
 
 /datum/uplink_item/device_tools/rad_laser
 	name = "Radioactive Microlaser"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8602857/105802674-89de4600-5f50-11eb-8ea2-2fe21af4487d.png)

Gottem.



But no this PR actually adjusts the power sink drain rate to be the same as a supercharged supermatter on an average shift (300,000) and will detonate in 20 seconds if it can leech that power at a consistent rate.




## Changelog
:cl: BurgerBB
balance: Reduced the drain of powersinks to be roughly an SM output. Powersinks should explode now. Powersinks are now 16 TC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
