### PR TITLE
Added Syndicate Cyborg Modules to DS-1

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat.dmm
@@ -5515,6 +5515,16 @@
 /obj/machinery/light/cold,
 /turf/open/floor/plating,
 /area/cruiser_dock)
+"Ck" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/closet/crate,
+/obj/item/borg/upgrade/transform/syndicatejack,
+/obj/item/borg/upgrade/transform/syndicatejack,
+/obj/item/borg/upgrade/transform/syndicatejack,
+/obj/item/borg/upgrade/transform/syndicatejack,
+/obj/item/borg/upgrade/transform/syndicatejack,
+/turf/open/floor/plasteel/dark,
+/area/cruiser_dock)
 "Cm" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -42079,7 +42089,7 @@ fX
 SW
 SW
 HB
-yY
+Ck
 ak
 aa
 aa

--- a/modular_skyrat/modules/altborgs/code/game/objects/items/robot_upgrade.dm
+++ b/modular_skyrat/modules/altborgs/code/game/objects/items/robot_upgrade.dm
@@ -1,0 +1,5 @@
+/obj/item/borg/upgrade/transform/syndicatejack
+    name = "borg module picker (Syndicate)"
+    desc = "Allows you to to turn a cyborg into a experimental syndicate cyborg."
+    icon_state = "cyborg_upgrade3"
+    new_module = /obj/item/robot_module/syndicatejack

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -792,13 +792,14 @@
 		/obj/item/shockpaddles/cyborg,
 		/obj/item/healthanalyzer/advanced,
 		/obj/item/retractor/advanced,
-		/obj/item/surgicaldrill,
+		/obj/item/cautery/advanced,
 		/obj/item/scalpel/advanced,
 		/obj/item/gun/medbeam,
 		/obj/item/reagent_containers/borghypo/syndicate,
 		/obj/item/borg/lollipop,
 		/obj/item/holosign_creator/cyborg,
 		/obj/item/stamp/chameleon,
+		/obj/item/borg_shapeshifter,
 		)
 	cyborg_base_icon = "synd_engi"
 	moduleselect_icon = "malf"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3453,6 +3453,7 @@
 #include "modular_skyrat\modules\alerts\code\firealarm.dm"
 #include "modular_skyrat\modules\alerts\code\set_security_level.dm"
 #include "modular_skyrat\modules\altborgs\code\game\objects\items\robot_items.dm"
+#include "modular_skyrat\modules\altborgs\code\game\objects\items\robot_upgrade.dm"
 #include "modular_skyrat\modules\altborgs\code\modules\mob\living\silicon\robot\inventory.dm"
 #include "modular_skyrat\modules\altborgs\code\modules\mob\living\silicon\robot\robot.dm"
 #include "modular_skyrat\modules\altborgs\code\modules\mob\living\silicon\robot\robot_modules.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Yeah, Made it possible for syndicate scientists to give the syndicate module to the cyborgs they create. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I kinda like having the syndicate cyborg used, especially when they are unused despite being in the code
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added syndicate module picker in the DS-1
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
