### PR TITLE
More stealth descriptions

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -392,6 +392,8 @@
 	light_system = MOVABLE_LIGHT
 
 /obj/item/flashlight/emp
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // SKYRAT EDIT
+	special_desc = "This flashlight is equipped with a miniature EMP generator." //SKYRAT EDIT
 	var/emp_max_charges = 4
 	var/emp_cur_charges = 4
 	var/charge_timer = 0

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -69,6 +69,8 @@ effective or pretty fucking useless.
 */
 
 /obj/item/healthanalyzer/rad_laser
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // SKYRAT EDIT
+	special_desc = "This syndicate-modified health analyzer will can emit delayed bursts of radiation to those it scans." //SKYRAT EDIT
 	custom_materials = list(/datum/material/iron=400)
 	var/irradiate = TRUE
 	var/stealth = FALSE

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -70,7 +70,7 @@ effective or pretty fucking useless.
 
 /obj/item/healthanalyzer/rad_laser
 	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // SKYRAT EDIT
-	special_desc = "This syndicate-modified health analyzer will can emit delayed bursts of radiation to those it scans." //SKYRAT EDIT
+	special_desc = "This syndicate-modified health analyzer can emit delayed bursts of radiation to those it scans." //SKYRAT EDIT
 	custom_materials = list(/datum/material/iron=400)
 	var/irradiate = TRUE
 	var/stealth = FALSE

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -350,7 +350,8 @@
 	overheat = FALSE
 
 /obj/item/assembly/flash/hypnotic
-	desc = "A modified flash device, programmed to emit a sequence of subliminal flashes that can send a vulnerable target into a hypnotic trance."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // SKYRAT EDIT
+	special_desc = "A modified flash device, programmed to emit a sequence of subliminal flashes that can send a vulnerable target into a hypnotic trance." //SKYRAT EDIT
 	flashing_overlay = "flash-hypno"
 	light_color = LIGHT_COLOR_PINK
 	cooldown = 20

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -388,6 +388,8 @@
 /obj/item/clothing/glasses/thermal/syndi	//These are now a traitor item, concealed as mesons.	-Pete
 	name = "chameleon thermals"
 	desc = "A pair of thermal optic goggles with an onboard chameleon generator."
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // SKYRAT EDIT
+	special_desc = "Chameleon thermal goggles employed by the Syndicate in infiltration operations." //SKYRAT EDIT, I don't think the regular description persists through chameleon changes.
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -100,7 +100,7 @@
 	can_flashlight = FALSE
 	max_mod_capacity = 0
 	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY //  SKYRAT EDIT
-	special_desc = "A syndicate weapon employed by infiltrators and assassins. Quietly shoots poison tipped darts which stun and slur the speech of its victims."
+	special_desc = "A syndicate weapon employed by infiltrators and assassins. Quietly shoots poison tipped darts which stun and slur the speech of its victims." //SKYRAT EDIT
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow/halloween
 	name = "candy corn crossbow"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -84,8 +84,8 @@
 	ammo_x_offset = 2
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow
-	name = "mini energy crossbow"
-	desc = "A weapon favored by syndicate stealth specialists."
+	name = "foam force crossbow" //SKYRAT EDIT, was mini energy crossbow
+	desc = "A weapon favored by many overactive children. Ages 8 and up." //SKYRAT EDIT
 	icon_state = "crossbow"
 	inhand_icon_state = "crossbow"
 	w_class = WEIGHT_CLASS_SMALL
@@ -99,6 +99,8 @@
 	unique_frequency = TRUE
 	can_flashlight = FALSE
 	max_mod_capacity = 0
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY //  SKYRAT EDIT
+	special_desc = "A syndicate weapon employed by infiltrators and assassins. Quietly shoots poison tipped darts which stun and slur the speech of its victims."
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow/halloween
 	name = "candy corn crossbow"


### PR DESCRIPTION
## About The Pull Request

Companion to #3136
Adds some syndicate descriptions to a few lookalike devices. Namely, the hypnotic flash, the microlaser health analyzer, the EMP flashlight, and thermals.
Makes the mini crossbow look more like a toy.

## Why It's Good For The Game

Doing Spess Jesus's work.

## Changelog
:cl: YakumoChen
tweak: Hypno flashes, radioactive microlasers, EMP flashlights, and Thermal goggles will hold up less to scrutiny by those who can discern Syndicate lookalikes.
tweak: Mini energy crossbows have been remodeled to look more like toys. Or maybe Donksoft crossbows look more like the real thing?
/:cl: