### PR TITLE
stealthy AI hacked law board with its own PR because controversy

### DIFF
--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -464,8 +464,12 @@ AI MODULES
 /******************** Hacked AI Module ******************/
 
 /obj/item/ai_module/syndicate // This one doesn't inherit from ion boards because it doesn't call ..() in transmitInstructions. ~Miauw
-	name = "Hacked AI Module"
-	desc = "An AI Module for hacking additional laws to an AI."
+	name = "modified circuit board" //SKYRAT EDIT, was 'hacked law module'. 
+	desc = "A suspicious looking, modified circuit board." //SKYRAT EDIT, previously "An AI Module for hacking additional laws to an AI."
+	special_desc_requirement = EXAMINE_CHECK_JOB EXAMINE_CHECK_FACTION //SKYRAT EDIT
+	special_desc_jobs = list(Captain, Research Director, Scientist, Roboticist) //SKYRAT EDIT, only those familiar with AIs can tell what it really is
+	special_desc_faction = list(Syndicate) //SKYRAT EDIT, Bypasses Detective check
+	special_desc = "This appears to actually be an AI Module for hacking additional laws to an AI." //SKYRAT EDIT
 	laws = list("")
 
 /obj/item/ai_module/syndicate/attack_self(mob/user)

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -466,7 +466,7 @@ AI MODULES
 /obj/item/ai_module/syndicate // This one doesn't inherit from ion boards because it doesn't call ..() in transmitInstructions. ~Miauw
 	name = "modified circuit board" //SKYRAT EDIT, was 'hacked law module'. 
 	desc = "A suspicious looking, modified circuit board." //SKYRAT EDIT, previously "An AI Module for hacking additional laws to an AI."
-	special_desc_requirement = EXAMINE_CHECK_JOB, EXAMINE_CHECK_FACTION //SKYRAT EDIT
+	special_desc_requirement = EXAMINE_CHECK_JOB; EXAMINE_CHECK_FACTION //SKYRAT EDIT
 	special_desc_jobs = list(Captain, Research Director, Scientist, Roboticist) //SKYRAT EDIT, only those familiar with AIs can tell what it really is
 	special_desc_faction = list(Syndicate) //SKYRAT EDIT, Bypasses Detective check
 	special_desc = "This appears to actually be an AI Module for hacking additional laws to an AI." //SKYRAT EDIT

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -467,7 +467,7 @@ AI MODULES
 	name = "modified circuit board" //SKYRAT EDIT, was 'hacked law module'. 
 	desc = "A suspicious looking, modified circuit board." //SKYRAT EDIT, previously "An AI Module for hacking additional laws to an AI."
 	special_desc_requirement = list(job, faction) //SKYRAT EDIT
-	special_desc_jobs = list(Captain, Research Director, Scientist, Roboticist) //SKYRAT EDIT, only those familiar with AIs can tell what it really is
+	special_desc_jobs = list(Captain, RD, Scientist, Roboticist) //SKYRAT EDIT, only those familiar with AIs can tell what it really is
 	special_desc_faction = list(Syndicate) //SKYRAT EDIT, Bypasses Detective check
 	special_desc = "This appears to actually be an AI Module for hacking additional laws to an AI." //SKYRAT EDIT
 	laws = list("")

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -466,7 +466,7 @@ AI MODULES
 /obj/item/ai_module/syndicate // This one doesn't inherit from ion boards because it doesn't call ..() in transmitInstructions. ~Miauw
 	name = "modified circuit board" //SKYRAT EDIT, was 'hacked law module'. 
 	desc = "A suspicious looking, modified circuit board." //SKYRAT EDIT, previously "An AI Module for hacking additional laws to an AI."
-	special_desc_requirement = EXAMINE_CHECK_JOB; EXAMINE_CHECK_FACTION //SKYRAT EDIT
+	special_desc_requirement = list(job, faction) //SKYRAT EDIT
 	special_desc_jobs = list(Captain, Research Director, Scientist, Roboticist) //SKYRAT EDIT, only those familiar with AIs can tell what it really is
 	special_desc_faction = list(Syndicate) //SKYRAT EDIT, Bypasses Detective check
 	special_desc = "This appears to actually be an AI Module for hacking additional laws to an AI." //SKYRAT EDIT

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -466,7 +466,7 @@ AI MODULES
 /obj/item/ai_module/syndicate // This one doesn't inherit from ion boards because it doesn't call ..() in transmitInstructions. ~Miauw
 	name = "modified circuit board" //SKYRAT EDIT, was 'hacked law module'. 
 	desc = "A suspicious looking, modified circuit board." //SKYRAT EDIT, previously "An AI Module for hacking additional laws to an AI."
-	special_desc_requirement = EXAMINE_CHECK_JOB EXAMINE_CHECK_FACTION //SKYRAT EDIT
+	special_desc_requirement = EXAMINE_CHECK_JOB, EXAMINE_CHECK_FACTION //SKYRAT EDIT
 	special_desc_jobs = list(Captain, Research Director, Scientist, Roboticist) //SKYRAT EDIT, only those familiar with AIs can tell what it really is
 	special_desc_faction = list(Syndicate) //SKYRAT EDIT, Bypasses Detective check
 	special_desc = "This appears to actually be an AI Module for hacking additional laws to an AI." //SKYRAT EDIT

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -468,7 +468,7 @@ AI MODULES
 	desc = "A suspicious looking, modified circuit board." //SKYRAT EDIT, previously "An AI Module for hacking additional laws to an AI."
 	special_desc_requirement = list("job, faction") //SKYRAT EDIT
 	special_desc_jobs = list("Captain, RD, Scientist, Roboticist") //SKYRAT EDIT, only those familiar with AIs can tell what it really is
-	special_desc_faction = list("Syndicate") //SKYRAT EDIT, Bypasses Detective check
+	special_desc_factions = list("Syndicate") //SKYRAT EDIT, Bypasses Detective check
 	special_desc = "This appears to actually be an AI Module for hacking additional laws to an AI." //SKYRAT EDIT
 	laws = list("")
 

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -466,9 +466,9 @@ AI MODULES
 /obj/item/ai_module/syndicate // This one doesn't inherit from ion boards because it doesn't call ..() in transmitInstructions. ~Miauw
 	name = "modified circuit board" //SKYRAT EDIT, was 'hacked law module'. 
 	desc = "A suspicious looking, modified circuit board." //SKYRAT EDIT, previously "An AI Module for hacking additional laws to an AI."
-	special_desc_requirement = list(job, faction) //SKYRAT EDIT
-	special_desc_jobs = list(Captain, RD, Scientist, Roboticist) //SKYRAT EDIT, only those familiar with AIs can tell what it really is
-	special_desc_faction = list(Syndicate) //SKYRAT EDIT, Bypasses Detective check
+	special_desc_requirement = list("job, faction") //SKYRAT EDIT
+	special_desc_jobs = list("Captain, RD, Scientist, Roboticist") //SKYRAT EDIT, only those familiar with AIs can tell what it really is
+	special_desc_faction = list("Syndicate") //SKYRAT EDIT, Bypasses Detective check
 	special_desc = "This appears to actually be an AI Module for hacking additional laws to an AI." //SKYRAT EDIT
 	laws = list("")
 


### PR DESCRIPTION
## About The Pull Request

Changes the hacked AI law board to appear as a 'modified circuit board' with a vaguely suspicious description.
Requires someone familiar with AIs (or an antag) to successfully identify. This includes the Captain and everyone in the Science department.

Likely to generate controversy so I put this in its own PR.

## Why It's Good For The Game
Encourages security RP a bit more. The board is still clearly suspicious, so security is unlikely to completely overlook it, but encourages security to investigate a little and get an expert to look at it. Or perhaps for a smooth traitor to explain it away.

## Changelog
:cl:
tweak: The traitor AI law module is a little harder for the everyman to identify. Ask for someone from science to take a look at it, security.
/:cl:
