### PR TITLE
[Modular] Adds positronic alert consoles to all modular maps

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -89319,7 +89319,7 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "dye" = (
-/obj/structure/sign/departments/science,
+/obj/machinery/posialert,
 /turf/closed/wall,
 /area/science/robotics/lab)
 "dyf" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -54633,6 +54633,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"tZr" = (
+/obj/machinery/posialert,
+/turf/closed/wall/r_wall,
+/area/science/robotics/lab)
 "uaq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -101383,7 +101387,7 @@ bbD
 aYV
 qXW
 aYV
-bfV
+tZr
 hKu
 cHM
 biL

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -91051,6 +91051,10 @@
 /obj/machinery/pinpointer_dispenser,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"xLU" = (
+/obj/machinery/posialert,
+/turf/closed/wall/r_wall,
+/area/science/robotics/lab)
 "xNf" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -126000,7 +126004,7 @@ aov
 aut
 bam
 aZS
-aZS
+xLU
 aYH
 aBN
 aYH

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -58434,6 +58434,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"fDr" = (
+/obj/machinery/posialert,
+/turf/closed/wall,
+/area/science/robotics/lab)
 "fDB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
@@ -63108,10 +63112,6 @@
 "jla" = (
 /obj/machinery/camera{
 	c_tag = "Science Robotics Workshop"
-	},
-/obj/machinery/newscaster{
-	pixel_x = -4;
-	pixel_y = 32
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -112367,7 +112367,7 @@ cDi
 cDi
 jMU
 cDi
-cDi
+fDr
 jla
 smS
 uqQ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Funce added the obj long ago (#2144) but now with modular mapping, I'm adding them in.

I've never touched mapping before but everything compiled fine and it worked when I clicked on it as ghost!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

wooo

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added positronic alert consoles to robotics. Ghosts can click on them to ping roboticists.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
