### PR TITLE
Adds special descs to chameleon items , energy swords(toy and real) , chameleon projector , implanters.

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -14,7 +14,7 @@
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
 	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
-	special_desc = "A projector used to seamlessly camouflage syndicate operatives to camouflage into the background" // Skyrat edit
+	special_desc = "A projector used to seamlessly camouflage syndicate operatives into the background" // Skyrat edit
 	var/can_use = 1
 	var/obj/effect/dummy/chameleon/active_dummy = null
 	var/saved_appearance = null

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -1,5 +1,5 @@
 /obj/item/chameleon
-	name = "chameleon projector"
+	name = "Strange object"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "shield0"
 	flags_1 = CONDUCT_1
@@ -13,6 +13,8 @@
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A projector used to seamlessly camouflage syndicate operatives to camouflage into the background"
 	var/can_use = 1
 	var/obj/effect/dummy/chameleon/active_dummy = null
 	var/saved_appearance = null

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -1,5 +1,5 @@
 /obj/item/chameleon
-	name = "Strange object"
+	name = "Strange object" // Skyrat edit , original was Chameleon projector
 	icon = 'icons/obj/device.dmi'
 	icon_state = "shield0"
 	flags_1 = CONDUCT_1
@@ -13,8 +13,8 @@
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A projector used to seamlessly camouflage syndicate operatives to camouflage into the background"
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "A projector used to seamlessly camouflage syndicate operatives to camouflage into the background" // Skyrat edit
 	var/can_use = 1
 	var/obj/effect/dummy/chameleon/active_dummy = null
 	var/saved_appearance = null

--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -28,6 +28,8 @@
 	resistance_flags = FIRE_PROOF
 	wound_bonus = -10
 	bare_wound_bonus = 20
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY
+	special_desc = "A double bladed energy sword employed by the Syndicate in raids"
 	var/w_class_on = WEIGHT_CLASS_BULKY
 	var/saber_color = "green"
 	var/two_hand_force = 34

--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -28,8 +28,8 @@
 	resistance_flags = FIRE_PROOF
 	wound_bonus = -10
 	bare_wound_bonus = 20
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY
-	special_desc = "A double bladed energy sword employed by the Syndicate in raids"
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY // Skyrat edit
+	special_desc = "A double bladed energy sword employed by the Syndicate in raids" // Skyrat edit
 	var/w_class_on = WEIGHT_CLASS_BULKY
 	var/saber_color = "green"
 	var/two_hand_force = 34

--- a/code/game/objects/items/implants/implant_freedom.dm
+++ b/code/game/objects/items/implants/implant_freedom.dm
@@ -35,8 +35,10 @@ No Implant Specifics"}
 
 
 /obj/item/implanter/freedom
-	name = "implanter (freedom)"
+	name = "implanter" // Skyrat edit , was implanter (freedom)
 	imp_type = /obj/item/implant/freedom
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "A Syndicate implanter used for a freedom implant" // Skyrat edit
 
 /obj/item/implantcase/freedom
 	name = "implant case - 'Freedom'"

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -28,8 +28,8 @@
 /obj/item/implanter/emp
 	name = "implanter" // Skyrat edit, was implanter (EMP)
 	imp_type = /obj/item/implant/emp
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A Syndicate implanter used for a EMP implant"
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "A Syndicate implanter used for a EMP implant" // Skyrat edit
 
 
 //Health Tracker Implant

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -26,8 +26,10 @@
 		qdel(src)
 
 /obj/item/implanter/emp
-	name = "implanter (EMP)"
+	name = "implanter" // Skyrat edit, was implanter (EMP)
 	imp_type = /obj/item/implant/emp
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A Syndicate implanter used for a EMP implant"
 
 
 //Health Tracker Implant
@@ -102,6 +104,8 @@
 	imp_type = /obj/item/implant/radio
 
 /obj/item/implanter/radio/syndicate
-	name = "implanter (internal syndicate radio)"
+	name = "implanter" // Skyrat edit , was originally implanter (internal syndicate radio)
 	imp_type = /obj/item/implant/radio/syndicate
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "A Syndicate implanter used for a internal radio implant" // Skyrat edit
 

