### PR TITLE
Reverts changes to some traitor items

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -1,5 +1,6 @@
 /obj/item/chameleon
-	name = "Strange object" // Skyrat edit , original was Chameleon projector
+	name = "chameleon projector"
+	desc = "A projector used to seamlessly camouflage the user as an inanimate object." // SKYRATE EDIT - This item had no description?
 	icon = 'icons/obj/device.dmi'
 	icon_state = "shield0"
 	flags_1 = CONDUCT_1
@@ -13,8 +14,6 @@
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE // Skyrat edit
-	special_desc = "A projector used to seamlessly camouflage syndicate operatives into the background" // Skyrat edit
 	var/can_use = 1
 	var/obj/effect/dummy/chameleon/active_dummy = null
 	var/saved_appearance = null

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -315,15 +315,13 @@
  * Toy swords
  */
 /obj/item/toy/sword
-	name = "energy sword" // Skyrat edit , was Toy Sword
-	desc = "May the force be with you." // Skyrat edit
+	name = "toy sword"
+	desc = "A cheap, plastic replica of an energy sword. Realistic sounds! Ages 8 and up."
 	icon = 'icons/obj/transforming_energy.dmi'
 	icon_state = "sword0"
 	inhand_icon_state = "sword0"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY // Skyrat edit
-	special_desc = "A cheap imitation of an energy sword" // Skyrat edit
 	var/active = 0
 	w_class = WEIGHT_CLASS_SMALL
 	attack_verb_continuous = list("attacks", "strikes", "hits")
@@ -446,8 +444,8 @@
  * Subtype of Double-Bladed Energy Swords
  */
 /obj/item/dualsaber/toy
-	name = "double-bladed energy sword" // Skyrat edit , was double-bladed toy sword
-	desc = "Handle with care!" // Skyrat edit
+	name = "double-bladed toy sword"
+	desc = "A cheap, plastic replica of TWO energy swords.  Double the fun!"
 	force = 0
 	throwforce = 0
 	throw_speed = 3
@@ -455,8 +453,6 @@
 	two_hand_force = 0
 	attack_verb_continuous = list("attacks", "strikes", "hits")
 	attack_verb_simple = list("attack", "strike", "hit")
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY //  Skyrat edit
-	special_desc = "A imitation of an double-bladed energy sword" // Skyrat edit
 
 /obj/item/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	return 0

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -84,8 +84,8 @@
 	ammo_x_offset = 2
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow
-	name = "foam force crossbow" //SKYRAT EDIT, was mini energy crossbow
-	desc = "A weapon favored by many overactive children. Ages 8 and up." //SKYRAT EDIT
+	name = "mini energy crossbow"
+	desc = "A weapon favored by syndicate stealth specialists."
 	icon_state = "crossbow"
 	inhand_icon_state = "crossbow"
 	w_class = WEIGHT_CLASS_SMALL
@@ -99,8 +99,6 @@
 	unique_frequency = TRUE
 	can_flashlight = FALSE
 	max_mod_capacity = 0
-	special_desc_requirement = EXAMINE_CHECK_SYNDICATE_TOY //  SKYRAT EDIT
-	special_desc = "A syndicate weapon employed by infiltrators and assassins. Quietly shoots poison tipped darts which stun and slur the speech of its victims." //SKYRAT EDIT
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow/halloween
 	name = "candy corn crossbow"


### PR DESCRIPTION
## About The Pull Request

We got a cool new dynamic description system for stealth items, and I think pretty much immediately the system was applied incorrectly. The best use of this system, as far as I am concerned, is to make "true" stealth items actually work as intended by moving their unique examine texts to this system, and making them use the examine texts of the items they are aping.

Instead, what happened was a bunch of previously obvious contraband items were haphazardly turned into stealth items by altering their names and descriptions. This PR reverts the latter changes, while keeping the changes that were true to the items' original intents intact.

## Why It's Good For The Game

Obvious contraband should remain obvious. The system should be used to harbor existing stealth items, **not make new ones**. In addition, the changes to toys were going to be annoying. Toys should be toys. Weapons should be weapons. The value and humor of the sight gag is completely lost if you have to closely examine the item itself to determine if they're a toy or not. 

## Changelog
:cl:
tweak: Reverted the dynamic description updates for chameleon projectors, toy eswords, and ebow. 
/:cl:
