### PR TITLE
Removes capital X KSS from forked tongues

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -81,7 +81,9 @@
 	var/static/regex/lizard_hiss = new("s+", "g")
 	var/static/regex/lizard_hiSS = new("S+", "g")
 	var/static/regex/lizard_kss = new(@"(\w)x", "g")
+	/* // SKYRAT EDIT: REMOVAL
 	var/static/regex/lizard_kSS = new(@"(\w)X", "g")
+	*/
 	var/static/regex/lizard_ecks = new(@"\bx([\-|r|R]|\b)", "g")
 	var/static/regex/lizard_eckS = new(@"\bX([\-|r|R]|\b)", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
@@ -89,7 +91,9 @@
 		message = lizard_hiss.Replace(message, "sss")
 		message = lizard_hiSS.Replace(message, "SSS")
 		message = lizard_kss.Replace(message, "$1kss")
+		/* // SKYRAT EDIT: REMOVAL
 		message = lizard_kSS.Replace(message, "$1KSS")
+		*/
 		message = lizard_ecks.Replace(message, "ecks$1")
 		message = lizard_eckS.Replace(message, "ECKS$1")
 	speech_args[SPEECH_MESSAGE] = message


### PR DESCRIPTION
## About The Pull Request

Removes the capital X going to KSS from the forked tongue hiss, this allows people who have taken the forked tongue to say things like RDX instead of RDKSS. This doesn't affect other hiss modifications of x, so any lower case x's will still continue to come out as kss https://i.gyazo.com/093429aa12ad329b690f33b9d058e469.png

## Why It's Good For The Game

It is quite difficult to read what lizards and other forked tongue users are trying to say when they are trying to speak X's, especially those found in acronyms like RDX. This will improve the overall readability of capital-letter forked tongue speak and has no downsides.

## Changelog
:cl:
del: Removes forked tongue KSS on capital X's
/:cl:

