### PR TITLE
Update to Abandoned Ship Ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box_skyrat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box_skyrat.dmm
@@ -1,0 +1,1296 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"az" = (
+/turf/closed/wall/mineral/titanium/interior,
+/area/ruin/space/has_grav/whiteship/box)
+"bN" = (
+/obj/machinery/light/small/red,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"bT" = (
+/obj/machinery/light,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/item/paper/crumpled{
+	info = "Remember to properly calibrate the mass-driver next time you need to use it. Nearly tore Harold's leg off last time we tried to use it.";
+	name = "old, crumpled note"
+	},
+/obj/item/pen{
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"cw" = (
+/obj/machinery/light/small/red{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"eD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"fd" = (
+/obj/item/light/tube/broken,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"fK" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/food/drinks/waterbottle/large,
+/obj/item/reagent_containers/food/drinks/waterbottle/large,
+/obj/item/reagent_containers/food/drinks/waterbottle/large,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"gK" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"gO" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"gS" = (
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"hj" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"hT" = (
+/obj/machinery/light,
+/obj/structure/closet/crate,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/brute,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"in" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/space/cashmoney,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"iK" = (
+/obj/item/chair,
+/turf/open/floor/mineral/titanium/white/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"iS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table_frame,
+/obj/item/shard{
+	icon_state = "small"
+	},
+/turf/open/floor/mineral/titanium/white/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"jb" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"ji" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"ku" = (
+/turf/open/floor/mineral/titanium/white/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"kK" = (
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/has_grav/whiteship/box)
+"lG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/food/canned/beans,
+/obj/item/food/canned/beans,
+/obj/item/food/canned/beans,
+/obj/item/food/canned/beans,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"lR" = (
+/obj/machinery/sleeper,
+/turf/open/floor/mineral/titanium/purple,
+/area/ruin/space/has_grav/whiteship/box)
+"md" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"mE" = (
+/turf/open/floor/mineral/titanium/purple,
+/area/ruin/space/has_grav/whiteship/box)
+"mR" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"nd" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"nH" = (
+/turf/template_noop,
+/area/template_noop)
+"nK" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"nL" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"oe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"oK" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"oN" = (
+/obj/item/shard{
+	icon_state = "small"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"pq" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"pu" = (
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"pv" = (
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"qz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"qI" = (
+/obj/structure/light_construct{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"qZ" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"rO" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	id = "oldship_ruin_gun"
+	},
+/obj/item/gps/spaceruin,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"sX" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"tU" = (
+/obj/structure/chair,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"uG" = (
+/obj/structure/shuttle/engine/propulsion/right{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"uS" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"wP" = (
+/obj/structure/closet/crate,
+/obj/item/storage/firstaid,
+/obj/item/storage/firstaid{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"yK" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"zG" = (
+/obj/effect/spawner/lootdrop/space/material,
+/obj/effect/spawner/lootdrop/space/material,
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"zO" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/stack/sheet/mineral/plasma,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"zY" = (
+/obj/machinery/door/poddoor{
+	id = "oldship_ruin_gun";
+	name = "pod bay door"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"Al" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"Ap" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/firedoor,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Ay" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Bb" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"BG" = (
+/obj/structure/table/reinforced,
+/obj/structure/sign/poster/random{
+	pixel_y = -32
+	},
+/turf/open/floor/mineral/titanium/purple,
+/area/ruin/space/has_grav/whiteship/box)
+"CC" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"DG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/light_construct,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"DU" = (
+/obj/structure/light_construct,
+/obj/item/light/tube/broken,
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"EA" = (
+/obj/effect/spawner/lootdrop/space/material,
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Gj" = (
+/obj/item/stack/sheet/mineral/titanium,
+/turf/open/floor/mineral/titanium/white/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"HR" = (
+/obj/structure/light_construct{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"HT" = (
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Ie" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"IA" = (
+/obj/item/trash/can/food/beans,
+/obj/item/reagent_containers/food/drinks/waterbottle/large/empty,
+/obj/item/trash/candy,
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Jk" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"Jv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/mini_fridge,
+/obj/item/reagent_containers/food/drinks/soda_cans/grey_bull,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Jy" = (
+/turf/closed/mineral/random,
+/area/ruin/space/has_grav/whiteship/box)
+"JF" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"Kg" = (
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"KT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Lv" = (
+/obj/structure/light_construct{
+	dir = 1
+	},
+/obj/structure/light_construct{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Nf" = (
+/obj/structure/closet/crate,
+/obj/item/book/manual/wiki/plumbing,
+/obj/item/book/manual/wiki/medicine,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"NQ" = (
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Oj" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/cards/deck{
+	pixel_y = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Ov" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"OJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"OT" = (
+/obj/item/gun/energy/laser/retro,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Px" = (
+/obj/machinery/computer/pod,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"PV" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"Qx" = (
+/obj/structure/closet/wardrobe/pjs,
+/turf/open/floor/mineral/titanium/purple,
+/area/ruin/space/has_grav/whiteship/box)
+"Sp" = (
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"Tr" = (
+/obj/item/shard{
+	icon_state = "small"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Ud" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Vm" = (
+/obj/structure/closet/crate,
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/book/manual/wiki/infections,
+/obj/item/book/manual/wiki/medical_cloning,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Vt" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"VQ" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"Xg" = (
+/obj/structure/grille/broken,
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"Xp" = (
+/obj/structure/shuttle/engine/propulsion/left{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"Xt" = (
+/obj/structure/light_construct,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Xy" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/mineral/titanium/white/airless,
+/area/ruin/space/has_grav/whiteship/box)
+
+(1,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+Jk
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(2,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+az
+pv
+az
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(3,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+zG
+pv
+Ie
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(4,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+Ie
+pv
+EA
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(5,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+zO
+pv
+gS
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(6,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+eD
+pv
+Xt
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(7,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+Ov
+pv
+pv
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(8,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+pv
+pv
+pv
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(9,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+mR
+Ov
+mR
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(10,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+az
+pv
+az
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(11,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+qZ
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(12,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+pv
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(13,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+qZ
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(14,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+kK
+az
+pv
+az
+kK
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+"}
+(15,1,1) = {"
+kK
+Xp
+CC
+CC
+CC
+uG
+kK
+kK
+az
+Ov
+pv
+IA
+az
+kK
+kK
+Xp
+CC
+CC
+CC
+uG
+kK
+"}
+(16,1,1) = {"
+kK
+kK
+VQ
+VQ
+VQ
+kK
+kK
+Lv
+pv
+pv
+pv
+pv
+KT
+bT
+kK
+kK
+VQ
+VQ
+VQ
+kK
+kK
+"}
+(17,1,1) = {"
+nH
+kK
+az
+gK
+Vt
+qz
+kK
+Oj
+pv
+pv
+pv
+pv
+pv
+nL
+kK
+Vt
+Vt
+uS
+az
+kK
+nH
+"}
+(18,1,1) = {"
+nH
+nH
+kK
+jb
+Vt
+bN
+kK
+OJ
+pv
+pv
+pv
+pv
+tU
+in
+kK
+cw
+qz
+PV
+kK
+nH
+nH
+"}
+(19,1,1) = {"
+nH
+nH
+kK
+kK
+kK
+sX
+kK
+kK
+kK
+gO
+Kg
+gO
+kK
+kK
+kK
+Jk
+kK
+kK
+az
+nH
+nH
+"}
+(20,1,1) = {"
+nH
+nH
+nH
+kK
+nL
+pv
+pv
+pv
+pv
+pv
+pv
+Ov
+pv
+pv
+pv
+pv
+hj
+az
+nH
+nH
+nH
+"}
+(21,1,1) = {"
+nH
+nH
+nH
+kK
+pq
+Ov
+pv
+pv
+pv
+pv
+Ud
+pv
+pv
+Ov
+pv
+pv
+nL
+kK
+nH
+nH
+nH
+"}
+(22,1,1) = {"
+nH
+nH
+kK
+kK
+kK
+kK
+kK
+Ov
+HT
+kK
+kK
+gO
+kK
+kK
+Ap
+oK
+kK
+kK
+kK
+nH
+nH
+"}
+(23,1,1) = {"
+nH
+kK
+kK
+nd
+pu
+Ay
+az
+pv
+pv
+kK
+lR
+pv
+mE
+qZ
+Tr
+pv
+qZ
+pv
+az
+kK
+nH
+"}
+(24,1,1) = {"
+nH
+kK
+Ov
+pv
+pv
+pv
+kK
+NQ
+NQ
+kK
+Qx
+pv
+BG
+kK
+HR
+pv
+kK
+pv
+fd
+kK
+nH
+"}
+(25,1,1) = {"
+nH
+kK
+HR
+pv
+pv
+HT
+kK
+pv
+pv
+kK
+lR
+pv
+mE
+qZ
+pv
+pv
+kK
+Ov
+Xt
+az
+nH
+"}
+(26,1,1) = {"
+nH
+kK
+pv
+pv
+pv
+Ov
+kK
+pv
+DG
+kK
+kK
+gO
+kK
+kK
+oe
+NQ
+kK
+Ov
+pv
+az
+nH
+"}
+(27,1,1) = {"
+nH
+qZ
+pv
+pv
+pv
+pv
+qZ
+pv
+pv
+Ov
+qI
+pv
+pv
+pv
+pv
+pv
+gO
+yK
+pv
+az
+nH
+"}
+(28,1,1) = {"
+nH
+qZ
+pv
+Ov
+pv
+pv
+kK
+pv
+pv
+Jy
+Jy
+Jy
+pv
+ji
+pv
+pv
+gO
+pv
+pv
+az
+nH
+"}
+(29,1,1) = {"
+nH
+kK
+pv
+pv
+pv
+Ov
+kK
+gO
+Jy
+Jy
+Jy
+Jy
+Jy
+Kg
+gO
+gO
+kK
+pv
+wP
+az
+nH
+"}
+(30,1,1) = {"
+nH
+kK
+eD
+pv
+Ov
+kK
+kK
+OT
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+Jy
+iK
+kK
+pv
+lG
+az
+nH
+"}
+(31,1,1) = {"
+nH
+kK
+Px
+nK
+kK
+kK
+Gj
+Jy
+Jy
+Jy
+Jy
+md
+Jy
+Bb
+md
+ku
+az
+Vm
+hT
+kK
+nH
+"}
+(32,1,1) = {"
+nH
+kK
+kK
+Al
+kK
+iS
+Xy
+md
+md
+md
+md
+nH
+md
+md
+md
+Jy
+az
+Nf
+fK
+kK
+nH
+"}
+(33,1,1) = {"
+nH
+nH
+kK
+rO
+kK
+iK
+JF
+md
+nH
+nH
+nH
+nH
+nH
+ku
+md
+DU
+az
+Jv
+kK
+kK
+nH
+"}
+(34,1,1) = {"
+nH
+nH
+kK
+zY
+kK
+az
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+Vt
+oN
+kK
+kK
+kK
+kK
+nH
+nH
+"}
+(35,1,1) = {"
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+Xg
+Sp
+kK
+kK
+nH
+nH
+nH
+nH
+nH
+"}

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -250,18 +250,16 @@
 	name = "Gondoland"
 	description = "Just an ordinary rock- wait, what's that thing?"
 
-
-	
-	// SKYRAT EDIT CHANGE START -- Reworked whiteship ruin
+// SKYRAT EDIT CHANGE START -- Reworked whiteship ruin
 /* SKYRAT EDIT CHANGE -- ORIGINAL COMMENTED OUT
 /datum/map_template/ruin/space/whiteshipruin_box
-    id = "whiteshipruin_box"
-    suffix = "whiteshipruin_box.dmm"
-*/ 
+id = "whiteshipruin_box"
+suffix = "whiteshipruin_box.dmm"*/
 
 /datum/map_template/ruin/space/whiteshipruin_box_skyrat //Skyrat Edit
 	id = "whiteshipruin_box_skyrat"
 	suffix = "whiteshipruin_box_skyrat.dmm"
+	 // SKYRAT EDIT CHANGE END
 	name = "NT Medical Ship"
 	description = "An ancient ship, said to be among the first discovered derelicts near Space Station 13 that was still in working order. \
 	Aged and deprecated by time, this relic of a vessel is now broken beyond repair."

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -256,10 +256,10 @@
 id = "whiteshipruin_box"
 suffix = "whiteshipruin_box.dmm"*/
 
-/datum/map_template/ruin/space/whiteshipruin_box_skyrat //Skyrat Edit
+/datum/map_template/ruin/space/whiteshipruin_box_skyrat//Skyrat Edit
 	id = "whiteshipruin_box_skyrat"
 	suffix = "whiteshipruin_box_skyrat.dmm"
-	 // SKYRAT EDIT CHANGE END
+	// SKYRAT EDIT CHANGE END
 	name = "NT Medical Ship"
 	description = "An ancient ship, said to be among the first discovered derelicts near Space Station 13 that was still in working order. \
 	Aged and deprecated by time, this relic of a vessel is now broken beyond repair."

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -250,9 +250,18 @@
 	name = "Gondoland"
 	description = "Just an ordinary rock- wait, what's that thing?"
 
+
+	
+	// SKYRAT EDIT CHANGE START -- Reworked whiteship ruin
+/* SKYRAT EDIT CHANGE -- ORIGINAL COMMENTED OUT
 /datum/map_template/ruin/space/whiteshipruin_box
-	id = "whiteshipruin_box"
-	suffix = "whiteshipruin_box.dmm"
+    id = "whiteshipruin_box"
+    suffix = "whiteshipruin_box.dmm"
+*/ 
+
+/datum/map_template/ruin/space/whiteshipruin_box_skyrat //Skyrat Edit
+	id = "whiteshipruin_box_skyrat"
+	suffix = "whiteshipruin_box_skyrat.dmm"
 	name = "NT Medical Ship"
 	description = "An ancient ship, said to be among the first discovered derelicts near Space Station 13 that was still in working order. \
 	Aged and deprecated by time, this relic of a vessel is now broken beyond repair."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Modernization of the apparently classic Abandoned Ship space ruin. I've given it some more personality as a derelict space ruin, and made it feel more lived in and old. The original ruin still exists in the code, and as a map file, but it simply won't spawn. Design wise, the ship's lost a lot of it's meaningless bulk (note the lack of 2x2 wall blocks), and every room has a purpose, rather than the large number of barren rooms. All original "space loot" has been kept, as well as a few extra goodies that shouldn't change game balance.

![b4](https://user-images.githubusercontent.com/73589390/106531038-789ab980-64bb-11eb-850c-c7944cca879c.png)
![after](https://user-images.githubusercontent.com/73589390/106531049-7df80400-64bb-11eb-904a-5f304fac018a.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

While the old map certainly had history, being box station's whiteship. It's design and lack of any real content or visual flair set it apart from other modern and well designed ruins, while the update aims to keep the spirit of the design alive, it makes tweaks to make the ruin something interesting to explore for newcomers, and a welcome respite for more experienced space-explorers.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added whiteshipruin_box_skyrat
tweak: set whiteshipruin_box_skyrat to spawn, rather than whiteshipruin_box
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
