### PR TITLE
Actually fix synth emotes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -166,11 +166,11 @@
 		if(HAS_TRAIT(L, TRAIT_EMOTEMUTE))
 			return FALSE
 	//SKYRAT EDIT BEGIN
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(allowed_species)
+	if(allowed_species)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
 			return FALSE
-			if(H.dna.species in allowed_species)
+			if(H.dna.species.type in allowed_species)
 				return TRUE
 	//SKYRAT EDIT END
 

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -27,6 +27,7 @@
 	var/cooldown = 0.8 SECONDS
 	//SKYRAT EDIT ADDITION BEGIN - EMOTES
 	var/sound_volume = 25 //Emote volume
+	var/list/allowed_species
 	//SKYRAT EDIT ADDITION END
 
 /datum/emote/New()
@@ -164,6 +165,15 @@
 		var/mob/living/L = user
 		if(HAS_TRAIT(L, TRAIT_EMOTEMUTE))
 			return FALSE
+	//SKYRAT EDIT BEGIN
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(allowed_species)
+			return FALSE
+			if(H.dna.species in allowed_species)
+				return TRUE
+	//SKYRAT EDIT END
+
 /**
 * Allows the intrepid coder to send a basic emote
 * Takes text as input, sends it out to those who need to know after some light parsing

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -170,7 +170,7 @@
 		var/check = FALSE
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
-			if(H.dna.species in allowed_species)
+			if(H.dna.species.type in allowed_species)
 				check = TRUE
 		return check
 	//SKYRAT EDIT END

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -167,11 +167,12 @@
 			return FALSE
 	//SKYRAT EDIT BEGIN
 	if(allowed_species)
+		var/check = FALSE
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
-			return FALSE
-			if(H.dna.species.type in allowed_species)
-				return TRUE
+			if(H.dna.species in allowed_species)
+				check = TRUE
+		return check
 	//SKYRAT EDIT END
 
 /**

--- a/modular_skyrat/modules/emotes/code/silicon_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/silicon_emotes.dm
@@ -15,7 +15,6 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/buzz-sigh.ogg'
 
-
 /datum/emote/silicon/buzzes2
 	key = "buzzes2"
 	message = "buzzes twice."

--- a/modular_skyrat/modules/emotes/code/silicon_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/silicon_emotes.dm
@@ -56,3 +56,10 @@
 	message = "blares an alarm!"
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/warning-buzzer.ogg'
+
+/datum/emote/silicon/beep
+	key = "beep"
+	key_third_person = "beeps"
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'modular_skyrat/modules/emotes/sound/emotes/twobeep.ogg'

--- a/modular_skyrat/modules/emotes/code/synth_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/synth_emotes.dm
@@ -44,8 +44,8 @@
 	cooldown = 2 SECONDS
 
 
-/datum/emote/living/human/beeps
-	key = "beeps"
+/datum/emote/living/human/beep2
+	key = "beep2"
 	key_third_person = "beeps"
 	message = "beeps."
 	message_param = "beeps at %t."

--- a/modular_skyrat/modules/emotes/code/synth_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/synth_emotes.dm
@@ -50,6 +50,7 @@
 	message = "beeps."
 	message_param = "beeps at %t."
 	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/twobeep.ogg'
 	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS

--- a/modular_skyrat/modules/emotes/code/synth_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/synth_emotes.dm
@@ -1,104 +1,107 @@
-/datum/emote/living/dwoop
+/datum/emote/living/human
+	mob_type_allowed_typecache = list(/mob/living/carbon/human)
+
+/datum/emote/living/human/dwoop
 	key = "dwoop"
 	key_third_person = "dwoops"
 	message = "chirps happily!"
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/dwoop.ogg'
-	mob_type_allowed_typecache = list(/mob/living/carbon/human/species/synth, /mob/living/carbon/human/species/synthliz, /mob/living/carbon/human/species/ipc)
+	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
 
-/datum/emote/living/yes
+/datum/emote/living/human/yes
 	key = "yes"
 	message = "emits an affirmative blip."
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/synth_yes.ogg'
-	mob_type_allowed_typecache = list(/mob/living/carbon/human/species/synth, /mob/living/carbon/human/species/synthliz, /mob/living/carbon/human/species/ipc)
+	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
 
-/datum/emote/living/no
+/datum/emote/living/human/no
 	key = "no"
 	message = "emits a negative blip."
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/synth_no.ogg'
-	mob_type_allowed_typecache = list(/mob/living/carbon/human/species/synth, /mob/living/carbon/human/species/synthliz, /mob/living/carbon/human/species/ipc)
+	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
 
-/datum/emote/living/boop
+/datum/emote/living/human/boop
 	key = "boop"
 	key_third_person = "boops"
 	message = "boops."
-	mob_type_allowed_typecache = list(/mob/living/carbon/human/species/synth, /mob/living/carbon/human/species/synthliz, /mob/living/carbon/human/species/ipc)
+	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
 
-/datum/emote/living/buzz
+/datum/emote/living/human/buzz
 	key = "buzz"
 	key_third_person = "buzzes"
 	message = "buzzes."
 	message_param = "buzzes at %t."
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/buzz-sigh.ogg'
-	mob_type_allowed_typecache = list(/mob/living/carbon/human/species/synth, /mob/living/carbon/human/species/synthliz, /mob/living/carbon/human/species/ipc)
+	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
 
-/datum/emote/living/beep
+/datum/emote/living/human/beep
 	key = "beep"
 	key_third_person = "beeps"
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/twobeep.ogg'
-	mob_type_allowed_typecache = list(/mob/living/carbon/human/species/synth, /mob/living/carbon/human/species/synthliz, /mob/living/carbon/human/species/ipc)
+	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
 
 
-/datum/emote/living/buzz2
+/datum/emote/living/human/buzz2
 	key = "buzz2"
 	message = "buzzes twice."
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/buzz-two.ogg'
-	mob_type_allowed_typecache = list(/mob/living/carbon/human/species/synth, /mob/living/carbon/human/species/synthliz, /mob/living/carbon/human/species/ipc)
+	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
 
-/datum/emote/living/chime
+/datum/emote/living/human/chime
 	key = "chime"
 	key_third_person = "chimes"
 	message = "chimes."
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/chime.ogg'
-	mob_type_allowed_typecache = list(/mob/living/carbon/human/species/synth, /mob/living/carbon/human/species/synthliz, /mob/living/carbon/human/species/ipc)
+	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
 
-/datum/emote/living/honk
+/datum/emote/living/human/honk
 	key = "honk"
 	key_third_person = "honks"
 	message = "honks."
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'sound/items/bikehorn.ogg'
-	mob_type_allowed_typecache = list(/mob/living/carbon/human/species/synth, /mob/living/carbon/human/species/synthliz, /mob/living/carbon/human/species/ipc)
+	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
 
-/datum/emote/living/ping
+/datum/emote/living/human/ping
 	key = "ping"
 	key_third_person = "pings"
 	message = "pings."
 	message_param = "pings at %t."
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/ping.ogg'
-	mob_type_allowed_typecache = list(/mob/living/carbon/human/species/synth, /mob/living/carbon/human/species/synthliz, /mob/living/carbon/human/species/ipc)
+	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
 
-/datum/emote/living/sad
+/datum/emote/living/human/sad
 	key = "sad"
 	message = "plays a sad trombone..."
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/misc/sadtrombone.ogg'
-	mob_type_allowed_typecache = list(/mob/living/carbon/human/species/synth, /mob/living/carbon/human/species/synthliz, /mob/living/carbon/human/species/ipc)
+	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
 
-/datum/emote/living/warn
+/datum/emote/living/human/warn
 	key = "warn"
 	message = "blares an alarm!"
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/warning-buzzer.ogg'
-	mob_type_allowed_typecache = list(/mob/living/carbon/human/species/synth, /mob/living/carbon/human/species/synthliz, /mob/living/carbon/human/species/ipc)
+	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS

--- a/modular_skyrat/modules/emotes/code/synth_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/synth_emotes.dm
@@ -43,11 +43,13 @@
 	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
 
+
 /datum/emote/living/human/beeps
 	key = "beeps"
 	key_third_person = "beeps"
+	message = "beeps."
+	message_param = "beeps at %t."
 	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/twobeep.ogg'
 	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS

--- a/modular_skyrat/modules/emotes/code/synth_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/synth_emotes.dm
@@ -43,15 +43,14 @@
 	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
 
-/datum/emote/living/human/beep
-	key = "beep"
+/datum/emote/living/human/beeps
+	key = "beeps"
 	key_third_person = "beeps"
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/twobeep.ogg'
 	allowed_species = list(/datum/species/robotic/ipc, /datum/species/synth, /datum/species/synth/military, /datum/species/robotic/synthliz)
 	cooldown = 2 SECONDS
-
 
 /datum/emote/living/human/buzz2
 	key = "buzz2"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Am dumb. This fixes it by adding an allowed species system for emotes.

## Changelog
:cl:
add: Actually fixes synth emotes by adding an allowed species function to emotes.
tweak: Synth *beeps is now *beep2
/:cl:

