### PR TITLE
[Modular] Ports Half Of The Oldbase's Prisons

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -90,7 +90,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/vending/hydroseeds,
+/obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aal" = (
@@ -2014,14 +2014,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"agN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/yellowsiding/corner{
-	dir = 1
-	},
-/area/security/prison)
 "agR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -2443,6 +2435,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ajP" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "ajS" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3652,6 +3654,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/processing)
+"aos" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Firing Range";
+	req_access_txt = "1"
+	},
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "aow" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -6892,12 +6902,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"axS" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "axV" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel,
@@ -17009,12 +17013,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"baO" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "baP" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -27596,6 +27594,34 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"bEG" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bEH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -31236,6 +31262,19 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"bQG" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "bQH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -34861,6 +34900,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
+"ceu" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "cew" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -34894,13 +34937,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"ceE" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/structure/holohoop,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ceF" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -36387,20 +36423,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"cmz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
-/area/security/prison)
 "cmD" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -36912,6 +36934,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cqy" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/security/prison)
 "cqz" = (
 /obj/machinery/light{
 	dir = 4
@@ -37232,31 +37260,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"csl" = (
-/obj/structure/closet/crate/hydroponics{
-	name = "raw produce"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "csu" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -38899,6 +38902,40 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"czA" = (
+/obj/structure/rack,
+/obj/item/wirecutters,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/item/seeds/cotton,
+/obj/item/seeds/cotton,
+/obj/item/seeds/onion/red,
+/obj/item/seeds/wheat/rice,
+/obj/item/seeds/wheat/oat,
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "czE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -38976,17 +39013,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cAa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "cAb" = (
 /obj/structure/closet,
 /obj/structure/disposalpipe/segment,
@@ -39609,6 +39635,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"cCZ" = (
+/obj/machinery/door/window/brigdoor/security/cell/westright{
+	id = "genpopcell1"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "cDg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40016,6 +40048,19 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"cFd" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "cFe" = (
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/window/plasma/reinforced{
@@ -40302,6 +40347,22 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"cGy" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "cGC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -40663,28 +40724,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"cIj" = (
-/obj/machinery/door/poddoor/shutters/window{
-	id = "visitation"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"cIJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/closet/crate/trashcart,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "cJV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
@@ -40748,6 +40787,12 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/supermatter)
+"cMO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "cMX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -41315,23 +41360,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"cWW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/security/prison)
-"cYK" = (
+"cYz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
+/turf/closed/wall,
 /area/security/prison)
 "cYY" = (
 /obj/effect/turf_decal/tile/purple,
@@ -41377,13 +41410,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"dbu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Workroom1"
+"cZA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"dbK" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "ddc" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/corner{
@@ -41402,6 +41443,24 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/engine,
 /area/science/genetics)
+"dey" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Workroom";
+	dir = 10;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/security/prison)
 "dfb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -41464,24 +41523,12 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"dhZ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark/side,
-/area/security/prison)
 "djP" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"dkw" = (
-/obj/structure/training_machine,
-/obj/item/target/syndicate,
-/turf/open/floor/plating,
-/area/security/prison)
 "dlp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41540,20 +41587,6 @@
 /obj/item/storage/secure/briefcase,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
-"dng" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/security/prison)
 "dni" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -41564,6 +41597,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dnB" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "doz" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
@@ -41583,12 +41623,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/engineering)
-"dpm" = (
-/obj/machinery/plate_press,
-/obj/structure/cable{
-	icon_state = "4-8"
+"dpa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/security/prison)
 "dpI" = (
 /obj/effect/turf_decal/stripes/line,
@@ -41652,22 +41700,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"dvN" = (
-/obj/structure/closet/crate/secure{
-	desc = "A secure crate containing various materials for building a customised test-site.";
-	name = "Firing Range Gear Crate";
-	req_access_txt = "1"
-	},
-/obj/item/target/syndicate,
-/obj/item/target/syndicate,
-/obj/item/target/clown,
-/obj/item/target/clown,
-/obj/item/target/alien,
-/obj/item/target/alien,
-/obj/item/target,
-/obj/item/target,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "dvO" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/airalarm/mixingchamber{
@@ -41721,6 +41753,10 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"dAN" = (
+/obj/structure/chair/sofa/corner,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "dBu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -41746,20 +41782,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"dCB" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "dCG" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
@@ -41777,6 +41799,17 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"dDp" = (
+/obj/effect/turf_decal/delivery/blue,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24;
+	pixel_y = 3
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "dDR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -42040,9 +42073,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dTk" = (
-/obj/structure/chair/sofa/corner,
-/turf/open/floor/plasteel/dark,
+"dSz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "dUr" = (
 /obj/machinery/power/apc/auto_name/west,
@@ -42069,6 +42105,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"dYg" = (
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "dYh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42090,6 +42132,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"dZy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
+	},
+/area/security/prison)
 "eaa" = (
 /obj/machinery/vending/wardrobe/peacekeeper_wardrobe,
 /obj/machinery/power/apc/auto_name/south,
@@ -42143,6 +42193,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"edN" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "eeU" = (
 /obj/structure/noticeboard{
 	dir = 1;
@@ -42206,6 +42269,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"ejz" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "ejU" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -42260,6 +42329,20 @@
 	icon_state = "wood-broken3"
 	},
 /area/maintenance/space_hut/cabin)
+"enq" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "eoi" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
@@ -42302,17 +42385,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/teleporter)
-"erA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "erO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
@@ -42320,10 +42392,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
-"erP" = (
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "esW" = (
 /obj/machinery/light{
 	dir = 1
@@ -42337,12 +42405,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"etV" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
+"ets" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
 /area/security/prison)
 "evp" = (
 /obj/machinery/door/firedoor,
@@ -42371,6 +42437,18 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"ewL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Prison -  Central";
+	dir = 9;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "ewX" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -42411,26 +42489,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"ezh" = (
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	id = "lockdown3";
-	name = "Lockdown"
-	},
-/obj/machinery/button/door{
-	id = "lockdown3";
-	name = "Lockdown";
-	pixel_y = 24;
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "ezn" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -42454,15 +42512,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/hallway/secondary/service)
-"eDp" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "eDG" = (
 /obj/structure/table/glass,
 /obj/item/storage/fancy/candle_box,
@@ -42470,6 +42519,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"eEh" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "eFD" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/disks{
@@ -42489,11 +42543,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"eGX" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "eIE" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
@@ -42517,6 +42566,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"eIT" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/soap,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "eIZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -42529,21 +42590,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"eJQ" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/toilet{
-	pixel_y = 16
-	},
-/obj/structure/window,
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison/safe)
 "eKA" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/machinery/light,
@@ -42565,12 +42611,6 @@
 /turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
-/area/security/prison)
-"eLp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "eNr" = (
 /obj/structure/closet/crate,
@@ -42603,15 +42643,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"ePP" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison/safe)
 "eQL" = (
 /obj/structure/chair{
 	name = "Judge"
@@ -42656,55 +42687,11 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"eSu" = (
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 4;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 8;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	name = "engineering corner"
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = 26;
-	prison_radio = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "eTo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
-"eTP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"eTS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "eUy" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -42719,21 +42706,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/vacant_room/office)
-"eUA" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
 "eVL" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -42756,37 +42728,22 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"eWO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/security/prison)
-"eZm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"eZr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/security/prison)
 "eZH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"eZN" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "fak" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -42819,10 +42776,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"faR" = (
+/obj/machinery/processor,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"fcA" = (
+/obj/structure/table,
+/obj/item/storage/box/chemimp{
+	pixel_x = 6
+	},
+/obj/item/storage/box/trackimp{
+	pixel_x = -3
+	},
+/obj/item/storage/lockbox/loyalty,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "fcG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"fcU" = (
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/obj/structure/plasticflaps,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "prisonconveyor";
+	name = "Conveyor Shutter"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "fdf" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/machinery/camera{
@@ -42832,12 +42818,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"fdy" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "fdT" = (
 /turf/open/genturf,
 /area/icemoon/surface/outdoors)
@@ -42871,6 +42851,19 @@
 /obj/structure/tank_holder/oxygen/red,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ffh" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "ffM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -42907,6 +42900,14 @@
 /obj/item/storage/fancy/cigarettes,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"fiN" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "fjm" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Dorm";
@@ -42940,34 +42941,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"fkC" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/machinery/camera{
-	c_tag = "Prison -  Garden";
-	dir = 6;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "flc" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -43023,25 +42996,6 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"fnQ" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/green,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = 26;
-	prison_radio = 1
-	},
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
 "fox" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
@@ -43134,6 +43088,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"fsO" = (
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/wood,
+/area/security/prison)
 "fsQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
@@ -43163,17 +43121,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/maintenance/fore)
-"ftU" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/security/prison)
 "fvi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -43183,6 +43130,30 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"fvp" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Cafeteria";
+	dir = 6;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"fxn" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/door/window/southright{
+	name = "shower"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison/safe)
 "fxr" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/dark,
@@ -43204,6 +43175,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
+"fyh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/wood,
+/area/security/prison)
+"fyn" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/machinery/door/window/eastright{
+	name = "shower"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison/safe)
 "fyP" = (
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway East";
@@ -43224,6 +43211,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"fzA" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "fzG" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -43296,6 +43290,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"fDj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  East";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
 "fDD" = (
 /obj/item/assembly/mousetrap,
 /turf/open/floor/plating,
@@ -43405,23 +43414,6 @@
 /obj/item/ai_module/core,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
-"fLk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/sparsegrass{
-	max_integrity = 1
-	},
-/turf/open/floor/plating/grass,
-/area/security/prison)
-"fLN" = (
-/obj/structure/bed,
-/obj/machinery/flasher{
-	id = "genpopcell1";
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
 "fMt" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -43454,6 +43446,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"fOm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "fPh" = (
 /obj/structure/sign/painting/library,
 /turf/closed/wall,
@@ -43549,6 +43550,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"fSq" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison/safe)
 "fSH" = (
 /obj/machinery/camera{
 	c_tag = "Prison Public Area";
@@ -43573,6 +43580,12 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
+/area/security/prison)
+"fTZ" = (
+/obj/machinery/jukebox{
+	req_one_access = null
+	},
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "fUn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -43643,6 +43656,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"fYp" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "fYu" = (
 /obj/machinery/firealarm{
 	pixel_y = 25
@@ -43667,6 +43689,31 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"fZe" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	name = "large flour sack";
+	possible_transfer_amounts = list(1,5,10,15,30,60,90);
+	volume = 90
+	},
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	name = "large flour sack";
+	possible_transfer_amounts = list(1,5,10,15,30,60,90);
+	volume = 90
+	},
+/obj/item/reagent_containers/food/condiment/mayonnaise,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/rice{
+	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	name = "large rice sack";
+	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
+	},
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "fZk" = (
 /obj/structure/table,
 /obj/machinery/airalarm{
@@ -43698,16 +43745,47 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"gaU" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Garden";
+	dir = 6;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"gbp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gby" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"gbN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "gbO" = (
 /turf/closed/wall,
 /area/medical/surgery)
@@ -43825,6 +43903,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"gkf" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "gkC" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/stripes/line{
@@ -43850,6 +43941,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
+"gmp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gnf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
@@ -43862,12 +43959,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"gnS" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "gnX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -43922,12 +44013,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/janitor)
-"gqW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+"gqQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark/side{
-	dir = 1
+	dir = 8
 	},
 /area/security/prison)
 "grP" = (
@@ -43954,6 +44048,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"gtf" = (
+/obj/effect/turf_decal/delivery/blue,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "guf" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/structure/cable,
@@ -43985,25 +44086,16 @@
 	dir = 1
 	},
 /area/security/prison)
-"gwW" = (
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	id = "lockdown4";
-	name = "Lockdown"
+"gxK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "lockdown4";
-	name = "Lockdown";
-	pixel_x = 25;
-	req_access_txt = "63"
+/obj/structure/flora/ausbushes/lavendergrass{
+	max_integrity = 1;
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/grass,
 /area/security/prison)
 "gyr" = (
 /obj/structure/cable,
@@ -44044,28 +44136,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"gBd" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "workhouse";
-	name = "Work Room"
-	},
-/obj/machinery/button/door{
-	id = "workhouse";
-	name = "Work Room";
-	pixel_y = 24;
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "gBO" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Stbd";
@@ -44131,15 +44201,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"gFl" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/security/prison)
 "gFn" = (
 /obj/structure/railing{
 	dir = 1
@@ -44195,21 +44256,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"gIi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "gIB" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -44276,15 +44322,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"gMh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "gNi" = (
 /obj/structure/sink{
 	dir = 8;
@@ -44326,25 +44363,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"gPz" = (
-/obj/structure/table,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
-	},
-/obj/item/storage/lockbox/loyalty,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"gPO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison";
-	req_access_txt = "63"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "gQb" = (
 /turf/open/genturf,
 /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
@@ -44384,12 +44402,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"gRz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "gRS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
@@ -44406,6 +44418,18 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"gTN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/yellowsiding/corner{
+	dir = 1
+	},
+/area/security/prison)
+"gUw" = (
+/obj/structure/chair/sofa,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "gUD" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -44444,6 +44468,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
+"gVj" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gVn" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -44455,6 +44495,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/construction)
+"gWJ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "gWZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -44506,11 +44555,6 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/space_hut/cabin)
-"gZt" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark/side,
-/area/security/prison)
 "gZK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -44527,6 +44571,18 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"hak" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "hau" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
@@ -44537,16 +44593,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/mining)
-"hbm" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
 "hcB" = (
 /obj/machinery/clonepod,
 /turf/open/floor/plasteel/dark,
@@ -44576,31 +44622,33 @@
 /mob/living/simple_animal/pet/fox/renault,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"heI" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+"hez" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/green,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "heL" = (
 /obj/structure/closet/secure_closet/cytology,
 /turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
-"hfr" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "hgj" = (
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
@@ -44658,13 +44706,6 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"hhA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/security/prison)
 "hhL" = (
 /obj/item/instrument/violin/golden{
 	pixel_y = 32
@@ -44696,22 +44737,6 @@
 "hjZ" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
-"hkS" = (
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 4;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 1;
-	name = "engineering corner"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hkT" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -44734,6 +44759,19 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"hmM" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bossofthisprisongym";
+	name = "Private Area"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
+"hnt" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hnE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -44758,15 +44796,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
-"hqU" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Janitorial"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "hrf" = (
 /obj/structure/table,
 /obj/item/assembly/signaler,
@@ -44782,6 +44811,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"hrw" = (
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hrZ" = (
 /obj/item/radio/intercom{
 	pixel_y = -29
@@ -44792,30 +44825,17 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"hsz" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/machinery/camera{
-	c_tag = "Prison - Kitchen";
-	dir = 6;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "htg" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/icemoon,
 /area/science/server)
-"htY" = (
-/obj/machinery/door/airlock/grunge{
-	desc = "Part of the green cell block";
-	name = "Cell - Green"
+"htx" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "huk" = (
 /obj/machinery/button/door{
 	desc = "A remote control-switch for the engineering security doors.";
@@ -44836,27 +44856,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/engineering)
-"hun" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/chair/sofa/left{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"hvv" = (
-/obj/structure/table,
-/obj/item/paper_bin/bundlenatural{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/pen/fountain{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "hvD" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -44903,16 +44902,23 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hxR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"hyt" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Clubroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "hyy" = (
 /obj/structure/tank_holder/extinguisher{
 	pixel_y = 8
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"hzj" = (
-/obj/machinery/griddle,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "hzQ" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -44939,13 +44945,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
-"hAw" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Clubroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "hAK" = (
 /obj/structure/table,
 /obj/item/storage/box/disks_nanite,
@@ -44978,19 +44977,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"hCD" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/security/prison)
 "hDb" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens Observation - Port Fore";
@@ -45016,9 +45002,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"hDi" = (
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "hDB" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -45052,6 +45035,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hDV" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall,
+/area/security/prison)
 "hEf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45112,10 +45099,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"hGg" = (
-/obj/structure/chair/sofa/right,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "hGo" = (
 /obj/item/storage/box/bodybags,
 /obj/structure/extinguisher_cabinet{
@@ -45138,6 +45121,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"hGp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
+	},
+/area/security/prison)
 "hGw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -45176,14 +45165,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"hIp" = (
-/obj/machinery/conveyor/auto{
-	dir = 4
+"hIu" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/security/prison)
+"hIG" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "hIM" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
@@ -45211,14 +45202,13 @@
 /obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"hKP" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+"hLe" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison";
+	req_access_txt = "63"
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "hPF" = (
 /obj/effect/landmark/event_spawn,
@@ -45278,25 +45268,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
-"hUS" = (
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	id = "lockdown1";
-	name = "Lockdown"
-	},
-/obj/machinery/button/door{
-	id = "lockdown1";
-	name = "Lockdown";
-	pixel_y = 24;
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "hVD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -45352,9 +45323,30 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hYS" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "hZk" = (
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"hZC" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "hZD" = (
 /obj/machinery/camera{
 	c_tag = "Security Office";
@@ -45407,13 +45399,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"icT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "icV" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -45456,11 +45441,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
-"ieH" = (
-/obj/machinery/light{
-	dir = 4
+"ieX" = (
+/obj/machinery/conveyor/auto{
+	dir = 1
 	},
-/turf/open/floor/plating/grass,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ife" = (
 /obj/structure/chair{
@@ -45577,19 +45565,31 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"ikm" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Clubroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+"ikh" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/skill_station,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ilV" = (
-/obj/item/toy/beach_ball/holoball,
+/obj/machinery/plate_press,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"imA" = (
+/obj/machinery/door/poddoor/shutters/window{
+	id = "visitation"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"imL" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison/safe)
 "ink" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -45597,13 +45597,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
-"int" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 10
-	},
-/area/security/prison)
 "inY" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -45654,17 +45647,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
-"iqQ" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"irI" = (
-/obj/structure/curtain,
-/obj/machinery/shower{
-	pixel_y = 20
+"irN" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Library"
 	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "irX" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/chair,
@@ -45709,7 +45698,7 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"ivu" = (
+"ivQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	alpha = 170;
 	dir = 4;
@@ -45717,17 +45706,18 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	alpha = 170;
+	dir = 1;
 	name = "engineering corner"
 	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = 26;
-	prison_radio = 1
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison/safe)
 "ivU" = (
@@ -45790,24 +45780,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"iAc" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"iAw" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
 "iAM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -45895,12 +45867,6 @@
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"iJi" = (
-/obj/machinery/jukebox{
-	req_one_access = null
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "iKz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -45917,18 +45883,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"iNi" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/security/prison)
 "iNn" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room"
@@ -45940,6 +45894,9 @@
 /obj/machinery/computer/security/labor,
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
+"iOl" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "iOI" = (
 /obj/structure/rack,
 /obj/item/wirecutters,
@@ -45950,6 +45907,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"iPr" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "iPt" = (
 /obj/machinery/door/window/brigdoor{
 	name = "Research Director Observation";
@@ -45968,15 +45941,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"iPM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "iQk" = (
 /obj/structure/chair{
 	dir = 1
@@ -45993,20 +45957,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"iRP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/green{
+"iRC" = (
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
+/turf/open/floor/wood,
 /area/security/prison)
 "iSr" = (
 /obj/structure/extinguisher_cabinet{
@@ -46028,17 +45983,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"iTD" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 4
+"iUK" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"iUj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "iVn" = (
 /obj/structure/closet/l3closet/scientist{
@@ -46049,6 +45998,10 @@
 "iVu" = (
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"iVw" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "iWe" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Garden Maintenance";
@@ -46069,18 +46022,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"iXa" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/machinery/door/window/eastright{
-	name = "shower"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison/safe)
+"iXb" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/wood,
+/area/security/prison)
 "iYg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -46169,10 +46114,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"jbS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "jbV" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
@@ -46192,15 +46133,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/storage/mining)
+"jdu" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/obj/machinery/griddle,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "jdH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jfu" = (
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "jgM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -46353,33 +46299,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"jnI" = (
-/obj/machinery/plate_press,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/machinery/button/door{
-	id = "Workroom1";
-	pixel_x = 24;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"jop" = (
-/obj/machinery/button/door{
-	id = "visitation";
-	name = "Visitation";
-	pixel_x = -24;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "joy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -46401,22 +46320,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/openspace,
 /area/science/xenobiology)
-"jpP" = (
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	id = "lockdown3";
-	name = "Lockdown"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "jqo" = (
 /obj/machinery/computer/prisoner/management,
 /turf/open/floor/plasteel/dark,
@@ -46499,16 +46402,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"jtT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/security/prison)
 "jvu" = (
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -46585,14 +46478,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"jAJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "jAK" = (
 /obj/machinery/rnd/server,
 /obj/structure/lattice/catwalk,
@@ -46752,13 +46637,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"jIo" = (
-/obj/effect/turf_decal/delivery/blue,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "jIN" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -46770,52 +46648,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jJh" = (
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 4;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 1;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	name = "engineering corner"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "jJO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"jKY" = (
-/obj/structure/closet/crate/hydroponics{
-	name = "raw produce"
-	},
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"jLo" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "jLM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -46860,6 +46697,13 @@
 	dir = 5
 	},
 /area/security/prison)
+"jOL" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "jPn" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -46883,23 +46727,27 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"jQt" = (
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+"jQV" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
 	},
-/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jQY" = (
@@ -46916,6 +46764,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"jRp" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jRs" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -47021,17 +46876,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
-"jVi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/security/prison)
 "jVl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47073,17 +46917,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"jVP" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/security/prison)
 "jXa" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
@@ -47094,6 +46927,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"jXi" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/computer/cryopod{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/carpet,
+/area/security/prison/safe)
 "jXT" = (
 /obj/structure/falsewall,
 /obj/structure/cable,
@@ -47112,16 +46956,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"kaz" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Kitchen"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "kbz" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -47227,13 +47061,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"kdT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/green,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
+"kdC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison)
 "ken" = (
 /obj/structure/cable,
@@ -47283,6 +47120,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"kiL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "kjH" = (
 /obj/machinery/light,
 /obj/structure/closet/firecloset,
@@ -47291,6 +47136,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"kjS" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "klg" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -47333,6 +47184,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/storage/mining)
+"knQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "koN" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -47358,13 +47217,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"kqH" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bossofthisprisongym";
-	name = "Private Area"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
 "krt" = (
 /turf/open/floor/carpet,
 /area/maintenance/space_hut/cabin)
@@ -47401,6 +47253,10 @@
 	dir = 4
 	},
 /area/security/prison)
+"ksY" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "ktd" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -47409,23 +47265,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"ktm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+"ktL" = (
+/obj/structure/closet/crate/secure{
+	desc = "A secure crate containing various materials for building a customised test-site.";
+	name = "Firing Range Gear Crate";
+	req_access_txt = "1"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
-"ktV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark/side{
-	dir = 5
-	},
+/obj/item/target/syndicate,
+/obj/item/target/syndicate,
+/obj/item/target/clown,
+/obj/item/target/clown,
+/obj/item/target/alien,
+/obj/item/target/alien,
+/obj/item/target,
+/obj/item/target,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "kul" = (
 /turf/closed/wall,
@@ -47450,6 +47304,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"kuE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/security/prison)
 "kvh" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -47468,6 +47334,19 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"kvM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "kwn" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -47511,6 +47390,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/aft)
+"kwX" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/janitorialcart{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "kxj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -47552,25 +47443,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"kzk" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark/side,
-/area/security/prison)
-"kzs" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/door/window/southright{
-	name = "shower"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison/safe)
 "kzL" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -47642,16 +47514,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"kBw" = (
-/obj/structure/chair/sofa/left{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "kFE" = (
 /obj/structure/chair{
 	dir = 8;
@@ -47744,19 +47606,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
-"kHp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kHN" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
@@ -47790,74 +47639,12 @@
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
 /area/medical/medbay/lobby)
-"kLj" = (
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 1;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 8;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	name = "engineering corner"
-	},
-/obj/structure/closet/crate/wooden,
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/instrument/eguitar,
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
 "kLM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"kLY" = (
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 4;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 1;
-	name = "engineering corner"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"kMi" = (
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 4;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 8;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	name = "engineering corner"
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
 "kMX" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
@@ -47966,6 +47753,13 @@
 	dir = 8
 	},
 /area/security/prison)
+"kUk" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plating/grass,
+/area/security/prison)
 "kVn" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -47991,12 +47785,6 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"kVX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "kWe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -48041,13 +47829,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"kZg" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/closet/crate/hydroponics{
-	name = "raw produce"
-	},
-/turf/open/floor/plating/grass,
-/area/security/prison)
 "kZR" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
@@ -48120,6 +47901,15 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"lhi" = (
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "lhu" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -48142,18 +47932,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
-"liK" = (
-/obj/machinery/button/door{
-	id = "bossofthisprisongym";
-	name = "Private Area";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access_txt = "63"
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "ljx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -48197,22 +47975,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"lqO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Workroom1"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "lrg" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/white,
@@ -48254,6 +48016,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"lui" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"luT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "lvw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -48359,6 +48141,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"lBO" = (
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/security/prison)
 "lCh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -48376,18 +48162,28 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"lCQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "lCT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
-"lCY" = (
-/obj/machinery/deepfryer,
-/obj/machinery/light{
-	dir = 1
+"lCV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
 /area/security/prison)
 "lEl" = (
 /obj/structure/disposalpipe/segment{
@@ -48402,23 +48198,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"lED" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "lEW" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"lFx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+"lFb" = (
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/airlock/security/glass{
+	name = "Firing Range";
+	req_access_txt = "1"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/washing_machine,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "lFP" = (
 /obj/machinery/computer/scan_consolenew{
@@ -48451,26 +48256,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"lHA" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/prison";
-	dir = 4;
-	name = "Prison Wing APC";
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "lHR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -48521,15 +48306,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"lJF" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "lJI" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -48575,21 +48351,43 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"lMk" = (
+"lLO" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/window/preopen{
-	id = "lockdown2";
+	id = "lockdown3";
 	name = "Lockdown"
 	},
 /obj/machinery/button/door{
-	id = "lockdown2";
+	id = "lockdown3";
 	name = "Lockdown";
-	pixel_x = 25;
+	pixel_y = 24;
 	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"lMG" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown1";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "lockdown1";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "lNo" = (
@@ -48619,11 +48417,9 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
-"lOP" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/training_machine,
-/obj/item/target/syndicate,
-/turf/open/floor/plating,
+"lOM" = (
+/obj/structure/bookcase/manuals/medical,
+/turf/open/floor/wood,
 /area/security/prison)
 "lOY" = (
 /obj/structure/cable,
@@ -48665,13 +48461,6 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"lPn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "lQm" = (
 /obj/machinery/camera{
 	c_tag = "Nanite Lab";
@@ -48716,12 +48505,6 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"lSs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "lSv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -48777,6 +48560,18 @@
 	},
 /turf/open/floor/plating,
 /area/medical/break_room)
+"lUs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "lUZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -48826,6 +48621,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/medical/storage)
+"mab" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "mbf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -48939,6 +48746,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"miD" = (
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of the green cell block";
+	name = "Cell - Green"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "miW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -48988,6 +48803,20 @@
 "mlw" = (
 /turf/closed/wall,
 /area/blueshield)
+"mna" = (
+/obj/structure/chair/sofa,
+/turf/open/floor/wood,
+/area/security/prison)
+"mof" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "mpJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -49026,6 +48855,18 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"mrh" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison/safe)
 "mrM" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -49076,10 +48917,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mvk" = (
-/obj/structure/chair/sofa,
-/turf/open/floor/wood,
-/area/security/prison)
 "mwN" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -49102,6 +48939,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/medical/pharmacy)
+"mym" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/wood,
+/area/security/prison)
 "myW" = (
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
@@ -49129,6 +48970,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"mAM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
+"mAN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "mBa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -49175,9 +49031,35 @@
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"mDl" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood,
+"mDP" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/window,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison/safe)
+"mEh" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "mEM" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -49188,6 +49070,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"mEO" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/prison";
+	dir = 4;
+	name = "Prison Wing APC";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "mEX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -49243,13 +49145,11 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"mHl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 1
+"mHk" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "mHR" = (
 /obj/structure/disposalpipe/segment,
@@ -49374,15 +49274,6 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"mOA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/security/prison)
 "mPh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49470,6 +49361,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"mUb" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "mUx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -49483,6 +49380,35 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"mUN" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "mVz" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -49490,6 +49416,22 @@
 /obj/effect/turf_decal/box/blue,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"mVJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
+"mVR" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	max_integrity = 1
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
 "mWw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -49514,13 +49456,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"mWZ" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
-	},
-/turf/closed/wall,
-/area/security/prison/safe)
 "mXr" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 4
@@ -49593,6 +49528,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"naX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "nbA" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
@@ -49650,10 +49592,6 @@
 /obj/machinery/photocopier,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
-"nen" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/security/prison)
 "neA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -49671,6 +49609,14 @@
 /obj/effect/landmark/start/research_director,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"neW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "nfk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -49706,42 +49652,6 @@
 "nka" = (
 /turf/open/openspace,
 /area/science/xenobiology)
-"nkH" = (
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 4;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 1;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 8;
-	name = "engineering corner"
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/toilet{
-	pixel_y = 16
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"nla" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark/side,
-/area/security/prison)
 "nli" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -49937,23 +49847,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
-"nvA" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
 "nwJ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -49994,6 +49887,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"nxG" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "nxP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/event_spawn,
@@ -50069,24 +49977,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"nAI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/lavendergrass{
-	max_integrity = 1;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/plating/grass,
-/area/security/prison)
-"nBd" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plating/grass,
-/area/security/prison)
 "nCf" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/stripes/line,
@@ -50160,16 +50050,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"nFG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/security/prison)
 "nFI" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -50218,6 +50098,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"nHA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
 "nIb" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -50240,12 +50126,6 @@
 	},
 /turf/open/openspace,
 /area/science/xenobiology)
-"nLq" = (
-/obj/structure/closet/crate/hydroponics{
-	name = "raw produce"
-	},
-/turf/open/floor/plating/grass,
-/area/security/prison)
 "nLS" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Storage";
@@ -50262,12 +50142,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"nMg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nMq" = (
 /obj/machinery/light_switch{
 	pixel_x = 26;
@@ -50309,15 +50183,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"nOw" = (
-/obj/machinery/button/door{
-	id = "bossofthisprisongym";
-	name = "Private Area";
-	pixel_x = -24;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison/safe)
 "nOC" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
@@ -50471,6 +50336,12 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"nUB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/security/prison/safe)
 "nWm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -50495,6 +50366,13 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"nWY" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "nXi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -50540,6 +50418,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nZi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Workroom1"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "nZo" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
@@ -50557,47 +50451,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"ocm" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"odB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Prison -  Workroom";
-	dir = 10;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel/dark/corner{
+/turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
 /area/security/prison)
 "oeg" = (
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"ofJ" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
+"ofm" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 9
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ofT" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"ogy" = (
-/obj/structure/curtain,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "ogG" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/disposalpipe/segment,
@@ -50673,6 +50549,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/mining)
+"olt" = (
+/obj/structure/table,
+/obj/item/paper_bin/bundlenatural{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/pen/fountain{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "omI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -50726,6 +50614,14 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"orT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/training_machine,
+/obj/item/target/syndicate,
+/turf/open/floor/plating,
+/area/security/prison)
 "otc" = (
 /obj/machinery/light{
 	dir = 4
@@ -50833,6 +50729,14 @@
 "owD" = (
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"oxV" = (
+/obj/structure/curtain{
+	alpha = 240;
+	color = "#454545";
+	name = "Changing Room"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "oxX" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -50849,16 +50753,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"oyz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/wood,
-/area/security/prison)
-"oyD" = (
-/obj/machinery/cryopod{
-	dir = 8
+"oyK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/circuit/green,
-/area/security/prison/safe)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
+"ozP" = (
+/obj/structure/curtain,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "ozS" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken2"
@@ -50870,36 +50780,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"oAq" = (
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 4;
-	name = "engineering corner"
+"oAr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 1;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 8;
-	name = "engineering corner"
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/toilet{
-	pixel_y = 16
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
+/turf/open/floor/plasteel/dark/corner,
+/area/security/prison)
 "oAN" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
@@ -50907,10 +50793,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"oCc" = (
-/obj/machinery/smartfridge,
-/turf/closed/wall,
-/area/security/prison)
+"oCI" = (
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/hos)
 "oCP" = (
 /obj/structure/flora/tree/pine,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -50919,19 +50804,6 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"oFA" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/security/prison)
 "oFI" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
@@ -50957,15 +50829,6 @@
 /obj/effect/landmark/start/security_sergeant,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"oKx" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "oKS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -50980,6 +50843,12 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
+"oMg" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "oMN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -50993,22 +50862,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"oNA" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
 "oND" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -51019,32 +50872,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"oOm" = (
-/obj/structure/chair/sofa,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "oOF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"oOH" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/gun_vendor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"oPe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/security/prison/safe)
 "oPj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51181,15 +51014,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
-"oYf" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 4
-	},
-/area/security/prison)
 "oYv" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -51233,13 +51057,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"oZx" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/chair/sofa,
-/turf/open/floor/wood,
-/area/security/prison)
 "paU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -51251,19 +51068,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"pbL" = (
-/obj/structure/table/glass,
-/obj/machinery/microwave{
-	pixel_y = 8
-	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "pcf" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
@@ -51317,11 +51121,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"pge" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+"pgK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "pgP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51458,12 +51261,6 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"poE" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "poL" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -51500,6 +51297,20 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"prj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/security/prison)
 "prA" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral{
@@ -51576,6 +51387,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
+"pun" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "puT" = (
 /obj/effect/turf_decal/tile/purple{
 	alpha = 255;
@@ -51610,6 +51432,17 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/vacant_room/commissary)
+"pvs" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/security/prison)
 "pwd" = (
 /obj/structure/flora/ausbushes/fullgrass{
 	pixel_x = -3;
@@ -51773,6 +51606,14 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"pDd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "pDu" = (
 /obj/machinery/computer/nanite_cloud_controller,
 /obj/effect/turf_decal/bot,
@@ -51810,6 +51651,36 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"pFp" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/closet/crate/wooden,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/instrument/eguitar,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
+"pFs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pFw" = (
 /obj/effect/turf_decal/tile/purple{
 	alpha = 255;
@@ -51894,6 +51765,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"pKr" = (
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pLn" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -51905,6 +51795,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
+"pNb" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pNh" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
@@ -52047,6 +51943,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"pTE" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "pTF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -52077,6 +51977,17 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"pUB" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "pVb" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
@@ -52100,18 +52011,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"pWy" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "pWN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"pWZ" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Clubroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "pXw" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
@@ -52169,6 +52083,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"qaN" = (
+/obj/structure/chair/sofa/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "qaX" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd2";
@@ -52187,6 +52107,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qcs" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "qcC" = (
 /obj/structure/sign/warning/pods{
 	pixel_x = 32
@@ -52196,6 +52121,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"qcR" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/security/prison)
 "qcV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -52302,6 +52236,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"qjt" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "qjL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -52323,13 +52263,20 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "qkO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/grown/log,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/grass,
+/area/security/prison)
+"qlX" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Janitorial"
 	},
-/turf/open/floor/plasteel/dark/side{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "qmt" = (
 /obj/structure/chair/stool,
@@ -52337,10 +52284,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/quartermaster/qm)
-"qmD" = (
-/obj/structure/bookcase/manuals/medical,
-/turf/open/floor/wood,
-/area/security/prison)
 "qmO" = (
 /obj/machinery/griddle,
 /obj/machinery/power/apc/auto_name/north,
@@ -52357,16 +52300,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
-"qoG" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/side,
-/area/security/prison)
 "qps" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -52450,6 +52383,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
+"qrW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "qti" = (
 /obj/effect/turf_decal/tile/purple{
 	alpha = 255;
@@ -52528,10 +52465,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"qzJ" = (
-/obj/machinery/light/small,
-/turf/open/floor/wood,
-/area/security/prison)
 "qzO" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/hallway/secondary/service)
@@ -52586,43 +52519,32 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qFP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "qGG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"qGI" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
-/obj/structure/plasticflaps,
-/obj/machinery/door/poddoor/shutters/window{
-	id = "prisonconveyor";
-	name = "Conveyor Shutter"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "qGZ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"qHw" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Prison -  Cafeteria";
-	dir = 6;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "qHR" = (
 /obj/machinery/computer/security/telescreen/interrogation{
 	pixel_y = 30
@@ -52639,6 +52561,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"qIz" = (
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/security/prison)
 "qJV" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/shotgun/riot{
@@ -52672,14 +52603,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"qLh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/training_machine,
-/obj/item/target/syndicate,
-/turf/open/floor/plating,
-/area/security/prison)
 "qMc" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -52707,6 +52630,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"qOb" = (
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of the green cell block";
+	name = "Cell - Green"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "qOz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -52770,10 +52703,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"qQE" = (
-/obj/structure/table/wood/fancy/black,
-/turf/open/floor/wood,
-/area/security/prison)
 "qQH" = (
 /obj/effect/spawner/lootdrop/minor/bowler_or_that,
 /obj/structure/rack,
@@ -52783,11 +52712,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
-"qRv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"qSd" = (
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark/side,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "qSS" = (
 /obj/structure/cable,
@@ -52841,6 +52772,26 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"qXf" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
+"qXz" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/security/prison)
 "qXW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52876,24 +52827,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/aft)
-"raf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+"rab" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Prison -  Green Wing";
-	dir = 1;
-	network = list("ss13","prison");
-	start_active = 1
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark/side,
-/area/security/prison)
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "rat" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -52910,10 +52858,6 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"raw" = (
-/obj/structure/chair/comfy/black,
-/turf/open/floor/wood,
-/area/security/prison)
 "raE" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=AftH";
@@ -52976,19 +52920,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
-"rfT" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
 "rgu" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -53026,6 +52957,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/break_room)
+"rhG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rid" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -53035,6 +52973,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"riB" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "riW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -53112,12 +53060,6 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"rqs" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/security/prison)
 "rrd" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -53165,6 +53107,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"ruk" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "ruy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -53175,12 +53130,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"rvt" = (
-/obj/item/grown/log,
-/obj/structure/closet/crate/hydroponics,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/plating/grass,
+"rvh" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
 /area/security/prison)
 "rye" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
@@ -53271,15 +53223,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
-"rAj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Workroom1"
+"rzW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/security/prison)
 "rAs" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -53302,16 +53250,16 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
-"rCC" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/grass,
-/area/security/prison)
-"rDd" = (
+"rDl" = (
 /obj/structure/table/glass,
-/turf/open/floor/plasteel,
+/obj/machinery/reagentgrinder,
+/obj/machinery/camera{
+	c_tag = "Prison - Kitchen";
+	dir = 6;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "rDO" = (
 /obj/machinery/camera{
@@ -53345,10 +53293,6 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"rDZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "rET" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -53393,20 +53337,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"rIS" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/green{
+"rIA" = (
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "rJl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
@@ -53428,21 +53367,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"rKM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "Prison -  East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 4
-	},
-/area/security/prison)
 "rKP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -53470,14 +53394,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
-"rMs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/security/prison)
 "rMz" = (
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot_blue,
@@ -53495,6 +53411,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"rNB" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "rOo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -53503,14 +53428,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rOV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/green,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/security/prison)
 "rOY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -53526,18 +53443,48 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rPv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rPX" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/maintenance/port)
+"rQK" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown4";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"rQP" = (
+/obj/structure/bed,
+/obj/item/bedsheet/rd/royal_cape,
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "rQR" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"rRB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"rRV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Workroom1"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "rRX" = (
 /obj/machinery/computer/rdconsole{
 	dir = 1
@@ -53593,23 +53540,38 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"rST" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown2";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "lockdown2";
+	name = "Lockdown";
+	pixel_x = 25;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"rTg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	max_integrity = 1
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
 "rTE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"rUs" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "rUB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -53663,10 +53625,6 @@
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
 /area/maintenance/space_hut/cabin)
-"rXo" = (
-/obj/structure/punching_bag,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rXY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -53727,25 +53685,6 @@
 /obj/item/stock_parts/cell/emproof,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"sbi" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor{
-	name = "EVA Equipment";
-	req_access_txt = "1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
-"sbm" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "sbQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
@@ -53823,18 +53762,14 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
-"sgy" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 9
+"sgz" = (
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	dir = 1;
-	pixel_x = 3;
-	pixel_y = 9
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
 	},
-/turf/open/floor/plasteel/checker,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "sgR" = (
 /obj/structure/table,
@@ -53860,18 +53795,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"shY" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"six" = (
-/obj/structure/table,
-/obj/item/soap,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "siK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -53897,6 +53820,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/medical)
+"skC" = (
+/obj/structure/table,
+/obj/item/soap,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "slk" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -54017,55 +53946,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"sqs" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"sqt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
-"srj" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
-"srr" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/dark/side,
-/area/security/prison)
-"sru" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "srx" = (
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/wood,
@@ -54080,6 +53960,19 @@
 /obj/structure/tank_holder,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"std" = (
+/obj/structure/table/glass,
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "stP" = (
 /obj/machinery/atmospherics/pipe/multiz/layer2{
 	color = "#ff0000";
@@ -54092,6 +53985,12 @@
 /obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"suO" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "suU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -54115,6 +54014,34 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"svl" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
+"svr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 10
+	},
+/area/security/prison)
 "swA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -54155,16 +54082,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"syN" = (
-/obj/machinery/door/airlock/grunge{
-	desc = "Part of the green cell block";
-	name = "Cell - Green"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
 "szO" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -54187,17 +54104,21 @@
 /obj/item/kirbyplants/fullysynthetic,
 /turf/open/floor/plasteel/showroomfloor,
 /area/hallway/secondary/service)
-"sAU" = (
+"sBt" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "sBI" = (
 /obj/structure/window/reinforced{
@@ -54205,9 +54126,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"sBT" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+"sCb" = (
+/obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/gun_vendor,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -54231,6 +54156,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"sEp" = (
+/obj/structure/rack,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "sGc" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -54319,6 +54257,22 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"sKN" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown3";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "sKS" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -54353,6 +54307,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"sLE" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/chair/sofa,
+/turf/open/floor/wood,
+/area/security/prison)
 "sLX" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -54369,6 +54330,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"sMw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "sNY" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -54410,6 +54382,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"sOI" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "sOU" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/tier_1,
@@ -54428,6 +54412,15 @@
 /obj/effect/turf_decal/bot_blue,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"sQg" = (
+/obj/machinery/button/door{
+	id = "bossofthisprisongym";
+	name = "Private Area";
+	pixel_x = -24;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "sQQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -54466,17 +54459,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"sVo" = (
-/obj/effect/turf_decal/delivery/blue,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24;
-	pixel_y = 3
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "sVI" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -54491,6 +54473,25 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/engineering)
+"sXs" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "sXy" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -54501,22 +54502,33 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"sXL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"sXS" = (
-/obj/effect/turf_decal/delivery/blue,
-/obj/machinery/door/airlock/security/glass{
-	name = "Firing Range";
-	req_access_txt = "1"
+"sYb" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"sYj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
+"sYD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
 	},
 /area/security/prison)
 "sZb" = (
@@ -54617,6 +54629,16 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"tcF" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Kitchen"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "tcY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54643,6 +54665,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"tfe" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "tge" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large{
@@ -54692,31 +54718,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"tix" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
-	name = "large flour sack";
-	possible_transfer_amounts = list(1,5,10,15,30,60,90);
-	volume = 90
-	},
-/obj/item/reagent_containers/food/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
-	name = "large flour sack";
-	possible_transfer_amounts = list(1,5,10,15,30,60,90);
-	volume = 90
-	},
-/obj/item/reagent_containers/food/condiment/mayonnaise,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice = 90);
-	name = "large rice sack";
-	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
-	},
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "tjy" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
@@ -54737,14 +54738,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"tjL" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/security/prison)
 "tjM" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -54774,29 +54767,16 @@
 /obj/effect/turf_decal/bot_blue,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"tkm" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tkC" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"tkL" = (
-/obj/structure/flora/ausbushes/sparsegrass{
-	max_integrity = 1
-	},
-/turf/open/floor/plating/grass,
-/area/security/prison)
-"tkM" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "tll" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
@@ -54830,6 +54810,12 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"tmO" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
 "tnw" = (
 /turf/closed/wall,
 /area/medical/genetics/cloning)
@@ -54901,14 +54887,6 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"tsz" = (
-/obj/structure/curtain{
-	alpha = 240;
-	color = "#454545";
-	name = "Changing Room"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "tte" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating{
@@ -54982,18 +54960,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"txm" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "txz" = (
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -55054,6 +55020,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"tAS" = (
+/obj/structure/chair/sofa/corner,
+/turf/open/floor/wood,
+/area/security/prison)
 "tBt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/virology/glass{
@@ -55073,6 +55043,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/medical/virology)
+"tCS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Green Wing";
+	dir = 1;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "tDw" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -55098,6 +55086,11 @@
 /obj/item/circuitboard/machine/dish_drive/bullet,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"tEd" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood,
+/area/security/prison)
 "tEH" = (
 /obj/structure/closet/secure_closet/security_medic,
 /obj/effect/turf_decal/tile/blue/darkblue{
@@ -55118,12 +55111,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"tGt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/grass,
-/area/security/prison)
 "tGE" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
@@ -55148,6 +55135,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"tHR" = (
+/obj/machinery/suit_storage_unit/security_peacekeeper,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/brigdoor{
+	name = "EVA Equipment";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "tHT" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
@@ -55160,6 +55158,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/maintenance/aft)
+"tJA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
+"tJD" = (
+/obj/structure/training_machine,
+/obj/item/target/syndicate,
+/turf/open/floor/plating,
+/area/security/prison)
 "tJO" = (
 /obj/structure/bed/dogbed/runtime,
 /mob/living/simple_animal/pet/cat/runtime,
@@ -55198,14 +55211,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"tLd" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/security/prison)
 "tLv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -55215,6 +55220,24 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"tLT" = (
+/obj/machinery/plate_press,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/machinery/button/door{
+	id = "Workroom1";
+	pixel_x = 24;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tMd" = (
 /obj/structure/table,
 /obj/machinery/syndicatebomb/training,
@@ -55228,6 +55251,10 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"tMR" = (
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tPr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/firealarm{
@@ -55237,6 +55264,10 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
+/area/security/prison)
+"tQh" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plating/grass,
 /area/security/prison)
 "tQk" = (
 /obj/machinery/camera{
@@ -55254,6 +55285,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"tQA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "tQM" = (
 /obj/structure/bed/dogbed/ian,
 /mob/living/simple_animal/pet/dog/corgi/ian{
@@ -55355,6 +55392,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"tUX" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tVr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -55456,18 +55497,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"udV" = (
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	id = "lockdown4";
-	name = "Lockdown"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "uea" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -55493,12 +55522,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
-"uez" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/security/prison)
 "ueK" = (
 /obj/structure/window/reinforced/fulltile/ice{
 	name = "frozen window"
@@ -55536,6 +55559,11 @@
 /obj/item/gun/energy/e_gun/dragnet,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"ugR" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "uhq" = (
 /obj/machinery/camera{
 	c_tag = "Public Mining Ladder";
@@ -55570,6 +55598,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
+"ujc" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "workhouse";
+	name = "Work Room"
+	},
+/obj/machinery/button/door{
+	id = "workhouse";
+	name = "Work Room";
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "ujh" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/airalarm{
@@ -55643,10 +55693,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"umZ" = (
-/obj/structure/chair/sofa/corner,
-/turf/open/floor/wood,
-/area/security/prison)
 "une" = (
 /obj/structure/closet/crate,
 /obj/item/instrument/piano_synth,
@@ -55737,11 +55783,18 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/corner,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"usE" = (
-/obj/structure/bed,
-/obj/item/bedsheet/rd/royal_cape,
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison/safe)
+"usD" = (
+/obj/machinery/button/door{
+	id = "bossofthisprisongym";
+	name = "Private Area";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "uvi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -55856,6 +55909,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"uCh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "uCq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -55880,26 +55937,43 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"uDP" = (
-/obj/structure/sign/poster/official/work_for_a_future{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/security/prison)
-"uEA" = (
-/obj/machinery/door/window/brigdoor/security/cell/westright{
-	id = "genpopcell1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
 "uES" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"uFU" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
+"uGa" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
+"uGq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "uGw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -55947,6 +56021,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"uIX" = (
+/obj/structure/bed,
+/obj/machinery/flasher{
+	id = "genpopcell1";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "uJY" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -56101,13 +56183,6 @@
 	},
 /turf/open/floor/grass,
 /area/crew_quarters/cryopod)
-"uXg" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "uXM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56123,6 +56198,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"uYW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "uZR" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -56151,18 +56234,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
-"vbp" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/item/soap,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "vbu" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
@@ -56353,6 +56424,36 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"vnJ" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "voe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -56384,6 +56485,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/mining)
+"voV" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "vpB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -56403,12 +56524,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"vqn" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "vqI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56422,14 +56537,38 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"vuS" = (
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/security/prison)
+"vrL" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison/safe)
 "vvP" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"vvY" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "vvZ" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -56451,22 +56590,6 @@
 /obj/effect/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"vyn" = (
-/obj/structure/table/glass,
-/obj/item/storage/bag/tray,
-/obj/item/storage/box/drinkingglasses{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/item/storage/box/cups{
-	pixel_x = -5
-	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = 3;
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "vyA" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -56506,16 +56629,6 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"vAL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/security/prison)
 "vAX" = (
 /obj/item/chair/wood,
 /turf/open/floor/wood{
@@ -56667,9 +56780,31 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"vHg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "vHt" = (
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"vIr" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "vIU" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light{
@@ -56721,28 +56856,11 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"vLz" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/wood,
-/area/security/prison)
 "vLX" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vMm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/security/prison)
 "vNp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -56808,6 +56926,22 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"vRo" = (
+/obj/structure/table/glass,
+/obj/item/storage/bag/tray,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/storage/box/cups{
+	pixel_x = -5
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "vRG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -56846,14 +56980,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"vTX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "vUt" = (
 /obj/structure/table,
 /obj/item/storage/box/hug{
@@ -56896,6 +57022,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"vXR" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
 "vYr" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=EVA2";
@@ -56953,13 +57086,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"waW" = (
-/obj/machinery/processor,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "wba" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -57125,31 +57251,10 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
-"whB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/security/prison)
 "whK" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"wiO" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole{
-	pixel_y = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "wiX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57177,6 +57282,15 @@
 	},
 /turf/open/floor/plating,
 /area/science/nanite)
+"wlf" = (
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "wlB" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -57233,25 +57347,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
-"wmP" = (
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/hos)
-"wmV" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "wpg" = (
 /turf/open/floor/plating,
 /area/science/genetics)
@@ -57279,11 +57374,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
-"wpx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/security/prison)
 "wqc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
@@ -57294,6 +57384,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"wru" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "wtb" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -57354,30 +57450,10 @@
 "wvq" = (
 /turf/closed/wall,
 /area/medical/cryo)
-"wvM" = (
-/obj/structure/rack,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison/safe)
 "wxF" = (
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"wyk" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "wyl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -57385,40 +57461,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wyy" = (
-/obj/structure/rack,
-/obj/item/wirecutters,
-/obj/item/shovel/spade,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/item/seeds/cotton,
-/obj/item/seeds/cotton,
-/obj/item/seeds/onion/red,
-/obj/item/seeds/wheat/rice,
-/obj/item/seeds/wheat/oat,
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "wzx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -57478,26 +57520,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"wCX" = (
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 4;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 8;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	name = "engineering corner"
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
 "wDJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -57509,6 +57531,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"wEj" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "wFc" = (
 /obj/machinery/light{
 	dir = 1
@@ -57527,6 +57557,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"wFo" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/training_machine,
+/obj/item/target/syndicate,
+/turf/open/floor/plating,
+/area/security/prison)
 "wFP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel/dark,
@@ -57591,15 +57627,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"wIy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "wIN" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -57623,6 +57650,15 @@
 /obj/effect/turf_decal/tile/blue/darkblue,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"wJd" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "wJm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -57653,24 +57689,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
-"wKq" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/green,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = 26;
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
 "wKw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -57722,6 +57740,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
+"wOj" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown4";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "lockdown4";
+	name = "Lockdown";
+	pixel_x = 25;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "wOk" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -57780,18 +57818,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"wRp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Prison -  Central";
-	dir = 9;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "wRF" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -57804,18 +57830,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"wSb" = (
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison/safe)
 "wTw" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -57857,12 +57871,6 @@
 "wVC" = (
 /turf/closed/wall/r_wall,
 /area/medical/storage)
-"wVG" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "wXs" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -57913,14 +57921,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"xal" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Firing Range";
-	req_access_txt = "1"
-	},
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "xaZ" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -57950,6 +57950,21 @@
 "xbG" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopod)
+"xbS" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"xdb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "xdk" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -58096,6 +58111,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"xhO" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "xhV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -58106,14 +58135,18 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"xiu" = (
-/obj/effect/turf_decal/tile/yellow,
+"xij" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "xiQ" = (
 /obj/structure/cable,
@@ -58223,24 +58256,6 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"xoQ" = (
-/obj/machinery/suit_storage_unit/security_peacekeeper,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/brigdoor{
-	name = "EVA Equipment";
-	req_access_txt = "1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
-"xoU" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Library"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "xpa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -58354,15 +58369,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"xwm" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "xwN" = (
 /turf/open/floor/plating,
 /area/engine/engine_smes)
@@ -58397,18 +58403,6 @@
 /obj/item/crowbar/red,
 /turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
-"xzH" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/janitorialcart{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "xzN" = (
 /obj/machinery/door/airlock/external{
 	name = "Common Mining Shuttle Bay"
@@ -58435,6 +58429,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
+"xAn" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/trashcart,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "xAv" = (
 /obj/machinery/light{
 	dir = 4
@@ -58448,12 +58458,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"xAT" = (
-/obj/structure/chair/sofa/corner{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "xCm" = (
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -58468,20 +58472,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"xEe" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+"xCS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Workroom1"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
+/turf/open/floor/plating,
+/area/security/prison)
 "xEM" = (
 /obj/structure/table,
 /obj/item/nanite_scanner,
@@ -58506,6 +58506,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xFT" = (
+/obj/structure/punching_bag,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xGq" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -58535,17 +58539,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xGY" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/computer/cryopod{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/floor/carpet,
-/area/security/prison/safe)
 "xGZ" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/power/port_gen/pacman,
@@ -58555,41 +58548,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/service)
-"xHK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
-/area/security/prison)
 "xIa" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xJd" = (
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 4;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	dir = 1;
-	name = "engineering corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	alpha = 170;
-	name = "engineering corner"
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
 "xLr" = (
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
@@ -58616,6 +58579,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"xNE" = (
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1
+	},
+/turf/closed/wall,
+/area/security/prison/safe)
 "xNR" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
 /obj/effect/turf_decal/tile/red{
@@ -58632,12 +58602,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"xOq" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
-/area/security/prison)
 "xOX" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
@@ -58660,14 +58624,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"xPf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "xPm" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -58695,6 +58651,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"xQa" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor{
+	name = "EVA Equipment";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
+"xQK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "xQZ" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
@@ -58735,6 +58706,15 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/white,
 /area/medical/break_room)
+"xSw" = (
+/obj/machinery/button/door{
+	id = "visitation";
+	name = "Visitation";
+	pixel_x = -24;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xSX" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
@@ -58768,6 +58748,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"xUs" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "xUW" = (
 /turf/open/floor/wood,
 /area/maintenance/space_hut/cabin)
@@ -58866,6 +58865,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"xZI" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/structure/holohoop,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xZS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -59012,14 +59018,13 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"yfX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"ygF" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
 	},
 /area/security/prison)
 "ygM" = (
@@ -59029,19 +59034,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"ygY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/side,
-/area/security/prison)
 "yis" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -78726,7 +78718,7 @@ boP
 acd
 ayy
 aDu
-jLo
+dnB
 aFq
 acd
 boP
@@ -78982,7 +78974,7 @@ boP
 boP
 acd
 ayy
-dkw
+tJD
 aDu
 aFq
 acd
@@ -79241,7 +79233,7 @@ acd
 ayy
 aDu
 aDu
-lOP
+wFo
 acd
 boP
 boP
@@ -79495,7 +79487,7 @@ bBM
 bBM
 bBM
 acd
-qLh
+orT
 aDu
 aDu
 aFq
@@ -79752,7 +79744,7 @@ boP
 boP
 boP
 acd
-iPM
+rRB
 aDu
 aDu
 aFq
@@ -80505,11 +80497,11 @@ bBM
 bBM
 boP
 boP
-erA
-jAJ
-jAJ
-jAJ
-vTX
+sMw
+neW
+neW
+neW
+oyK
 boP
 boP
 boP
@@ -80762,12 +80754,12 @@ bBM
 boP
 boP
 uTo
-sru
+xdb
 abb
-rCC
+vXR
 abb
-cAa
-vTX
+kdC
+oyK
 boP
 boP
 boP
@@ -81018,14 +81010,14 @@ bBM
 bBM
 boP
 uTo
-sru
-nBd
+xdb
+kUk
 aaL
 aaL
 aaL
 abb
-cAa
-vTX
+kdC
+oyK
 boP
 boP
 boP
@@ -81275,14 +81267,14 @@ boP
 boP
 boP
 voA
-rIS
-nAI
+nxG
+gxK
 aaL
-nLq
 aaL
-tkL
+aaL
+mVR
 abb
-xPf
+uYW
 boP
 boP
 boP
@@ -81295,11 +81287,11 @@ aai
 aai
 aai
 azu
-jIo
+gtf
 agK
 agK
-sXS
-sBT
+lFb
+iUK
 usq
 vhQ
 qff
@@ -81532,10 +81524,10 @@ aGL
 aeL
 auE
 vTk
-csl
-tGt
+hez
+nHA
 aaL
-tkL
+mVR
 aaL
 aaL
 abb
@@ -81789,18 +81781,18 @@ aIG
 ksN
 trX
 wbO
-fkC
-tGt
-rvt
+gaU
+nHA
+qkO
 aaL
 aaL
 aaK
 aaY
 acd
-nkH
+mUN
 ads
 acd
-nkH
+mUN
 agF
 acd
 acd
@@ -81808,12 +81800,12 @@ acd
 acd
 acd
 aai
-oOH
-wyk
+sCb
+nWY
 agK
 agK
-xal
-sBT
+aos
+iUK
 lcA
 snU
 aai
@@ -82046,29 +82038,29 @@ agh
 agh
 agh
 aiS
-wyy
-fLk
+czA
+rTg
 aaL
 aaL
-kZg
+tQh
 aaL
 abb
 acd
-kLY
+sXs
 aGJ
 acd
-hkS
+gVj
 aGJ
 acd
-vbp
+eIT
 acd
 asi
-oNA
+cGy
 aai
 azx
-sVo
+dDp
 agK
-dvN
+ktL
 abd
 iPI
 iGX
@@ -82308,19 +82300,19 @@ aao
 aau
 aaL
 aaL
-ieH
+tmO
 abb
 acd
-jJh
-eSu
+jQV
+bEG
 acd
-jJh
-eSu
+jQV
+bEG
 acd
 apz
-ogy
-srj
-nvA
+ozP
+iPr
+uFU
 aai
 aai
 aai
@@ -82560,7 +82552,7 @@ agh
 agh
 agh
 aiS
-eWO
+cYz
 acd
 acd
 aaw
@@ -82817,25 +82809,25 @@ agh
 agh
 agh
 wek
-vMm
+kuE
 aaq
 aax
-sAU
+mab
 aEs
-oFA
-sYj
+cFd
+mAN
 azv
 aeP
-hCD
+edN
 aeg
 aeP
 abg
 aoG
 apH
 aqN
-oAq
+vnJ
 atu
-kLj
+pFp
 szV
 aDu
 aai
@@ -83073,15 +83065,15 @@ agh
 agh
 agh
 agh
-xHK
-rqs
+dZy
+oAr
 aar
 aaO
 aaW
 aaE
-uez
+cqy
 aaO
-lMk
+rST
 aeh
 aku
 aeh
@@ -83090,15 +83082,15 @@ aku
 amp
 apQ
 aqV
-xJd
-ivu
-kMi
+ivQ
+svl
+vvY
 azL
 aDu
 aai
 aGu
-tsz
-sBT
+oxV
+iUK
 jDk
 ulk
 abd
@@ -83330,8 +83322,8 @@ auF
 aKL
 kTl
 kTl
-agN
-qRv
+gTN
+cMO
 acd
 acd
 abd
@@ -83343,15 +83335,15 @@ acx
 afa
 afa
 afa
-sqs
-xiu
-kzk
+tkm
+wJd
+rIA
 azL
 azL
 azL
 azL
 azL
-hfr
+ejz
 aai
 aai
 acd
@@ -83588,7 +83580,7 @@ bqF
 auK
 jvu
 jvu
-qRv
+cMO
 acd
 aSj
 abf
@@ -83596,22 +83588,22 @@ aal
 aSj
 abf
 acd
-ceE
+xZI
 jvu
-ilV
+hrw
 jvu
 akC
 anM
 apK
 aqN
-oAq
+vnJ
 atz
 awi
 szV
 aDu
-hvv
+olt
 aai
-ofJ
+lhi
 vmG
 rHf
 ulk
@@ -83844,31 +83836,31 @@ jvu
 bUe
 lNV
 jvu
-jbS
-gZt
+uCh
+eEh
 acd
 aaA
 aaC
 aaG
 aaN
-sgy
+gkf
 acd
-vqn
+pNb
 adB
-eDp
+ofm
 adB
-shY
+mUb
 anO
 apQ
 aqV
-xJd
-ivu
-wCX
+ivQ
+svl
+voV
 azL
 aDu
-vuS
+hIu
 aai
-lJF
+rNB
 agK
 jDk
 vUt
@@ -84101,21 +84093,21 @@ auT
 dSj
 mhu
 jvu
-rXo
-qRv
+xFT
+cMO
 acd
-qHw
-pWy
+fvp
+htx
 abs
-axS
-pWy
+lui
+htx
 acd
 acd
 aEr
 acd
 acd
 acd
-hUS
+lMG
 apT
 azL
 azL
@@ -84359,7 +84351,7 @@ eKM
 mNa
 tPr
 aaO
-xOq
+mHk
 acd
 aaI
 aaI
@@ -84368,19 +84360,19 @@ abs
 abs
 aft
 acd
-xzH
-heI
+kwX
+mEh
 arS
 akD
-iNi
-srr
-ara
+sOI
+tfe
+ikh
 azL
 awR
 awR
 azL
 aDu
-nen
+rvh
 aai
 aJD
 mYn
@@ -84616,24 +84608,24 @@ fak
 nli
 acd
 acd
-kaz
+tcF
 acd
-eGX
-eGX
+qcs
+qcs
 abs
 aaR
 abs
 acb
 acd
-lFx
+ruk
 aen
 aEu
 acd
-rMs
+odB
 aPM
 ara
 azL
-fLN
+uIX
 awR
 azL
 aEr
@@ -84872,21 +84864,21 @@ azt
 fpx
 ovx
 acd
-fdy
-kVX
-waW
-hDi
-eGX
+hIG
+tQA
+faR
+iOl
+qcs
 aaI
 aap
 abs
 aft
 acd
-cIJ
+xAn
 aeo
 afx
 acd
-whB
+sYD
 aPM
 ara
 azL
@@ -84895,8 +84887,8 @@ awR
 azL
 agK
 aEw
-qGI
-xwm
+fcU
+ieX
 agK
 usq
 hrf
@@ -85129,29 +85121,29 @@ aqN
 fSV
 puT
 acd
-lCY
-iUj
-hDi
-hDi
-eGX
+qjt
+cZA
+iOl
+iOl
+qcs
 aaI
 aap
-iJi
+fTZ
 acd
 acd
 acd
-hqU
+qlX
 acd
 acd
-cYK
+pun
 aPM
 ara
 asw
-uEA
+cCZ
 awX
-mWZ
+xNE
 agK
-hIp
+wlf
 aai
 wVq
 agK
@@ -85386,17 +85378,17 @@ azL
 gwO
 pFw
 acd
-hzj
-hDi
-iAc
-hDi
-eGX
+xbS
+iOl
+pTE
+iOl
+qcs
 aaI
 aaS
 abw
 ace
 acJ
-jVP
+uGa
 aep
 afz
 aBX
@@ -85404,13 +85396,13 @@ aoc
 apW
 aBX
 aBX
-hhA
+lCQ
 aBX
-gFl
+gWJ
 aBX
-int
+svr
 aGR
-mHl
+knQ
 qdH
 clP
 acd
@@ -85643,22 +85635,22 @@ aAM
 gwO
 pJj
 acd
-jKY
-sXL
-six
-gbN
-eLp
-rDZ
-gRz
+jdu
+uGq
+skC
+xQK
+oMg
+pgK
+wru
 abx
 acf
 jvu
-nMg
+pFs
 jvu
 afB
 jvu
-lPn
-icT
+rhG
+gbp
 aBY
 asC
 aBY
@@ -85667,7 +85659,7 @@ azM
 aBY
 aEx
 aGS
-oKx
+sgz
 agK
 lcA
 xgR
@@ -85900,31 +85892,31 @@ aCJ
 gDa
 qti
 acd
-pbL
-hDi
-rUs
-hDi
+std
+iOl
+pUB
+iOl
 acd
 aaJ
 abs
 abz
-wpx
-ktV
-wIy
-sbm
-gMh
-wRp
+ets
+hGp
+mAM
+wEj
+fOm
+ewL
 aop
 apZ
-tkM
-sqt
-qkO
+vIr
+hZC
+vHg
 axr
 azP
 aBZ
 aEy
 aGT
-lHA
+mEO
 ddc
 rHf
 rSI
@@ -86157,27 +86149,27 @@ aEp
 gwO
 pJj
 acd
-vyn
-hDi
-hDi
-hDi
-oCc
+vRo
+iOl
+iOl
+iOl
+hDV
 acd
 acf
 aiS
 azL
 azL
 adC
-oPe
+nUB
 azL
 acd
-ezh
-jpP
+lLO
+sKN
 azL
 azL
 azL
 azL
-cIj
+imA
 acd
 acd
 aai
@@ -86414,29 +86406,29 @@ azL
 gwO
 pJj
 acd
-hsz
-iqQ
-uXg
-tix
+rDl
+iVw
+jOL
+fZe
 acd
-tLd
+qSd
 jvu
 aPM
 azL
 acV
 adD
-ePP
+vrL
 azL
 akP
-yfX
+tJA
 aqm
 azL
 asD
-iXa
+fyn
 azL
-jop
-iTD
-poE
+xSw
+suO
+hnt
 jvu
 aai
 kQl
@@ -86680,23 +86672,23 @@ all
 jvu
 aPM
 azL
-wSb
-xGY
-oyD
+mrh
+jXi
+fSq
 azL
 alf
-jtT
-ygY
-htY
+ajP
+kvM
+miD
 asG
-xEe
+enq
 azL
-oYf
-jfu
-rDd
+ygF
+tMR
+tUX
 aGX
-gPO
-sBT
+hLe
+iUK
 qrN
 rXY
 kcV
@@ -86928,28 +86920,28 @@ azt
 fpx
 qti
 acd
-xAT
-baO
-wVG
+qaN
+dYg
+kjS
 aeH
 acd
 all
-eTP
-srr
+qrW
+tfe
 azL
 azL
 azL
 azL
 azL
 acd
-yfX
+tJA
 aby
 aqN
-rfT
-wKq
+bQG
+sYb
 azL
 aaM
-liK
+usD
 avb
 aHr
 aai
@@ -87185,19 +87177,19 @@ azL
 gwO
 pJj
 acd
-oZx
-vLz
-gnS
-oyz
-hAw
-gqW
+sLE
+tEd
+iRC
+fyh
+hyt
+kiL
 jvu
 aPM
 acd
 ada
 adH
 aeF
-qmD
+lOM
 acd
 aoV
 aqm
@@ -87206,7 +87198,7 @@ azL
 azL
 azL
 azL
-kqH
+hmM
 abH
 aaZ
 aaZ
@@ -87442,28 +87434,28 @@ azL
 hWj
 puT
 acd
-mvk
-mDl
-gnS
-qzJ
+mna
+iXb
+iRC
+lBO
 acd
-tjL
-rPv
-nla
-xoU
+fiN
+hxR
+dSz
+irN
 adb
 aeH
 aeH
 agf
 acd
 aoY
-qoG
+dbK
 azL
 asD
-iXa
+fyn
 azL
-wvM
-nOw
+sEp
+sQg
 abH
 tDP
 iSP
@@ -87699,28 +87691,28 @@ aqN
 hgD
 pJj
 acd
-umZ
-kBw
-eZm
+tAS
+eZN
+rzW
 aeH
 acd
-tjL
-lSs
-dhZ
+fiN
+gmp
+fzA
 akD
-wiO
+mof
 aeH
-raw
-qQE
+mym
+fsO
 acd
-jtT
-ygY
-htY
+ajP
+kvM
+miD
 asG
-xEe
+enq
 azL
-irI
-usE
+imL
+rQP
 abH
 rtz
 dRi
@@ -87958,10 +87950,10 @@ qti
 acd
 acd
 acd
-ikm
+pWZ
 acd
 acd
-rMs
+odB
 jvu
 aPM
 acd
@@ -87970,11 +87962,11 @@ acd
 acd
 acd
 acd
-yfX
+tJA
 aby
 aqN
-rfT
-wKq
+bQG
+sYb
 abH
 abH
 abH
@@ -88213,22 +88205,22 @@ azL
 gwO
 ryQ
 tRa
-cWW
-cWW
-vAL
-hKP
-cWW
-mOA
-etV
-nFG
-udV
-rOV
-eZr
-dng
-rOV
-rOV
-kdT
-raf
+naX
+naX
+mVJ
+fYp
+naX
+qcR
+jRp
+lCV
+rQK
+pDd
+ffh
+luT
+pDd
+pDd
+qXz
+tCS
 abH
 abH
 abH
@@ -88470,22 +88462,22 @@ aEq
 jNs
 sni
 tRz
-qkO
-qkO
-dCB
-ktm
-qkO
-rKM
-kHp
-ftU
-gwW
-wmV
-gIi
-txm
-eTS
-eTS
-iRP
-cmz
+vHg
+vHg
+xhO
+lUs
+vHg
+fDj
+xij
+pvs
+wOj
+sBt
+qFP
+qXf
+hak
+hak
+dpa
+prj
 aai
 boP
 boP
@@ -88733,15 +88725,15 @@ acd
 acd
 acd
 acd
-gBd
+ujc
 aiS
 azL
 azL
-syN
-oPe
+qOb
+nUB
 azL
-hGg
-erP
+ksY
+ceu
 agK
 aai
 boP
@@ -88989,16 +88981,16 @@ aDu
 aDu
 aDu
 aEr
-uDP
-jVi
-ocm
+qIz
+gqQ
+dey
 azL
-eJQ
-eUA
-iAw
+mDP
+rab
+lED
 azL
-oOm
-erP
+gUw
+ceu
 agK
 aai
 boP
@@ -89246,16 +89238,16 @@ aai
 aai
 aai
 aai
-jnI
-dpm
-jQt
+tLT
+ilV
+pKr
 szV
-kzs
-hbm
-fnQ
+fxn
+riB
+xUs
 azL
-dTk
-hun
+dAN
+hYS
 agK
 aai
 boP
@@ -89267,7 +89259,7 @@ vAI
 kVz
 gdu
 kct
-gPz
+fcA
 alt
 fZk
 vEA
@@ -89503,9 +89495,9 @@ boP
 boP
 boP
 aai
-rAj
-lqO
-dbu
+xCS
+nZi
+rRV
 abH
 abH
 abH
@@ -89774,7 +89766,7 @@ bBM
 boP
 boP
 adR
-sbi
+xQa
 iVu
 pkd
 xeM
@@ -90038,7 +90030,7 @@ iVu
 iVu
 iVu
 iVu
-pge
+ugR
 abo
 tll
 fxr
@@ -90545,7 +90537,7 @@ boP
 boP
 boP
 adR
-xoQ
+tHR
 iVu
 cmS
 fBM
@@ -91059,7 +91051,7 @@ boP
 boP
 boP
 adR
-wmP
+oCI
 abq
 abq
 mMA
@@ -91316,7 +91308,7 @@ boP
 boP
 boP
 boP
-wmP
+oCI
 abT
 acs
 acR
@@ -92344,7 +92336,7 @@ boP
 boP
 boP
 boP
-wmP
+oCI
 abW
 abk
 gII
@@ -92601,12 +92593,12 @@ boP
 boP
 boP
 boP
-wmP
-wmP
-wmP
+oCI
+oCI
+oCI
 abr
-wmP
-wmP
+oCI
+oCI
 abq
 tll
 qKz

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -57,12 +57,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors)
-"aaf" = (
-/obj/structure/sign/warning/securearea{
-	pixel_y = -32
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "aah" = (
 /obj/structure/cable,
 /turf/open/floor/plating/icemoon,
@@ -82,19 +76,28 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "aak" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aal" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aam" = (
 /obj/effect/spawner/randomsnackvend,
@@ -105,45 +108,50 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "aao" = (
-/obj/machinery/computer/bookmanagement,
-/obj/structure/table,
-/obj/machinery/newscaster{
-	pixel_x = -32
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/grass,
 /area/security/prison)
 "aap" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aaq" = (
-/obj/structure/cable,
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/security/prison)
 "aar" = (
-/obj/structure/chair/stool,
-/obj/structure/cable,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "aas" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	desc = "Why does this place even have windows?!";
+	id = "GenpopBath";
+	name = "Bathroom Privacy Shutters"
+	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aat" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/prison)
 "aau" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating/grass,
 /area/security/prison)
 "aav" = (
 /obj/machinery/requests_console{
@@ -164,47 +172,68 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aaw" = (
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aax" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
 /area/security/prison)
 "aay" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/structure/cable,
-/obj/item/instrument/harmonica,
-/turf/open/floor/plasteel,
+/obj/structure/rack,
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = -6
+	},
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = -6
+	},
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating,
 /area/security/prison)
-"aaz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+"aaA" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice{
+	pixel_x = 4;
+	pixel_y = 4
+	},
 /obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaA" = (
-/obj/effect/spawner/randomarcade,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaB" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aaC" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
+	pixel_x = 5;
+	pixel_y = 7
 	},
-/turf/open/floor/plasteel,
+/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aaD" = (
 /obj/effect/turf_decal/tile/brown{
@@ -217,160 +246,104 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aaE" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaF" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cafe"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 10
+	},
 /area/security/prison)
 "aaG" = (
-/obj/machinery/camera{
-	c_tag = "Prison Common Room";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaH" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aaI" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aaJ" = (
-/turf/closed/wall/r_wall,
-/area/security/prison/safe)
-"aaK" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/plate_press,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaL" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"aaK" = (
+/obj/structure/flora/ausbushes/ywflowers{
+	max_integrity = 1
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
+"aaL" = (
+/turf/open/floor/plating/grass,
 /area/security/prison)
 "aaM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
+	},
 /area/security/prison)
 "aaN" = (
 /obj/structure/table,
-/obj/item/folder,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/photo_album/prison,
-/obj/item/camera,
-/turf/open/floor/plasteel,
+/obj/item/reagent_containers/food/drinks/coffee,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aaO" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaP" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"aaQ" = (
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Prison Yard";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "aaR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aaS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaT" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Permabrig Maintenance";
-	req_access_txt = "1"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
-"aaU" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "aaV" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaW" = (
-/obj/structure/table,
-/obj/item/toy/cards/deck,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaY" = (
-/obj/item/stack/sheet/cardboard{
-	amount = 14
-	},
-/obj/item/stack/package_wrap,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Prison Workshop";
-	dir = 4;
-	network = list("ss13","prison")
+/turf/open/floor/plating,
+/area/security/prison)
+"aaW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
+"aaY" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light,
+/turf/open/floor/plating/grass,
 /area/security/prison)
 "aaZ" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
-"aba" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "abb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plasteel,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plating/grass,
 /area/security/prison)
 "abc" = (
 /turf/closed/wall,
@@ -380,45 +353,44 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "abe" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Common Room"
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = -8
 	},
-/turf/open/floor/plasteel,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = -4
+	},
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 4
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 8
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 12
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating,
 /area/security/prison)
 "abf" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Common Room"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
-"abi" = (
-/obj/machinery/light{
+"abg" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
 /area/security/prison)
 "abk" = (
 /obj/machinery/keycard_auth{
@@ -430,42 +402,6 @@
 /obj/item/taperecorder,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"abm" = (
-/obj/structure/table,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
-/obj/item/key/security,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"abn" = (
-/obj/structure/rack,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "abo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -486,11 +422,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "abs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "abt" = (
 /obj/effect/turf_decal/tile/brown{
@@ -530,43 +462,33 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "abw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "abx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aby" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "abz" = (
-/turf/closed/wall,
-/area/security/prison/safe)
-"abA" = (
-/turf/open/floor/plating,
-/area/security/prison/safe)
-"abB" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "abC" = (
 /obj/machinery/camera/motion{
 	c_tag = "Armory - External";
@@ -575,68 +497,79 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "abD" = (
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"abE" = (
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"abF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abG" = (
-/obj/machinery/door/airlock/security{
-	name = "Prison Workshop"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abH" = (
-/obj/structure/table,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
-	},
-/obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/area/security/prison/safe)
+"abE" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
+"abF" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
+"abG" = (
+/obj/effect/landmark/start/prisoner,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
+"abH" = (
+/turf/closed/wall/r_wall,
+/area/security/prison/safe)
 "abI" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot{
@@ -718,6 +651,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "abK" = (
@@ -760,6 +696,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "abN" = (
+/obj/structure/table,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
+/obj/item/key/security,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "abQ" = (
@@ -863,19 +803,28 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "abY" = (
-/obj/machinery/door/airlock/security{
-	name = "Prison Yard"
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
 	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/machinery/button/door{
+	desc = "At least Nanotrasen is giving criminals the option of privacy.";
+	id = "GenpopBath";
+	name = "Bathroom Shutters";
+	pixel_x = 24;
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "abZ" = (
 /obj/effect/landmark/start/quartermaster,
@@ -891,17 +840,12 @@
 /turf/open/openspace/icemoon,
 /area/security/execution/transfer)
 "acb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/effect/turf_decal/bot,
+/obj/machinery/light,
+/obj/effect/spawner/randomarcade{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "acc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -913,40 +857,19 @@
 /turf/closed/wall,
 /area/security/prison)
 "ace" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/beach_ball/holoball,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
 /area/security/prison)
 "acf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/holohoop{
-	dir = 8
+/obj/machinery/door/airlock/public/glass{
+	name = "Cafe"
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "acg" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ach" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/vending/security_ammo,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "acn" = (
 /obj/item/storage/secure/safe/hos{
@@ -980,18 +903,10 @@
 "acu" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"acw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Permabrig North";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "acx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acy" = (
@@ -1036,26 +951,26 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "acD" = (
-/obj/machinery/door/airlock/security{
-	name = "Prison Yard"
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
 /area/security/prison)
 "acE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"acG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "GenpopPool";
+	name = "Security Shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison)
 "acH" = (
 /obj/structure/table,
@@ -1074,16 +989,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "acJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"acK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "acN" = (
 /obj/structure/chair/stool/bar,
@@ -1139,11 +1048,19 @@
 /turf/open/floor/plating,
 /area/security/main)
 "acV" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/cryopod{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Cryogenics";
+	dir = 4;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/circuit/green,
 /area/security/prison/safe)
 "acW" = (
 /obj/structure/cable,
@@ -1161,58 +1078,54 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"acY" = (
-/obj/structure/closet/crate,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/onion,
-/obj/item/food/grown/onion,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "ada" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
+/obj/structure/bookcase/random/nonfiction,
+/obj/machinery/camera{
+	c_tag = "Prison -  Library";
+	dir = 6;
+	network = list("ss13","prison");
+	start_active = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/prison)
 "adb" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "adc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
-"add" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/soap/nanotrasen,
-/turf/open/floor/plasteel/freezer,
-/area/security/prison/safe)
-"ade" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison/safe)
-"adf" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall/r_wall,
 /area/security/prison)
+"add" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/security/prison)
+"ade" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Maintenance"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"adf" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "adh" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -1272,40 +1185,27 @@
 /turf/open/floor/plating,
 /area/security/main)
 "ads" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "adt" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"adu" = (
-/obj/structure/bed,
-/obj/item/bedsheet/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
 "adv" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -1338,14 +1238,6 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"ady" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "adz" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -1368,69 +1260,53 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "adB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "adC" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/grunge{
+	name = "Cryogenics"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison/safe)
 "adD" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/carpet,
 /area/security/prison/safe)
-"adE" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "adG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "adH" = (
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"adI" = (
-/obj/structure/table,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/rice,
-/turf/open/floor/plasteel/white,
+/obj/structure/bookcase/manuals/research_and_development,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "adJ" = (
-/obj/machinery/shower{
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/dark,
 /area/security/prison/safe)
 "adM" = (
 /obj/machinery/light,
@@ -1448,12 +1324,21 @@
 /area/engine/break_room)
 "adO" = (
 /obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light/small,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel/freezer,
-/area/security/prison/safe)
+/area/security/prison)
 "adP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -1479,13 +1364,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "adU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "adW" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -1534,44 +1424,37 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aeb" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 8"
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "aec" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/security/prison/safe)
 "aed" = (
@@ -1601,54 +1484,43 @@
 /turf/open/floor/plating/icemoon,
 /area/security/execution/transfer)
 "aef" = (
-/obj/machinery/biogenerator,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
+"aeg" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aeg" = (
-/obj/machinery/seed_extractor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "aeh" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/item/seeds/onion,
-/obj/item/seeds/garlic,
-/obj/item/seeds/potato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/security/prison)
 "aej" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1678,38 +1550,34 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aen" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aeo" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Central";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aep" = (
-/obj/machinery/light/small{
-	brightness = 3;
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/mob/living/simple_animal/mouse/brown/tom,
-/turf/open/floor/plating,
-/area/security/prison/safe)
-"aeq" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/trash/chips,
-/obj/item/trash/candy,
-/turf/open/floor/plating,
-/area/security/prison/safe)
-"aer" = (
-/obj/structure/window,
-/obj/effect/decal/cleanable/food/flour,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/plasteel/white,
+/area/security/prison)
+"aeo" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"aep" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/security/prison)
 "aeu" = (
 /obj/machinery/camera{
@@ -1743,10 +1611,8 @@
 /turf/open/floor/plasteel,
 /area/storage/mining)
 "aeF" = (
-/obj/machinery/door/window/southleft{
-	name = "Permabrig Kitchen"
-	},
-/turf/open/floor/plasteel/white,
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/wood,
 /area/security/prison)
 "aeG" = (
 /obj/structure/cable,
@@ -1755,90 +1621,80 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aeH" = (
-/obj/structure/table,
-/obj/structure/window,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/prison)
 "aeI" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/freezer,
-/area/security/prison/safe)
-"aeJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison/safe)
-"aeK" = (
-/obj/machinery/door/airlock{
-	name = "Permabrig Showers"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison/safe)
-"aeL" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aeN" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
+"aeJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
+"aeK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
+"aeL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "GenpopPool";
+	name = "Security Shutters"
+	},
+/turf/open/floor/plating,
 /area/security/prison)
-"aeP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
+"aeN" = (
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of a colour coded cell bock. This is an orange cell.";
+	name = "Cell - Orange"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"aeP" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/security/prison)
 "aeQ" = (
 /obj/machinery/light{
@@ -1886,14 +1742,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "afa" = (
-/obj/machinery/door/airlock/security{
-	name = "Prison Forestry"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -1909,12 +1759,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"afp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "afq" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -1939,15 +1783,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aft" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/randomarcade{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "afu" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1983,60 +1823,42 @@
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "afx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "afy" = (
-/obj/machinery/door/airlock{
-	name = "Cleaning Closet"
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/area/security/prison)
 "afz" = (
-/obj/item/storage/bag/trash,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "afA" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
 "afB" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 12
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bottle/ammonia,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/turf/open/floor/plasteel,
+/area/security/prison)
 "afE" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"afF" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"afG" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"afJ" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "afO" = (
 /obj/machinery/door/airlock/command{
 	name = "Command Tool Storage";
@@ -2084,10 +1906,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "agf" = (
-/obj/machinery/light{
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/prison)
 "agg" = (
 /obj/machinery/power/solar{
@@ -2098,28 +1920,22 @@
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors)
 "agh" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison/safe)
+/turf/open/water/overlay/hotspring,
+/area/security/prison)
 "agj" = (
 /turf/closed/wall,
 /area/security/brig)
 "agk" = (
-/obj/machinery/camera{
-	c_tag = "Prison Cell Block North";
-	dir = 4;
-	network = list("ss13","prison")
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 8
+	},
 /area/security/prison)
 "agm" = (
 /obj/machinery/light{
@@ -2149,22 +1965,24 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "agF" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/obj/structure/table,
+/obj/item/toy/cards/deck,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "agH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -2195,6 +2013,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
+/area/security/prison)
+"agN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/yellowsiding/corner{
+	dir = 1
+	},
 /area/security/prison)
 "agR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -2513,15 +2339,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aiS" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall,
 /area/security/prison)
 "aiT" = (
 /turf/closed/wall,
@@ -2749,13 +2570,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aku" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/plant_analyzer,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "akw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -2768,26 +2589,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "akC" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Laundry"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "akD" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/trash/sosjerky,
-/obj/item/trash/boritos,
-/obj/item/trash/can,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
 /area/security/prison)
 "akE" = (
 /obj/structure/sign/warning/deathsposal{
@@ -2838,9 +2645,12 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "akP" = (
-/obj/structure/table,
-/obj/item/food/energybar,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/games,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "akQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2894,10 +2704,21 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "alf" = (
-/obj/structure/chair{
-	dir = 8
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/item/toy/cards/deck,
+/obj/item/pen/fountain,
+/obj/item/pen/fourcolor,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "alg" = (
 /obj/structure/sign/poster/contraband/random{
@@ -2921,8 +2742,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "alj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plasteel,
+/obj/machinery/camera{
+	c_tag = "Prison -  Exercise Room";
+	dir = 6;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
 /area/security/prison)
 "alk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -2931,23 +2759,19 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "all" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "alm" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison/safe)
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
+	},
+/area/security/prison)
 "aln" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -2960,15 +2784,18 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "alo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "alp" = (
 /turf/open/floor/plating,
 /area/security/processing)
@@ -3060,25 +2887,26 @@
 /turf/closed/wall,
 /area/maintenance/port/aft)
 "alM" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 7"
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/prison/safe)
 "alN" = (
@@ -3137,41 +2965,30 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "alY" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/curtain,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"alZ" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/obj/effect/landmark/start/prisoner,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/musician/piano{
+	icon_state = "piano";
+	name = "Grand Piano"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison/safe)
-"alZ" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Forestry";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "amd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -3230,12 +3047,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "amp" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "amr" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -3630,15 +3451,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "anM" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "anN" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -3651,19 +3471,13 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "anO" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
 	},
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "anU" = (
 /obj/machinery/door/firedoor,
@@ -3733,11 +3547,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aoc" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Cafeteria"
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
 /area/security/prison)
 "aod" = (
 /obj/structure/cable,
@@ -3823,14 +3636,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aop" = (
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
 /area/security/prison)
 "aoq" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -3847,9 +3660,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aoG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/security/prison)
 "aoH" = (
 /obj/structure/table,
@@ -3921,8 +3739,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoV" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "aoW" = (
 /obj/structure/table,
@@ -3935,12 +3762,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoY" = (
-/obj/machinery/camera{
-	c_tag = "Prison Cafeteria";
-	dir = 8;
-	network = list("ss13","prison")
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "aoZ" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
@@ -3977,12 +3807,15 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "apf" = (
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "apg" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -4088,15 +3921,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "apz" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/shovel/spade,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "apB" = (
 /obj/machinery/camera{
@@ -4129,10 +3958,18 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "apH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/camera{
+	c_tag = "Prison -  Orange Wing";
+	dir = 1;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 10
+	},
 /area/security/prison)
 "apI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -4147,25 +3984,11 @@
 /turf/closed/wall,
 /area/construction/mining/aux_base)
 "apK" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Prison Laundry";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "apL" = (
 /obj/structure/table,
@@ -4196,16 +4019,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "apQ" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "apR" = (
 /obj/item/paper/fluff/jobs/security/beepsky_mom,
@@ -4216,14 +4037,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apT" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown1";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "apV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -4235,17 +4059,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apW" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Cafeteria"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "apX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -4258,13 +4078,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "apZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/corner,
 /area/security/prison)
 "aqa" = (
 /obj/machinery/light/small{
@@ -4329,9 +4147,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aqm" = (
-/obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/servingdish,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "aqn" = (
 /obj/structure/bed,
@@ -4393,20 +4218,24 @@
 /turf/closed/wall,
 /area/crew_quarters/fitness)
 "aqt" = (
-/obj/structure/toilet/greyscale{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
 	dir = 8;
-	open = 1
+	name = "strong purple corner"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison/safe)
@@ -4477,31 +4306,35 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aqF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aqG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aqI" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/table,
+/obj/item/paper_bin/bundlenatural{
+	pixel_x = -6;
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/item/pen/fountain{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
+"aqG" = (
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/clothing/neck/human_petcollar/locked,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "aqJ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -4529,13 +4362,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqN" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/security/prison/safe)
 "aqO" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -4559,30 +4388,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"aqU" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aqV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of a colour coded cell bock. This is an orange cell.";
+	name = "Cell - Orange"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "aqW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4602,18 +4415,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"aqX" = (
-/obj/structure/cable,
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -30;
-	prison_radio = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aqY" = (
 /obj/machinery/light{
 	dir = 8
@@ -4636,8 +4437,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ara" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "arb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -4667,14 +4468,6 @@
 "arf" = (
 /turf/closed/wall,
 /area/crew_quarters/dorms)
-"arg" = (
-/obj/machinery/vending/sustenance,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "arh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Dormitories Maintenance";
@@ -4790,10 +4583,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"arD" = (
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "arE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -4818,23 +4607,14 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "arH" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison/safe)
 "arI" = (
 /obj/structure/cable,
@@ -4843,23 +4623,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/table,
+/obj/item/pda,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/security/prison/safe)
 "arK" = (
 /turf/open/floor/plating{
@@ -4867,26 +4637,15 @@
 	},
 /area/maintenance/port/fore)
 "arL" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 5"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison/safe)
 "arM" = (
 /obj/effect/loot_site_spawner,
@@ -4920,14 +4679,27 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "arS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/clothing/gloves/color/blue,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/mop,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/item/storage/bag/trash,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "arT" = (
 /obj/structure/rack,
@@ -4956,28 +4728,6 @@
 /obj/item/stamp/law,
 /turf/open/floor/wood,
 /area/lawoffice)
-"arY" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 6"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
 "arZ" = (
 /obj/structure/filingcabinet,
 /obj/structure/disposalpipe/segment,
@@ -5050,30 +4800,23 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "asi" = (
-/obj/machinery/light/small{
+/obj/machinery/shower{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/mirror{
+	pixel_y = 26
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
-"asj" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "ask" = (
 /obj/structure/dresser,
@@ -5178,13 +4921,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "asw" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig South";
-	dir = 8;
-	network = list("ss13","prison")
+/obj/machinery/door_timer{
+	id = "genpopcell1";
+	name = "Punishment Cell"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/closed/wall,
+/area/security/prison/safe)
 "asx" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -5217,15 +4959,32 @@
 /turf/closed/wall,
 /area/maintenance/department/electrical)
 "asC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/cola/red,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "asD" = (
-/obj/structure/table,
-/obj/item/kitchen/fork/plastic,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison/safe)
 "asE" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
@@ -5234,12 +4993,18 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "asG" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "asH" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/tile/yellow{
@@ -5542,14 +5307,21 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "atu" = (
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "atv" = (
 /obj/structure/table,
 /obj/item/shard,
@@ -5581,12 +5353,25 @@
 	},
 /area/maintenance/starboard/fore)
 "atz" = (
-/obj/machinery/door/airlock/security{
-	name = "Cell Block"
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
 	},
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/structure/chair/comfy{
+	color = "#e8a768";
+	name = "orange comfy chair"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "atA" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -5977,38 +5762,26 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auE" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/bedsheet/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "GenpopPool";
+	name = "Security Shutters"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/turf/open/floor/plating,
+/area/security/prison)
 "auF" = (
-/obj/structure/toilet/greyscale{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/yellowsiding{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/area/security/prison)
 "auG" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -6033,11 +5806,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "auK" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/bed,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "auL" = (
@@ -6098,9 +5867,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "auT" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "auU" = (
@@ -6169,11 +5936,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "avb" = (
-/obj/structure/cable,
-/obj/machinery/airalarm{
-	pixel_y = 23
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "avc" = (
 /obj/structure/closet,
@@ -6462,13 +6227,6 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"avT" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "avV" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -6535,13 +6293,24 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "awi" = (
-/obj/machinery/door/airlock/security{
-	name = "Cell Block"
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
 	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/table,
+/obj/item/toy/cards/deck,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "awj" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -6726,16 +6495,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"awO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "awP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -6750,12 +6509,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "awR" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "awS" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -6796,17 +6551,12 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "awX" = (
-/obj/machinery/door/airlock/security{
-	name = "Permabrig Visitation"
+/obj/machinery/door/window/brigdoor/security/cell/westleft{
+	id = "genpopcell1"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "awY" = (
 /obj/machinery/light{
 	dir = 1
@@ -6862,19 +6612,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"axd" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "axe" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
@@ -6976,14 +6713,20 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "axr" = (
-/obj/machinery/flasher{
-	id = "visitorflash";
-	pixel_y = 28
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Prison -  South";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/security/prison)
 "axs" = (
 /obj/structure/disposalpipe/segment,
@@ -7018,14 +6761,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"axv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "axw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -7102,15 +6837,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"axJ" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "axK" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -7166,6 +6892,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"axS" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "axV" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel,
@@ -7209,27 +6941,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"ayc" = (
-/obj/machinery/button/flasher{
-	id = "visitorflash";
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/button/door{
-	id = "visitation";
-	name = "Visitation Shutters";
-	pixel_x = 6;
-	pixel_y = 25;
-	req_access_txt = "2"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ayd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -7383,48 +7094,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ayy" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/landmark/start/prisoner,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/turf/open/floor/plating,
+/area/security/prison)
 "ayz" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
 "ayA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/turf/open/floor/plating,
+/area/security/prison)
 "ayB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -7454,27 +7137,12 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/fore)
 "ayF" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 4"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/window/southleft{
+	dir = 8;
+	name = "shooting range"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/area/security/prison)
 "ayG" = (
 /turf/closed/wall/r_wall,
 /area/gateway)
@@ -7760,33 +7428,30 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "azt" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of the purple cell block.";
+	name = "Cell - Purple"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "azu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Prison Cell Block Central";
-	dir = 1;
-	network = list("ss13","prison")
+/obj/machinery/vending/security_ammo,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "azv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown2";
+	name = "Lockdown"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "azw" = (
 /obj/machinery/light_switch{
@@ -7796,11 +7461,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "azx" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/gun_vendor,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "azy" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -7861,31 +7523,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"azH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"azI" = (
-/obj/machinery/camera{
-	c_tag = "Prison Cell Block East";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"azJ" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permainner";
-	name = "Permabrig Transfer"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "azK" = (
 /obj/machinery/light{
 	dir = 8
@@ -7893,19 +7530,13 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "azL" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permainner";
-	name = "Permabrig Transfer"
+/turf/closed/wall,
+/area/security/prison/safe)
+"azM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"azM" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "azN" = (
@@ -7925,10 +7556,20 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "azP" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+/obj/machinery/button/door{
+	id = "visitation";
+	name = "Visitation";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "63"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/security/prison)
 "azQ" = (
 /obj/machinery/door/firedoor,
@@ -8257,15 +7898,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"aAy" = (
-/obj/machinery/door/airlock/security{
-	name = "Isolation Cell";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
 "aAz" = (
 /obj/machinery/computer/monitor{
 	dir = 1;
@@ -8275,23 +7907,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "aAA" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 3"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/area/security/prison)
 "aAB" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -8366,41 +7984,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aAM" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 2"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/soap,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
-"aAN" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 1"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/area/security/prison)
 "aAO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -8515,13 +8109,6 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"aBd" = (
-/obj/machinery/flasher{
-	id = "transferflash";
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aBe" = (
 /turf/open/floor/plasteel/dark,
 /area/gateway)
@@ -8809,37 +8396,24 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aBX" = (
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "visitation";
-	name = "Visitation Shutters"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
 	},
-/obj/machinery/door/window/southright,
-/turf/open/floor/plasteel,
 /area/security/prison)
 "aBY" = (
-/obj/structure/table,
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "visitation";
-	name = "Visitation Shutters"
-	},
-/obj/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aBZ" = (
-/obj/structure/table,
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "visitation";
-	name = "Visitation Shutters"
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel,
 /area/security/prison)
 "aCa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -9084,13 +8658,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aCJ" = (
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "visitation";
-	name = "Visitation Shutters"
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/machinery/door/window/southleft,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aCM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -9233,15 +8806,8 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "aDu" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
+/turf/open/floor/plating,
+/area/security/prison)
 "aDv" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral{
@@ -9343,14 +8909,11 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "aDJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
+/turf/open/floor/plating,
+/area/security/prison)
 "aDK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -9492,18 +9055,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEf" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Isolation Cell";
-	req_access_txt = "2"
+/obj/structure/table/reinforced,
+/obj/item/clothing/ears/earmuffs{
+	pixel_y = 7
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "aEj" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral{
@@ -9545,119 +9102,101 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "aEp" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Security Prison - North Hallway";
+	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/vending/clothing,
 /turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/area/security/prison)
 "aEq" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall,
 /area/security/prison/safe)
 "aEr" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/security/prison)
+"aEs" = (
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
-"aEs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Prison -  West";
+	dir = 4;
+	network = list("ss13","prison");
+	start_active = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
 /area/security/prison)
 "aEt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/plasteel,
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/item/radio/off,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/plating,
 /area/security/prison)
 "aEu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Security Prison - Janitorial";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "aEv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/closed/wall,
+/area/security/prison/safe)
 "aEw" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/conveyor/auto{
+	dir = 5
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aEx" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "aEy" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
 /area/security/prison)
 "aEA" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -9932,11 +9471,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "aFq" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/security/prison)
 "aFs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9945,9 +9482,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFt" = (
-/obj/structure/bed,
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "aFu" = (
 /turf/closed/wall,
 /area/library)
@@ -9986,42 +9525,30 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aFC" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/dish_drive/bullet{
+	succrange = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"aFE" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
 /area/security/prison/safe)
-"aFE" = (
-/obj/structure/toilet/greyscale{
-	dir = 4;
-	open = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
 "aFF" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/gloves,
+/obj/item/poster/random_contraband,
+/obj/machinery/light/small,
+/obj/structure/cable,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/plating,
 /area/security/prison/safe)
 "aFG" = (
 /obj/effect/turf_decal/tile/blue{
@@ -10346,38 +9873,16 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
 "aGt" = (
-/obj/structure/bed,
+/obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/bedsheet/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/turf/open/floor/plating,
+/area/security/prison)
 "aGu" = (
-/obj/structure/toilet/greyscale{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "aGv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
@@ -10526,60 +10031,34 @@
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "aGJ" = (
-/obj/structure/bed,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/bedsheet/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
-"aGK" = (
-/obj/structure/table,
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = -8
-	},
-/obj/item/clothing/under/rank/prisoner{
-	pixel_x = 8;
-	pixel_y = 5
+/obj/structure/chair/comfy/brown{
+	color = "#c45c57";
+	desc = "Remarkably soft, with plush cozy cushions, premium memory-foam and covered in stain-resistant fabric. Made by Kat-Kea???!";
+	dir = 8;
+	name = "Premium Cozy Chair"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"aGK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "aGL" = (
-/obj/structure/table,
-/obj/item/clothing/under/rank/prisoner/skirt{
-	pixel_x = -13;
-	pixel_y = 5
-	},
-/obj/item/clothing/under/rank/prisoner/skirt{
-	pixel_x = 9;
-	pixel_y = 5
-	},
-/obj/item/clothing/under/rank/prisoner{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
 /area/security/prison)
 "aGO" = (
 /obj/structure/cable,
@@ -10617,31 +10096,28 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison)
 "aGS" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison";
+	req_access_txt = "63"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aGT" = (
-/obj/machinery/camera{
-	c_tag = "Prison Visitation";
-	dir = 1;
-	network = list("ss13","prison")
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison)
 "aGU" = (
 /obj/machinery/light/small{
@@ -10668,13 +10144,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGX" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/corner,
 /area/security/prison)
 "aGY" = (
 /obj/machinery/airalarm{
@@ -10799,14 +10269,9 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "aHr" = (
-/obj/machinery/light/small{
-	dir = 4
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
 /area/security/prison)
 "aHs" = (
 /obj/docking_port/stationary{
@@ -11308,15 +10773,18 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "aIG" = (
-/obj/machinery/door/airlock/security{
-	name = "Isolation Cell";
-	req_access_txt = "2"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
+/obj/machinery/button/door{
+	id = "GenpopPool";
+	name = "Shutter Control";
+	pixel_x = -25
+	},
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 4
+	},
+/area/security/prison)
 "aIH" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -11725,16 +11193,12 @@
 /turf/closed/wall,
 /area/crew_quarters/bar)
 "aJD" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permaouter";
-	name = "Permabrig Transfer";
-	req_access_txt = "2"
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aJE" = (
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -11891,13 +11355,16 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aKb" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permaouter";
-	name = "Permabrig Transfer";
-	req_access_txt = "2"
+/obj/machinery/button/door{
+	id = "prisonconveyor";
+	name = "Conveyor Shutter Control";
+	pixel_y = 24;
+	req_access_txt = "63"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aKc" = (
 /obj/machinery/door/firedoor,
@@ -12108,9 +11575,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "aKL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 8
+	},
 /area/security/prison)
 "aKM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -13641,14 +13115,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aPM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "aPN" = (
 /obj/machinery/airalarm{
@@ -14408,10 +13878,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aSj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "aSk" = (
 /obj/structure/table,
@@ -17539,6 +17009,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"baO" = (
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "baP" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -23426,13 +22902,14 @@
 /turf/open/floor/plating,
 /area/storage/mining)
 "bqF" = (
-/obj/machinery/cryopod{
+/obj/structure/bed,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/computer/cryopod{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bqH" = (
@@ -32623,13 +32100,15 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bUe" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/structure/training_machine,
-/obj/item/target/syndicate,
-/turf/open/floor/plating,
-/area/security/main)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bUl" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
@@ -35415,6 +34894,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ceE" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/structure/holohoop,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ceF" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -36793,21 +36279,14 @@
 /area/engine/engineering)
 "clP" = (
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
-	},
-/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "clQ" = (
@@ -36908,6 +36387,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"cmz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/security/prison)
 "cmD" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -37739,6 +37232,31 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"csl" = (
+/obj/structure/closet/crate/hydroponics{
+	name = "raw produce"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "csu" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -39458,6 +38976,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cAa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "cAb" = (
 /obj/structure/closet,
 /obj/structure/disposalpipe/segment,
@@ -41134,6 +40663,28 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"cIj" = (
+/obj/machinery/door/poddoor/shutters/window{
+	id = "visitation"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"cIJ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/trashcart,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "cJV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
@@ -41352,12 +40903,6 @@
 /obj/item/radio/intercom{
 	dir = 4;
 	pixel_x = 27
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
 	},
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
@@ -41770,6 +41315,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"cWW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
+"cYK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "cYY" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -41814,14 +41377,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"dbu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Workroom1"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "ddc" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ddy" = (
@@ -41836,8 +41404,12 @@
 /area/science/genetics)
 "dfb" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "dfx" = (
@@ -41892,12 +41464,24 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"dhZ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "djP" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"dkw" = (
+/obj/structure/training_machine,
+/obj/item/target/syndicate,
+/turf/open/floor/plating,
+/area/security/prison)
 "dlp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41956,6 +41540,20 @@
 /obj/item/storage/secure/briefcase,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
+"dng" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "dni" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -41985,6 +41583,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/engineering)
+"dpm" = (
+/obj/machinery/plate_press,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dpI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -42047,6 +41652,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"dvN" = (
+/obj/structure/closet/crate/secure{
+	desc = "A secure crate containing various materials for building a customised test-site.";
+	name = "Firing Range Gear Crate";
+	req_access_txt = "1"
+	},
+/obj/item/target/syndicate,
+/obj/item/target/syndicate,
+/obj/item/target/clown,
+/obj/item/target/clown,
+/obj/item/target/alien,
+/obj/item/target/alien,
+/obj/item/target,
+/obj/item/target,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "dvO" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/airalarm/mixingchamber{
@@ -42074,11 +41695,11 @@
 /area/maintenance/starboard/aft)
 "dxg" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -42125,6 +41746,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"dCB" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "dCG" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
@@ -42369,11 +42004,17 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "dQP" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Equipment Room";
+/obj/machinery/suit_storage_unit/security_peacekeeper,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor{
+	name = "EVA Equipment";
 	req_access_txt = "1"
 	},
-/obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "dRi" = (
@@ -42383,14 +42024,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "dSj" = (
-/obj/machinery/dish_drive/bullet{
-	succrange = 4
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dSx" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
@@ -42398,6 +42040,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dTk" = (
+/obj/structure/chair/sofa/corner,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "dUr" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
@@ -42656,6 +42302,17 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/teleporter)
+"erA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "erO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
@@ -42663,6 +42320,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
+"erP" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "esW" = (
 /obj/machinery/light{
 	dir = 1
@@ -42676,6 +42337,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"etV" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "evp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -42743,6 +42411,26 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"ezh" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown3";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "lockdown3";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "ezn" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -42766,6 +42454,15 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/hallway/secondary/service)
+"eDp" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eDG" = (
 /obj/structure/table/glass,
 /obj/item/storage/fancy/candle_box,
@@ -42792,6 +42489,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"eGX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "eIE" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
@@ -42827,6 +42529,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"eJQ" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/window,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison/safe)
 "eKA" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/machinery/light,
@@ -42838,13 +42555,21 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "eKM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/structure/cable,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
-	dir = 9
-	},
+/area/security/prison)
+"eLp" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "eNr" = (
@@ -42878,6 +42603,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"ePP" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison/safe)
 "eQL" = (
 /obj/structure/chair{
 	name = "Judge"
@@ -42922,11 +42656,55 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"eSu" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eTo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
+"eTP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"eTS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "eUy" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -42941,6 +42719,21 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/vacant_room/office)
+"eUA" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "eVL" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -42963,6 +42756,31 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"eWO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/security/prison)
+"eZm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"eZr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "eZH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -42970,11 +42788,28 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "fak" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown5";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "lockdown5";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/main)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "faH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -42997,6 +42832,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"fdy" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "fdT" = (
 /turf/open/genturf,
 /area/icemoon/surface/outdoors)
@@ -43099,6 +42940,34 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"fkC" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Garden";
+	dir = 6;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "flc" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -43154,6 +43023,25 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"fnQ" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "fox" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
@@ -43166,14 +43054,22 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "fpx" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/main)
+/area/security/prison)
 "fpT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -43267,6 +43163,17 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/maintenance/fore)
+"ftU" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/security/prison)
 "fvi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -43498,6 +43405,23 @@
 /obj/item/ai_module/core,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
+"fLk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	max_integrity = 1
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
+"fLN" = (
+/obj/structure/bed,
+/obj/machinery/flasher{
+	id = "genpopcell1";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "fMt" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -43631,17 +43555,25 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "fSV" = (
-/obj/machinery/gun_vendor,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "fUn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -43772,6 +43704,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"gbN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "gbO" = (
 /turf/closed/wall,
 /area/medical/surgery)
@@ -43926,6 +43862,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"gnS" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "gnX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -43980,6 +43922,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/janitor)
+"gqW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "grP" = (
 /obj/machinery/camera{
 	c_tag = "Server Room";
@@ -44020,12 +43970,41 @@
 /turf/open/floor/plasteel,
 /area/science/nanite)
 "gwO" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/ears/earmuffs{
-	pixel_y = 7
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
+"gwW" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown4";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "lockdown4";
+	name = "Lockdown";
+	pixel_x = 25;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/prison)
 "gyr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -44065,6 +44044,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"gBd" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "workhouse";
+	name = "Work Room"
+	},
+/obj/machinery/button/door{
+	id = "workhouse";
+	name = "Work Room";
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "gBO" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Stbd";
@@ -44080,11 +44081,22 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "gDa" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/training_machine,
-/obj/item/target/syndicate,
-/turf/open/floor/plating,
-/area/security/main)
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "gDr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -44119,6 +44131,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"gFl" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "gFn" = (
 /obj/structure/railing{
 	dir = 1
@@ -44174,6 +44195,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"gIi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "gIB" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -44240,6 +44276,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"gMh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "gNi" = (
 /obj/structure/sink{
 	dir = 8;
@@ -44281,6 +44326,25 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"gPz" = (
+/obj/structure/table,
+/obj/item/storage/box/chemimp{
+	pixel_x = 6
+	},
+/obj/item/storage/box/trackimp{
+	pixel_x = -3
+	},
+/obj/item/storage/lockbox/loyalty,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"gPO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison";
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "gQb" = (
 /turf/open/genturf,
 /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
@@ -44320,6 +44384,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gRz" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "gRS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
@@ -44436,6 +44506,11 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/space_hut/cabin)
+"gZt" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "gZK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -44462,6 +44537,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/mining)
+"hbm" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "hcB" = (
 /obj/machinery/clonepod,
 /turf/open/floor/plasteel/dark,
@@ -44491,10 +44576,31 @@
 /mob/living/simple_animal/pet/fox/renault,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"heI" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "heL" = (
 /obj/structure/closet/secure_closet/cytology,
 /turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
+"hfr" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "hgj" = (
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
@@ -44512,9 +44618,19 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "hgD" = (
-/obj/machinery/suit_storage_unit/security_peacekeeper,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "hgK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -44542,6 +44658,13 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"hhA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "hhL" = (
 /obj/item/instrument/violin/golden{
 	pixel_y = 32
@@ -44573,6 +44696,22 @@
 "hjZ" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
+"hkS" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hkT" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -44619,6 +44758,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
+"hqU" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Janitorial"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "hrf" = (
 /obj/structure/table,
 /obj/item/assembly/signaler,
@@ -44644,11 +44792,30 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"hsz" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/machinery/camera{
+	c_tag = "Prison - Kitchen";
+	dir = 6;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "htg" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/icemoon,
 /area/science/server)
+"htY" = (
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of the green cell block";
+	name = "Cell - Green"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "huk" = (
 /obj/machinery/button/door{
 	desc = "A remote control-switch for the engineering security doors.";
@@ -44669,6 +44836,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/engineering)
+"hun" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"hvv" = (
+/obj/structure/table,
+/obj/item/paper_bin/bundlenatural{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/pen/fountain{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "hvD" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -44721,6 +44909,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"hzj" = (
+/obj/machinery/griddle,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "hzQ" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -44747,6 +44939,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
+"hAw" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Clubroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "hAK" = (
 /obj/structure/table,
 /obj/item/storage/box/disks_nanite,
@@ -44779,6 +44978,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hCD" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "hDb" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens Observation - Port Fore";
@@ -44804,6 +45016,9 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"hDi" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "hDB" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -44897,6 +45112,10 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"hGg" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "hGo" = (
 /obj/item/storage/box/bodybags,
 /obj/structure/extinguisher_cabinet{
@@ -44957,6 +45176,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"hIp" = (
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "hIM" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 9
@@ -44983,6 +45211,15 @@
 /obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"hKP" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "hPF" = (
 /obj/effect/landmark/event_spawn,
 /mob/living/simple_animal/bot/secbot{
@@ -45041,6 +45278,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
+"hUS" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown1";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "lockdown1";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "hVD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -45055,12 +45311,24 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "hWj" = (
-/obj/machinery/door/window/southleft{
-	dir = 4;
-	name = "shooting range"
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "hWN" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -45139,6 +45407,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"icT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "icV" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -45181,6 +45456,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
+"ieH" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
 "ife" = (
 /obj/structure/chair{
 	dir = 8;
@@ -45296,6 +45577,19 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"ikm" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Clubroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"ilV" = (
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ink" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -45303,6 +45597,13 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
+"int" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 10
+	},
+/area/security/prison)
 "inY" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -45353,6 +45654,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
+"iqQ" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"irI" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison/safe)
 "irX" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/chair,
@@ -45397,6 +45709,27 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"ivu" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "ivU" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -45457,6 +45790,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"iAc" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"iAw" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "iAM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -45544,6 +45895,12 @@
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"iJi" = (
+/obj/machinery/jukebox{
+	req_one_access = null
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "iKz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -45560,6 +45917,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"iNi" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "iNn" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room"
@@ -45599,6 +45968,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"iPM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "iQk" = (
 /obj/structure/chair{
 	dir = 1
@@ -45615,6 +45993,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"iRP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "iSr" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -45635,6 +46028,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"iTD" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"iUj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "iVn" = (
 /obj/structure/closet/l3closet/scientist{
 	pixel_x = -2
@@ -45664,6 +46069,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"iXa" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/machinery/door/window/eastright{
+	name = "shower"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison/safe)
 "iYg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -45752,6 +46169,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"jbS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jbV" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
@@ -45776,6 +46197,10 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jfu" = (
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jgM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -45928,6 +46353,33 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"jnI" = (
+/obj/machinery/plate_press,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/machinery/button/door{
+	id = "Workroom1";
+	pixel_x = 24;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"jop" = (
+/obj/machinery/button/door{
+	id = "visitation";
+	name = "Visitation";
+	pixel_x = -24;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "joy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -45949,6 +46401,22 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/openspace,
 /area/science/xenobiology)
+"jpP" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown3";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jqo" = (
 /obj/machinery/computer/prisoner/management,
 /turf/open/floor/plasteel/dark,
@@ -46031,11 +46499,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"jvu" = (
+"jtT" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
+"jvu" = (
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jvR" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -46109,6 +46585,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
+"jAJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "jAK" = (
 /obj/machinery/rnd/server,
 /obj/structure/lattice/catwalk,
@@ -46268,6 +46752,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"jIo" = (
+/obj/effect/turf_decal/delivery/blue,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jIN" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -46279,11 +46770,52 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jJh" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jJO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"jKY" = (
+/obj/structure/closet/crate/hydroponics{
+	name = "raw produce"
+	},
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"jLo" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "jLM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -46311,17 +46843,22 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jNs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jPn" = (
 /obj/machinery/door/airlock/maintenance{
@@ -46346,6 +46883,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"jQt" = (
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jQY" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -46465,6 +47021,17 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"jVi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "jVl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46506,6 +47073,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"jVP" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "jXa" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
@@ -46517,15 +47095,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "jXT" = (
-/obj/machinery/button/flasher{
-	id = "transferflash";
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/structure/falsewall,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "jYM" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/depsec/engineering,
@@ -46539,6 +47112,16 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"kaz" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Kitchen"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "kbz" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -46644,6 +47227,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"kdT" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/security/prison)
 "ken" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel,
@@ -46753,14 +47344,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kpe" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "kpl" = (
 /obj/machinery/gulag_teleporter,
 /obj/effect/turf_decal/delivery/blue,
@@ -46772,6 +47358,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"kqH" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bossofthisprisongym";
+	name = "Private Area"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "krt" = (
 /turf/open/floor/carpet,
 /area/maintenance/space_hut/cabin)
@@ -46803,16 +47396,11 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "ksN" = (
-/obj/effect/turf_decal/delivery/blue,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24;
-	pixel_y = 3
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/prison)
 "ktd" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -46821,6 +47409,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"ktm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
+"ktV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
+	},
+/area/security/prison)
 "kul" = (
 /turf/closed/wall,
 /area/engine/engine_smes)
@@ -46946,6 +47552,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"kzk" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
+"kzs" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/door/window/southright{
+	name = "shower"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison/safe)
 "kzL" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -47017,6 +47642,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"kBw" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "kFE" = (
 /obj/structure/chair{
 	dir = 8;
@@ -47109,6 +47744,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
+"kHp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kHN" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
@@ -47142,12 +47790,74 @@
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
 /area/medical/medbay/lobby)
+"kLj" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/closet/crate/wooden,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/instrument/eguitar,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "kLM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"kLY" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"kMi" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "kMX" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
@@ -47251,12 +47961,11 @@
 	},
 /area/science/research)
 "kTl" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 8
 	},
-/obj/machinery/vending/security_ammo,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/prison)
 "kVn" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -47282,6 +47991,12 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"kVX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "kWe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -47326,6 +48041,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"kZg" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/closet/crate/hydroponics{
+	name = "raw produce"
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
 "kZR" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
@@ -47420,6 +48142,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
+"liK" = (
+/obj/machinery/button/door{
+	id = "bossofthisprisongym";
+	name = "Private Area";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "ljx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -47463,6 +48197,22 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"lqO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Workroom1"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "lrg" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/white,
@@ -47632,6 +48382,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
+"lCY" = (
+/obj/machinery/deepfryer,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "lEl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -47650,6 +48407,19 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"lFx" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "lFP" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
@@ -47681,6 +48451,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lHA" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/prison";
+	dir = 4;
+	name = "Prison Wing APC";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "lHR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -47731,6 +48521,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"lJF" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "lJI" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -47776,6 +48575,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"lMk" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown2";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "lockdown2";
+	name = "Lockdown";
+	pixel_x = 25;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "lNo" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -47786,9 +48602,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "lNV" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/security/main)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lOw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -47801,6 +48619,12 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"lOP" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/training_machine,
+/obj/item/target/syndicate,
+/turf/open/floor/plating,
+/area/security/prison)
 "lOY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -47841,6 +48665,13 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"lPn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lQm" = (
 /obj/machinery/camera{
 	c_tag = "Nanite Lab";
@@ -47885,6 +48716,12 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"lSs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lSv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -48062,12 +48899,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/psychology)
 "mhu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "mhJ" = (
 /obj/structure/disposalpipe/segment{
@@ -48243,6 +49076,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mvk" = (
+/obj/structure/chair/sofa,
+/turf/open/floor/wood,
+/area/security/prison)
 "mwN" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -48338,6 +49175,10 @@
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"mDl" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/wood,
+/area/security/prison)
 "mEM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -48402,6 +49243,14 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"mHl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "mHR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -48502,21 +49351,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mNa" = (
-/obj/item/target,
-/obj/item/target,
-/obj/item/target/alien,
-/obj/item/target/alien,
-/obj/item/target/clown,
-/obj/item/target/clown,
-/obj/item/target/syndicate,
-/obj/item/target/syndicate,
-/obj/structure/closet/crate/secure{
-	desc = "A secure crate containing various materials for building a customised test-site.";
-	name = "Firing Range Gear Crate";
-	req_access_txt = "1"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/turf/open/floor/plasteel/dark/corner,
+/area/security/prison)
 "mNe" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet/blue,
@@ -48535,6 +49374,15 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"mOA" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/security/prison)
 "mPh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48666,6 +49514,13 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
+"mWZ" = (
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1
+	},
+/turf/closed/wall,
+/area/security/prison/safe)
 "mXr" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 4
@@ -48687,11 +49542,6 @@
 /area/maintenance/aft)
 "mYn" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "mYO" = (
@@ -48800,6 +49650,10 @@
 /obj/machinery/photocopier,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
+"nen" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/security/prison)
 "neA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -48821,7 +49675,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ngw" = (
@@ -48852,13 +49706,52 @@
 "nka" = (
 /turf/open/openspace,
 /area/science/xenobiology)
-"nli" = (
-/obj/structure/window/reinforced{
+"nkH" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"nla" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
+"nli" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown5";
+	name = "Lockdown"
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/prison)
 "nlo" = (
 /obj/structure/industrial_lift,
 /turf/open/openspace,
@@ -49044,6 +49937,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"nvA" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "nwJ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -49159,6 +50069,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"nAI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/lavendergrass{
+	max_integrity = 1;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
+"nBd" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plating/grass,
+/area/security/prison)
 "nCf" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/stripes/line,
@@ -49232,6 +50160,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"nFG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/security/prison)
 "nFI" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -49302,6 +50240,12 @@
 	},
 /turf/open/openspace,
 /area/science/xenobiology)
+"nLq" = (
+/obj/structure/closet/crate/hydroponics{
+	name = "raw produce"
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
 "nLS" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Storage";
@@ -49318,6 +50262,12 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel,
 /area/science/storage)
+"nMg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nMq" = (
 /obj/machinery/light_switch{
 	pixel_x = 26;
@@ -49359,6 +50309,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"nOw" = (
+/obj/machinery/button/door{
+	id = "bossofthisprisongym";
+	name = "Private Area";
+	pixel_x = -24;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "nOC" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
@@ -49598,12 +50557,47 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"ocm" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Workroom";
+	dir = 10;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/security/prison)
 "oeg" = (
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"ofJ" = (
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "ofT" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"ogy" = (
+/obj/structure/curtain,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "ogG" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/disposalpipe/segment,
@@ -49810,11 +50804,18 @@
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
 "ovx" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "owa" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
@@ -49848,6 +50849,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"oyz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/wood,
+/area/security/prison)
+"oyD" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison/safe)
 "ozS" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken2"
@@ -49859,6 +50870,36 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"oAq" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "oAN" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
@@ -49866,6 +50907,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"oCc" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall,
+/area/security/prison)
 "oCP" = (
 /obj/structure/flora/tree/pine,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -49874,6 +50919,19 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"oFA" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "oFI" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
@@ -49899,6 +50957,15 @@
 /obj/effect/landmark/start/security_sergeant,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"oKx" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "oKS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -49926,6 +50993,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"oNA" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "oND" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -49936,12 +51019,32 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"oOm" = (
+/obj/structure/chair/sofa,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "oOF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"oOH" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/gun_vendor,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"oPe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/security/prison/safe)
 "oPj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50078,6 +51181,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
+"oYf" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
 "oYv" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -50121,6 +51233,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"oZx" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/chair/sofa,
+/turf/open/floor/wood,
+/area/security/prison)
 "paU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -50132,6 +51251,19 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"pbL" = (
+/obj/structure/table/glass,
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "pcf" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
@@ -50185,6 +51317,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"pge" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "pgP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50321,6 +51458,12 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"poE" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "poL" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -50434,12 +51577,19 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "puT" = (
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/gun_vendor,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "pva" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -50661,20 +51811,16 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "pFw" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "2"
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "pFO" = (
 /obj/machinery/camera{
@@ -50714,9 +51860,16 @@
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
 "pJj" = (
-/obj/machinery/vending/security_ammo,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "pKi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -50947,6 +52100,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"pWy" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "pWN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -51075,12 +52234,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
 "qdH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
-	},
-/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "qdT" = (
@@ -51167,12 +52322,25 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"qkO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "qmt" = (
 /obj/structure/chair/stool,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/quartermaster/qm)
+"qmD" = (
+/obj/structure/bookcase/manuals/medical,
+/turf/open/floor/wood,
+/area/security/prison)
 "qmO" = (
 /obj/machinery/griddle,
 /obj/machinery/power/apc/auto_name/north,
@@ -51189,6 +52357,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"qoG" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "qps" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -51254,14 +52432,14 @@
 /area/science/genetics)
 "qrN" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/darkblue/filled/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -51273,11 +52451,14 @@
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
 "qti" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "qtI" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
@@ -51312,12 +52493,20 @@
 /area/maintenance/starboard/aft)
 "qxh" = (
 /obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
 	},
-/obj/item/storage/box/armament_tokens_energy,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "qyN" = (
@@ -51339,6 +52528,10 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"qzJ" = (
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/security/prison)
 "qzO" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/hallway/secondary/service)
@@ -51399,11 +52592,37 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"qGI" = (
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/obj/structure/plasticflaps,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "prisonconveyor";
+	name = "Conveyor Shutter"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "qGZ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"qHw" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Cafeteria";
+	dir = 6;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "qHR" = (
 /obj/machinery/computer/security/telescreen/interrogation{
 	pixel_y = 30
@@ -51453,6 +52672,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"qLh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/training_machine,
+/obj/item/target/syndicate,
+/turf/open/floor/plating,
+/area/security/prison)
 "qMc" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -51543,6 +52770,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"qQE" = (
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/wood,
+/area/security/prison)
 "qQH" = (
 /obj/effect/spawner/lootdrop/minor/bowler_or_that,
 /obj/structure/rack,
@@ -51552,6 +52783,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
+"qRv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "qSS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -51639,6 +52876,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/aft)
+"raf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Green Wing";
+	dir = 1;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "rat" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -51655,6 +52910,10 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"raw" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/wood,
+/area/security/prison)
 "raE" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=AftH";
@@ -51682,14 +52941,22 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "rcG" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Prison -  Purple Wing";
+	dir = 10;
+	network = list("ss13","prison");
+	start_active = 1
 	},
-/turf/open/floor/plating,
-/area/security/main)
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "rdl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -51709,6 +52976,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
+"rfT" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "rgu" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -51832,6 +53112,12 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"rqs" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/security/prison)
 "rrd" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -51889,6 +53175,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"rvt" = (
+/obj/item/grown/log,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/grass,
+/area/security/prison)
 "rye" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 4
@@ -51902,10 +53195,23 @@
 /turf/closed/wall/mineral/wood,
 /area/maintenance/space_hut/cabin)
 "ryQ" = (
-/obj/structure/training_machine,
-/obj/item/target/syndicate,
-/turf/open/floor/plating,
-/area/security/main)
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/security/prison)
 "rzl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -51965,6 +53271,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
+"rAj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Workroom1"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "rAs" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/sign/departments/psychology{
@@ -51986,6 +53302,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
+"rCC" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
+"rDd" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rDO" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room Toilets";
@@ -52018,6 +53345,10 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"rDZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "rET" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -52062,6 +53393,21 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"rIS" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "rJl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -52082,6 +53428,21 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"rKM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  East";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
 "rKP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -52109,6 +53470,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
+"rMs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "rMz" = (
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot_blue,
@@ -52134,6 +53503,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rOV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "rOY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -52149,6 +53526,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rPv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rPX" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -52218,6 +53599,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"rUs" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "rUB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -52271,6 +53663,10 @@
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
 /area/maintenance/space_hut/cabin)
+"rXo" = (
+/obj/structure/punching_bag,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rXY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -52331,6 +53727,25 @@
 /obj/item/stock_parts/cell/emproof,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"sbi" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor{
+	name = "EVA Equipment";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
+"sbm" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "sbQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
@@ -52408,6 +53823,19 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
+"sgy" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "sgR" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/green,
@@ -52432,6 +53860,18 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"shY" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"six" = (
+/obj/structure/table,
+/obj/item/soap,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "siK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -52489,9 +53929,23 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "sni" = (
-/obj/effect/turf_decal/bot_blue,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "snm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/caution/stand_clear/blue,
@@ -52563,6 +54017,55 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"sqs" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"sqt" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
+"srj" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
+"srr" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
+"sru" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "srx" = (
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/wood,
@@ -52652,6 +54155,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"syN" = (
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of the green cell block";
+	name = "Cell - Green"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "szO" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -52666,22 +54179,38 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "szV" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "sAD" = (
 /obj/effect/turf_decal/trimline/white/line,
 /obj/item/kirbyplants/fullysynthetic,
 /turf/open/floor/plasteel/showroomfloor,
 /area/hallway/secondary/service)
+"sAU" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "sBI" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"sBT" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "sCZ" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -52937,6 +54466,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"sVo" = (
+/obj/effect/turf_decal/delivery/blue,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24;
+	pixel_y = 3
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "sVI" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -52961,6 +54501,24 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"sXL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"sXS" = (
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/airlock/security/glass{
+	name = "Firing Range";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"sYj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "sZb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
@@ -53134,6 +54692,31 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"tix" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	name = "large flour sack";
+	possible_transfer_amounts = list(1,5,10,15,30,60,90);
+	volume = 90
+	},
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	name = "large flour sack";
+	possible_transfer_amounts = list(1,5,10,15,30,60,90);
+	volume = 90
+	},
+/obj/item/reagent_containers/food/condiment/mayonnaise,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/rice{
+	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	name = "large rice sack";
+	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
+	},
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "tjy" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
@@ -53154,6 +54737,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"tjL" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "tjM" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -53187,6 +54778,25 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"tkL" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	max_integrity = 1
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
+"tkM" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "tll" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
@@ -53281,14 +54891,24 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "trX" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 4
+	},
+/area/security/prison)
 "tsw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"tsz" = (
+/obj/structure/curtain{
+	alpha = 240;
+	color = "#454545";
+	name = "Changing Room"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "tte" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating{
@@ -53362,6 +54982,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"txm" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "txz" = (
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -53486,6 +55118,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"tGt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/grass,
+/area/security/prison)
 "tGE" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
@@ -53560,6 +55198,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"tLd" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "tLv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -53583,12 +55229,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "tPr" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/security/prison)
 "tQk" = (
 /obj/machinery/camera{
@@ -53616,11 +55264,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "tRa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown6";
+	name = "Lockdown"
 	},
-/turf/open/floor/plating,
-/area/security/main)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "tRv" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
@@ -53636,11 +55290,25 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "tRz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown6";
+	name = "Lockdown"
 	},
-/turf/open/floor/plating,
-/area/security/main)
+/obj/machinery/button/door{
+	id = "lockdown6";
+	name = "Lockdown";
+	pixel_x = 25;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "tRM" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -53788,6 +55456,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"udV" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown4";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "uea" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -53813,6 +55493,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing)
+"uez" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/security/prison)
 "ueK" = (
 /obj/structure/window/reinforced/fulltile/ice{
 	name = "frozen window"
@@ -53846,6 +55532,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/item/gun/energy/e_gun/dragnet,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "uhq" = (
@@ -53955,15 +55643,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"umZ" = (
+/obj/structure/chair/sofa/corner,
+/turf/open/floor/wood,
+/area/security/prison)
 "une" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Visitation";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/crate,
+/obj/item/instrument/piano_synth,
+/obj/item/toy/cards/deck,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/crowbar,
+/turf/open/floor/plating,
 /area/security/prison)
 "uoD" = (
 /obj/structure/disposalpipe/segment{
@@ -54005,20 +55695,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "uqn" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
+/obj/effect/turf_decal/bot_blue,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "urb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -54058,6 +55737,11 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/corner,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"usE" = (
+/obj/structure/bed,
+/obj/item/bedsheet/rd/royal_cape,
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "uvi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -54196,6 +55880,21 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"uDP" = (
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/security/prison)
+"uEA" = (
+/obj/machinery/door/window/brigdoor/security/cell/westright{
+	id = "genpopcell1"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "uES" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -54338,19 +56037,16 @@
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "uTo" = (
-/obj/machinery/camera{
-	c_tag = "Prison Isolation Cell";
-	dir = 8;
-	network = list("ss13","prison");
-	view_range = 5
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison/safe)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "uTu" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -54405,6 +56101,13 @@
 	},
 /turf/open/floor/grass,
 /area/crew_quarters/cryopod)
+"uXg" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "uXM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54448,6 +56151,18 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
+"vbp" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/soap,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "vbu" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
@@ -54537,6 +56252,67 @@
 /area/security/prison)
 "vij" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/structure/table,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "vkC" = (
@@ -54566,11 +56342,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "vmG" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -54595,11 +56368,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "voA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/main)
+/area/security/prison)
 "voE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
@@ -54625,6 +56403,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"vqn" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vqI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54638,6 +56422,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"vuS" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/security/prison)
 "vvP" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/plating,
@@ -54663,6 +56451,22 @@
 /obj/effect/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"vyn" = (
+/obj/structure/table/glass,
+/obj/item/storage/bag/tray,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/storage/box/cups{
+	pixel_x = -5
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "vyA" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -54702,6 +56506,16 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"vAL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "vAX" = (
 /obj/item/chair/wood,
 /turf/open/floor/wood{
@@ -54907,11 +56721,28 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"vLz" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood,
+/area/security/prison)
 "vLX" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vMm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/security/prison)
 "vNp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -54999,14 +56830,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "vTk" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Visitation Observation";
-	req_access_txt = "2"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
 /area/security/prison)
 "vTE" = (
 /obj/machinery/airalarm{
@@ -55018,6 +56846,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"vTX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "vUt" = (
 /obj/structure/table,
 /obj/item/storage/box/hug{
@@ -55117,6 +56953,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"waW" = (
+/obj/machinery/processor,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "wba" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -55143,9 +56986,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/engineering)
 "wbO" = (
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/security/prison)
 "wbV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -55183,28 +57028,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "wek" = (
-/obj/machinery/button/door{
-	id = "permaouter";
-	name = "Outer Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 6;
-	pixel_y = 25;
-	req_access_txt = "2";
-	specialfunctions = 4
-	},
-/obj/machinery/button/door{
-	id = "permainner";
-	name = "Inner Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -6;
-	pixel_y = 25;
-	req_access_txt = "2";
-	specialfunctions = 4
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
+	},
 /area/security/prison)
 "weJ" = (
 /obj/structure/closet/secure_closet/chief_medical,
@@ -55296,10 +57125,31 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
+"whB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "whK" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"wiO" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "wiX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55383,6 +57233,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
+"wmP" = (
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/hos)
+"wmV" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "wpg" = (
 /turf/open/floor/plating,
 /area/science/genetics)
@@ -55410,6 +57279,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
+"wpx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/security/prison)
 "wqc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
@@ -55480,10 +57354,30 @@
 "wvq" = (
 /turf/closed/wall,
 /area/medical/cryo)
+"wvM" = (
+/obj/structure/rack,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "wxF" = (
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"wyk" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "wyl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -55491,6 +57385,40 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wyy" = (
+/obj/structure/rack,
+/obj/item/wirecutters,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/item/seeds/cotton,
+/obj/item/seeds/cotton,
+/obj/item/seeds/onion/red,
+/obj/item/seeds/wheat/rice,
+/obj/item/seeds/wheat/oat,
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "wzx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -55550,6 +57478,26 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"wCX" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "wDJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -55643,6 +57591,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"wIy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "wIN" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -55696,6 +57653,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
+"wKq" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "wKw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -55805,6 +57780,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wRp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Prison -  Central";
+	dir = 9;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "wRF" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -55817,6 +57804,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"wSb" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison/safe)
 "wTw" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -55858,6 +57857,12 @@
 "wVC" = (
 /turf/closed/wall/r_wall,
 /area/medical/storage)
+"wVG" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "wXs" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -55908,6 +57913,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"xal" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Firing Range";
+	req_access_txt = "1"
+	},
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "xaZ" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -56093,6 +58106,15 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"xiu" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "xiQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -56201,6 +58223,24 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"xoQ" = (
+/obj/machinery/suit_storage_unit/security_peacekeeper,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/brigdoor{
+	name = "EVA Equipment";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
+"xoU" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Library"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "xpa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -56314,6 +58354,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"xwm" = (
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "xwN" = (
 /turf/open/floor/plating,
 /area/engine/engine_smes)
@@ -56348,6 +58397,18 @@
 /obj/item/crowbar/red,
 /turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
+"xzH" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/janitorialcart{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "xzN" = (
 /obj/machinery/door/airlock/external{
 	name = "Common Mining Shuttle Bay"
@@ -56387,6 +58448,12 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"xAT" = (
+/obj/structure/chair/sofa/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "xCm" = (
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -56401,6 +58468,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"xEe" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "xEM" = (
 /obj/structure/table,
 /obj/item/nanite_scanner,
@@ -56454,6 +58535,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xGY" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/computer/cryopod{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/carpet,
+/area/security/prison/safe)
 "xGZ" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/power/port_gen/pacman,
@@ -56463,11 +58555,41 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/service)
+"xHK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
+	},
+/area/security/prison)
 "xIa" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xJd" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "xLr" = (
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
@@ -56510,6 +58632,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"xOq" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/security/prison)
 "xOX" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
@@ -56532,6 +58660,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"xPf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "xPm" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -56876,6 +59012,16 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"yfX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "ygM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -56883,6 +59029,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"ygY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "yis" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -76307,12 +78466,12 @@ gQb
 boP
 boP
 boP
-boP
-boP
-boP
-boP
-boP
-boP
+acd
+acd
+acd
+acd
+acd
+acd
 boP
 boP
 boP
@@ -76564,12 +78723,12 @@ gQb
 boP
 boP
 boP
-boP
-boP
-boP
-boP
-boP
-boP
+acd
+ayy
+aDu
+jLo
+aFq
+acd
 boP
 boP
 boP
@@ -76821,12 +78980,12 @@ gQb
 boP
 boP
 boP
-boP
-boP
-boP
-boP
-boP
-boP
+acd
+ayy
+dkw
+aDu
+aFq
+acd
 boP
 boP
 boP
@@ -77078,12 +79237,12 @@ gQb
 boP
 boP
 boP
-boP
-boP
-boP
-boP
-boP
-boP
+acd
+ayy
+aDu
+aDu
+lOP
+acd
 boP
 boP
 boP
@@ -77335,11 +79494,11 @@ bBM
 bBM
 bBM
 bBM
-bBM
-bBM
-bBM
-bBM
-bBM
+acd
+qLh
+aDu
+aDu
+aFq
 afA
 afA
 afA
@@ -77592,11 +79751,11 @@ boP
 boP
 boP
 boP
-boP
-boP
-boP
-boP
-boP
+acd
+iPM
+aDu
+aDu
+aFq
 afA
 aWA
 aca
@@ -77830,30 +79989,30 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
-aaf
-aaJ
-adc
-adc
-aaJ
-adc
-adc
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+acd
+ayy
+aDu
+aDu
+aFq
 afA
 aWA
 aWA
@@ -78086,29 +80245,29 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 bBM
 boP
-aaJ
-add
-adJ
-aeI
-adJ
-alm
-abz
-adu
-arH
-abz
-auE
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+acd
 ayy
-abz
+aDu
 aDu
 aFq
 afA
@@ -78342,30 +80501,30 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 bBM
 boP
-aaJ
-ade
-adO
-aeJ
-agh
-ade
-abz
-aqt
-arJ
-abz
-auF
+boP
+erA
+jAJ
+jAJ
+jAJ
+vTX
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+acd
 ayA
-abz
+aDJ
 aDJ
 aFt
 afA
@@ -78599,33 +80758,33 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
-aaJ
-abz
-abz
-aeK
-abz
-abz
-abz
-abz
-arL
-abz
-abz
+boP
+uTo
+sru
+abb
+rCC
+abb
+cAa
+vTX
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+acd
 ayF
-abz
+aEf
 aEf
 aFC
-aaJ
+aai
 hIM
 sOH
 sOH
@@ -78850,40 +81009,40 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
+bBM
 bBM
 bBM
 bBM
 bBM
 bBM
 boP
-aak
-bqF
-adU
-aeL
-agk
-alo
-aKL
-aqF
-azt
-aKL
-auK
-azt
-aAy
-uqn
 uTo
-aIG
-mhu
+sru
+nBd
+aaL
+aaL
+aaL
+abb
+cAa
+vTX
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+acd
+agK
+uqn
+uqn
+agK
+abd
+wVq
 dxg
 peg
 nfk
@@ -79107,40 +81266,40 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
 boP
 boP
 boP
 boP
-aak
-adf
-arS
-aaq
-aaq
-arS
-apf
-aqG
-arS
-aaq
-aaq
+boP
+boP
+voA
+rIS
+nAI
+aaL
+nLq
+aaL
+tkL
+abb
+xPf
+boP
+boP
+boP
+boP
+boP
+aai
+aai
+aai
+aai
+aai
+aai
 azu
-abz
-abz
-abz
-aaJ
-wVq
+jIo
+agK
+agK
+sXS
+sBT
 usq
 vhQ
 qff
@@ -79364,39 +81523,39 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-bBM
-bBM
-bBM
-bBM
 bBM
 boP
+acD
+aeL
+auE
+aGL
+aeL
+auE
+vTk
+csl
+tGt
+aaL
+tkL
+aaL
+aaL
+abb
 aai
 aai
 aai
 aai
-aaJ
-abz
-aeb
-abz
-abz
-alM
-abz
-abz
-arY
-abz
-aap
+aai
+aai
+aai
+aGt
+aDu
+aDu
+aDu
+aai
 acg
 aAA
-aEp
-aFE
-aaJ
+agK
+agK
+abd
 wVq
 lCh
 acd
@@ -79621,40 +81780,40 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
-boP
-boP
-boP
-boP
-aai
+acE
+afy
+afy
+aIG
+ksN
+trX
+wbO
+fkC
+tGt
+rvt
+aaL
+aaL
 aaK
 aaY
-abD
-abz
+acd
+nkH
 ads
-aec
-abz
+acd
+nkH
 agF
-aec
-abz
-ads
-aec
-abz
-avb
-azv
-abz
-asi
-adu
-aaJ
-wVq
+acd
+acd
+acd
+acd
+acd
+aai
+oOH
+wyk
+agK
+agK
+xal
+sBT
 lcA
 snU
 aai
@@ -79878,39 +82037,39 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
-aaf
-aai
-aai
-aai
-aai
-aai
+boP
+acE
+agh
+agh
+agh
+agh
+agh
+aiS
+wyy
+fLk
 aaL
-aba
-abE
-abz
-adu
-asi
-abz
+aaL
+kZg
+aaL
+abb
+acd
+kLY
 aGJ
-alY
-abz
-adu
+acd
+hkS
+aGJ
+acd
+vbp
+acd
 asi
-abz
-auT
+oNA
+aai
 azx
-abz
-abz
-abz
-aaJ
+sVo
+agK
+dvN
+abd
 iPI
 iGX
 ulk
@@ -80135,39 +82294,39 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
+adc
+agh
+agh
+agh
+agh
+agh
+aiS
 aak
 aao
 aau
-aaB
-acd
-aaK
+aaL
+aaL
+ieH
 abb
-abF
-abz
-abz
-abz
-abz
-abz
-abz
-abz
-abz
-abz
-abz
-aaq
-acg
-aAM
-aEq
-aFF
-aaJ
+acd
+jJh
+eSu
+acd
+jJh
+eSu
+acd
+apz
+ogy
+srj
+nvA
+aai
+aai
+aai
+aai
+aai
+aai
 wVq
 jDk
 ulk
@@ -80392,39 +82551,39 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
-aai
-aap
+acE
+agh
+agh
+agh
+agh
+agh
+aiS
+eWO
+acd
+acd
 aaw
-aaw
 acd
 acd
 acd
-abG
 acd
-acd
-aef
 aeN
 aiS
-alZ
+acd
+aeN
+aiS
+acd
 apz
-aqI
-acd
-acd
-avT
-azH
-abz
+azL
+azL
+azL
+azL
+azL
+aDu
 aEr
 aGt
-aaJ
+aai
 wVq
 jDk
 ulk
@@ -80649,39 +82808,39 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
-aak
+acE
+agh
+agh
+agh
+agh
+agh
+wek
+vMm
 aaq
 aax
-aau
+sAU
 aEs
-aaw
-abd
+oFA
+sYj
 azv
-acw
-acd
+aeP
+hCD
 aeg
 aeP
 abg
 aoG
 apH
 aqN
-acd
+oAq
 atu
-aaq
-azv
-abz
-abz
-abz
-aaJ
+kLj
+szV
+aDu
+aai
+aai
+aai
 yis
 jDk
 pns
@@ -80904,42 +83063,42 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
+bBM
 bBM
 boP
-aai
+adc
+agh
+agh
+agh
+agh
+agh
+xHK
+rqs
 aar
 aaO
 aaW
 aaE
-aat
-abd
-azv
-aaw
-acd
+uez
+aaO
+lMk
 aeh
-azv
+aku
+aeh
+aeh
 aku
 amp
-amp
-aqU
-acd
-aaw
-aaq
-ach
-aAN
-aEp
+apQ
+aqV
+xJd
+ivu
+kMi
+azL
+aDu
+aai
 aGu
-aaJ
-wVq
+tsz
+sBT
 jDk
 ulk
 abd
@@ -81161,41 +83320,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
-aak
-aas
-aay
-aaV
+boP
+boP
+add
+agk
+auF
+aKL
+kTl
+kTl
+agN
+qRv
+acd
+acd
+abd
 aaF
-aaw
-abe
-azH
+abd
+acd
+acd
 acx
-acd
-acd
 afa
+afa
+afa
+sqs
+xiu
+kzk
+azL
+azL
+azL
+azL
+azL
+hfr
+aai
+aai
 acd
-acd
-acd
-acd
-acd
-aaw
-aaq
-azI
-abz
-alY
-aGJ
-aaJ
 wVq
 jDk
 ulk
@@ -81418,41 +83577,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
 aai
 aai
-aaz
-aaq
+aai
+alj
+auK
+bqF
+auK
+jvu
+jvu
+qRv
+acd
+aSj
+abf
 aal
 aSj
 abf
-afp
-aSj
-ady
-aSj
-afp
+acd
+ceE
+jvu
+ilV
+jvu
 akC
 anM
 apK
-aaP
-acd
+aqN
+oAq
 atz
 awi
-acd
-abz
-abz
-abz
-aaJ
+szV
+aDu
+hvv
+aai
+ofJ
 vmG
 rHf
 ulk
@@ -81675,42 +83834,42 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
-boP
-aak
+aai
+aay
+acd
+all
+jvu
+bUe
+lNV
+jvu
+jbS
+gZt
+acd
 aaA
 aaC
 aaG
 aaN
-abd
-arS
-aaw
-adB
-aat
-aft
+sgy
 acd
+vqn
+adB
+eDp
+adB
+shY
 anO
 apQ
 aqV
-acd
-aaw
-aaq
-azJ
-aaw
-aEs
-aGK
+xJd
+ivu
+wCX
+azL
+aDu
+vuS
 aai
-tPr
+lJF
+agK
 jDk
 vUt
 aai
@@ -81932,42 +84091,42 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
-bBM
-aaf
+boP
 aai
-aai
-aai
+aaV
+ade
+all
+auT
+dSj
+mhu
+jvu
+rXo
+qRv
+acd
+qHw
+pWy
+abs
+axS
+pWy
+acd
+acd
+aEr
 acd
 acd
 acd
-abY
-acD
-acd
-aaL
-arS
-acd
-acd
+hUS
 apT
-apT
-acd
-aaw
-awO
 azL
-aSj
+azL
+azL
+azL
+azL
+aDu
 aEt
-aGL
 aai
-wek
+wVq
+agK
 jDk
 vij
 acd
@@ -82189,40 +84348,40 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
-boP
-boP
 aai
-aaw
-aaQ
-abi
-aft
-aaw
+abe
 acd
-aaw
+alm
+avb
+eKM
+mNa
+tPr
+aaO
+xOq
+acd
+aaI
+aaI
+abs
+abs
+abs
+aft
+acd
+xzH
+heI
 arS
 akD
-acd
-acd
-acd
-acd
-aaL
-arS
-acd
-aBd
-aEu
-aSj
+iNi
+srr
+ara
+azL
+awR
+awR
+azL
+aDu
+nen
+aai
 aJD
 mYn
 dfb
@@ -82446,42 +84605,42 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-bBM
-bBM
 bBM
 boP
-aai
-aaH
-aaR
-abj
-acb
-acE
+abH
+azL
+azL
+azL
+azL
+fak
+nli
 acd
+acd
+kaz
+acd
+eGX
+eGX
+abs
+aaR
+abs
+acb
+acd
+lFx
 aen
 aEu
-aSj
-aSj
+acd
+rMs
 aPM
-aqX
-asj
-aSj
+ara
+azL
+fLN
 awR
-abd
-aaw
-aEv
-aaw
+azL
+aEr
+acd
+aai
 aKb
-szV
+agK
 jDk
 tXK
 acd
@@ -82703,43 +84862,43 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
-aai
-aaw
+abH
+abD
+adf
+alo
+azt
+fpx
+ovx
+acd
+fdy
+kVX
+waW
+hDi
+eGX
+aaI
 aap
 abs
-acG
-acJ
+aft
 acd
+cIJ
 aeo
 afx
-agf
-aaw
-azv
+acd
+whB
+aPM
 ara
-aaw
-aaw
-azv
-abd
-alf
+azL
+awR
+awR
+azL
+agK
 aEw
-alf
-aai
-jXT
-jDk
+qGI
+xwm
+agK
+usq
 hrf
 acd
 agJ
@@ -82960,43 +85119,43 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
-aai
+abH
+abE
+adJ
+alM
+aqN
+fSV
+puT
+acd
+lCY
+iUj
+hDi
+hDi
+eGX
 aaI
-aaq
-abs
-acG
-acJ
-abz
-abz
-afy
-abz
-aaw
-azv
-aaw
+aap
+iJi
+acd
+acd
+acd
+hqU
+acd
+acd
+cYK
+aPM
+ara
 asw
-acd
+uEA
 awX
-acd
-acd
-acd
-acd
+mWZ
+agK
+hIp
 aai
-kpe
-pFw
+wVq
+agK
+lCh
 acd
 acd
 acX
@@ -83217,41 +85376,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
-aai
-aat
+abH
+azL
+azL
+azL
+azL
+gwO
+pFw
+acd
+hzj
+hDi
+iAc
+hDi
+eGX
+aaI
 aaS
 abw
 ace
 acJ
-abz
+jVP
 aep
 afz
-abz
+aBX
 aoc
 apW
-acd
-acd
-acd
-azv
-aau
 aBX
-aau
+aBX
+hhA
+aBX
+gFl
+aBX
+int
 aGR
-aai
+mHl
 qdH
 clP
 acd
@@ -83474,43 +85633,43 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
-aai
-aaH
-aap
+aas
+abF
+adO
+acd
+aAM
+gwO
+pJj
+acd
+jKY
+sXL
+six
+gbN
+eLp
+rDZ
+gRz
 abx
 acf
-acK
-abz
-aeq
+jvu
+nMg
+jvu
 afB
-abz
-aaw
-azv
-arg
+jvu
+lPn
+icT
+aBY
 asC
-acd
-axd
+aBY
+aBY
 azM
 aBY
 aEx
 aGS
-aai
-eKM
-jNs
+oKx
+agK
+lcA
 xgR
 agj
 hgj
@@ -83731,41 +85890,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
-bBM
-aai
+boP
+aas
+abG
+adU
+alY
+aCJ
+gDa
+qti
+acd
+pbL
+hDi
+rUs
+hDi
+acd
 aaJ
-aaT
+abs
 abz
-abz
-abz
-abz
-abz
-abz
-abz
+wpx
+ktV
+wIy
+sbm
+gMh
+wRp
 aop
 apZ
-aaw
-aat
-acd
+tkM
+sqt
+qkO
 axr
 azP
 aBZ
 aEy
 aGT
-aai
+lHA
 ddc
 rHf
 rSI
@@ -83988,42 +86147,42 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 boP
-boP
-boP
-aaJ
-aaU
-abA
-abA
-abA
-adC
-abz
-afF
-afF
-aat
-acG
-afF
-afF
+aas
+abY
+aeb
 acd
-aaw
-aau
-aCJ
-aau
-ach
-une
-mhu
+aEp
+gwO
+pJj
+acd
+vyn
+hDi
+hDi
+hDi
+oCc
+acd
+acf
+aiS
+azL
+azL
+adC
+oPe
+azL
+acd
+ezh
+jpP
+azL
+azL
+azL
+azL
+cIj
+acd
+acd
+aai
+aai
+wVq
 dfb
 iQk
 agj
@@ -84245,40 +86404,40 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 boP
-aaJ
+aai
+abH
+azL
+azL
+azL
+gwO
+pJj
+acd
+hsz
+iqQ
+uXg
+tix
+acd
+tLd
 jvu
-abB
-abA
+aPM
+azL
 acV
 adD
-abz
-afG
+ePP
+azL
 akP
-aaw
-abh
-arD
+yfX
+aqm
+azL
 asD
-acd
-axv
-axv
-acd
-axv
-axv
+iXa
+azL
+jop
+iTD
+poE
+jvu
 aai
 kQl
 kWo
@@ -84502,42 +86661,42 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 boP
-aaJ
-aaJ
-aaJ
-aaJ
-abz
-abz
-abz
-afJ
-alf
-aaw
-acG
-alf
-asG
+boP
+abH
+aec
+alZ
+aqN
+hgD
+rcG
 acd
-axJ
-arD
-arD
-arD
+acd
+acd
+acd
+acd
+acd
+all
+jvu
+aPM
+azL
+wSb
+xGY
+oyD
+azL
+alf
+jtT
+ygY
+htY
+asG
+xEe
+azL
+oYf
+jfu
+rDd
 aGX
-aai
-wVq
+gPO
+sBT
 qrN
 rXY
 kcV
@@ -84759,41 +86918,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
+bBM
 boP
-boP
-boP
-boP
-aai
-acY
-adE
-aer
-aaw
-alj
-aoG
-aby
-aaw
-aat
+abH
+aef
+apf
+azt
+fpx
+qti
 acd
-ayc
+xAT
+baO
+wVG
+aeH
+acd
+all
+eTP
+srr
+azL
+azL
+azL
+azL
+azL
+acd
+yfX
+aby
+aqN
+rfT
+wKq
+azL
 aaM
-aaM
-aaM
+liK
+avb
 aHr
-vTk
+aai
 fSH
 cQl
 jkz
@@ -85017,38 +87176,38 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 boP
-aai
+abH
+aeI
+aqt
+azL
+gwO
+pJj
+acd
+oZx
+vLz
+gnS
+oyz
+hAw
+gqW
+jvu
+aPM
+acd
 ada
 adH
 aeF
-aat
-all
+qmD
+acd
 aoV
 aqm
-aqm
-aoV
-aai
-aaZ
-aaZ
-aaZ
-aaZ
+azL
+azL
+azL
+azL
+azL
+kqH
+abH
 aaZ
 aaZ
 aaZ
@@ -85274,38 +87433,38 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 boP
-aai
+abH
+azL
+azL
+azL
+hWj
+puT
+acd
+mvk
+mDl
+gnS
+qzJ
+acd
+tjL
+rPv
+nla
+xoU
 adb
-adI
+aeH
 aeH
 agf
-aat
+acd
 aoY
-aaw
-aat
-aaw
-aai
-boP
-boP
-aaZ
-abm
+qoG
+azL
+asD
+iXa
+azL
+wvM
+nOw
+abH
 tDP
 iSP
 adi
@@ -85531,37 +87690,37 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-aaf
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
 bBM
 boP
-aaZ
+abH
+aec
+aqF
+aqN
+hgD
+pJj
+acd
+umZ
+kBw
+eZm
+aeH
+acd
+tjL
+lSs
+dhZ
+akD
+wiO
+aeH
+raw
+qQE
+acd
+jtT
+ygY
+htY
+asG
+xEe
+azL
+irI
+usE
 abH
 rtz
 dRi
@@ -85788,38 +87947,38 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-boP
-boP
-boP
-boP
-boP
-boP
-boP
-boP
-boP
-boP
-boP
-boP
 bBM
 boP
-aaZ
-abn
+abH
+aef
+apf
+azt
+fpx
+qti
+acd
+acd
+acd
+ikm
+acd
+acd
+rMs
+jvu
+aPM
+acd
+acd
+acd
+acd
+acd
+acd
+yfX
+aby
+aqN
+rfT
+wKq
+abH
+abH
+abH
+abH
 xoJ
 qJV
 obK
@@ -86045,35 +88204,35 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-boP
-boP
-boP
-boP
-boP
-boP
-boP
-boP
 bBM
+boP
+abH
+aeI
+aqt
+azL
+gwO
+ryQ
+tRa
+cWW
+cWW
+vAL
+hKP
+cWW
+mOA
+etV
+nFG
+udV
+rOV
+eZr
+dng
+rOV
+rOV
+kdT
+raf
+abH
+abH
+abH
+abH
 abC
 aaZ
 abJ
@@ -86302,32 +88461,32 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 boP
-boP
-boP
-boP
-boP
-boP
-boP
+abH
+abH
+azL
+aEq
+jNs
+sni
+tRz
+qkO
+qkO
+dCB
+ktm
+qkO
+rKM
+kHp
+ftU
+gwW
+wmV
+gIi
+txm
+eTS
+eTS
+iRP
+cmz
+aai
 boP
 boP
 bBM
@@ -86559,35 +88718,35 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 boP
 boP
+abH
+aqG
+aEv
+jXT
+azL
+acd
+acd
+aEr
+acd
+acd
+acd
+acd
+gBd
+aiS
+azL
+azL
+syN
+oPe
+azL
+hGg
+erP
+agK
+aai
 boP
 boP
-boP
-abp
-abp
-abp
-abp
-abp
+bBM
 boP
 aaZ
 abQ
@@ -86816,35 +88975,35 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
+bBM
+boP
+aeJ
+arH
+aFE
+kpe
+szV
+une
+aDu
+aDu
+aDu
+aDu
+aEr
+uDP
+jVi
+ocm
+azL
+eJQ
+eUA
+iAw
+azL
+oOm
+erP
+agK
+aai
 boP
 boP
-boP
-boP
-boP
-abp
-hgD
-ovx
-hgD
-abp
+bBM
 boP
 aaZ
 sur
@@ -87074,41 +89233,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
+boP
+aeK
+arJ
+aFF
+abH
+abH
+aai
+aai
+aai
+aai
+aai
+aai
+jnI
+dpm
+jQt
+szV
+kzs
+hbm
+fnQ
+azL
+dTk
+hun
+agK
+aai
 boP
 boP
-boP
-boP
-boP
-abp
-hgD
-iVu
-trX
-abp
+bBM
 boP
 aaZ
 vAI
 kVz
 gdu
 kct
-abN
+gPz
 alt
 fZk
 vEA
@@ -87331,35 +89490,35 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
+boP
+abH
+arL
+aGK
+abH
 boP
 boP
 boP
 boP
-abp
-abp
-abp
-dQP
-abo
-abp
-abo
+boP
+boP
+aai
+rAj
+lqO
+dbu
+abH
+abH
+abH
+abH
+abH
+aai
+aai
+aai
+aai
+boP
+adR
+adR
+adR
 aaZ
 aaZ
 aaZ
@@ -87588,35 +89747,35 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 boP
 boP
 boP
 boP
 boP
-abp
-fSV
-ksN
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+bBM
+boP
+boP
+adR
+sbi
 iVu
-mNa
-abo
-lmU
 pkd
 xeM
 pka
@@ -87845,33 +90004,33 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
+bBM
 boP
 boP
-boP
-abp
-puT
-nli
-iVu
-iVu
+adR
 dQP
 iVu
 iVu
@@ -87879,7 +90038,7 @@ iVu
 iVu
 iVu
 iVu
-iVu
+pge
 abo
 tll
 fxr
@@ -88124,12 +90283,12 @@ gQb
 gQb
 boP
 boP
-abp
-pJj
-wbO
-iVu
-iVu
-abo
+boP
+boP
+boP
+boP
+adR
+dQP
 iVu
 rMz
 rMz
@@ -88381,12 +90540,12 @@ gQb
 gQb
 boP
 boP
-abp
-kTl
-nli
-iVu
-iVu
-dQP
+boP
+boP
+boP
+boP
+adR
+xoQ
 iVu
 cmS
 fBM
@@ -88638,12 +90797,12 @@ boP
 boP
 boP
 boP
+boP
+boP
+boP
+boP
+adR
 abp
-qti
-sni
-sni
-iVu
-abo
 dlO
 lmU
 lmU
@@ -88895,12 +91054,12 @@ gQb
 gQb
 gQb
 boP
-abp
-hWj
-gwO
-gwO
-dSj
-abq
+boP
+boP
+boP
+boP
+adR
+wmP
 abq
 abq
 mMA
@@ -89152,12 +91311,12 @@ boP
 boP
 boP
 boP
-abp
-tRz
-afn
-afn
-lNV
-abq
+boP
+boP
+boP
+boP
+boP
+wmP
 abT
 acs
 acR
@@ -89409,11 +91568,11 @@ gQb
 gQb
 gQb
 boP
-abp
-tRz
-afn
-afn
-lNV
+boP
+boP
+boP
+boP
+boP
 abr
 abS
 acr
@@ -89666,11 +91825,11 @@ boP
 boP
 boP
 boP
-abo
-tRz
-afn
-afn
-lNV
+boP
+boP
+boP
+boP
+boP
 abr
 abV
 nIb
@@ -89923,11 +92082,11 @@ gQb
 gQb
 fdT
 boP
-abo
-fpx
-afn
-afn
-lNV
+boP
+boP
+boP
+boP
+boP
 abr
 abU
 act
@@ -90180,12 +92339,12 @@ boP
 boP
 boP
 boP
-abo
-bUe
-afn
-afn
-lNV
-abq
+boP
+boP
+boP
+boP
+boP
+wmP
 abW
 abk
 gII
@@ -90437,17 +92596,17 @@ gQb
 gQb
 gQb
 boP
-abo
-tRz
-afn
-afn
-gDa
-abq
-abq
-abq
+boP
+boP
+boP
+boP
+boP
+wmP
+wmP
+wmP
 abr
-abq
-abq
+wmP
+wmP
 abq
 tll
 qKz
@@ -90694,12 +92853,12 @@ gQb
 gQb
 gQb
 boP
-abp
-tRz
-ryQ
-afn
-lNV
-abo
+boP
+boP
+boP
+boP
+boP
+boP
 boP
 boP
 boP
@@ -90951,12 +93110,12 @@ gQb
 gQb
 gQb
 boP
-abp
-tRa
-fak
-rcG
-voA
-abo
+boP
+boP
+boP
+boP
+boP
+boP
 boP
 boP
 boP
@@ -91208,12 +93367,12 @@ gQb
 gQb
 gQb
 boP
-abp
-abp
-abp
-abp
-abp
-abp
+boP
+boP
+boP
+boP
+boP
+boP
 boP
 ajW
 abp

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -43581,12 +43581,6 @@
 	dir = 1
 	},
 /area/security/prison)
-"fTZ" = (
-/obj/machinery/jukebox{
-	req_one_access = null
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "fUn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -85128,7 +85122,7 @@ iOl
 qcs
 aaI
 aap
-fTZ
+abs
 acd
 acd
 acd

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -60342,9 +60342,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "jOK" = (
-/obj/machinery/jukebox{
-	req_one_access = null
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plasteel/checker,

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -108,11 +108,13 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aaq" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Security Space - Prison North";
+	dir = 1;
+	network = list("ss13","prison")
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/space/basic,
+/area/space)
 "aar" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/siding/wood{
@@ -145,76 +147,37 @@
 /turf/open/space,
 /area/space)
 "aaw" = (
-/obj/structure/cable,
+/obj/structure/bed,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/item/bedsheet/green,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "aax" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
-"aay" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/glasses/blindfold,
-/obj/item/clothing/mask/muzzle,
-/obj/item/electropack,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
-"aaz" = (
-/obj/structure/chair/stool,
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aaA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
-"aaB" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
 "aaC" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	name = "justice injector"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/grass,
+/area/security/prison)
 "aaE" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/toy/plush/beeplushie{
-	desc = "Maybe hugging this will make you feel better about yourself.";
-	name = "Therabee"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/grass,
 /area/security/prison)
 "aaF" = (
 /obj/machinery/vending/boozeomat,
@@ -229,80 +192,20 @@
 /area/crew_quarters/bar)
 "aaG" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "executionfireblast"
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	desc = "Why does this place even have windows?!";
+	id = "GenpopBath";
+	name = "Bathroom Privacy Shutters"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
-"aaH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "executionfireblast"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/plating,
+/area/security/prison)
 "aaI" = (
-/obj/machinery/door/window/brigdoor{
-	name = "Justice Chamber";
-	req_access_txt = "3"
-	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Justice Chamber";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "executionfireblast"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/grass,
+/area/security/prison)
 "aaJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -358,95 +261,17 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aaP" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = -4;
-	pixel_y = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	desc = "Why does this place even have windows?!";
+	id = "GenpopBath";
+	name = "Bathroom Privacy Shutters"
 	},
-/obj/item/reagent_containers/glass/bottle/chloralhydrate,
-/obj/item/reagent_containers/glass/bottle/toxin{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/glass/bottle/facid{
-	name = "fluorosulfuric acid bottle";
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/dropper,
-/obj/machinery/airalarm/all_access{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/button/ignition{
-	id = "executionburn";
-	name = "Justice Ignition Switch";
-	pixel_x = -25;
-	pixel_y = 36
-	},
-/obj/machinery/button/door{
-	id = "executionfireblast";
-	name = "Justice Area Lockdown";
-	pixel_x = -25;
-	pixel_y = 26;
-	req_access_txt = "2"
-	},
-/obj/item/assembly/signaler{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/machinery/button/flasher{
-	id = "justiceflash";
-	name = "Justice Flash Control";
-	pixel_x = -36;
-	pixel_y = 36;
-	req_access_txt = "1"
-	},
-/obj/machinery/button/door{
-	id = "SecJusticeChamber";
-	layer = 4;
-	name = "Justice Vent Control";
-	pixel_x = -36;
-	pixel_y = 26;
-	req_access_txt = "3"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
-"aaQ" = (
-/obj/structure/table,
-/obj/item/folder/red{
-	pixel_x = 3
-	},
-/obj/item/taperecorder{
-	pixel_x = -3
-	},
-/obj/item/storage/fancy/cigarettes,
-/obj/item/assembly/flash/handheld,
-/obj/item/reagent_containers/spray/pepper,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/plating,
+/area/security/prison)
 "aaR" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -462,34 +287,16 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aaS" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/grass,
+/area/security/prison)
 "aaT" = (
-/obj/structure/closet/secure_closet/injection{
-	name = "educational injections";
-	pixel_x = 2
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/grass,
+/area/security/prison)
 "aaU" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -532,31 +339,40 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/solar/starboard/fore)
-"aaZ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aba" = (
-/obj/structure/chair/office{
+/obj/effect/turf_decal/bot,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"abb" = (
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
-"abb" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/prison)
 "abc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/light,
+/obj/machinery/biogenerator,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/prison)
 "abd" = (
 /obj/machinery/light{
 	dir = 1
@@ -573,14 +389,18 @@
 /turf/closed/wall,
 /area/security/prison)
 "abf" = (
-/obj/structure/cable,
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of the green cell block";
+	name = "Cell - Green"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "abi" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown{
@@ -606,61 +426,53 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "abn" = (
-/obj/item/radio/intercom{
-	pixel_x = -28
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
-/obj/item/clothing/mask/balaclava,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
-"abo" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/structure/table,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
+"abo" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/sink{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "abp" = (
 /obj/structure/sign/poster/random,
 /turf/closed/wall,
 /area/maintenance/central)
 "abq" = (
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = -25
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/machinery/shower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "abt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -711,82 +523,86 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
 "abx" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 5
+	},
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/education)
 "aby" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/education)
 "abz" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/education)
 "abC" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "abD" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "abF" = (
-/obj/machinery/meter,
-/obj/machinery/door/window/westleft{
-	dir = 1;
-	name = "gas ports"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/structure/cable,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "abG" = (
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 1;
-	icon_state = "right";
-	name = "gas ports"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "justice gas pump"
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/prison)
 "abJ" = (
-/turf/closed/wall,
-/area/security/execution/education)
-"abK" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "abM" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "abO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -813,138 +629,97 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "abV" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/education)
 "abX" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/structure/chair,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/area/security/execution/education)
 "abZ" = (
-/obj/item/storage/bag/trash,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/button/door{
+	desc = "At least Nanotrasen is giving criminals the option of privacy.";
+	id = "GenpopBath";
+	name = "Bathroom Shutters";
+	pixel_x = 24;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "aca" = (
-/obj/item/tank/internals/oxygen/red{
-	pixel_x = -4;
-	pixel_y = -1
-	},
-/obj/item/tank/internals/oxygen/red{
-	pixel_x = 4;
-	pixel_y = -1
-	},
-/obj/item/tank/internals/anesthetic{
-	pixel_x = 2
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/wrench,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	contents = newlist(/obj/item/toy/snappop/phoenix);
+	dir = 4
+	},
+/obj/structure/sink{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "acb" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/prison)
 "acd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/janitor)
 "ace" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_y = 6
+/obj/machinery/power/apc/highcap/ten_k{
+	area = "/area/security/prison";
+	dir = 1;
+	name = "Prison APC";
+	pixel_y = 24
 	},
-/obj/machinery/camera{
-	c_tag = "Prison Sanitarium";
-	network = list("ss13","prison")
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "acg" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aci" = (
-/obj/machinery/door/airlock/external{
-	name = "Security External Airlock";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"acj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
+"aci" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ack" = (
 /obj/structure/lattice/catwalk,
@@ -968,116 +743,73 @@
 	},
 /area/medical/medbay/central)
 "acq" = (
-/obj/machinery/door/airlock{
-	name = "Cleaning Closet"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	desc = "Get out, get out, run, RUN! Every tale of this station points to this being a bad place to be!";
+	glass = 0;
+	id_tag = "InterrogationLock1";
+	name = "Interrogation Room";
+	req_one_access_txt = "63;4"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "acv" = (
-/turf/closed/wall/r_wall,
-/area/security/execution/education)
+/obj/machinery/camera{
+	c_tag = "Security Prison - West Hallway";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "acw" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/iannewyear,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
-"acx" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/glasses/blindfold,
-/obj/item/clothing/mask/muzzle,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "acz" = (
 /obj/item/stack/cable_coil,
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
 "acE" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
 	},
-/area/security/prison)
-"acF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"acH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "acI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"acJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"acK" = (
-/obj/effect/spawner/randomarcade,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"acL" = (
-/obj/item/folder/red,
-/obj/item/pen,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/obj/item/folder/white{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "acM" = (
-/obj/structure/bed/roller,
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
+/obj/machinery/button/door{
+	id = "Prison Gate";
+	name = "PRISON LOCKDOWN";
+	pixel_y = -24;
+	req_access_txt = "1"
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/camera{
+	c_tag = "Security - Prison Foyer";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "acP" = (
 /turf/closed/wall,
@@ -1123,49 +855,51 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
-"acX" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Cell 4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
 "acZ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/structure/bookcase/manuals/medical,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/prison)
 "adb" = (
-/turf/open/floor/plasteel/dark/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/area/security/prison)
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/rack,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "adc" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "add" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/beach_ball/holoball,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plasteel,
-/area/security/prison)
-"adh" = (
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "adj" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
@@ -1189,40 +923,22 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "adq" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/machinery/shower{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"adr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "ads" = (
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/structure/cable,
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "adt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "adv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -1230,40 +946,32 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "adw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
+"adx" = (
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel,
-/area/security/prison)
-"adx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/disposal/delivery_chute{
-	dir = 4;
-	name = "Prisoner Transfer"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/plasticflaps/opaque{
-	name = "Prisoner Transfer"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "ady" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
+/obj/structure/lattice,
 /obj/machinery/camera{
-	c_tag = "Prison Cell Block 2";
-	dir = 4;
+	c_tag = "Security Space - Prison North West";
+	dir = 1;
 	network = list("ss13","prison")
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/turf/open/space/basic,
+/area/space/nearstation)
 "adB" = (
 /obj/structure/cable,
 /mob/living/carbon/human/species/monkey,
@@ -1284,12 +992,21 @@
 /turf/open/space/basic,
 /area/space)
 "adG" = (
-/obj/machinery/computer/bookmanagement,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/effect/landmark/start/prisoner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "adH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -1317,38 +1034,46 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "adN" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"adO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
+/area/security/prison/safe)
+"adO" = (
+/obj/structure/curtain,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "adR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plasteel/dark/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/area/security/prison)
-"adS" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "adX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -1405,86 +1130,66 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"aeg" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
-"aeh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
 "aei" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Cell 3"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
-"aej" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"ael" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aem" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aen" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/landmark/start/prisoner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aep" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
+"aej" = (
+/obj/machinery/camera{
+	c_tag = "Security Space - Prison North East";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/space/basic,
+/area/space)
+"ael" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
+"aem" = (
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of the purple cell block.";
+	name = "Cell - Purple"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
+"aen" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/clothing{
+	premium = list(/obj/item/clothing/under/suit/checkered = 4, /obj/item/clothing/head/mailman = 2, /obj/item/clothing/under/misc/mailman = 2, /obj/item/clothing/suit/jacket/leather = 4, /obj/item/clothing/suit/jacket/leather/overcoat = 4, /obj/item/clothing/under/pants/mustangjeans = 3, /obj/item/clothing/neck/necklace/dope = 5, /obj/item/clothing/suit/jacket/letterman_nanotrasen = 5, /obj/item/clothing/suit/hooded/wintercoat/polychromic = 5, /obj/item/clothing/glasses/welding = 1)
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aeq" = (
 /turf/closed/wall/r_wall,
@@ -1505,6 +1210,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"aet" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "aey" = (
 /turf/closed/wall,
 /area/security/range)
@@ -1546,59 +1259,78 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aeJ" = (
-/turf/closed/wall/r_wall,
-/area/security/prison/safe)
+/obj/structure/table,
+/obj/item/melee/baseball_bat{
+	attack_verb = list("punished","smacked","pulverised","cracked");
+	desc = "An old bat with dried blood filling its crooks and crevices, this bat is used to quench sadistic thirst. If the mind doesn't break to this torture device, the body will break.";
+	name = "\improper Mind Breaker"
+	},
+/obj/item/electropack,
+/obj/item/assembly/signaler,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "aeM" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /obj/machinery/camera{
-	c_tag = "Prison Cell Block 1";
-	dir = 1;
+	c_tag = "Security Prison - North Hallway";
 	network = list("ss13","prison")
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/vending/autodrobe{
+	premium = list(/obj/item/clothing/neck/human_petcollar/locked = 10,/obj/item/clothing/neck/human_petcollar/locked/choker = 10,/obj/item/clothing/neck/human_petcollar/locked/leather = 10)
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aeN" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aeO" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aeP" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aeQ" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aeS" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aeT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aeU" = (
-/obj/structure/chair/stool,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/table,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
 	},
 /turf/open/floor/plasteel,
+/area/security/prison/safe)
+"aeO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
+"aeP" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
+"aeQ" = (
+/turf/open/floor/plating,
 /area/security/prison)
+"aeS" = (
+/obj/structure/cable,
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"aeT" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/security/prison)
+"aeU" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "aeV" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/green{
@@ -1609,14 +1341,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"aeW" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aeY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -1631,15 +1355,27 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "afa" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/structure/cable,
-/obj/item/instrument/harmonica,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	contents = newlist(/obj/item/toy/snappop/phoenix);
+	dir = 4
+	},
+/obj/structure/sink{
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "afb" = (
 /obj/machinery/light{
 	dir = 4
@@ -1668,10 +1404,21 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "afd" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "afn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
@@ -1855,86 +1602,120 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "afG" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Cell 2"
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison/safe)
 "afI" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Cell 1"
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison/safe)
 "afJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
-"afM" = (
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark/corner,
-/area/security/prison)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "afN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of the purple cell block.";
+	name = "Cell - Purple"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit/security_peacekeeper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/prison/safe)
 "afO" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/prison)
 "afP" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/prison)
 "afQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "afT" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/security/brig)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "afU" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/dark/side,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "afV" = (
 /obj/structure/lattice/catwalk,
@@ -2158,49 +1939,77 @@
 	},
 /area/maintenance/solars/port/fore)
 "agG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
-"agH" = (
-/turf/closed/wall,
-/area/security/prison/safe)
-"agI" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"agH" = (
+/obj/structure/falsewall/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
+"agI" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "agJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Security E.V.A. Storage";
-	req_access_txt = "3"
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "agN" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"agO" = (
-/obj/structure/chair/stool,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"agP" = (
-/obj/structure/table,
-/obj/item/toy/cards/deck,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "agR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
@@ -2359,52 +2168,43 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "ahu" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ahv" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ahw" = (
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark/side{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/area/security/prison)
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
+"ahv" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "ahx" = (
 /turf/closed/wall,
 /area/security/brig)
 "ahz" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ahB" = (
 /obj/structure/cable,
@@ -2639,17 +2439,9 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "air" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "visitation";
-	name = "Visitation Shutters"
-	},
-/obj/machinery/door/window/southleft{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/machinery/suit_storage_unit/security_peacekeeper,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ait" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -2658,25 +2450,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"aiv" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Laundry";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aiA" = (
 /obj/item/storage/secure/safe{
 	name = "armory safe A";
@@ -2900,28 +2673,28 @@
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "ajn" = (
-/obj/structure/table,
-/obj/item/folder,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/photo_album/prison,
-/obj/item/camera,
-/obj/machinery/light,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "ajo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "ajp" = (
-/obj/machinery/camera{
-	c_tag = "Prison Common Room";
-	dir = 1;
-	network = list("ss13","prison")
+/turf/open/floor/plating,
+/area/security/prison/safe)
+"ajq" = (
+/obj/machinery/shower{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "ajr" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -3211,27 +2984,18 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"akt" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "visitation";
-	name = "Visitation Shutters"
+"akz" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/obj/machinery/door/window/southright{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green,
 /obj/structure/table,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
-/area/security/prison)
-"akz" = (
-/obj/structure/chair/stool,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "akI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -3544,10 +3308,11 @@
 /turf/closed/wall,
 /area/maintenance/port)
 "alL" = (
-/turf/open/floor/plasteel/dark/side{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "alM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -3557,33 +3322,19 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "alN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"alO" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "alP" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/security/prison)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "alT" = (
 /obj/machinery/light{
 	dir = 4
@@ -3873,27 +3624,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"ani" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"anj" = (
-/obj/structure/disposaloutlet{
-	dir = 8;
-	name = "Prisoner Delivery"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "ank" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -4177,33 +3907,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoj" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
 "aol" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/fore)
 "aom" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aon" = (
 /obj/structure/table,
@@ -5595,30 +5310,16 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asn" = (
-/obj/structure/closet/crate,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/onion,
-/obj/item/food/grown/onion,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/docking_port/stationary/random{
+	id = "pod_2_lavaland";
+	name = "lavaland"
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/turf/open/space,
+/area/space)
 "aso" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
 /area/security/prison)
 "asB" = (
 /obj/machinery/light/small{
@@ -6022,13 +5723,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "atL" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/window{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison)
 "atP" = (
 /obj/structure/disposalpipe/segment{
@@ -10217,6 +9916,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
+"aHz" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
+/area/security/prison/safe)
 "aHC" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -12134,10 +11837,7 @@
 /area/quartermaster/storage)
 "aNL" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/prison)
 "aNM" = (
 /obj/machinery/door/poddoor/shutters{
@@ -14140,14 +13840,17 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aST" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/table,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "aSU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -15303,13 +15006,17 @@
 	},
 /area/hallway/secondary/entry)
 "aVG" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/prison/safe)
 "aVK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -18110,6 +17817,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"bbV" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
 "bcb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21534,15 +21247,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bkx" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "bky" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
@@ -26435,15 +26144,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
-"bxE" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "bxN" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -37819,6 +37519,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"ccn" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Dining Area"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "ccp" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -42358,6 +42066,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/storage)
+"cso" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Security Space - Prison East";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "csp" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -42542,12 +42259,26 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "csO" = (
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/electropack,
 /obj/structure/table,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/item/storage/pill_bottle/dice{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "csT" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable,
@@ -42801,6 +42532,15 @@
 "cva" = (
 /turf/closed/wall,
 /area/maintenance/space_hut)
+"cvf" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "cvl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -43451,12 +43191,19 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cBe" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "cBr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -43675,6 +43422,11 @@
 /obj/item/instrument/guitar,
 /turf/open/space/basic,
 /area/space/nearstation)
+"cDG" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "cDN" = (
 /obj/structure/chair/sofa/left,
 /turf/open/floor/carpet,
@@ -43796,16 +43548,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cEm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "cEz" = (
 /obj/structure/closet/wardrobe/grey,
@@ -47006,6 +46759,15 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"cSL" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cSP" = (
 /obj/docking_port/stationary/random{
 	id = "pod_lavaland";
@@ -47087,6 +46849,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"cUk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"cUG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "cUH" = (
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
@@ -47351,6 +47128,16 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"cXa" = (
+/obj/machinery/light/small,
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/security/prison)
 "cXc" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -47484,6 +47271,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"cYz" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "cYD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -48132,6 +47927,31 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"det" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = -8
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = -4
+	},
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 4
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 8
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 12
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating,
+/area/security/prison)
 "deu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -48702,10 +48522,13 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "dgX" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "dha" = (
 /obj/structure/lattice,
@@ -49442,6 +49265,18 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"djs" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/janitorialcart{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "djt" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
@@ -49534,6 +49369,16 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
+"dkF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "dkR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -49688,6 +49533,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"dop" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dou" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -49803,6 +49655,14 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"dtd" = (
+/obj/machinery/camera{
+	c_tag = "Security Prison - Dining Room";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "dtl" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -50188,6 +50048,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery/room_b)
+"dyN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "dzc" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -50199,6 +50068,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"dzv" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "dzK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/vehicle/ridden/wheelchair,
@@ -50206,6 +50081,17 @@
 	icon_state = "panelscorched"
 	},
 /area/medical/abandoned)
+"dzM" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "dAd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -50836,22 +50722,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "dFK" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/item/seeds/onion,
-/obj/item/seeds/garlic,
-/obj/item/seeds/potato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "dGP" = (
 /obj/structure/training_machine,
@@ -50950,6 +50828,12 @@
 /obj/item/clothing/mask/surgical,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"dJH" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dKC" = (
 /obj/machinery/light{
 	dir = 1
@@ -51120,18 +51004,60 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"dSc" = (
+/obj/structure/closet/crate,
+/obj/item/instrument/piano_synth,
+/obj/item/toy/cards/deck,
+/turf/open/floor/plating,
+/area/security/prison)
 "dSh" = (
 /obj/item/paper_bin/carbon,
 /obj/item/pen/fountain,
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"dTP" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "dTT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dUJ" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/structure/sink{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "dWv" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -51149,19 +51075,16 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "dXp" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/prison)
 "dXV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -51217,12 +51140,18 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
 "ebw" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ebP" = (
@@ -51421,16 +51350,26 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "ejE" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	desc = "Get out, get out, run, RUN! Every tale of this station points to this being a bad place to be!";
+	glass = 0;
+	id_tag = "InterrogationLock1";
+	name = "Interrogation Room";
+	req_one_access_txt = "63;4"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/execution/education)
 "ejL" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -51538,6 +51477,16 @@
 /mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"enA" = (
+/obj/machinery/camera{
+	c_tag = "Security Prison - East Hallway";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "enV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -51605,22 +51554,22 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "epU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "eqf" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/structure/table,
+/obj/item/pda,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "eqC" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -51721,6 +51670,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/customs)
+"esF" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/structure/sign/poster/official/obey{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "esU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -51820,16 +51783,20 @@
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
 "ewR" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/structure/table,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/prison)
 "exh" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
@@ -51989,6 +51956,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"eBB" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eBK" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -52055,6 +52029,44 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"eDi" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
+"eDk" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/sink{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "eDt" = (
 /obj/machinery/computer/slot_machine{
 	pixel_y = 2
@@ -52082,20 +52094,38 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "eEe" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
+/obj/structure/rack,
+/obj/item/wirecutters,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/green,
+/obj/item/seeds/cotton,
+/obj/item/seeds/cotton,
+/obj/item/seeds/onion/red,
+/obj/item/seeds/wheat/rice,
+/obj/item/seeds/wheat/oat,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "eEi" = (
 /obj/effect/turf_decal/trimline/purple/corner{
@@ -52228,15 +52258,11 @@
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "eII" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "eIP" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/sign/poster/official/safety_eye_protection{
@@ -52438,6 +52464,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"eOS" = (
+/obj/machinery/camera{
+	c_tag = "Security Prison - Central Hallway";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ePo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52511,6 +52544,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"eRX" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "eSm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/light_construct{
@@ -52599,11 +52646,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "eWu" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
+/obj/structure/table,
+/obj/item/taperecorder{
+	pixel_x = -3
 	},
+/obj/item/storage/box/bodybags,
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/area/security/execution/education)
 "eXh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -52630,12 +52680,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
 "eXB" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/security/prison/safe)
 "eXS" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -52699,6 +52747,12 @@
 "eZU" = (
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
+"fae" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fat" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -52890,11 +52944,11 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "fgU" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/gloves,
+/obj/item/poster/random_contraband,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "fhk" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/line,
@@ -52929,6 +52983,16 @@
 	},
 /turf/open/floor/holofloor/dark,
 /area/science/cytology)
+"fio" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "fiq" = (
 /obj/machinery/mass_driver/shack{
 	dir = 8
@@ -53012,16 +53076,10 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "fjy" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "fjz" = (
 /obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
@@ -53128,6 +53186,26 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"fmd" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/structure/chair/comfy{
+	color = "#e8a768";
+	dir = 8;
+	name = "orange comfy chair"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "fme" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -53136,39 +53214,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "fmr" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/box/drinkingglasses,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/obj/structure/cable,
+/obj/structure/falsewall,
+/turf/open/floor/plating,
 /area/security/prison)
 "fmA" = (
 /turf/open/floor/engine,
@@ -53213,12 +53261,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "fos" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "foz" = (
 /obj/structure/disposalpipe/segment{
@@ -53291,11 +53336,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"fst" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fsT" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"ftq" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "ftK" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
@@ -53311,27 +53373,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ftV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Isolation Cell";
-	dir = 8;
-	network = list("ss13","prison","isolation")
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/structure/cable,
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "fui" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -53510,11 +53555,17 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "fBP" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "fBV" = (
 /obj/structure/cable,
@@ -53794,10 +53845,17 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "fJX" = (
-/obj/machinery/light_switch{
-	pixel_y = 26
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
 	},
-/turf/open/floor/plasteel/freezer,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "fKU" = (
 /obj/structure/disposalpipe/segment,
@@ -53889,14 +53947,8 @@
 /turf/open/floor/plating,
 /area/engine/storage_shared)
 "fML" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/turf/closed/wall/mineral/plastitanium,
+/area/space)
 "fMS" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -54015,10 +54067,8 @@
 /turf/open/floor/plasteel,
 /area/science/cytology)
 "fPR" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/wood,
 /area/security/prison)
 "fRi" = (
 /obj/effect/turf_decal/stripes/line{
@@ -54081,6 +54131,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"fSt" = (
+/obj/machinery/door/poddoor/shutters/window{
+	id = "bossofthisprisongym1";
+	name = "Visitation"
+	},
+/obj/machinery/button/door{
+	id = "bossofthisprisongym1";
+	name = "Private Area";
+	pixel_x = -24;
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "fTi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -54523,15 +54591,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "gfP" = (
-/obj/structure/table,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/chair/sofa/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/prison)
 "ggG" = (
 /obj/machinery/door/airlock/security{
@@ -54648,6 +54711,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"gjv" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "gjw" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -54868,6 +54938,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"gpI" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/sustenance{
+	name = "\improper Prison Sustenance";
+	premium = list(/obj/item/stack/cable_coil/random = 2, /obj/item/wirecutters = 1, /obj/item/wrench = 1, /obj/item/analyzer = 1, /obj/item/screwdriver = 1, /obj/item/flashlight = 2);
+	products = list(/obj/item/reagent_containers/food/snacks/tofu = 12, /obj/item/reagent_containers/food/drinks/ice = 4, /obj/item/reagent_containers/food/snacks/candy_corn = 4, /obj/item/reagent_containers/food/snacks/chips = 4, /obj/item/reagent_containers/food/snacks/sosjerky = 4, /obj/item/reagent_containers/food/drinks/mug/tea = 3, /obj/item/reagent_containers/food/drinks/mug/coco = 3)
+	},
+/obj/structure/sign/poster/official/obey{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "gqA" = (
 /obj/machinery/button/door{
 	id = "abandoned_kitchen";
@@ -54905,6 +54987,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"grj" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "grU" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
@@ -54982,13 +55071,12 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "guu" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	name = "justice injector"
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "gvn" = (
 /obj/structure/chair/sofa/corp/left{
 	desc = "Looks like someone threw it out. Covered in donut crumbs.";
@@ -54997,12 +55085,21 @@
 /turf/open/space/basic,
 /area/space)
 "gvA" = (
-/obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -55064,11 +55161,11 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "gxF" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+/obj/structure/chair/sofa/left,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/prison)
 "gxH" = (
 /obj/structure/cable,
@@ -55152,13 +55249,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "gzR" = (
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen/interrogation{
-	name = "isolation room monitor";
-	network = list("isolation");
-	pixel_y = 31
+/obj/structure/sign/poster/official/obey{
+	pixel_x = -32
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "gAd" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -55167,19 +55261,9 @@
 /turf/open/floor/engine,
 /area/science/cytology)
 "gAf" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/sparker{
-	id = "executionburn";
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/wood,
+/area/security/prison)
 "gAo" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
@@ -55202,10 +55286,10 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "gBC" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/prison)
 "gCa" = (
 /obj/structure/table,
@@ -55363,19 +55447,9 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "gFy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/wood,
+/area/security/prison)
 "gGb" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/cell/high/plus{
@@ -55566,6 +55640,30 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"gLv" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Dining Area"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"gLy" = (
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"gMt" = (
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of a colour coded cell bock. This is an orange cell.";
+	name = "Cell - Orange"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "gMG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -55605,21 +55703,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"gNS" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "gNX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55636,6 +55719,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"gOp" = (
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "gOu" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
@@ -55644,11 +55738,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/surgery/room_b)
-"gON" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "gPA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -55849,6 +55938,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"gWy" = (
+/obj/structure/filingcabinet,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "gXi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -56115,13 +56214,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery/room_b)
 "hgv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/trimline/red/warning{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/effect/spawner/randomarcade,
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "hgI" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -56187,6 +56285,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"hjg" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "hkv" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -56226,13 +56332,16 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "hlB" = (
-/obj/machinery/light,
-/obj/item/stack/sheet/cardboard{
-	amount = 14
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/item/stack/package_wrap,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/machinery/computer/arcade/battle,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "hlN" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
@@ -56338,11 +56447,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hoA" = (
-/obj/structure/rack,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "hpi" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -56487,10 +56600,21 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "htR" = (
-/turf/open/floor/plasteel/dark/corner{
+/obj/machinery/cryopod{
 	dir = 4
 	},
-/area/security/prison)
+/obj/machinery/camera{
+	c_tag = "Security Prison - Arcade";
+	network = list("ss13","prison")
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison/safe)
 "huV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -56565,6 +56689,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"hwW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hxi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -56641,6 +56774,29 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery/room_b)
+"hzn" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/education)
 "hzY" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -56651,6 +56807,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"hAR" = (
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "hAY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
@@ -56722,6 +56884,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"hDG" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hEd" = (
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
@@ -56805,16 +56974,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/abandoned)
 "hFX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/computer/cryopod{
+	pixel_y = 26
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/area/security/prison)
+/turf/open/floor/carpet,
+/area/security/prison/safe)
 "hGd" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -56842,6 +57012,31 @@
 /obj/effect/turf_decal/bot_blue,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"hHO" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"hHZ" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "hIt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -56878,17 +57073,11 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "hJU" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
+/obj/machinery/cryopod{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/circuit/green,
+/area/security/prison/safe)
 "hKT" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -56983,17 +57172,20 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "hNd" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
+"hNt" = (
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "hNJ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -57033,6 +57225,25 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"hOS" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/security/prison)
+"hPf" = (
+/obj/machinery/camera{
+	c_tag = "Secutity Prison - Visitation";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "hPU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57083,7 +57294,7 @@
 /area/science/research)
 "hTp" = (
 /obj/structure/cable,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "hTO" = (
 /obj/machinery/light/small,
@@ -57210,6 +57421,30 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
 /area/medical/abandoned)
+"hYJ" = (
+/obj/structure/table,
+/obj/item/surgical_drapes,
+/obj/item/flashlight/lamp,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
+"hYR" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/education)
 "hZj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/scientist,
@@ -57300,16 +57535,10 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "ibL" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/structure/sink{
-	pixel_y = 29
-	},
-/mob/living/simple_animal/mouse/brown/tom,
+/obj/machinery/light/small,
+/obj/structure/rack,
 /turf/open/floor/plating,
-/area/security/prison/safe)
+/area/security/prison)
 "ibS" = (
 /obj/item/poster/wanted/missing,
 /obj/structure/table,
@@ -57421,6 +57650,37 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/storage)
+"iev" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown1";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "lockdown1";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"iew" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"ieA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "ieK" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
@@ -57463,6 +57723,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"igb" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ihn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -57534,6 +57801,10 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room/office)
+"iiE" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "iiU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/grille,
@@ -57641,27 +57912,26 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "ilm" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ilo" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/airalarm{
+/obj/effect/landmark/start/prisoner,
+/obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -23
+	pixel_x = -24
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
+/area/security/prison)
+"imi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
 /area/security/prison)
 "imI" = (
 /obj/machinery/holopad,
@@ -57785,6 +58055,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"iqf" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/security/prison)
 "iqM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
@@ -57824,6 +58098,12 @@
 "isZ" = (
 /turf/closed/wall,
 /area/medical/surgery/room_c)
+"itB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "itG" = (
 /obj/machinery/newscaster{
 	pixel_x = 1;
@@ -57949,6 +58229,13 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"ixR" = (
+/obj/structure/table,
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "iyA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -57960,19 +58247,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "iyN" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "iyV" = (
@@ -58017,6 +58292,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"iBd" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iBC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -58144,23 +58425,15 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "iGI" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/glasses/blindfold,
-/obj/item/clothing/mask/muzzle,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
-"iGJ" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "iGT" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -58278,6 +58551,28 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"iKp" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "iKM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -58330,6 +58625,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"iLJ" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "iLR" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/green{
@@ -58397,8 +58699,17 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "iND" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Two"
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -58432,6 +58743,46 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/customs)
+"iOx" = (
+/obj/structure/closet/secure_closet/injection,
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/button/ignition{
+	id = "executionburn";
+	name = "Justice Ignition Switch";
+	pixel_x = -25;
+	pixel_y = 36
+	},
+/obj/machinery/button/flasher{
+	id = "justiceflash";
+	name = "Justice Flash Control";
+	pixel_x = -36;
+	pixel_y = 36;
+	req_access_txt = "1"
+	},
+/obj/machinery/button/door{
+	id = "SecJusticeChamber";
+	layer = 4;
+	name = "Justice Vent Control";
+	pixel_x = -36;
+	pixel_y = 26;
+	req_access_txt = "3"
+	},
+/obj/item/reagent_containers/glass/bottle/chloralhydrate{
+	name = "chloral hydrate bottle"
+	},
+/obj/item/reagent_containers/glass/bottle/facid{
+	name = "fluorosulfuric acid bottle";
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "iOF" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
@@ -58554,16 +58905,8 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "iUh" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Visitation"
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "iUr" = (
 /obj/machinery/computer/secure_data,
@@ -58691,10 +59034,27 @@
 /obj/item/wrench,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"iXK" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "iYp" = (
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"iYr" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/cola/black,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "iYu" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -58772,15 +59132,29 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "jbB" = (
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	name = "large flour sack";
+	possible_transfer_amounts = list(1,5,10,15,30,60,90);
+	volume = 90
 	},
-/turf/open/floor/plating,
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	name = "large flour sack";
+	possible_transfer_amounts = list(1,5,10,15,30,60,90);
+	volume = 90
+	},
+/obj/item/reagent_containers/food/condiment/mayonnaise,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/rice{
+	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	name = "large rice sack";
+	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
+	},
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "jcp" = (
 /obj/machinery/door/firedoor,
@@ -58922,15 +59296,6 @@
 /obj/item/gavelhammer,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"jgM" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "jgR" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue{
@@ -58949,23 +59314,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "jib" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/trash/chips,
-/obj/item/trash/candy,
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
-"jik" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/griddle,
+/turf/open/floor/plasteel,
 /area/security/prison)
+"jik" = (
+/obj/structure/bed,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/electropack,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "jir" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -59072,6 +59430,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"jlm" = (
+/obj/structure/sign/poster/official/obey{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jlw" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/stripes/line,
@@ -59276,16 +59642,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/engineering)
-"jsA" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
 "jsZ" = (
 /obj/machinery/computer/operating,
 /obj/machinery/light/small{
@@ -59558,6 +59914,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"jBE" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/education)
 "jBH" = (
 /obj/item/folder/white{
 	pixel_x = 4;
@@ -59648,10 +60023,13 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "jEO" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
+/obj/structure/bookcase/manuals/research_and_development,
+/obj/machinery/camera{
+	c_tag = "Security Prison - Library";
+	dir = 4;
+	network = list("ss13","prison")
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/prison)
 "jEW" = (
 /obj/structure/disposalpipe/segment{
@@ -59887,36 +60265,28 @@
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
 "jNH" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "jNJ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Security Prison - Kitchen";
+	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/flasher{
-	id = "IsolationFlash";
-	pixel_y = 28
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/white,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "jNL" = (
 /turf/open/floor/plating,
@@ -59968,6 +60338,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"jOK" = (
+/obj/machinery/jukebox{
+	req_one_access = null
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "jPr" = (
 /obj/item/storage/secure/safe/hos{
 	pixel_x = 36;
@@ -60187,6 +60565,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jUi" = (
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/clothing/gloves/color/blue,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/mop,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/storage/bag/trash,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "jUu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -60231,6 +60631,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"jWg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "jWM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -60265,18 +60669,11 @@
 /area/maintenance/port/aft)
 "jYQ" = (
 /obj/structure/table,
-/obj/item/storage/box/bodybags{
-	pixel_x = 4;
-	pixel_y = 2
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/obj/item/pen,
-/obj/item/storage/box/prisoner,
-/obj/machinery/camera{
-	c_tag = "Prison Hallway Port";
-	dir = 1;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "jYU" = (
 /obj/structure/disposalpipe/segment,
@@ -60406,8 +60803,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "keM" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/freezer,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "kfF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -60567,13 +60967,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
 "klc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison)
 "kld" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -60732,8 +61128,19 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "kqk" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/trimline/red/warning{
+/obj/machinery/light/small,
+/obj/machinery/camera{
+	c_tag = "Security - EVA Storage";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -60846,11 +61253,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kvf" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
+/obj/structure/table,
+/obj/item/storage/bag/tray,
+/obj/item/kitchen/rollingpin,
+/obj/item/storage/box/cups{
+	pixel_x = -5
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "kvD" = (
@@ -60929,7 +61343,14 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "kxJ" = (
-/turf/open/floor/plating,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "kyp" = (
 /obj/structure/table,
@@ -60947,9 +61368,24 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "kyr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "workhouse";
+	name = "Work Room"
+	},
+/obj/machinery/button/door{
+	id = "workhouse";
+	name = "Work Room";
+	pixel_y = -24;
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "kyG" = (
 /obj/machinery/door/firedoor,
@@ -60998,6 +61434,9 @@
 /obj/effect/turf_decal,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"kBa" = (
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "kBb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -61116,6 +61555,22 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kDT" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "kDW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plasteel/white,
@@ -61137,10 +61592,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"kFl" = (
-/obj/structure/chair{
+"kEZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"kFl" = (
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "kFq" = (
@@ -61153,12 +61616,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery/room_c)
-"kFW" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/security/prison)
 "kGe" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
@@ -61173,19 +61630,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "kGE" = (
-/obj/machinery/camera{
-	c_tag = "Prison Central";
-	dir = 8;
-	network = list("ss13","prison")
+/obj/structure/bookcase/random/nonfiction,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/prison)
 "kHa" = (
 /obj/effect/turf_decal/tile/blue{
@@ -61211,15 +61660,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms)
 "kHF" = (
-/obj/machinery/door/poddoor{
-	id = "SecJusticeChamber";
-	name = "Justice Vent"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/shower{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/security/execution/education)
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "kHU" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -61259,10 +61704,16 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "kIE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/prison)
+/area/security/brig)
 "kIL" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -61402,19 +61853,31 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "kNq" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/structure/cable,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"kOt" = (
+/obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Visitation"
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "kOK" = (
 /turf/open/space/basic,
 /area/maintenance/port/aft)
+"kOM" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "kPt" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -61684,10 +62147,11 @@
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "kUQ" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/orange,
-/obj/item/restraints/handcuffs,
-/obj/item/reagent_containers/spray/pepper,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "kWn" = (
@@ -61712,8 +62176,21 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "kXk" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "kXs" = (
@@ -61724,15 +62201,22 @@
 /turf/open/floor/plating,
 /area/science/storage)
 "kXv" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+/obj/machinery/plate_press,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/wood,
 /area/security/prison)
+"kYi" = (
+/obj/structure/flora/rock/icy,
+/turf/open/floor/grass,
+/area/security/prison/safe)
 "kZk" = (
 /obj/structure/chair/sofa/corp/right{
 	desc = "Looks like someone threw it out. Covered in donut crumbs.";
@@ -61800,19 +62284,33 @@
 /turf/open/floor/grass,
 /area/science/research)
 "lbt" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/camera{
+	c_tag = "Security Prison - Hydroponics";
+	dir = 8;
+	network = list("ss13","prison")
 	},
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"lbN" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "lcJ" = (
@@ -61857,6 +62355,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms)
+"ldz" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "ldJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -61875,18 +62380,21 @@
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "leJ" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Prison Forestry"
+/obj/item/tank/internals/anesthetic{
+	pixel_x = -3;
+	pixel_y = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/structure/rack,
+/obj/item/tank/internals/anesthetic{
+	pixel_x = 3;
+	pixel_y = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/item/storage/backpack/duffelbag/sec/surgery,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -29
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "lfs" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue{
@@ -61964,6 +62472,31 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"lgX" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "lhv" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -62081,6 +62614,22 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"llO" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "lme" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -62104,6 +62653,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/lab)
+"lnI" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Janitorial"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "lnO" = (
 /obj/structure/light_construct{
 	dir = 1
@@ -62163,33 +62718,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"lqa" = (
-/obj/structure/table/reinforced,
-/obj/item/kitchen/fork/plastic,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"lqc" = (
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
-"lqc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	id_tag = "prisonereducation";
-	name = "Prisoner Education Chamber";
-	req_access_txt = "3"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "lqU" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -62334,6 +62869,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/storage)
+"ltq" = (
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of a colour coded cell bock. This is an orange cell.";
+	name = "Cell - Orange"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "ltA" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Firing Range";
@@ -62620,19 +63164,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "lDT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/holohoop{
-	dir = 8
+/obj/structure/closet/crate/hydroponics{
+	name = "raw produce"
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Yard";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "lEV" = (
 /obj/structure/cable,
@@ -62655,14 +63190,22 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "lFH" = (
-/obj/structure/window,
-/obj/effect/decal/cleanable/food/flour,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/closed/wall/r_wall,
+/area/space)
+"lFU" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "lGi" = (
 /obj/structure/sign/warning/securearea,
 /obj/structure/disposalpipe/segment{
@@ -62820,6 +63363,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "lLu" = (
@@ -62991,6 +63537,28 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lPv" = (
+/obj/structure/rack,
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = -6
+	},
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = -6
+	},
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating,
+/area/security/prison)
 "lPE" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -63013,6 +63581,38 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"lPV" = (
+/obj/machinery/door/airlock/security/glass{
+	desc = "The red door means be scared that you're here. Unless you're the person in red.";
+	name = "Prison";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"lQo" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "lQr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -63226,6 +63826,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"lZx" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lZV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63246,9 +63852,12 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "mcb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "mcg" = (
@@ -63307,6 +63916,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"mde" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "mdx" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Service Maintenance";
@@ -63360,11 +63976,11 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "meC" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/structure/chair/sofa{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/wood,
 /area/security/prison)
 "meE" = (
 /obj/machinery/airalarm{
@@ -63426,6 +64042,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"mfA" = (
+/obj/structure/table,
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "mfN" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -63526,6 +64149,19 @@
 "mjT" = (
 /turf/closed/wall,
 /area/medical/psychology)
+"mkN" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "mla" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63547,15 +64183,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "mlG" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood,
+/area/security/prison)
 "mmb" = (
 /obj/structure/fluff/broken_flooring{
 	icon_state = "singular"
@@ -63625,10 +64256,9 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "mnI" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/obj/structure/table/wood/poker,
+/obj/item/flashlight/glowstick/red,
+/turf/open/floor/wood,
 /area/security/prison)
 "mnS" = (
 /obj/item/poster/random_contraband,
@@ -63710,26 +64340,20 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"mqn" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "mqo" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "maintwarehouse"
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
+"mqI" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Dining Area"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "mqJ" = (
 /obj/structure/chair{
 	name = "Judge"
@@ -63957,13 +64581,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"mzr" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bottle/ammonia,
+"mzb" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"mzr" = (
+/obj/structure/chair/sofa/right{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "mzv" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -64151,6 +64779,20 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard)
+"mFC" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"mFF" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "mGc" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -64304,14 +64946,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"mKK" = (
-/obj/machinery/vending/sustenance,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "mKO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -64356,6 +64990,25 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"mMx" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/hydroseeds,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "mMD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -64403,6 +65056,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"mNm" = (
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "mNW" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
@@ -64419,6 +65078,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"mOP" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "mPb" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 8
@@ -64462,6 +65134,13 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms)
+"mPV" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison/safe)
 "mQh" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 4
@@ -64600,6 +65279,14 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine,
 /area/crew_quarters/heads/hor)
+"mVm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "mVt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -64627,6 +65314,10 @@
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plasteel/white,
 /area/medical/abandoned)
+"mWc" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "mWg" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -64650,16 +65341,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"mYf" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Sanitarium";
-	req_access_txt = "2"
+"mXj" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"mYf" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 29
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"mYy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/grass,
 /area/security/prison)
 "mYP" = (
 /obj/machinery/door/window/northleft{
@@ -64936,11 +65640,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "niI" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "Security Blast Door"
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "niJ" = (
@@ -64996,12 +65699,16 @@
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "nkV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -29
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "nla" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65228,6 +65935,12 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"nvp" = (
+/obj/structure/sign/poster/official/obey{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nvq" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -65411,11 +66124,15 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "nCo" = (
-/obj/structure/bed,
-/obj/item/bedsheet/red,
-/obj/effect/landmark/start/prisoner,
+/obj/structure/closet/crate,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
 /turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
+/area/security/execution/education)
 "nCQ" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -65591,12 +66308,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "nHC" = (
-/obj/structure/table,
-/obj/item/storage/box/prisoner{
-	pixel_y = 8
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
 	},
-/obj/item/storage/box/prisoner,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/security/prison)
 "nHL" = (
 /obj/structure/cable,
@@ -65690,10 +66409,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "nKb" = (
-/obj/structure/cable,
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/turf/closed/wall,
+/area/security/prison/safe)
 "nKc" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow{
@@ -65795,24 +66512,13 @@
 /turf/closed/wall,
 /area/medical/surgery/room_b)
 "nMg" = (
-/obj/machinery/light/small,
-/obj/machinery/camera{
-	c_tag = "Security - EVA Storage";
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "nMl" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -65903,6 +66609,21 @@
 	dir = 1
 	},
 /area/engine/atmos)
+"nNE" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/item/bedsheet/green,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "nOc" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
@@ -66017,6 +66738,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "nPS" = (
@@ -66173,18 +66898,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"nUQ" = (
-/obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/servingdish,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "nUW" = (
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 8
@@ -66197,6 +66910,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
+"nVC" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nVM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66324,28 +67050,20 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "oah" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/button/flasher{
-	id = "IsolationFlash";
-	pixel_x = -23;
-	pixel_y = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"oaq" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
+"oaq" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison/safe)
 "obg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -66635,6 +67353,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"okb" = (
+/obj/structure/table,
+/obj/machinery/light,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "okg" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /turf/open/floor/plasteel/dark,
@@ -66663,32 +67386,20 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "okP" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/dropper,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"omh" = (
-/obj/structure/toilet/greyscale{
-	dir = 8
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
+/area/security/prison)
+"omh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/carpet,
 /area/security/prison/safe)
 "omn" = (
 /obj/machinery/door/firedoor,
@@ -66815,10 +67526,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "orL" = (
-/obj/machinery/biogenerator,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -66836,6 +67545,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"osC" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "osT" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;47"
@@ -66929,27 +67647,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ovf" = (
-/obj/structure/table,
-/obj/item/clothing/under/rank/prisoner/skirt{
-	pixel_x = -13;
-	pixel_y = 5
-	},
-/obj/item/clothing/under/rank/prisoner/skirt{
-	pixel_x = 9;
-	pixel_y = 5
-	},
-/obj/item/clothing/under/rank/prisoner{
-	pixel_x = -2;
-	pixel_y = 5
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ovj" = (
 /turf/closed/wall,
@@ -67005,6 +67705,32 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"ovZ" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/structure/sink{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "owh" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -67073,6 +67799,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"ozf" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "ozg" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -67123,12 +67865,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"oAL" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/shovel/spade,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/security/prison)
 "oBd" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -67183,10 +67919,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "oCL" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Visitation";
-	req_access_txt = "2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -67194,8 +67926,11 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/airlock/security/glass{
+	name = "Security E.V.A. Storage";
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "oCQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -67209,6 +67944,16 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"oDd" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "oDq" = (
 /obj/structure/table,
 /obj/item/training_toolbox,
@@ -67296,6 +68041,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"oFq" = (
+/obj/structure/table,
+/obj/machinery/computer/libraryconsole{
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "oFC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -67305,18 +68057,33 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"oFQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera{
-	c_tag = "Prison Workshop";
-	dir = 8;
-	network = list("ss13","prison")
+"oFJ" = (
+/obj/structure/table,
+/obj/item/stack/license_plates/empty/fifty{
+	pixel_x = -3;
+	pixel_y = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/item/stack/license_plates/empty/fifty{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel,
+/obj/item/stack/license_plates/empty/fifty{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stack/license_plates/empty/fifty{
+	pixel_x = -3
+	},
+/obj/item/stack/license_plates/empty/fifty{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/wood,
 /area/security/prison)
+"oGr" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
+/area/security/prison/safe)
 "oGL" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -67334,20 +68101,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"oGS" = (
-/obj/machinery/plate_press,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "oGU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
+/area/security/brig)
+"oGY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
 /area/security/prison)
 "oHc" = (
 /obj/machinery/door/firedoor,
@@ -67392,6 +68162,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"oHU" = (
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "oHZ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction,
@@ -67421,6 +68199,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/storage)
+"oJl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "oJt" = (
 /obj/structure/table,
 /obj/machinery/newscaster/security_unit{
@@ -67534,17 +68321,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "oMJ" = (
-/obj/machinery/door/airlock{
-	name = "Prison Showers"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 9
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/wood,
 /area/security/prison)
 "oMO" = (
 /obj/structure/disposalpipe/segment{
@@ -67706,6 +68486,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"oSj" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "oSx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -67786,6 +68577,21 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"oUY" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "oVx" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/med_data/laptop{
@@ -67880,17 +68686,17 @@
 /turf/open/floor/plating,
 /area/maintenance/space_hut)
 "oXP" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "justice gas pump"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "oXZ" = (
 /obj/item/pen,
 /obj/structure/table/reinforced,
@@ -67933,15 +68739,11 @@
 /turf/open/floor/plating,
 /area/maintenance/space_hut)
 "oYd" = (
-/obj/machinery/flasher{
-	id = "visitorflash";
-	pixel_y = 28
+/obj/machinery/door/airlock/grunge{
+	name = "Kitchen"
 	},
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/trimline/red/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "oYv" = (
 /obj/effect/turf_decal/loading_area/white{
@@ -68240,6 +69042,11 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
+"pfF" = (
+/obj/structure/table,
+/obj/item/poster/random_contraband,
+/turf/open/floor/plating,
+/area/security/prison)
 "pgl" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/structure/cable,
@@ -68301,17 +69108,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"piK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/light_switch{
-	pixel_y = 26
+"pie" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"pih" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"piK" = (
+/obj/machinery/plate_press,
+/turf/open/floor/wood,
 /area/security/prison)
 "piM" = (
 /obj/machinery/power/solar{
@@ -68343,6 +69157,25 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"pkw" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
+	},
+/obj/machinery/door/airlock/security/glass{
+	desc = "The red door means be scared that you're here. Unless you're the person in red.";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "plu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68399,10 +69232,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pna" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/camera{
+	c_tag = "Security Prison - Workroom";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "pnz" = (
 /obj/structure/cable,
@@ -68469,9 +69307,13 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "poG" = (
-/obj/machinery/suit_storage_unit/security_peacekeeper,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "poP" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/table/wood,
@@ -68516,14 +69358,21 @@
 /obj/structure/window/plasma/reinforced/spawner/west,
 /turf/open/space/basic,
 /area/space/nearstation)
-"pqo" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "Security Blast Door"
+"ppT" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
 	},
-/obj/effect/turf_decal/delivery,
+/turf/open/floor/plating,
+/area/security/prison)
+"pqo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "pqy" = (
@@ -68626,24 +69475,13 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "puC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/smartfridge,
+/turf/closed/wall,
 /area/security/prison)
 "puI" = (
-/obj/item/soap/nanotrasen,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/freezer,
+/obj/structure/closet/crate/freezer,
+/obj/structure/cable,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "puQ" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -68770,6 +69608,22 @@
 /obj/item/stack/sheet/glass,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"pyA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "pzj" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -68778,28 +69632,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "pAv" = (
-/obj/structure/table,
-/obj/structure/window,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/item/book/manual/chef_recipes,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/obj/structure/rack,
+/turf/open/floor/plating,
 /area/security/prison)
 "pAA" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -68930,6 +69764,10 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "pDY" = (
@@ -68969,6 +69807,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"pFi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "pFV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
@@ -69012,6 +69857,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
+"pHv" = (
+/obj/machinery/flasher{
+	id = "justiceflash";
+	name = "mounted justice flash";
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "pHS" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -69246,12 +70102,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "pOv" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "Security Blast Door"
-	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "pOP" = (
@@ -69395,17 +70249,31 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"pVK" = (
-/obj/machinery/flasher{
-	id = "justiceflash";
-	name = "mounted justice flash";
-	pixel_x = 28
+"pVl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"pVK" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/prison)
 "pWt" = (
 /obj/item/seeds/watermelon,
 /obj/machinery/hydroponics/soil{
@@ -69469,6 +70337,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"pXZ" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
+	},
+/obj/machinery/door/airlock/security/glass{
+	desc = "The red door means be scared that you're here. Unless you're the person in red.";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "pYm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -69556,6 +70441,10 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"qaU" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/security/prison)
 "qby" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -69564,19 +70453,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"qbz" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
 "qbF" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -69915,6 +70791,39 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"qkT" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "qls" = (
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 4
@@ -70000,40 +70909,25 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qoj" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/grass,
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "qok" = (
-/obj/machinery/seed_extractor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table/wood/poker,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/prison)
 "qoz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "qoF" = (
-/obj/machinery/button/flasher{
-	id = "visitorflash";
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/button/door{
-	id = "visitation";
-	name = "Visitation Shutters";
-	pixel_x = 6;
-	pixel_y = 25;
-	req_access_txt = "2"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/suit_storage_unit/security_peacekeeper,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "qpc" = (
@@ -70077,6 +70971,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"qqv" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "qrp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -70219,6 +71121,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"qtp" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "qtr" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -70232,11 +71146,16 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "qtH" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -70460,16 +71379,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qzo" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/structure/loom,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/prison)
 "qzD" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -70634,42 +71549,23 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "qCa" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/safe)
-"qCh" = (
-/obj/structure/cable,
-/obj/structure/table,
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
+/obj/structure/table/wood/poker,
+/obj/item/storage/pill_bottle/dice{
 	pixel_y = 4
-	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = -8
-	},
-/obj/item/clothing/under/rank/prisoner{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
+/area/security/prison)
+"qCh" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "qCy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -70715,6 +71611,24 @@
 	},
 /turf/open/floor/circuit/green,
 /area/science/nanite)
+"qDV" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Security Prison - Janitorial";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "qEk" = (
 /obj/structure/table,
 /obj/item/clothing/suit/cyborg_suit,
@@ -70739,6 +71653,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qEV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "qEW" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -70802,9 +71721,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "qFF" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/structure/cable,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "qFQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -70965,20 +71889,14 @@
 /turf/open/floor/engine/cult,
 /area/library)
 "qLm" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/grass,
 /area/security/prison)
 "qLA" = (
 /obj/structure/chair/office{
@@ -71054,12 +71972,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"qPp" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "qPL" = (
 /obj/machinery/pinpointer_dispenser,
 /turf/closed/wall,
@@ -71113,19 +72025,17 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "qQr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/door/airlock/public/glass{
+	name = "Hydroponics"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "qQw" = (
 /obj/structure/cable,
@@ -71237,6 +72147,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qTq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "qTL" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/item/food/grown/banana,
@@ -71427,6 +72346,15 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"qZY" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "rac" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -71465,13 +72393,14 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "raW" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/prison)
 "rbo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -71484,17 +72413,26 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "rbG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/grass,
+/area/security/prison)
+"rbN" = (
+/obj/structure/chair/sofa/corp/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "rch" = (
-/turf/closed/wall/mineral/plastitanium,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "rcj" = (
 /obj/structure/rack,
@@ -71555,23 +72493,19 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "rdt" = (
-/obj/machinery/button/door{
-	id = "prisonereducation";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -25;
-	specialfunctions = 4
+/obj/machinery/door/airlock/grunge{
+	name = "Clubroom"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/prison/safe)
 "rdB" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -71636,6 +72570,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/cytology)
+"reR" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "reY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -71792,8 +72734,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "rjm" = (
-/obj/structure/cable,
-/turf/open/floor/plasteel/white,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "rjI" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -71812,6 +72756,15 @@
 /obj/effect/landmark/start/geneticist,
 /turf/open/floor/plasteel/dark,
 /area/science/genetics)
+"rjT" = (
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of the green cell block";
+	name = "Cell - Green"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "rjV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -71837,11 +72790,25 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "rkf" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "rlb" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -71901,6 +72868,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
+"rmB" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "rmM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -71951,6 +72926,14 @@
 	},
 /turf/open/floor/circuit/green,
 /area/science/nanite)
+"rnO" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "rok" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -72004,6 +72987,17 @@
 	},
 /turf/open/floor/engine,
 /area/science/cytology)
+"rpn" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "rpD" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -72173,6 +73167,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"rvC" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "rvS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -72261,16 +73277,33 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/storage)
+"ryy" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/obj/item/toy/cards/deck,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "ryK" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "rzm" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
@@ -72484,6 +73517,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"rIA" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bossofthisprisongym";
+	name = "Private Area"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "rID" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -72647,13 +73687,8 @@
 	},
 /area/science/lab)
 "rQw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/freezer,
+/obj/structure/bookcase/manuals/engineering,
+/turf/open/floor/wood,
 /area/security/prison)
 "rQQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -72888,6 +73923,15 @@
 /obj/effect/turf_decal/siding,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"rXx" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rXB" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -73004,14 +74048,19 @@
 /turf/open/floor/engine,
 /area/science/cytology)
 "scn" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "visitation";
-	name = "Visitation Shutters"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/security_peacekeeper,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "scp" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -73033,6 +74082,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"scM" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "scO" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "toxinsaccess";
@@ -73103,20 +74158,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/dark,
 /area/science/storage)
-"sdT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/camera{
-	c_tag = "Prison Cafeteria";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/item/food/energybar,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "sdU" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -73243,6 +74284,10 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"skX" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "skY" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
@@ -73770,6 +74815,11 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"sAM" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "sAT" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -73839,6 +74889,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"sCi" = (
+/obj/machinery/button/door{
+	id = "bossofthisprisongym";
+	name = "Private Area";
+	pixel_x = -24;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "sCv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -73859,6 +74918,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"sDo" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "sDs" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -73943,6 +75008,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"sEO" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "sFe" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck Control";
@@ -73976,6 +75056,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
+"sHQ" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "sIi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -73986,12 +75078,25 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery/room_b)
 "sIk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "sIA" = (
 /obj/machinery/door/airlock/external{
 	name = "Transport Airlock"
@@ -74028,6 +75133,35 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"sJC" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"sKi" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/table,
+/obj/item/toy/cards/deck,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "sKL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -74231,6 +75365,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"sRL" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "sSr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -74323,24 +75466,6 @@
 /obj/item/bedsheet,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"sVR" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Cafeteria"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "sWX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chemistry Maintenance";
@@ -74348,6 +75473,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"sXa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"sXY" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "sYA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -74575,6 +75709,21 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard)
+"tfa" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown1";
+	name = "Lockdown"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"tfh" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "tfA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -74661,14 +75810,23 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tiy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "tiC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -74734,16 +75892,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/customs)
-"tlJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "tmp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -74792,6 +75940,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"tnY" = (
+/obj/machinery/camera{
+	c_tag = "Security Space - Prison West";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/space/basic,
+/area/space)
 "toP" = (
 /obj/structure/rack,
 /obj/item/stock_parts/matter_bin,
@@ -74868,11 +76024,19 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "trJ" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/security/prison)
+/obj/machinery/door/airlock/grunge{
+	name = "Arcade"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/safe)
 "trV" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -75010,14 +76174,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/storage)
 "tua" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "tuq" = (
 /obj/machinery/computer/security/labor{
@@ -75254,6 +76418,10 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"tCV" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "tCZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -75382,22 +76550,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tGb" = (
-/obj/machinery/button/door{
-	id = "PermaLockdown";
-	name = "Panic Button";
-	pixel_x = -1;
-	pixel_y = -24;
-	req_access_txt = "2"
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "tGe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -75428,6 +76589,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"tIB" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tIK" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -75620,14 +76787,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "tMX" = (
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "tNa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -75690,13 +76850,26 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "tOw" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"tOX" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -75817,12 +76990,25 @@
 	},
 /area/maintenance/port/aft)
 "tSU" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 10
+	},
+/obj/machinery/button/door{
+	id = "InterrogationLock1";
+	name = "Interrogation Lock";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/execution/education";
+	dir = 1;
+	name = "Prisoner Education Chamber APC";
+	pixel_y = 24
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "tTw" = (
 /obj/structure/chair/stool,
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
@@ -75852,17 +77038,8 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "tUX" = (
-/obj/structure/table,
-/obj/item/storage/box/hug{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/razor{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/turf/closed/wall/r_wall,
+/area/security/prison/safe)
 "tVd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -75878,6 +77055,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/cytology)
+"tVi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "tWl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
@@ -75953,6 +77134,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"tZh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "uax" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -76085,6 +77270,12 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"ueF" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "ueU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -76128,7 +77319,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/cytology)
 "ufC" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ufL" = (
@@ -76205,6 +77396,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"uja" = (
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "ujz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -76242,6 +77439,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ukT" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ulq" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
@@ -76381,9 +77585,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "urv" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "urx" = (
 /obj/machinery/door/firedoor,
@@ -76745,6 +77959,17 @@
 "uCb" = (
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"uCH" = (
+/obj/structure/chair/sofa/corp/left,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "uDx" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -77009,6 +78234,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"uKX" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "uKY" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -77133,16 +78372,67 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"uOy" = (
-/obj/machinery/door/airlock/security{
-	id_tag = "IsolationCell";
-	name = "Isolation Cell";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+"uOv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"uOy" = (
+/obj/structure/table,
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	dir = 4;
+	name = "old sink";
+	pixel_x = -12
+	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"uOW" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"uPd" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/toy/cards/deck,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/item/poster/random_contraband,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
+"uPm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "uPM" = (
 /obj/structure/sign/painting/library{
@@ -77179,6 +78469,18 @@
 /obj/item/storage/box/lethalshot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"uQs" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/sign/poster/official/obey{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "uRe" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -77221,6 +78523,10 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"uRJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
 "uRM" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -77368,17 +78674,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "uYG" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/security/prison)
+"uYJ" = (
+/obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "uYL" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -77556,13 +78859,39 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"vfF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
+"vfs" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
+"vfF" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"vfY" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "vgd" = (
 /obj/item/taperecorder,
@@ -77596,6 +78925,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "vhW" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "viE" = (
@@ -77643,6 +78983,19 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"viV" = (
+/obj/structure/rack,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "vja" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -77673,6 +79026,22 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"vjw" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/effect/landmark/start/prisoner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "vjA" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -77783,12 +79152,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "voJ" = (
-/obj/machinery/vending/cola/red,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/processor,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "voK" = (
 /obj/structure/cable,
@@ -77811,6 +79176,16 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/storage_shared)
+"vpK" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vpX" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -77835,6 +79210,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"vqD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/execution/education)
 "vrx" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue,
@@ -77879,22 +79258,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "vrL" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+/obj/machinery/door/airlock/grunge{
+	name = "Kitchen"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "vrW" = (
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
 "vrY" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "vso" = (
 /obj/machinery/atmospherics/pipe/manifold/dark/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -78013,6 +79388,22 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"vxb" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/machinery/camera{
+	c_tag = "Security Prison - South Hallway";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vxU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -78022,6 +79413,20 @@
 	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"vyb" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "vyv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78041,10 +79446,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"vyz" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vyS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/storage_shared)
+"vzg" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "vzC" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -78150,6 +79571,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"vAQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "vBx" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm{
@@ -78173,6 +79601,12 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"vBW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vCd" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/glass/bucket,
@@ -78312,8 +79746,16 @@
 	},
 /area/engine/storage_shared)
 "vFX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "vGs" = (
@@ -78417,12 +79859,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "vLo" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "SecLocker";
+	name = "Security Lockers Shutters"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison)
 "vLs" = (
 /obj/structure/disposalpipe/segment,
@@ -78465,6 +79908,14 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"vMn" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "vMD" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "roboticsprivacy2";
@@ -78618,12 +80069,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "vSn" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/space)
 "vST" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
@@ -78719,25 +80166,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
-"vVl" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
+"vVf" = (
+/obj/machinery/door/window/brigdoor{
+	name = "Justice Chamber";
+	req_access_txt = "3"
 	},
-/obj/structure/cable,
-/obj/machinery/light_switch{
-	pixel_y = 26
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Justice Chamber";
+	req_access_txt = "3"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "vVt" = (
-/obj/structure/table,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "vVC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -78761,13 +80208,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "vVP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/space)
 "vWu" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
@@ -79032,6 +80477,19 @@
 	},
 /turf/open/floor/plating,
 /area/science/genetics)
+"wgz" = (
+/obj/machinery/button/door{
+	id = "bossofthisprisongym";
+	name = "Private Area";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "wgD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -79117,16 +80575,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "wih" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -29
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/space)
 "wij" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -79144,12 +80597,13 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "wiy" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plasteel/freezer,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "wiD" = (
 /obj/structure/cable,
@@ -79174,16 +80628,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
-"wiZ" = (
-/obj/machinery/door/airlock/external{
-	name = "Security External Airlock";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "wjF" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/delivery,
@@ -79284,6 +80728,10 @@
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wnY" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/security/prison/safe)
 "woe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -79376,22 +80824,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "wqm" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/curtain{
+	alpha = 240;
+	color = "#454545";
+	name = "Changing Room"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "wqM" = (
 /obj/machinery/camera{
 	c_tag = "Science Hallway - Admin";
@@ -79428,6 +80867,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"wrH" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "wrO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
@@ -79682,6 +81130,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"wAQ" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "wBb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -79797,25 +81256,19 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "wGf" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "PermaLockdown";
-	name = "Lockdown Shutters"
-	},
 /obj/structure/cable,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permaouter";
-	name = "Permabrig Transfer";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
+"wGl" = (
+/obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "wGC" = (
 /obj/structure/window/reinforced{
@@ -79901,13 +81354,10 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "wIK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
+/obj/structure/chair/comfy/brown{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/security/prison)
 "wJc" = (
 /obj/structure/window/reinforced{
@@ -79917,6 +81367,12 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"wJE" = (
+/obj/machinery/light/small,
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/security/prison)
 "wKj" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -80126,6 +81582,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
+"wPr" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown1";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "wPP" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/purple,
@@ -80191,6 +81663,16 @@
 "wQA" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"wQJ" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "wQZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -80286,10 +81768,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "wTZ" = (
-/obj/machinery/shower{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/wood,
 /area/security/prison)
 "wVo" = (
 /obj/structure/cable,
@@ -80308,6 +81793,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/abandoned)
+"wVT" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "wWj" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Morgue Maintenance";
@@ -80371,15 +81876,21 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "wYi" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
+/area/security/prison/safe)
 "wYq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"wZt" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/security/prison)
 "wZw" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -80437,12 +81948,9 @@
 /turf/open/floor/engine,
 /area/science/cytology)
 "xbP" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/safe)
 "xcw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -80459,12 +81967,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "xcN" = (
-/obj/docking_port/stationary/random{
-	id = "pod_2_lavaland";
-	name = "lavaland"
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
 	},
-/turf/open/space,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xdj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -80546,15 +82058,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "xeX" = (
-/obj/machinery/door/window/southleft{
-	name = "Permabrig Kitchen"
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/grass,
+/area/security/prison/safe)
 "xfo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
@@ -80667,12 +82177,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
 "xjZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	desc = "The red door means be scared that you're here. Unless you're the person in red.";
+	name = "Prison";
+	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "xke" = (
@@ -80680,6 +82192,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"xkf" = (
+/obj/structure/closet/crate/bin,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/pen/fourcolor,
+/obj/item/pen/fountain,
+/obj/item/toy/cards/deck,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/security/prison)
 "xlr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -80713,16 +82238,16 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "xlT" = (
-/obj/structure/chair/stool,
-/obj/machinery/camera{
-	c_tag = "Prison Visitation";
-	network = list("ss13","prison")
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
 	},
-/obj/effect/turf_decal/trimline/red/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xmf" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
@@ -80746,6 +82271,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"xmP" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "xnx" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -80813,14 +82355,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "xoR" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/prison)
 "xoZ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -80948,9 +82483,7 @@
 /turf/open/floor/wood,
 /area/library)
 "xsq" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "xsx" = (
 /obj/effect/turf_decal/stripes/line,
@@ -81000,16 +82533,18 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/central)
 "xuw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/sparker{
+	id = "executionburn";
+	pixel_x = -25
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "xuA" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
@@ -81026,6 +82561,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xvN" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Maintenance"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "xwh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -81103,10 +82644,6 @@
 	},
 /turf/open/floor/holofloor/dark,
 /area/science/cytology)
-"xxT" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/security/prison)
 "xxU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -81144,6 +82681,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/cafeteria)
+"xzI" = (
+/obj/machinery/vending/games,
+/turf/open/floor/plating,
+/area/security/prison)
 "xAL" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -81181,10 +82722,19 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "xBL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "xBZ" = (
 /obj/effect/turf_decal/trimline/purple/line{
@@ -81325,6 +82875,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"xGt" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xHb" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -81387,6 +82946,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"xHE" = (
+/obj/structure/curtain,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "xHK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -81481,29 +83044,40 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xKw" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
+/obj/machinery/smartfridge/food,
+/turf/closed/wall,
 /area/security/prison)
 "xKx" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
 "xKy" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Prison Workshop"
+/obj/machinery/plate_press,
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/prison)
+"xLw" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/structure/chair/comfy{
+	color = "#e8a768";
+	name = "orange comfy chair"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "xLF" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -81675,15 +83249,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "xRq" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/white,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "xSd" = (
 /obj/structure/table,
@@ -81712,6 +83280,24 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"xSR" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/education)
 "xSU" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room";
@@ -81793,6 +83379,11 @@
 "xVl" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"xVB" = (
+/obj/item/bedsheet/rd/royal_cape,
+/obj/structure/bed/pod,
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison/safe)
 "xWw" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -81880,18 +83471,11 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "xXB" = (
-/obj/machinery/hydroponics/soil,
-/obj/machinery/camera{
-	c_tag = "Prison Forestry";
-	dir = 4;
-	network = list("ss13","prison")
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Two"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/security/prison)
+/turf/open/floor/plasteel,
+/area/space)
 "xXL" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -82058,24 +83642,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "ybE" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/item/plant_analyzer,
-/turf/open/floor/grass,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison)
 "ybN" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/closed/wall/r_wall,
+/area/security/execution/education)
 "ycH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -82083,6 +83657,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"ydh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "ydn" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -82165,11 +83746,9 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "yes" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
+/obj/machinery/light/small,
 /obj/structure/cable,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/prison)
 "yeM" = (
 /obj/structure/disposalpipe/segment,
@@ -82180,12 +83759,12 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "yfg" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "yfG" = (
 /obj/machinery/computer/arcade/orion_trail{
 	desc = "For gamers only. Casuals need not apply.";
@@ -82270,6 +83849,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"yii" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "yiz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -82294,18 +83878,8 @@
 /turf/open/floor/holofloor/dark,
 /area/science/cytology)
 "ykb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "PermaLockdown";
-	name = "Lockdown Shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/security/prison)
+/turf/open/floor/grass,
+/area/security/prison/safe)
 "ykk" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/disks_nanite{
@@ -82336,16 +83910,15 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "ylH" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/door/poddoor{
+	id = "SecJusticeChamber";
+	name = "Justice Vent"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/execution/education)
 
 (1,1,1) = {"
 aaa
@@ -100394,17 +101967,17 @@ aaa
 aaa
 aaa
 aaa
-lMJ
 aaa
 aaa
 aaa
-vrW
 aaa
 aaa
-lMJ
 aaa
-lMJ
-vrW
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100651,19 +102224,19 @@ aaa
 aaa
 aaa
 aaa
-lMJ
 aaa
 aaa
 aaa
-vrW
 aaa
 aaa
-aep
-aep
-aep
-aax
-aax
-aax
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aak
 aaa
@@ -100902,25 +102475,25 @@ aaa
 aaa
 aaa
 aaa
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-vrW
-lMJ
-aep
-aep
-xbP
-ybE
-xXB
-oAL
-aax
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aak
 aaa
@@ -101159,25 +102732,25 @@ aaa
 aaa
 aaa
 aaa
-lMJ
-aaa
-lMJ
 aaa
 aaa
 aaa
-lMJ
 aaa
 aaa
 aaa
-vrW
 aaa
-aep
-orL
-gBC
-aNL
-kvf
-aST
-aax
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aak
 aak
@@ -101413,29 +102986,29 @@ aaa
 aaa
 aaa
 aaa
-lMJ
-lMJ
-lMJ
-lMJ
 aaa
-vrW
-vrW
-vrW
-vrW
-vrW
-lMJ
-lMJ
-lMJ
-vrW
-lMJ
-aep
-qok
-adh
-adh
-aaw
-meC
-aax
-aax
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -101670,29 +103243,29 @@ aaa
 aaa
 aaa
 aaa
-lMJ
-aaa
-aaa
-vrW
-vrW
-vrW
-aaa
-lMJ
-aaa
-vrW
 aaa
 aaa
 aaa
-vrW
 aaa
-aax
-dFK
-tOw
-dgX
-vSn
-meC
-trJ
-aax
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 vrW
 vrW
 lMJ
@@ -101927,29 +103500,29 @@ aaa
 aaa
 aaa
 aaa
-lMJ
 aaa
 aaa
-vrW
 aaa
-lMJ
 aaa
-aax
-aep
-alP
-alP
-alP
-aax
-alP
-aax
-aax
-abe
-xxT
-xxT
-iyN
-aVG
-qoj
-aep
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaj
 aav
@@ -102175,6 +103748,12 @@ aaa
 aaa
 aaa
 aaa
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
 aaa
 aaa
 aaa
@@ -102182,32 +103761,26 @@ aaa
 aaa
 aaa
 aaa
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
 aaa
-aaa
-lMJ
-aaa
-vrW
-vrW
-aaa
-aep
-aep
-aax
-ajn
-abe
-asn
-fmr
-lFH
-mKK
-sdT
-nUQ
-nUQ
-lqa
-xxT
-vVl
+nYJ
 ybN
-oAL
-aep
-aaa
+ybN
+ybN
+ybN
+ybN
+ybN
+ybN
+ybN
+ybN
+ybN
+ybN
 vrW
 aav
 aaa
@@ -102430,48 +104003,48 @@ aaa
 aaa
 aaa
 aaa
+lMJ
+aaa
+aaa
+lMJ
+aaa
+aaa
+lMJ
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+tnY
 aaa
 aaa
+lMJ
 aaa
 aaa
 aaa
 lMJ
-lMJ
-vrW
 aaa
 aaa
-aep
-adG
-agN
-aaw
-abe
-aso
-aaZ
-xeX
-aaZ
-aaZ
+aaa
+aaf
+ylH
 abM
 xuw
 bkx
-abe
-aep
+vqD
+iOx
 leJ
-agH
+hYJ
 aeJ
-aeJ
-aeJ
-aeJ
-aeJ
-aeJ
+ybN
+aaa
+aaa
+aaa
+aaa
 lMJ
 aaa
-aaf
+aaa
 aio
 ajl
 akr
@@ -102686,49 +104259,49 @@ aaa
 aaa
 aaa
 aaa
+fwb
+fwb
+fwb
 aaa
+aox
+aox
+aox
+aox
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-lMJ
-aaa
-vrW
-lMJ
 aax
 aax
-aeS
-adh
-aaw
-abe
-atL
-gfP
-pAv
-voJ
+wGf
+ybE
+klc
+aax
+aax
+aaa
+aox
+aox
+aox
+aox
+aox
+aaa
+aaa
+aaa
+aaf
 ylH
 hNd
 jik
 guu
-aep
+vVf
 abx
 abV
-agH
+xSR
 eWu
-aeg
-agH
-eWu
-aeg
-aeJ
+ybN
 aaa
 aaa
-aaf
+aaa
+aaa
+lMJ
+aaa
+aaa
 aio
 aio
 aks
@@ -102944,48 +104517,48 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
+lMJ
 aaa
 aaa
+lMJ
 aaa
+aax
+pAv
+aeQ
+aNL
+ppT
+aeQ
+aax
 aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
 lMJ
 aaa
-vrW
 aaa
-aep
-aaq
-aeT
-adh
-ajp
-abe
-abe
-aep
-abe
-abe
-gNS
+aaa
+aaf
+ylH
 acg
-jik
+pHv
 vVt
-abe
+vqD
 aby
 abX
-agH
+jBE
 nCo
-aeh
-agH
-nCo
-aeh
-aeJ
+ybN
+aaa
+aaa
+aaa
+aaa
 lMJ
-aaf
-aaf
+aaa
+aaa
 aaf
 aio
 aio
@@ -103201,48 +104774,48 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+lMJ
+lMJ
 lMJ
 aaa
-vrW
 aaa
-aep
-aaw
-aeU
-agO
-aaw
-aaq
-vrL
-yfg
-fgU
+aax
+aax
+aax
 abe
 abe
-sVR
+fmr
 abe
-abe
-abe
+aeQ
+aax
+aax
+aax
+aaa
+aaa
+aaa
+aax
+aax
+aax
+aax
+aax
+ybN
+ybN
+ybN
+ybN
+ybN
 abz
-abX
-agH
+hYR
+hzn
 afJ
-acX
-agH
-afJ
-aei
-aeJ
-aeJ
-aaa
-aaa
+ybN
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
 aaf
 aaf
 aaf
@@ -103458,49 +105031,49 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 lMJ
-lMJ
-vrW
-lMJ
+aaa
+aaa
 aax
-aaz
-aeW
-agP
-agO
-adh
+gfP
+meC
+qoj
+xoR
+gFy
+abe
+aeQ
+aeQ
+cXa
+tUX
+tUX
+tUX
+tUX
+tUX
 fPR
 rjm
 jEO
 ilo
-pna
+abe
 qzo
 pna
-pna
-pna
+oFJ
+ybN
 tSU
 oXP
 cBe
 yfg
-qzo
-ady
-yfg
-qzo
-xKw
-aeJ
-aeJ
-aeJ
-aeJ
+ybN
+aaa
+aaa
+aaa
+aaa
+lMJ
+aaa
+aaa
+lMJ
 aaa
 aaa
 dne
@@ -103712,54 +105285,54 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fwb
 aaa
 aaa
 lMJ
 aaa
-vrW
 aaa
 aax
-abK
+aax
+aax
+aax
+gxF
+mlG
+qok
+wIK
+gFy
+hOS
+aeQ
+aeQ
+aeQ
+nKb
 afa
 ahu
 akz
-ani
+nKb
 kGE
 xoR
 acZ
 uYG
-xoR
+abe
 kXv
+wrH
 xoR
-xoR
-xoR
-uYG
-adS
+ybN
+ybN
+ybN
 ejE
-xoR
-adS
-adq
-adN
-aej
-aeO
-afJ
-nCo
-eWu
-aeJ
+ybN
+ybN
+aaa
+aaa
+aaa
+aaa
 lMJ
+aaa
+aaa
 lMJ
+aaa
+aaa
 aip
 aoh
 dnP
@@ -103968,53 +105541,53 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+fwb
+lMJ
+lMJ
+lMJ
+lMJ
+ady
+aax
+aeQ
+aso
+abe
+gAf
+mnI
+qCa
+wIK
+yes
+nKb
+nKb
+aeU
+nKb
+nKb
+afd
+ahv
+aaw
+nKb
+oFq
+dyN
+oMJ
+xoR
+abe
+xKy
+uPm
+xoR
+agH
+aeQ
+aax
+kOM
+xsq
+aax
 aaa
 aaa
 aaa
 aaa
 lMJ
 aaa
-vrW
 aaa
-aep
-adh
-afd
-ahv
-aaw
-adr
-abe
-abe
-oMJ
-abe
-abe
-xKy
-abe
-abe
-agH
-agH
-agH
-agH
-xsq
-adh
-adr
-pgX
-aem
-aeN
-afG
-agG
-qCa
-aeJ
+lMJ
 aaa
 aaa
 dne
@@ -104226,52 +105799,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fwb
 aaa
 aaa
 lMJ
 aaa
-vrW
 aaa
-aep
-acK
-afM
-abf
-ahw
-anj
+klc
+aeS
+atL
 abe
+gBC
+mzr
+qCh
+xoR
+gFy
+nKb
+uPd
+oDd
+vjw
+nKb
+nKb
+abf
+nKb
+nKb
+gWy
 wTZ
 rQw
-wTZ
+xoR
 abe
 piK
 fBP
-oGS
-agH
+xoR
+aax
 ibL
-abZ
+aax
 acq
-aaw
-adh
-ads
-adO
-ael
-aeM
-agH
-agH
-agH
-aeJ
+aax
+aax
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
 lMJ
 lMJ
 dne
@@ -104482,56 +106055,56 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+fwb
 lMJ
 lMJ
-vrW
+lMJ
+lMJ
 lMJ
 aax
-aax
+aeT
+aNL
+fmr
+gFy
+gFy
+qFF
+gFy
+gFy
+nKb
+eDk
+vMn
+uKX
+rjT
 afU
 ahz
 alN
-aoj
+abe
 abe
 fJX
-puI
-keM
 abe
-jbB
+abe
+abe
+abe
 kyr
-hlB
-agH
-jib
-mzr
-agH
+abe
+aax
+aax
+aax
+kDT
 acE
-adb
-fos
-htR
-aem
-eqf
-afI
-agG
-qCa
-aeJ
+aax
+aaa
+aaa
 aaa
 aaa
 lMJ
+aaa
+lMJ
+aaa
+aaa
+aaa
+aaa
 dne
 apC
 doe
@@ -104740,55 +106313,55 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fwb
 aaa
 aaa
 lMJ
 aaa
-vrW
-vrW
-vrW
+aaa
 aax
-aax
-aiv
-alO
-aom
+aeQ
+aeQ
 abe
+xoR
+mYf
+raW
+xoR
+xoR
+nKb
+nKb
+nKb
+nKb
+nKb
+rXx
 wiy
-qbz
-jsA
-abe
 tMX
-oFQ
-oGS
-agH
+aom
+tMX
+wiy
+tMX
+tMX
+hDG
+tMX
+wiy
+tMX
+aax
 abD
-iGJ
-agH
-acF
-nkV
-adt
-alL
-ilm
-aeO
-afJ
-nCo
-omh
-aeJ
+wqm
+pyA
+ufC
+aax
+aaa
+aaa
+aaa
+aaa
 lMJ
+aaa
 lMJ
-lMJ
+aaa
+aaa
+aaa
+aaa
 dne
 awS
 aRG
@@ -105000,52 +106573,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 lMJ
 aaa
 aaa
-aaa
-lMJ
-aaa
 aax
+aeQ
+aeQ
+nKb
+nKb
+nKb
+rdt
+nKb
+nKb
+nKb
+afa
+hHZ
+lFU
+rjT
+oSj
+sXY
+fos
+hjg
+acv
+tOw
+fos
+uOW
+xlT
+fos
+hwW
+fae
 aax
-aax
-aax
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
+abe
+abe
+iKp
 acI
-adc
-vVP
-alL
-ilm
-aeP
-agH
-agH
-agH
-aeJ
-aep
-aep
 aax
+aaa
+aaa
+aaa
+aaa
+lMJ
+aaa
+lMJ
+aaa
+aaa
+aaa
+aaa
 aio
 dne
 dne
@@ -105252,57 +106825,57 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fwb
 aaa
 aaa
 aaa
 aaa
 lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-aaf
-kHF
-epU
-gAf
-aaA
-aaG
-aaP
-wih
-abn
+aaa
+tUX
+tUX
+aeU
+nKb
+nKb
+hgv
+nkV
+rkf
+wYi
+ykb
+nKb
+xmP
+rmB
+nNE
+nKb
+rXx
+wiy
+fst
+abe
+abe
+abe
+abe
+abe
+abe
+abe
+abe
+abe
+aax
 eII
 wqm
-acv
-acH
-adc
-vVP
-adR
-fjy
-aeQ
-iUh
-agI
-fML
-xRq
-fML
-jNH
-fgU
+pyA
+ufC
+aax
+aaa
+aaa
+aaa
+aaa
+lMJ
+aaa
+lMJ
+aaa
+aaa
+aaa
+aaa
 aio
 aol
 anb
@@ -105508,58 +107081,58 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+lMJ
+fwb
+lMJ
+aox
+lMJ
+lMJ
+lMJ
+lMJ
+tUX
+ael
+afG
+aST
+nKb
+hlB
+nMg
+ryK
+xbP
+wnY
+nKb
+nKb
+nKb
+nKb
+nKb
+sHQ
+wiy
+ukT
+abe
+uja
 kHF
-oaq
-aay
-aaB
-aaH
-aaQ
+abe
 aba
-abo
-abF
-aca
-acv
-acI
-add
-vVP
-hFX
-aen
-gxF
-kNq
-gxF
-gxF
-raW
-yes
-mnI
-wYi
+aba
+aba
+aba
+aba
+aax
+abe
+abe
+llO
+ufC
+aax
+aaa
+aaa
+aaa
+aaa
+lMJ
+aaa
+lMJ
+aaa
+aaa
+aaa
+aaa
 aio
 aol
 apD
@@ -105766,56 +107339,56 @@ aaa
 aaa
 aaa
 aaa
+fwb
+aaa
+aox
 aaa
 aaa
+lMJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-kHF
-tiy
+tUX
+abo
+afI
+aVG
+nKb
+hoA
+oah
+rkf
+xbP
+aHz
+nKb
+djs
+eRX
+jUi
+abe
+vyz
+nVC
+hNt
+xHE
+kBa
+skX
+abe
 pVK
 aaC
 aaI
 rbG
 abb
-dXp
+aax
 abG
 acb
-acv
-acJ
-lDT
-adw
-cEm
+mkN
+ufC
+aax
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
 ajm
 ajm
 ajm
 ajm
-ajm
-oYd
-aep
-hgv
 ajm
 ajm
 ajm
@@ -106025,55 +107598,55 @@ aaa
 aaa
 aaa
 aaa
+aox
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tUX
+tUX
+tUX
+tUX
+nKb
+afN
+nKb
+nKb
+htR
+oaq
+sIk
+wYi
+ykb
+nKb
+mOP
+sJC
+lbN
+abe
+iev
+wPr
+tfa
+abe
+uja
+kHF
+abe
+mMx
+mYy
+itB
+aaS
+abc
+aax
+sDo
+xsq
+iGI
+ufC
+aax
 aaa
 aaa
 aaa
 aaa
 lMJ
-acv
-acv
-acv
-acv
-acv
-acv
-aaS
-abc
-rdt
-acv
-acv
-acv
-aax
-aax
-ykb
-wGf
-ajm
-poG
-afN
-gFy
+aaa
 ajm
 air
 scn
-akt
-ajm
+vFX
+ahx
 and
 aon
 vsp
@@ -106279,55 +107852,55 @@ aaa
 aaa
 aaa
 aaa
+fwb
 aaa
 aaa
+aox
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tUX
+abn
+adc
+adG
+nKb
+afO
+cEm
+nKb
+hFX
+omh
+tiy
+xbP
+oGr
+nKb
+dkF
+qZY
+qDV
+abe
+tMX
+wiy
+nvp
+abe
+abe
+hOS
+abe
+eEe
+aaE
+oJl
+aaT
+ewR
+aax
+wQJ
+xsq
+iGI
+ufC
+aax
 aaa
 aaa
 aaa
 aaa
 lMJ
 aaa
-aaf
-aax
-eEe
-aaE
-acv
-aaT
-ewR
-abq
-acv
-mqn
-iGI
-acL
-aep
-adx
-ryK
 ajm
 avk
-afO
-nMg
-ahx
-xlT
 vFX
 kqk
 ahx
@@ -106535,55 +108108,55 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nYJ
+fwb
+lMJ
+lMJ
+aox
+lMJ
+tUX
+abo
+add
+adN
+aem
+afP
+dgX
+nKb
+hJU
+hJU
+sIk
+xeX
+kYi
+nKb
+ozf
+qZY
+dzM
+abe
+igb
+wiy
+tMX
+abe
+aeQ
+aeQ
+abe
+lbt
+qLm
+qTq
+aaT
+oUY
+aax
+abJ
+okP
+iGI
+ufC
+aax
 aaa
 aaa
 aaa
 aaa
 lMJ
 aaa
-aaf
-alP
-lbt
-qLm
-acv
-acv
-acv
-lqc
-abJ
-okP
-gON
-jgM
-mYf
-wIK
-puC
 ajm
-poG
-afP
-gFy
-ahx
 qoF
 kXk
 gvA
@@ -106793,56 +108366,56 @@ aaa
 aaa
 aaa
 aaa
+fwb
 aaa
 aaa
+aox
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-lMJ
-aaa
-aaf
-aax
-jNJ
-ftV
-qQr
-uOy
-oah
-rkf
+tUX
+nKb
+nKb
+nKb
+nKb
+afT
+dgX
+nKb
+nKb
+nKb
+trJ
+nKb
+nKb
+nKb
 abe
+lnI
+abe
+abe
+eOS
+wiy
+tMX
+abe
+abe
+abe
+abe
+abe
+abe
+qQr
+abe
+abe
+aax
+aax
 ace
-acx
+iGI
 acM
-aep
-klc
-tGb
+aax
+ajm
+aiq
+aiq
+aiq
+aiq
+ajm
 ajm
 ajm
 ahx
-agJ
-ahx
-aiq
-aiq
 oCL
 ahx
 elv
@@ -107050,56 +108623,56 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fwb
 aaa
 aaa
 aox
-ack
-aox
+aaa
+aaG
+abq
+adq
+abe
+aen
+afT
+dgX
+tMX
+tMX
+orL
+tua
+tMX
+tMX
+tMX
+hDG
+tMX
+gzR
+aom
+tMX
+wiy
+tMX
+aom
+iBd
+hDG
 rch
-aax
-aax
+tMX
+tIB
 urv
-urv
+pih
 gzR
 klc
-abe
-aep
-aep
-aep
-aep
-ovf
-tua
-wIK
-mlG
+fio
+aci
+iGI
+iiE
+pXZ
+gkc
+mPb
+mPb
+mPb
 niI
-iAW
+qqb
 pDj
 gkc
-vrY
+mPb
 uYj
 mPb
 sUw
@@ -107307,54 +108880,54 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fwb
 aaa
 aaa
 aox
 aaa
-aaa
-aaa
-aaa
-wOY
+aaP
+abF
+ads
+adO
+kFl
+agG
+dFK
+hTp
+ilm
+ovf
+tGb
+hTp
+hTp
+hTp
+hTp
+hTp
+hTp
+mFF
+qEV
+aet
+dop
+mFF
+hTp
+hTp
+hTp
+ilm
+hTp
 kxJ
-aax
+hTp
 hTp
 xjZ
 qtH
 kFl
-kFl
+rpn
 kUQ
 nHC
-qCh
-hTp
-ryK
-aiq
-pOv
+rSz
+pFi
 iAW
-aiq
+iAW
+pOv
+yii
+ieA
 rSz
 iAW
 rHf
@@ -107564,51 +109137,51 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fwb
 aaa
 aaa
 aox
+aaa
+aaG
+abZ
+adt
+abe
+aeM
+agI
+dXp
+fos
+fos
+fos
+tOw
+xlT
+cSL
+uOW
+vBW
+fos
+jlm
+hjg
+fos
+sAM
+dJH
+hjg
 xcN
-aaa
-aaa
-aaa
-abu
+sEO
+vxb
+tOX
+xcN
 xBL
 iND
-hTp
-klc
+esF
+ydh
 vhW
-vhW
-vhW
-vhW
-vhW
+cYz
+kEZ
+uOv
+pkw
 oGU
 kIE
-ebw
-hJU
+sYA
+sYA
 pqo
 lLi
 nPH
@@ -107821,52 +109394,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fwb
 aaa
 aaa
 aox
-aaa
-aaa
-aaa
-aaa
-wOY
-kFW
-aax
+aaq
+tUX
 nKb
-tlJ
-eXB
-mcb
-bxE
-mcb
-mcb
-vfF
-vhW
-jYQ
-ajm
+nKb
+nKb
+nKb
 afT
+dgX
+abe
+abe
+oYd
+abe
+abe
+abe
+abe
+gLv
+abe
+abe
+abe
+oHU
+wiy
+xGt
+abe
+abe
+abe
+nKb
+gMt
+nKb
+nKb
+gMt
+nKb
+tUX
+aax
+mcb
+kFl
+ufC
+aax
+ajm
+aiq
+aiq
+aiq
+aiq
 ajm
 ajm
 ahx
@@ -108077,52 +109650,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+fwb
+lMJ
+lMJ
 aox
-aox
-aox
-rch
-aax
-aax
-aax
-aax
+lMJ
+tUX
+aca
+adw
+adR
+aem
+afP
+dgX
+abe
+iyN
+tMX
+uOy
+abe
+uYJ
+wGl
+mWc
+uYJ
+kOt
+abe
+pie
+wiy
+vpK
+abe
+uja
+ajq
+nKb
+qkT
+rvC
+nKb
+qkT
 csO
 tUX
-abe
+abG
 aci
-abe
-qPp
-vhW
-sIk
-hoA
-aep
-ajm
+kFl
+ufC
+aax
+aaa
+aaa
+lMJ
+aaa
 lMJ
 aaa
 ajm
@@ -108335,50 +109908,50 @@ aaa
 aaa
 aaa
 aaa
+fwb
 aaa
 aaa
+aox
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-lMJ
-aaa
-aaa
-aaa
-aaa
-lMJ
-aaa
-aax
-aep
-aep
-aax
-acj
+tUX
+adb
+adx
+aei
+nKb
+agJ
+ebw
 abe
+iUh
+tMX
+vfF
+abe
+rnO
+hHO
+mWc
+cDG
+vyb
+abe
+tMX
+wiy
+xGt
+xHE
+kBa
+skX
+nKb
+vfs
+fmd
+nKb
+vfs
+fmd
+tUX
+wQJ
+xsq
+kFl
 ufC
 vLo
-qFF
-aep
-aep
+aaa
+aaa
+lMJ
 aaa
 lMJ
 aaa
@@ -108595,46 +110168,46 @@ aaa
 aaa
 aaa
 aaa
+aox
+aaa
+tUX
+tUX
+tUX
+tUX
+nKb
+afN
+nKb
+nKb
+jbB
+tMX
+voJ
+abe
+dTP
+vzg
+mWc
+dTP
+vzg
+abe
+aom
+iXK
+aom
+abe
+uja
+kHF
+nKb
+ovZ
+eDi
+nKb
+ovZ
+eDi
+tUX
+sDo
+xsq
+kFl
+tfh
+vLo
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-aaa
-aaa
-aaa
-aaa
-aax
-wiZ
-aax
-aax
-aax
-aep
-aep
 lMJ
 aaa
 lMJ
@@ -108850,46 +110423,46 @@ aaa
 aaa
 aaa
 aaa
+fwb
+aaa
+aox
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-lMJ
-lMJ
-aaf
-aaa
-aaa
-ack
-aaa
-aaa
-aaf
+tUX
+aca
+agN
+epU
+nKb
+jib
+pgX
+tMX
+xKw
+gLy
+gLy
+mWc
+gLy
+ueF
+abe
+tMX
+wiy
+uQs
+nKb
+nKb
+nKb
+nKb
+nKb
+nKb
+nKb
+nKb
+nKb
+tUX
+abJ
+dzv
+mde
+iew
+vLo
 aaa
 aaa
 aaf
@@ -109106,47 +110679,47 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
-aaf
-ack
-aaf
-aaf
-aaf
+lMJ
+fwb
+lMJ
+aox
+lMJ
+lMJ
+lMJ
+lMJ
+tUX
+aeN
+ajn
+aVG
+nKb
+jNH
+tMX
+tMX
+xRq
+gLy
+gLy
+mzb
+jWg
+jWg
+mqI
+tZh
+cUk
+xGt
+nKb
+dUJ
+xLw
+sKi
+nKb
+rbN
+osC
+hAR
+mNm
+aax
+aax
+klc
+lPV
+klc
+aax
 aaf
 lMJ
 lMJ
@@ -109364,46 +110937,46 @@ aaa
 aaa
 aaa
 aaa
+fwb
 aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+tUX
+tUX
+aeU
+nKb
+nKb
+jNJ
+tMX
+tMX
+xRq
+gLy
+gLy
+jOK
+tVi
+tVi
+ccn
+sXa
+eBB
+wAQ
+ltq
+lgX
+lQo
+wVT
+nKb
+uCH
+wZt
+mNm
+hAR
+sRL
+hAR
+mNm
+ldz
+mXj
+aax
 aaa
 aaa
 lMJ
@@ -109626,41 +111199,41 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+tUX
+ajp
+eqf
+nKb
+jYQ
+tMX
+tMX
+xRq
+gLy
+gLy
+mWc
+gLy
+dtd
+abe
+tMX
+wiy
+xGt
+nKb
+nKb
+nKb
+nKb
+nKb
+hAR
+mNm
+hAR
+grj
+ixR
+ftq
+hAR
+iLJ
+hAR
+vLo
 aaa
 aaa
 lMJ
@@ -109880,44 +111453,44 @@ aaa
 aaa
 aaa
 aaa
+fwb
 aaa
 aaa
+lMJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+tUX
+ajp
+ajp
+nKb
+keM
+tMX
+tMX
+abe
+qtp
+kOt
+mWc
+uYJ
+kOt
+abe
+igb
+pVl
+fos
+enA
+fos
+fos
+fSt
+mVm
+cUG
+mVm
+cUG
+oGY
+vAQ
+imi
+mNm
+ldz
+iLJ
+vLo
 aaa
 aaa
 ank
@@ -110136,45 +111709,45 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+nYJ
+fwb
+lMJ
+lMJ
+lMJ
+aox
+lMJ
+tUX
+alL
+eXB
+nKb
+kvf
+poG
+tMX
+abe
+ryy
+qqv
+mWc
+reR
+okb
+abe
+tMX
+tMX
+lZx
+tMX
+tMX
+vfY
+uRJ
+mNm
+hAR
+sRL
+hAR
+mNm
+hAR
+mNm
+hAR
+mNm
+cvf
+vLo
 aaf
 lMJ
 agS
@@ -110394,44 +111967,44 @@ aaa
 aaa
 aaa
 aaa
+fwb
 aaa
 aaa
+lMJ
+aox
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+aeO
+alP
+fgU
+nKb
+abe
+puC
+vrL
+abe
+dTP
+mFC
+mWc
+dTP
+vzg
+abe
+gpI
+iYr
+abe
+abe
+xvN
+abe
+aax
+hAR
+wgz
+ixR
+ftq
+hPf
+gOp
+ixR
+mNm
+gjv
+mfA
+aax
 aaa
 aqa
 agS
@@ -110650,45 +112223,45 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aav
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aav
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+lMJ
+fwb
+lMJ
+lMJ
+lMJ
+aox
+lMJ
+tUX
+alP
+fjy
+ftV
+kNq
+kNq
+vrY
+abe
+abe
+abe
+fmr
+abe
+abe
+abe
+abe
+abe
+abe
+xzI
+aeQ
+xkf
+tUX
+nKb
+rIA
+tUX
+aax
+aax
+aax
+aax
+aax
+aax
+aax
+aax
 aaa
 aiD
 ikn
@@ -110908,36 +112481,36 @@ aaa
 aaa
 aaa
 aaa
+fwb
 aaa
 aaa
+lMJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aac
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aej
+tUX
+tUX
+tUX
+tUX
+lqc
+kNq
+vrY
+abe
+aeQ
+aeQ
+aNL
+aeQ
+dSc
+abe
+aeQ
+aeQ
+hOS
+lPv
+iqf
+qaU
+tUX
+viV
+sCi
+tUX
 aaa
 aaa
 aaa
@@ -111168,33 +112741,33 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
 aaa
+lMJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aax
+lDT
+puI
+kNq
+fmr
+aNL
+aNL
+aNL
+aeQ
+aeQ
+hOS
+ppT
+pfF
+abe
+det
+aeQ
+aeQ
+tUX
+mPV
+xVB
+tUX
 aaa
 aaa
 aaa
@@ -111425,33 +112998,33 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
 aaa
+lMJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aax
+aax
+aax
+aax
+aax
+scM
+aeQ
+aNL
+aeQ
+wJE
+aax
+aax
+aax
+aax
+aax
+tCV
+aax
+tUX
+tUX
+tUX
+tUX
 aaa
 aaa
 aaa
@@ -111680,33 +113253,33 @@ aaa
 aaa
 aaa
 aaa
+aaA
+fwb
+fwb
+fwb
 aaa
 aaa
+lMJ
+aaa
+lMJ
+aaa
+lMJ
+aaa
+aax
+aax
+wGf
+bbV
+klc
+aax
+aax
+aaa
+lMJ
 aaa
 aaa
+lMJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -111939,31 +113512,31 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
 aaa
+lMJ
+aaa
+lMJ
+aaa
+lMJ
+aaa
+aaa
+lMJ
 aaa
 aaa
 aaa
+cso
 aaa
 aaa
+lMJ
 aaa
 aaa
+lMJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -112199,30 +113772,30 @@ aaa
 aaa
 aaa
 aaa
+fwb
+fwb
+nYJ
+fwb
+fwb
+fwb
+fwb
+aaa
+lMJ
 aaa
 aaa
 aaa
+lMJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nYJ
+fwb
+fwb
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
 aaa
 aaa
 aaa
@@ -112457,29 +114030,29 @@ aaa
 aaa
 aaa
 aaa
+lMJ
+aaa
+lMJ
+aaa
+lMJ
+aaa
+aaa
+lMJ
+aaa
+aaa
+aaa
+lMJ
+aaa
+aaa
+lMJ
+aaa
+aaa
+fwb
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -112714,29 +114287,29 @@ aaa
 aaa
 aaa
 aaa
+aox
+aox
+aox
+aox
+aox
+aaa
+fwb
+fwb
+fwb
+nYJ
+fwb
+fwb
+fwb
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aav
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+fwb
+lMJ
+aox
+lMJ
+lMJ
+lMJ
 aaa
 aaa
 aaa
@@ -112971,30 +114544,30 @@ aaa
 aaa
 aaa
 aaa
+lMJ
+aaa
+lMJ
+aaa
+lMJ
+aaa
+aaa
+lMJ
+aaa
+lMJ
+aaa
+lMJ
 aaa
 aaa
 aaa
 aaa
 aaa
+fwb
+aaa
+aox
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aav
 aaa
 aaa
 aaa
@@ -113235,19 +114808,19 @@ aaa
 aaa
 aaa
 aaa
+aox
+aox
+aox
+aox
+aox
 aaa
 aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aox
 aaa
 aaa
 aaa
@@ -113492,19 +115065,19 @@ aaa
 aaa
 aaa
 aaa
+lMJ
+aaa
+lMJ
+aaa
+lMJ
 aaa
 aaa
 aaa
 aaa
 aaa
+fwb
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aox
 aaa
 aaa
 aaa
@@ -130446,14 +132019,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aeP
+aoj
+aeP
+fML
+lFH
+lFH
+lFH
+lFH
 aaa
 aaa
 aaa
@@ -130703,14 +132276,14 @@ aaa
 aaa
 aaa
 aaa
+aeP
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+wOY
+vSn
+lFH
 aaa
 aaa
 aaa
@@ -130960,14 +132533,14 @@ aaa
 aaa
 aaa
 aaa
+aeP
+asn
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abu
+vVP
+xXB
 aaa
 aaa
 aaa
@@ -131217,14 +132790,14 @@ aaa
 aaa
 aaa
 aaa
+aeP
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+wOY
+wih
+lFH
 aaa
 aaa
 aaa
@@ -131474,14 +133047,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aeP
+aeP
+aeP
+fML
+lFH
+lFH
+lFH
+lFH
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -69162,11 +69162,6 @@
 	id = "Prison Gate";
 	name = "Security Blast Door"
 	},
-/obj/machinery/door/airlock/security/glass{
-	desc = "The red door means be scared that you're here. Unless you're the person in red.";
-	name = "Brig";
-	req_access_txt = "63"
-	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
@@ -69174,6 +69169,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "plu" = (
@@ -70342,16 +70341,15 @@
 	id = "Prison Gate";
 	name = "Security Blast Door"
 	},
-/obj/machinery/door/airlock/security/glass{
-	desc = "The red door means be scared that you're here. Unless you're the person in red.";
-	name = "Brig";
-	req_access_txt = "63"
-	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "pYm" = (
@@ -82178,7 +82176,6 @@
 /area/security/checkpoint/science)
 "xjZ" = (
 /obj/machinery/door/airlock/security/glass{
-	desc = "The red door means be scared that you're here. Unless you're the person in red.";
 	name = "Prison";
 	req_access_txt = "63"
 	},

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -1307,8 +1307,8 @@
 /area/security/prison/safe)
 "aeP" = (
 /obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "aeQ" = (
 /turf/open/floor/plating,
 /area/security/prison)
@@ -3908,8 +3908,8 @@
 /area/maintenance/port/fore)
 "aoj" = (
 /obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/security/brig)
 "aol" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel/dark,
@@ -53947,8 +53947,11 @@
 /turf/open/floor/plating,
 /area/engine/storage_shared)
 "fML" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/space)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "fMS" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -63190,8 +63193,14 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "lFH" = (
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/security/brig)
 "lFU" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -80067,8 +80076,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "vSn" = (
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Two"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vST" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
@@ -80205,12 +80217,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"vVP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/space)
 "vWu" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
@@ -80572,12 +80578,6 @@
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"wih" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/space)
 "wij" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -83467,12 +83467,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"xXB" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Two"
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "xXL" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -107375,13 +107369,13 @@ abG
 acb
 mkN
 ufC
-aax
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
+aeP
+aoj
+aoj
+ajm
+ajm
+ajm
+ajm
 ajm
 ajm
 ajm
@@ -107632,13 +107626,13 @@ sDo
 xsq
 iGI
 ufC
-aax
+aeP
 aaa
 aaa
 aaa
 aaa
-lMJ
-aaa
+wOY
+fML
 ajm
 air
 scn
@@ -107889,14 +107883,14 @@ wQJ
 xsq
 iGI
 ufC
-aax
+aeP
+asn
 aaa
 aaa
 aaa
-aaa
-lMJ
-aaa
-ajm
+abu
+fML
+vSn
 avk
 vFX
 kqk
@@ -108146,13 +108140,13 @@ abJ
 okP
 iGI
 ufC
-aax
+aeP
 aaa
 aaa
 aaa
 aaa
-lMJ
-aaa
+wOY
+lFH
 ajm
 qoF
 kXk
@@ -108403,12 +108397,12 @@ aax
 ace
 iGI
 acM
-aax
+aeP
+aoj
+aoj
 ajm
-aiq
-aiq
-aiq
-aiq
+ajm
+ajm
 ajm
 ajm
 ajm
@@ -132016,14 +132010,14 @@ aaa
 aaa
 aaa
 aaa
-aeP
-aoj
-aeP
-fML
-lFH
-lFH
-lFH
-lFH
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -132273,14 +132267,14 @@ aaa
 aaa
 aaa
 aaa
-aeP
 aaa
 aaa
 aaa
 aaa
-wOY
-vSn
-lFH
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -132530,14 +132524,14 @@ aaa
 aaa
 aaa
 aaa
-aeP
-asn
 aaa
 aaa
 aaa
-abu
-vVP
-xXB
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -132787,14 +132781,14 @@ aaa
 aaa
 aaa
 aaa
-aeP
 aaa
 aaa
 aaa
 aaa
-wOY
-wih
-lFH
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -133044,14 +133038,14 @@ aaa
 aaa
 aaa
 aaa
-aeP
-aeP
-aeP
-fML
-lFH
-lFH
-lFH
-lFH
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This ports the prison designs from Oldbase - well, half of them, I got fed up trying to convert the rest of the maps to modern /tg/ from citcode. This PR changes IceBoxStation and Metastation - I did my best to not affect the existing security layout, but sometimes it was just unavoidable, due to my requirement to keep the armory exposed to space.
Icebox Prison:
![image](https://user-images.githubusercontent.com/50649185/106982914-fae0e300-6732-11eb-94e9-c2e05e2633be.png)
Meta Prison:
![image](https://user-images.githubusercontent.com/50649185/106982982-21068300-6733-11eb-9739-4bf707d5ccd6.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The current prison designs are literally made purely to be broken out of, with RP as an afterthought. Considering prisoners aren't supposed to break out without admin approval, that severely hampers any and all reason to actually play prisoner and RP. This half-fixes it, because it changes half the maps.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: IceBox and Metastation have their old prisons again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
