### PR TITLE
[Semi-modular] View Latest Ticket ahelp command for players

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -536,7 +536,8 @@
 	if(player_ckey)
 		create_message("note", player_ckey, admin_ckey, note_reason, null, null, 0, 0, null, 0, severity)
 	var/client/C = GLOB.directory[player_ckey]
-	var/datum/admin_help/AH = admin_ticket_log(player_ckey, "[kna] [msg]")
+	// var/datum/admin_help/AH = admin_ticket_log(player_ckey, "[kna] [msg]") // SKYRAT EDIT ORIGINAL
+	var/datum/admin_help/AH = admin_ticket_log(player_ckey, "[kna] [msg]", FALSE) // SKYRAT EDIT --  Player ticket viewing
 	var/appeal_url = "No ban appeal url set!"
 	appeal_url = CONFIG_GET(string/banappeals)
 	var/is_admin = FALSE

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -215,10 +215,11 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	statclick = new(null, src)
 	_interactions = list()
+	_interactions_player = list() // SKYRAT EDIT ADDITION -- Player ticket viewing
 
 	if(is_bwoink)
 		AddInteraction("<font color='blue'>[key_name_admin(usr)] PM'd [LinkedReplyName()]</font>")
-		AddInteractionPlayer("<font color='blue'>[key_name_admin(usr, null, FALSE)] PM'd [LinkedReplyName()]</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
+		AddInteractionPlayer("<font color='blue'>[key_name_admin(usr, FALSE)] PM'd [LinkedReplyName()]</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
 		message_admins("<font color='blue'>Ticket [TicketHref("#[id]")] created</font>")
 	else
 		MessageNoRecipient(msg)
@@ -332,7 +333,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		initiator.current_ticket = src
 
 	AddInteraction("<font color='purple'>Reopened by [key_name_admin(usr)]</font>")
-	AddInteractionPlayer("<font color='purple'>Reopened by [key_name_admin(usr, null, FALSE)]</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
+	AddInteractionPlayer("<font color='purple'>Reopened by [key_name_admin(usr, FALSE)]</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
 	var/msg = "<span class='adminhelp'>Ticket [TicketHref("#[id]")] reopened by [key_name_admin(usr)].</span>"
 	message_admins(msg)
 	log_admin_private(msg)
@@ -364,7 +365,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	state = AHELP_CLOSED
 	GLOB.ahelp_tickets.ListInsert(src)
 	AddInteraction("<font color='red'>Closed by [key_name].</font>")
-	AddInteractionPlayer("<font color='red'>Closed by [key_name].</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
+	AddInteractionPlayer("<font color='red'>Closed by [key_name_admin(usr, FALSE)].</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
 	if(!silent)
 		SSblackbox.record_feedback("tally", "ahelp_stats", 1, "closed")
 		var/msg = "Ticket [TicketHref("#[id]")] closed by [key_name]."
@@ -391,7 +392,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	addtimer(CALLBACK(initiator, /client/proc/giveadminhelpverb), 50)
 
 	AddInteraction("<font color='green'>Resolved by [key_name].</font>")
-	AddInteractionPlayer("<font color='green'>Resolved by [key_name].</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
+	AddInteractionPlayer("<font color='green'>Resolved by [key_name_admin(usr, FALSE)].</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
 	to_chat(initiator, "<span class='adminhelp'>Your ticket has been resolved by an admin. The Adminhelp verb will be returned to you shortly.</span>", confidential = TRUE)
 	if(!silent)
 		SSblackbox.record_feedback("tally", "ahelp_stats", 1, "resolved")
@@ -426,7 +427,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	message_admins(msg)
 	log_admin_private(msg)
 	AddInteraction("Rejected by [key_name].")
-	AddInteractionPlayer("Rejected by [key_name].") // SKYRAT EDIT ADDITION -- Player ticket viewing
+	AddInteractionPlayer("Rejected by [key_name_admin(usr, FALSE)].") // SKYRAT EDIT ADDITION -- Player ticket viewing
 	SSblackbox.LogAhelp(id, "Rejected", "Rejected by [usr.key]", null, usr.ckey)
 	Close(silent = TRUE)
 
@@ -453,7 +454,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	message_admins(msg)
 	log_admin_private(msg)
 	AddInteraction("Marked as IC issue by [key_name]")
-	AddInteractionPlayer("Marked as IC issue by [key_name]") // SKYRAT EDIT ADDITION -- Player ticket viewing
+	AddInteractionPlayer("Marked as IC issue by [key_name_admin(usr, FALSE)]") // SKYRAT EDIT ADDITION -- Player ticket viewing
 	SSblackbox.LogAhelp(id, "IC Issue", "Marked as IC issue by [usr.key]", null,  usr.ckey)
 	Resolve(silent = TRUE)
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -218,6 +218,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	if(is_bwoink)
 		AddInteraction("<font color='blue'>[key_name_admin(usr)] PM'd [LinkedReplyName()]</font>")
+		AddInteractionPlayer("<font color='blue'>[key_name_admin(usr, null, FALSE)] PM'd [LinkedReplyName()]</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
 		message_admins("<font color='blue'>Ticket [TicketHref("#[id]")] created</font>")
 	else
 		MessageNoRecipient(msg)
@@ -286,6 +287,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	var/admin_msg = "<span class='adminnotice'><span class='adminhelp'>Ticket [TicketHref("#[id]", ref_src)]</span><b>: [LinkedReplyName(ref_src)] [FullMonty(ref_src)]:</b> <span class='linkify'>[keywords_lookup(msg)]</span></span>"
 
 	AddInteraction("<font color='red'>[LinkedReplyName(ref_src)]: [msg]</font>")
+	AddInteractionPlayer("<font color='red'>[LinkedReplyName(ref_src)]: [msg]</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
 	log_admin_private("Ticket #[id]: [key_name(initiator)]: [msg]")
 
 	//send this msg to all admins
@@ -330,6 +332,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		initiator.current_ticket = src
 
 	AddInteraction("<font color='purple'>Reopened by [key_name_admin(usr)]</font>")
+	AddInteractionPlayer("<font color='purple'>Reopened by [key_name_admin(usr, null, FALSE)]</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
 	var/msg = "<span class='adminhelp'>Ticket [TicketHref("#[id]")] reopened by [key_name_admin(usr)].</span>"
 	message_admins(msg)
 	log_admin_private(msg)
@@ -361,6 +364,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	state = AHELP_CLOSED
 	GLOB.ahelp_tickets.ListInsert(src)
 	AddInteraction("<font color='red'>Closed by [key_name].</font>")
+	AddInteractionPlayer("<font color='red'>Closed by [key_name].</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
 	if(!silent)
 		SSblackbox.record_feedback("tally", "ahelp_stats", 1, "closed")
 		var/msg = "Ticket [TicketHref("#[id]")] closed by [key_name]."
@@ -387,6 +391,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	addtimer(CALLBACK(initiator, /client/proc/giveadminhelpverb), 50)
 
 	AddInteraction("<font color='green'>Resolved by [key_name].</font>")
+	AddInteractionPlayer("<font color='green'>Resolved by [key_name].</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
 	to_chat(initiator, "<span class='adminhelp'>Your ticket has been resolved by an admin. The Adminhelp verb will be returned to you shortly.</span>", confidential = TRUE)
 	if(!silent)
 		SSblackbox.record_feedback("tally", "ahelp_stats", 1, "resolved")
@@ -421,6 +426,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	message_admins(msg)
 	log_admin_private(msg)
 	AddInteraction("Rejected by [key_name].")
+	AddInteractionPlayer("Rejected by [key_name].") // SKYRAT EDIT ADDITION -- Player ticket viewing
 	SSblackbox.LogAhelp(id, "Rejected", "Rejected by [usr.key]", null, usr.ckey)
 	Close(silent = TRUE)
 
@@ -447,6 +453,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	message_admins(msg)
 	log_admin_private(msg)
 	AddInteraction("Marked as IC issue by [key_name]")
+	AddInteractionPlayer("Marked as IC issue by [key_name]") // SKYRAT EDIT ADDITION -- Player ticket viewing
 	SSblackbox.LogAhelp(id, "IC Issue", "Marked as IC issue by [usr.key]", null,  usr.ckey)
 	Resolve(silent = TRUE)
 
@@ -587,7 +594,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 //Use this proc when an admin takes action that may be related to an open ticket on what
 //what can be a client, ckey, or mob
-/proc/admin_ticket_log(what, message)
+// /proc/admin_ticket_log(what, message) // SKYRAT EDIT ORIGINAL
+/proc/admin_ticket_log(what, message, admin_only = TRUE) // SKYRAT EDIT CHANGE -- Player ticket viewing
 	var/client/C
 	var/mob/Mob = what
 	if(istype(Mob))
@@ -596,11 +604,19 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		C = what
 	if(istype(C) && C.current_ticket)
 		C.current_ticket.AddInteraction(message)
+		// SKYRAT EDIT ADDITION START -- Player ticket viewing
+		if(!admin_only)
+			C.current_ticket.AddInteractionPlayer(message)
+		// SKYRAT EDIT ADDITION END
 		return C.current_ticket
 	if(istext(what))	//ckey
 		var/datum/admin_help/AH = GLOB.ahelp_tickets.CKey2ActiveTicket(what)
 		if(AH)
 			AH.AddInteraction(message)
+			// SKYRAT EDIT ADDITION START -- Player ticket viewing
+			if(!admin_only)
+				AH.AddInteractionPlayer(message)
+			// SKYRAT EDIT ADDITION END
 			return AH
 
 //

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -286,7 +286,7 @@
 					confidential = TRUE)
 
 				// admin_ticket_log(recipient, "<font color='purple'>PM From [key_name_admin(src)]: [keywordparsedmsg]</font>") // SKYRAT EDIT ORIGINAL
-				admin_ticket_log(recipient, "<font color='purple'>PM From [key_name_admin(src, null, FALSE)]: [keywordparsedmsg]</font>", FALSE) // SKYRAT EDIT CHANGE -- Player ticket viewing
+				admin_ticket_log(recipient, "<font color='purple'>PM From [key_name_admin(src, FALSE)]: [keywordparsedmsg]</font>", FALSE) // SKYRAT EDIT CHANGE -- Player ticket viewing
 
 				if(!already_logged) //Reply to an existing ticket
 					SSblackbox.LogAhelp(recipient.current_ticket.id, "Reply", msg, recipient.ckey, src.ckey)

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -205,6 +205,7 @@
 			html = "<span class='notice'>PM to-<b>Admins</b>: <span class='linkify'>[rawmsg]</span></span>",
 			confidential = TRUE)
 		var/datum/admin_help/AH = admin_ticket_log(src, "<font color='red'>Reply PM from-<b>[key_name(src, TRUE, TRUE)]</b> to <i>External</i>: [keywordparsedmsg]</font>")
+		AH.AddInteractionPlayer("<font color='red'>Reply PM from-<b>[key_name(src, TRUE, FALSE)]</b> to <i>External</i>: [keywordparsedmsg]</font>") // SKYRAT EDIT ADDITION -- Player ticket viewing
 		externalreplyamount--
 		send2adminchat("[AH ? "#[AH.id] " : ""]Reply: [ckey]", rawmsg)
 	else
@@ -223,13 +224,16 @@
 					confidential = TRUE)
 				//omg this is dumb, just fill in both their tickets
 				var/interaction_message = "<font color='purple'>PM from-<b>[key_name(src, recipient, 1)]</b> to-<b>[key_name(recipient, src, 1)]</b>: [keywordparsedmsg]</font>"
-				admin_ticket_log(src, interaction_message)
+				// admin_ticket_log(src, interaction_message) // SKYRAT EDIT ORIGINAL
+				admin_ticket_log(src, interaction_message, FALSE) // SKYRAT EDIT CHANGE -- Player ticket viewing
 				if(recipient != src)	//reeee
-					admin_ticket_log(recipient, interaction_message)
+					// admin_ticket_log(recipient, interaction_message) // SKYRAT EDIT ORIGINAL
+					admin_ticket_log(recipient, interaction_message, FALSE) // SKYRAT EDIT CHANGE -- Player ticket viewing
 				SSblackbox.LogAhelp(current_ticket.id, "Reply", msg, recipient.ckey, src.ckey)
 			else		//recipient is an admin but sender is not
 				var/replymsg = "Reply PM from-<b>[key_name(src, recipient, 1)]</b>: <span class='linkify'>[keywordparsedmsg]</span>"
-				admin_ticket_log(src, "<font color='red'>[replymsg]</font>")
+				// admin_ticket_log(src, "<font color='red'>[replymsg]</font>") // SKYRAT EDIT ORIGINAL
+				admin_ticket_log(src, "<font color='red'>[replymsg]</font>", FALSE) // SKYRAT EDIT CHANGE -- Player ticket viewing
 				to_chat(recipient,
 					type = MESSAGE_TYPE_ADMINPM,
 					html = "<span class='danger'>[replymsg]</span>",
@@ -281,7 +285,8 @@
 					html = "<span class='notice'>Admin PM to-<b>[key_name(recipient, src, 1)]</b>: <span class='linkify'>[msg]</span></span>",
 					confidential = TRUE)
 
-				admin_ticket_log(recipient, "<font color='purple'>PM From [key_name_admin(src)]: [keywordparsedmsg]</font>")
+				// admin_ticket_log(recipient, "<font color='purple'>PM From [key_name_admin(src)]: [keywordparsedmsg]</font>") // SKYRAT EDIT ORIGINAL
+				admin_ticket_log(recipient, "<font color='purple'>PM From [key_name_admin(src, null, FALSE)]: [keywordparsedmsg]</font>", FALSE) // SKYRAT EDIT CHANGE -- Player ticket viewing
 
 				if(!already_logged) //Reply to an existing ticket
 					SSblackbox.LogAhelp(recipient.current_ticket.id, "Reply", msg, recipient.ckey, src.ckey)

--- a/modular_skyrat/modules/admin/code/admin_help.dm
+++ b/modular_skyrat/modules/admin/code/admin_help.dm
@@ -40,7 +40,7 @@
 			dat += "CLOSED</b>"
 		else
 			dat += "UNKNOWN</b>"
-	dat += "<br><br>Opened at: [gameTimestamp("hh:mm:ss", closed_at)] (Approx [DisplayTimeText(world.time - opened_at)] ago)"
+	dat += "<br><br>Opened at: [gameTimestamp("hh:mm:ss", opened_at)] (Approx [DisplayTimeText(world.time - opened_at)] ago)"
 	if(closed_at)
 		dat += "<br>Closed at: [gameTimestamp("hh:mm:ss", closed_at)] (Approx [DisplayTimeText(world.time - closed_at)] ago)"
 	dat += "<br><br>"

--- a/modular_skyrat/modules/admin/code/admin_help.dm
+++ b/modular_skyrat/modules/admin/code/admin_help.dm
@@ -1,5 +1,6 @@
 /datum/admin_help
 	var/handler
+	var/list/_interactions_player
 
 //Let the initiator know their ahelp is being handled
 /datum/admin_help/proc/HandleIssue(key_name = key_name_admin(usr))
@@ -23,5 +24,38 @@
 	message_admins(msg)
 	log_admin_private(msg)
 	AddInteraction("Being handled by [key_name]")
+	AddInteractionPlayer("Being handled by [key_name]")
 
 	handler = "[usr.ckey]"
+
+/datum/admin_help/proc/PlayerTicketPanel()
+	var/list/dat = list("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Player Ticket</title></head>")
+	var/ref_src = "[REF(src)]"
+	dat += "<b>State: "
+	switch(state)
+		if(AHELP_ACTIVE)
+			dat += "<font color='red'>OPEN</font>"
+		if(AHELP_RESOLVED)
+			dat += "<font color='green'>RESOLVED</font>"
+		if(AHELP_CLOSED)
+			dat += "CLOSED"
+		else
+			dat += "UNKNOWN"
+	dat += "</b>[FOURSPACES][PlayerTicketHref("Refresh", ref_src)]"
+	dat += "<br><br>Opened at: [gameTimestamp("hh:mm:ss", closed_at)] (Approx [DisplayTimeText(world.time - opened_at)] ago)"
+	if(closed_at)
+		dat += "<br>Closed at: [gameTimestamp("hh:mm:ss", closed_at)] (Approx [DisplayTimeText(world.time - closed_at)] ago)"
+	dat += "<br><br>"
+	dat += "<br><b>Log:</b><br><br>"
+	for(var/I in _interactions_player)
+		dat += "[I]<br>"
+
+	usr << browse(dat.Join(), "window=ahelp[id];size=620x480")
+
+/datum/admin_help/proc/PlayerTicketHref(msg, ref_src, action = "player_ticket")
+	if(!ref_src)
+		ref_src = "[REF(src)]"
+	return "<A HREF='?_src_=holder;[HrefToken(TRUE)];ahelp_player=[ref_src];ahelp_action=[action]'>[msg]</A>"
+
+/datum/admin_help/proc/AddInteractionPlayer(formatted_message)
+	_interactions_player += "[time_stamp()]: [formatted_message]"

--- a/modular_skyrat/modules/admin/code/admin_help.dm
+++ b/modular_skyrat/modules/admin/code/admin_help.dm
@@ -24,24 +24,22 @@
 	message_admins(msg)
 	log_admin_private(msg)
 	AddInteraction("Being handled by [key_name]")
-	AddInteractionPlayer("Being handled by [key_name]")
+	AddInteractionPlayer("Being handled by [key_name_admin(usr, FALSE)]")
 
 	handler = "[usr.ckey]"
 
 /datum/admin_help/proc/PlayerTicketPanel()
 	var/list/dat = list("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Player Ticket</title></head>")
-	var/ref_src = "[REF(src)]"
 	dat += "<b>State: "
 	switch(state)
 		if(AHELP_ACTIVE)
-			dat += "<font color='red'>OPEN</font>"
+			dat += "<font color='red'>OPEN</font></b>"
 		if(AHELP_RESOLVED)
-			dat += "<font color='green'>RESOLVED</font>"
+			dat += "<font color='green'>RESOLVED</font></b>"
 		if(AHELP_CLOSED)
-			dat += "CLOSED"
+			dat += "CLOSED</b>"
 		else
-			dat += "UNKNOWN"
-	dat += "</b>[FOURSPACES][PlayerTicketHref("Refresh", ref_src)]"
+			dat += "UNKNOWN</b>"
 	dat += "<br><br>Opened at: [gameTimestamp("hh:mm:ss", closed_at)] (Approx [DisplayTimeText(world.time - opened_at)] ago)"
 	if(closed_at)
 		dat += "<br>Closed at: [gameTimestamp("hh:mm:ss", closed_at)] (Approx [DisplayTimeText(world.time - closed_at)] ago)"
@@ -51,11 +49,6 @@
 		dat += "[I]<br>"
 
 	usr << browse(dat.Join(), "window=ahelp[id];size=620x480")
-
-/datum/admin_help/proc/PlayerTicketHref(msg, ref_src, action = "player_ticket")
-	if(!ref_src)
-		ref_src = "[REF(src)]"
-	return "<A HREF='?_src_=holder;[HrefToken(TRUE)];ahelp_player=[ref_src];ahelp_action=[action]'>[msg]</A>"
 
 /datum/admin_help/proc/AddInteractionPlayer(formatted_message)
 	_interactions_player += "[time_stamp()]: [formatted_message]"

--- a/modular_skyrat/modules/admin/code/adminhelp.dm
+++ b/modular_skyrat/modules/admin/code/adminhelp.dm
@@ -1,17 +1,26 @@
-// File for more general procs, admin_help.dm is focused on the datum
-/client/verb/viewtickets()
+// File for more general procs, admin_help.dm is focused on the datum/admin_help/
+/client/verb/viewlatestticket()
 	set category = "Admin"
 	set name = "View Latest Ticket"
 
 	if(!current_ticket)
 		// Check if the client had previous tickets, and show the latest one
-		var/list/prev_tickets
+		var/list/prev_tickets = list()
 		var/datum/admin_help/last_AH
-		for(var/datum/admin_help/AH in GLOB.ahelp_tickets)
+        // Check all resolved tickets for this player
+		for(var/datum/admin_help/AH in GLOB.ahelp_tickets.resolved_tickets)
+			if(AH.initiator_ckey == ckey) // Initiator is a misnomer, it's always the non-admin player even if an admin bwoinks first
+				prev_tickets += AH
+				to_chat(world, "rslv ticket found [AH]")
+		// Check all closed tickets for this player
+		for(var/datum/admin_help/AH in GLOB.ahelp_tickets.closed_tickets)
 			if(AH.initiator_ckey == ckey)
 				prev_tickets += AH
-		if(LAZYLEN(prev_tickets)) // Take the last entry of prev_tickets and open the panel on it
+        // Take the most recent entry of prev_tickets and open the panel on it
+		if(LAZYLEN(prev_tickets))
+			to_chat(world, "[LAZYLEN(prev_tickets)]")
 			last_AH = pop(prev_tickets)
+			to_chat(world, "[last_AH] is last AH")
 			last_AH.PlayerTicketPanel()
 			return
 		

--- a/modular_skyrat/modules/admin/code/adminhelp.dm
+++ b/modular_skyrat/modules/admin/code/adminhelp.dm
@@ -11,16 +11,13 @@
 		for(var/datum/admin_help/AH in GLOB.ahelp_tickets.resolved_tickets)
 			if(AH.initiator_ckey == ckey) // Initiator is a misnomer, it's always the non-admin player even if an admin bwoinks first
 				prev_tickets += AH
-				to_chat(world, "rslv ticket found [AH]")
 		// Check all closed tickets for this player
 		for(var/datum/admin_help/AH in GLOB.ahelp_tickets.closed_tickets)
 			if(AH.initiator_ckey == ckey)
 				prev_tickets += AH
         // Take the most recent entry of prev_tickets and open the panel on it
 		if(LAZYLEN(prev_tickets))
-			to_chat(world, "[LAZYLEN(prev_tickets)]")
 			last_AH = pop(prev_tickets)
-			to_chat(world, "[last_AH] is last AH")
 			last_AH.PlayerTicketPanel()
 			return
 		

--- a/modular_skyrat/modules/admin/code/adminhelp.dm
+++ b/modular_skyrat/modules/admin/code/adminhelp.dm
@@ -1,0 +1,22 @@
+// File for more general procs, admin_help.dm is focused on the datum
+/client/verb/viewtickets()
+	set category = "Admin"
+	set name = "View Latest Ticket"
+
+	if(!current_ticket)
+		// Check if the client had previous tickets, and show the latest one
+		var/list/prev_tickets
+		var/datum/admin_help/last_AH
+		for(var/datum/admin_help/AH in GLOB.ahelp_tickets)
+			if(AH.initiator_ckey == ckey)
+				prev_tickets += AH
+		if(LAZYLEN(prev_tickets)) // Take the last entry of prev_tickets and open the panel on it
+			last_AH = pop(prev_tickets)
+			last_AH.PlayerTicketPanel()
+			return
+		
+		// client had no tickets this round
+		to_chat(src, "<span class='warning'>You have not had an ahelp ticket this round.</span>")
+		return
+
+	current_ticket.PlayerTicketPanel()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3374,6 +3374,7 @@
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\carbon_say.dm"
 #include "modular_skyrat\master_files\code\modules\power\lighting.dm"
 #include "modular_skyrat\modules\admin\code\admin_help.dm"
+#include "modular_skyrat\modules\admin\code\adminhelp.dm"
 #include "modular_skyrat\modules\admin\code\aooc.dm"
 #include "modular_skyrat\modules\admin\code\loud_say.dm"
 #include "modular_skyrat\modules\admin\code\sooc.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a verb to the Admin tab that opens up a window with their latest ticket.

In order to strip admin character names from all interactions in this window, this had to be made semi-modular.

**Regular admin ticket view:**
![image](https://user-images.githubusercontent.com/20977204/106361617-30469480-631f-11eb-8fd7-832179b369df.png)

**What the players see:**
![image](https://user-images.githubusercontent.com/20977204/106361618-32105800-631f-11eb-9fd4-427683bff4ac.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows players to keep overview easier over their ahelp tickets and questions.

Testmerge only is advisable since it touches admin stuff. I tested it and fixed all bugs/inaccuracies I could find though.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the 'View Latest Ticket' command to the ahelp menu for all players.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
