### PR TITLE
[TM Only] Fixed security slots.

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -91,7 +91,7 @@
 /datum/config_entry/number/security_scaling_coeff	//how much does the amount of players get divided by to determine open security officer positions
 	config_entry_value = 8
 	integer = FALSE
-	min_val = 1
+	min_val = 0
 
 /datum/config_entry/number/traitor_objectives_amount
 	config_entry_value = 2


### PR DESCRIPTION
Quick patch for a bug which causes the configs to work incorrectly, because it says "set to 0 to disable" but the config entry forces it to the minimal value of 1.