### PR TITLE
Removes the clown ERT/ERP ERT

### DIFF
--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -72,6 +72,8 @@
 	mission = "Assist in conflict resolution."
 	polldesc = "an unpaid internship opportunity with Nanotrasen"
 
+//SKYRAT EDIT REMOVAL START
+/*
 /datum/ert/erp
 	roles = list(/datum/antagonist/ert/security/party, /datum/antagonist/ert/clown/party, /datum/antagonist/ert/engineer/party, /datum/antagonist/ert/janitor/party)
 	leader_role = /datum/antagonist/ert/commander/party
@@ -80,3 +82,5 @@
 	mission = "Create entertainment for the crew."
 	polldesc = "a Code Rainbow Nanotrasen Emergency Response Party"
 	code = "Rainbow"
+*/
+//SKYRAT EDIT REMOVAL END

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -136,6 +136,8 @@
 	outfit = /datum/outfit/centcom/centcom_intern/leader
 	role = "Head Intern"
 
+//SKYRAT EDIT REMOVAL START
+/*
 /datum/antagonist/ert/clown
 	role = "Clown"
 	outfit = /datum/outfit/centcom/ert/clown
@@ -163,6 +165,8 @@
 /datum/antagonist/ert/commander/party
 	role = "Party Coordinator"
 	outfit = /datum/outfit/centcom/ert/commander/party
+*/
+//SKYRAT EDIT REMOVAL END
 
 /datum/antagonist/ert/create_team(datum/team/ert/new_team)
 	if(istype(new_team))

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -287,6 +287,8 @@
 		/obj/item/melee/baton/loaded=1,\
 		/obj/item/grenade/clusterbuster/cleaner=3)
 
+//SKYRAT EDIT REMOVAL START
+/*
 /datum/outfit/centcom/ert/clown
 	name = "ERT Clown"
 
@@ -315,6 +317,8 @@
 	H.dna.add_mutation(CLOWNMUT)
 	for(var/datum/mutation/human/clumsy/M in H.dna.mutations)
 		M.mutadone_proof = TRUE
+*/
+//SKYRAT EDIT REMOVAL END
 
 /datum/outfit/centcom/centcom_intern
 	name = "CentCom Intern"
@@ -351,6 +355,8 @@
 	l_hand = /obj/item/megaphone
 	head = /obj/item/clothing/head/intern
 
+//SKYRAT EDIT REMOVAL START
+/*
 /datum/outfit/centcom/ert/janitor/party
 	name = "ERP Cleaning Service"
 
@@ -424,3 +430,5 @@
 	backpack_contents = list(/obj/item/storage/box/survival/engineer=1,\
 		/obj/item/storage/box/fireworks=3,\
 		/obj/item/food/cake/birthday=1)
+*/
+//SKYRAT EDIT REMOVAL END


### PR DESCRIPTION
## About The Pull Request

PR reopen.
What it says in the title. No items are removed, only the team template. (I think)

## Why It's Good For The Game

>They never get used anyway

>Removing LRP features is good.

>@ Major Wehweh#7271 told me to reopen the PR.

## Changelog
admin: Removes the option to spawn a Clown ERT/ERP ERT
/:cl: