### PR TITLE
[Modular] Adds jukebox and disco ball crate, removes access requirements

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -214,6 +214,20 @@
 					/obj/item/storage/box/matches)
 	crate_name = "candle crate"
 
+/datum/supply_pack/misc/jukebox
+	name = "Jukebox Crate"
+	desc = "Contains a regular old jukebox. It can play music!"
+	cost = CARGO_CRATE_VALUE * 20
+	contains = list(/obj/machinery/jukebox)
+	crate_name = "jukebox crate"
+
+/datum/supply_pack/misc/jukebox_disco
+	name = "Radiant Dance Machine Crate"
+	desc = "Contains the new and improved Radiant Dance Machine Mark IV! Capable of playing a large selections of music, while projecting a fabulous lightshow."
+	cost = CARGO_CRATE_VALUE * 50
+	contains = list(/obj/machinery/jukebox/disco)
+	crate_name = "dance machine crate"
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Food Stuff //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/modular_skyrat/modules/jukebox/code/controllers/subsystem/game/machinery/dance_machine.dm
+++ b/modular_skyrat/modules/jukebox/code/controllers/subsystem/game/machinery/dance_machine.dm
@@ -19,7 +19,6 @@
 	desc = "The first three prototypes were discontinued after mass casualty incidents."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "disco"
-	req_access = list(ACCESS_ENGINE)
 	anchored = FALSE
 	var/list/spotlights = list()
 	var/list/sparkles = list()
@@ -27,7 +26,6 @@
 /obj/machinery/jukebox/disco/indestructible
 	name = "radiant dance machine mark V"
 	desc = "Now redesigned with data gathered from the extensive disco and plasma research."
-	req_access = null
 	anchored = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	flags_1 = NODECONSTRUCT_1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the jukebox cargo crate (4k) and discoball cargo crate (5k).
Removes bartender access from the jukebox, and engine (????) access from the disco ball.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

lets anyone select songs, and lets them be actually purchased without admin spawn. Bring the music!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a jukebox and disco ball crate to cargo.
tweak: Removed strange access requirements on the disco ball and jukebox.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