--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -4,7 +4,7 @@
 	actions_types = list(/datum/action/item_action/agent_box)
 
 /obj/item/implanter/stealth
-	name = "implanter" // Skyrat edit , was ooriginaly implanter (stealth)
+	name = "implanter" // Skyrat edit , was originaly implanter (stealth)
 	imp_type = /obj/item/implant/stealth
 	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
 	special_desc = "A Syndicate implanter used for a stealth implant" // Skyrat edit

--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -4,8 +4,10 @@
 	actions_types = list(/datum/action/item_action/agent_box)
 
 /obj/item/implanter/stealth
-	name = "implanter (stealth)"
+	name = "implanter" // Skyrat edit , was ooriginaly implanter (stealth)
 	imp_type = /obj/item/implant/stealth
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "A Syndicate implanter used for a stealth implant" // Skyrat edit
 
 //Box Object
 

--- a/code/game/objects/items/implants/implant_storage.dm
+++ b/code/game/objects/items/implants/implant_storage.dm
@@ -36,5 +36,7 @@
 	return ..()
 
 /obj/item/implanter/storage
-	name = "implanter (storage)"
+	name = "implanter" // Skyrat edit , original was implanter (storage)
 	imp_type = /obj/item/implant/storage
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "A Syndicate implanter used for a storage implant" // Skyrat edit

--- a/code/game/objects/items/implants/implantuplink.dm
+++ b/code/game/objects/items/implants/implantuplink.dm
@@ -24,12 +24,16 @@
 		qdel(src)
 
 /obj/item/implanter/uplink
-	name = "implanter (uplink)"
+	name = "implanter" // Skyrat edit , original was implanter (uplink)
 	imp_type = /obj/item/implant/uplink
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "A Syndicate implanter for an uplink" // Skyrat edit
 
 /obj/item/implanter/uplink/precharged
-	name = "implanter (precharged uplink)"
+	name = "implanter" // Skyrat edit , original waws implanter (precharged uplink)
 	imp_type = /obj/item/implant/uplink/precharged
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "A Syndicate implanter for a precharged uplink" // Skyrat edit
 
 /obj/item/implant/uplink/precharged
 	starting_tc = TELECRYSTALS_PRELOADED_IMPLANT

--- a/code/game/objects/items/implants/implantuplink.dm
+++ b/code/game/objects/items/implants/implantuplink.dm
@@ -30,7 +30,7 @@
 	special_desc = "A Syndicate implanter for an uplink" // Skyrat edit
 
 /obj/item/implanter/uplink/precharged
-	name = "implanter" // Skyrat edit , original waws implanter (precharged uplink)
+	name = "implanter" // Skyrat edit , original was implanter (precharged uplink)
 	imp_type = /obj/item/implant/uplink/precharged
 	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
 	special_desc = "A Syndicate implanter for a precharged uplink" // Skyrat edit

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -104,7 +104,7 @@
 	embedding = list("embed_chance" = 75, "impact_pain_mult" = 10)
 	armour_penetration = 35
 	block_chance = 50
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY // Skyrat edit
 	special_desc = "A energy sword employed by syndicate operatives" // Skyrat edit 
 
 /obj/item/melee/transforming/energy/sword/transform_weapon(mob/living/user, supress_message_text)

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -104,6 +104,8 @@
 	embedding = list("embed_chance" = 75, "impact_pain_mult" = 10)
 	armour_penetration = 35
 	block_chance = 50
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A energy sword employed by syndicate operatives"
 
 /obj/item/melee/transforming/energy/sword/transform_weapon(mob/living/user, supress_message_text)
 	. = ..()

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -104,8 +104,8 @@
 	embedding = list("embed_chance" = 75, "impact_pain_mult" = 10)
 	armour_penetration = 35
 	block_chance = 50
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A energy sword employed by syndicate operatives"
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "A energy sword employed by syndicate operatives" // Skyrat edit 
 
 /obj/item/melee/transforming/energy/sword/transform_weapon(mob/living/user, supress_message_text)
 	. = ..()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -315,15 +315,15 @@
  * Toy swords
  */
 /obj/item/toy/sword
-	name = "energy sword"
-	desc = "May the force be with you."
+	name = "energy sword" // Skyrat edit , was Toy Sword
+	desc = "May the force be with you." // Skyrat edit
 	icon = 'icons/obj/transforming_energy.dmi'
 	icon_state = "sword0"
 	inhand_icon_state = "sword0"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY
-	special_desc = "A cheap imitation of an energy sword"
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY // Skyrat edit
+	special_desc = "A cheap imitation of an energy sword" // Skyrat edit
 	var/active = 0
 	w_class = WEIGHT_CLASS_SMALL
 	attack_verb_continuous = list("attacks", "strikes", "hits")

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -315,13 +315,15 @@
  * Toy swords
  */
 /obj/item/toy/sword
-	name = "toy sword"
-	desc = "A cheap, plastic replica of an energy sword. Realistic sounds! Ages 8 and up."
+	name = "energy sword"
+	desc = "May the force be with you."
 	icon = 'icons/obj/transforming_energy.dmi'
 	icon_state = "sword0"
 	inhand_icon_state = "sword0"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY
+	special_desc = "A cheap imitation of an energy sword"
 	var/active = 0
 	w_class = WEIGHT_CLASS_SMALL
 	attack_verb_continuous = list("attacks", "strikes", "hits")
@@ -444,8 +446,8 @@
  * Subtype of Double-Bladed Energy Swords
  */
 /obj/item/dualsaber/toy
-	name = "double-bladed toy sword"
-	desc = "A cheap, plastic replica of TWO energy swords.  Double the fun!"
+	name = "double-bladed energy sword"
+	desc = "Handle with care!"
 	force = 0
 	throwforce = 0
 	throw_speed = 3
@@ -453,6 +455,8 @@
 	two_hand_force = 0
 	attack_verb_continuous = list("attacks", "strikes", "hits")
 	attack_verb_simple = list("attack", "strike", "hit")
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY
+	special_desc = "A imitation of an double-bladed energy sword"
 
 /obj/item/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	return 0

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -446,8 +446,8 @@
  * Subtype of Double-Bladed Energy Swords
  */
 /obj/item/dualsaber/toy
-	name = "double-bladed energy sword"
-	desc = "Handle with care!"
+	name = "double-bladed energy sword" // Skyrat edit , was double-bladed toy sword
+	desc = "Handle with care!" // Skyrat edit
 	force = 0
 	throwforce = 0
 	throw_speed = 3
@@ -455,8 +455,8 @@
 	two_hand_force = 0
 	attack_verb_continuous = list("attacks", "strikes", "hits")
 	attack_verb_simple = list("attack", "strike", "hit")
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY
-	special_desc = "A imitation of an double-bladed energy sword"
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY //  Skyrat edit
+	special_desc = "A imitation of an double-bladed energy sword" // Skyrat edit
 
 /obj/item/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	return 0

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -303,8 +303,8 @@
 	random_sensor = FALSE
 	resistance_flags = NONE
 	can_adjust = FALSE
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A chameleon jumpsuit employed by the Syndicate in infiltration operations."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "A chameleon jumpsuit employed by the Syndicate in infiltration operations." // Skyrat edit
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
@@ -335,8 +335,8 @@
 	blood_overlay_type = "armor"
 	resistance_flags = NONE
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A chameleon vest employed by the Syndicate in infiltration operations."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit 
+	special_desc = "A chameleon vest employed by the Syndicate in infiltration operations." // Skyrat edit
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -365,8 +365,8 @@
 	inhand_icon_state = "meson"
 	resistance_flags = NONE
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "Chameleon glasses employed by the Syndicate in infiltration operations."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "Chameleon glasses employed by the Syndicate in infiltration operations." // Skyrat edit
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -393,8 +393,8 @@
 	name = "insulated gloves"
 	icon_state = "yellow"
 	inhand_icon_state = "ygloves"
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A pair of chameleon gloves employed by the Syndicate in infiltration operations."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "A pair of chameleon gloves employed by the Syndicate in infiltration operations." // Skyrat edit
 
 	resistance_flags = NONE
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
@@ -477,8 +477,8 @@
 	permeability_coefficient = 0.01
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
 	w_class = WEIGHT_CLASS_SMALL
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A chameleon mask employed by the Syndicate in infiltration operations."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "A chameleon mask employed by the Syndicate in infiltration operations." // Skyrat edit
 
 	var/voice_change = 1 ///This determines if the voice changer is on or off.
 
@@ -533,8 +533,8 @@
 	resistance_flags = NONE
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A pair of chameleon shoes employed by the Syndicate in infiltration operations."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
+	special_desc = "A pair of chameleon shoes employed by the Syndicate in infiltration operations." // Skyrat edit
 
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
@@ -559,8 +559,8 @@
 	desc = "A pair of black shoes."
 	clothing_flags = NOSLIP
 	can_be_bloody = FALSE
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A pair of chameleon shoes with an anti-slip coating employed by the Syndicate in infiltration operations."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE  // Skyrat edit
+	special_desc = "A pair of chameleon shoes with an anti-slip coating employed by the Syndicate in infiltration operations."  // Skyrat edit
 
 
 /obj/item/clothing/shoes/chameleon/noslip/broken/Initialize()
@@ -569,8 +569,8 @@
 
 /obj/item/storage/backpack/chameleon
 	name = "backpack"
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A chameleon backpack employed by the Syndicate in infiltration operations."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE  // Skyrat edit
+	special_desc = "A chameleon backpack employed by the Syndicate in infiltration operations."  // Skyrat edit
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -594,8 +594,8 @@
 /obj/item/storage/belt/chameleon
 	name = "toolbelt"
 	desc = "Holds tools."
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A chameleon belt employed by the Syndicate in infiltration operations."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE  // Skyrat edit
+	special_desc = "A chameleon belt employed by the Syndicate in infiltration operations."  // Skyrat edit
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -624,8 +624,8 @@
 
 /obj/item/radio/headset/chameleon
 	name = "radio headset"
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A chameleon headset employed by the Syndicate in infiltration operations."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE  // Skyrat edit
+	special_desc = "A chameleon headset employed by the Syndicate in infiltration operations."  // Skyrat edit
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -689,8 +689,8 @@
 	resistance_flags = NONE
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 	w_class = WEIGHT_CLASS_SMALL
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A chameleon tie employed by the Syndicate in infiltration operations."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE  // Skyrat edit
+	special_desc = "A chameleon tie employed by the Syndicate in infiltration operations."  // Skyrat edit
 
 
 /obj/item/clothing/neck/chameleon

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -303,6 +303,8 @@
 	random_sensor = FALSE
 	resistance_flags = NONE
 	can_adjust = FALSE
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A chameleon jumpsuit employed by the Syndicate in infiltration operations."
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
@@ -333,6 +335,8 @@
 	blood_overlay_type = "armor"
 	resistance_flags = NONE
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A chameleon vest employed by the Syndicate in infiltration operations."
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -361,6 +365,8 @@
 	inhand_icon_state = "meson"
 	resistance_flags = NONE
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "Chameleon glasses employed by the Syndicate in infiltration operations."
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -387,6 +393,8 @@
 	name = "insulated gloves"
 	icon_state = "yellow"
 	inhand_icon_state = "ygloves"
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A pair of chameleon gloves employed by the Syndicate in infiltration operations."
 
 	resistance_flags = NONE
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
@@ -415,6 +423,8 @@
 	name = "grey cap"
 	desc = "It's a baseball hat in a tasteful grey colour."
 	icon_state = "greysoft"
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A chameleon hat employed by the Syndicate in infiltration operations."
 
 	resistance_flags = NONE
 	armor = list(MELEE = 5, BULLET = 5, LASER = 5, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
@@ -467,6 +477,8 @@
 	permeability_coefficient = 0.01
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
 	w_class = WEIGHT_CLASS_SMALL
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A chameleon mask employed by the Syndicate in infiltration operations."
 
 	var/voice_change = 1 ///This determines if the voice changer is on or off.
 
@@ -521,6 +533,9 @@
 	resistance_flags = NONE
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A pair of chameleon shoes employed by the Syndicate in infiltration operations."
+
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -544,6 +559,9 @@
 	desc = "A pair of black shoes."
 	clothing_flags = NOSLIP
 	can_be_bloody = FALSE
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A pair of chameleon shoes with an anti-slip coating employed by the Syndicate in infiltration operations."
+
 
 /obj/item/clothing/shoes/chameleon/noslip/broken/Initialize()
 	. = ..()
@@ -551,6 +569,9 @@
 
 /obj/item/storage/backpack/chameleon
 	name = "backpack"
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A chameleon backpack employed by the Syndicate in infiltration operations."
+
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
 /obj/item/storage/backpack/chameleon/Initialize()
@@ -573,6 +594,9 @@
 /obj/item/storage/belt/chameleon
 	name = "toolbelt"
 	desc = "Holds tools."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A chameleon belt employed by the Syndicate in infiltration operations."
+
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
 /obj/item/storage/belt/chameleon/Initialize()
@@ -600,6 +624,9 @@
 
 /obj/item/radio/headset/chameleon
 	name = "radio headset"
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A chameleon headset employed by the Syndicate in infiltration operations."
+
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
 /obj/item/radio/headset/chameleon/Initialize()
@@ -662,6 +689,9 @@
 	resistance_flags = NONE
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 	w_class = WEIGHT_CLASS_SMALL
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A chameleon tie employed by the Syndicate in infiltration operations."
+
 
 /obj/item/clothing/neck/chameleon
 	var/datum/action/item_action/chameleon/change/chameleon_action

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -478,7 +478,7 @@
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
 	w_class = WEIGHT_CLASS_SMALL
 	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
-	special_desc = "A chameleon mask employed by the Syndicate in infiltration operations." // Skyrat edit
+	special_desc = "A chameleon mask employed by the Syndicate in infiltration operations, frequently used to mimic the voice of other crewmembers using fake id's." // Skyrat edit
 
 	var/voice_change = 1 ///This determines if the voice changer is on or off.
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -194,6 +194,9 @@
 /*
  * Sleepypens
  */
+/obj/item/pen/sleepy 
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE  // Skyrat edit
+	special_desc = "A Armour piercing syringe concealed in a pen , used by the Syndicate in covert operations."  // Skyrat edit
 
 /obj/item/pen/sleepy/attack(mob/living/M, mob/user)
 	if(!istype(M))

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -220,8 +220,8 @@
 	attack_verb_continuous = list("slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts") //these won't show up if the pen is off
 	attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
-	special_desc = "A concealed energy dagger , used by the Syndicate in covert operations."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE  // Skyrat edit
+	special_desc = "A concealed energy dagger , used by the Syndicate in covert operations."  // Skyrat edit
 	var/on = FALSE
 
 /obj/item/pen/edagger/ComponentInitialize()

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -220,6 +220,8 @@
 	attack_verb_continuous = list("slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts") //these won't show up if the pen is off
 	attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A concealed energy dagger , used by the Syndicate in covert operations."
 	var/on = FALSE
 
 /obj/item/pen/edagger/ComponentInitialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds special descs to chameleon clothing , energy swords (toy and real) , special desc for the cameleon projector and implanters
Implanter no longer tell you what they had in them by default , energy swords are no longer distinguishable ,  chameleon projector is now a Strange object like the ones that can be found in maint 
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Security officers can no longer use "but it was  the items description!" as a way to metagame what should be stealthy traitor items


## Changelog
add: Special descriptions for chameleon clothing , energy swords (toy and real) , chameleon projector  and implanters
tweak : Tweaked the  item descriptions and names to no longer include the implant names

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
