### PR TITLE
[ASSOPS] Removes The Orbital Mech Pad From DS-1

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat.dmm
@@ -6450,13 +6450,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/cruiser_dock)
-"GQ" = (
-/obj/machinery/computer/mechpad{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/cruiser_dock)
 "GY" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -8904,11 +8897,6 @@
 "WN" = (
 /obj/effect/mob_spawn/human/syndicate/assops/syndicate_assistant,
 /turf/open/floor/carpet,
-/area/cruiser_dock)
-"WP" = (
-/obj/machinery/mechpad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
 /area/cruiser_dock)
 "WR" = (
 /obj/structure/window/reinforced{
@@ -43228,8 +43216,8 @@ pt
 aA
 Yo
 ma
-GQ
-WP
+aA
+aA
 Yo
 ma
 aA


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Why was this even in robotics to begin with. Round 606 I tested it out and was able to send a DS-1 death ripley to the station. Probably works the other way around too, and no, I don't want to find out for myself.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
as funny as a ghostrole being able to send mail-order ripleys to cargo and robotics is, this is obviously unintentional and could be exploited to hell and back.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
Omitted, again

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
