### PR TITLE
Adds tinyfans to mining shuttles

### DIFF
--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -53,6 +53,7 @@
 	name = "Labor Shuttle Airlock";
 	req_access_txt = "2"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/labor)
 "j" = (
@@ -113,6 +114,7 @@
 	port_direction = 4;
 	width = 9
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/labor)
 "r" = (

--- a/_maps/shuttles/labour_delta.dmm
+++ b/_maps/shuttles/labour_delta.dmm
@@ -65,6 +65,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/labor)
 "k" = (
@@ -249,6 +250,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/labor)
 "x" = (

--- a/_maps/shuttles/labour_kilo.dmm
+++ b/_maps/shuttles/labour_kilo.dmm
@@ -84,6 +84,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "j" = (
@@ -237,6 +238,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "v" = (

--- a/_maps/shuttles/mining_box.dmm
+++ b/_maps/shuttles/mining_box.dmm
@@ -42,6 +42,7 @@
 	port_direction = 4;
 	width = 7
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "i" = (

--- a/_maps/shuttles/mining_common_kilo.dmm
+++ b/_maps/shuttles/mining_common_kilo.dmm
@@ -96,6 +96,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "n" = (

--- a/_maps/shuttles/mining_common_meta.dmm
+++ b/_maps/shuttles/mining_common_meta.dmm
@@ -42,6 +42,7 @@
 	port_direction = 4;
 	width = 7
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "i" = (

--- a/_maps/shuttles/mining_delta.dmm
+++ b/_maps/shuttles/mining_delta.dmm
@@ -92,6 +92,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/white,
 /area/shuttle/mining)
 "j" = (
@@ -133,6 +134,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/white,
 /area/shuttle/mining)
 "n" = (

--- a/_maps/shuttles/mining_freight.dmm
+++ b/_maps/shuttles/mining_freight.dmm
@@ -94,6 +94,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "n" = (

--- a/_maps/shuttles/mining_kilo.dmm
+++ b/_maps/shuttles/mining_kilo.dmm
@@ -296,6 +296,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining/large)
 "J" = (
@@ -353,6 +354,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining/large)
 

--- a/_maps/shuttles/mining_large.dmm
+++ b/_maps/shuttles/mining_large.dmm
@@ -404,6 +404,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining/large)
 "E" = (
@@ -458,6 +459,7 @@
 	width = 7
 	},
 /obj/structure/cable,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining/large)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a tinyfan in the airlock to Box, Kilo, Meta, and Delta public, labour, and mining shuttles. As well as the large mining shuttle, and the large kilo mining shuttle.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I'm pretty sure I speak for many people when I say that having lavaland gasses, especially BZ, in Central Primary Hallway every shift is annoying. Having the entire station hallucinating because there's 0.01 mols of BZ in the air is cause enough for Nanotrasen to spend the extra credits on some tiny fans.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added tinyfans to mining shuttle airlocks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
