### PR TITLE
Removes LRP/Transformation Anomalous Crystal Variants

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -468,7 +468,8 @@
 /obj/machinery/anomalous_crystal/ex_act()
 	ActivationReaction(null, ACTIVATE_BOMB)
 
-/obj/machinery/anomalous_crystal/honk //Strips and equips you as a clown. I apologize for nothing
+/* SKYRAT EDIT REMOVAL -- Deletes Clowning, you're welcome.
+/obj/machinery/anomalous_crystal/honk //Strips and equips you as a clown. I apologize for nothing 
 	observer_desc = "This crystal strips and equips its targets as clowns."
 	possible_methods = list(ACTIVATE_MOB_BUMP, ACTIVATE_SPEECH)
 	activation_sound = 'sound/items/bikehorn.ogg'
@@ -482,6 +483,7 @@
 		C.equip(H)
 		qdel(C)
 		affected_targets.Add(H)
+SKYRAT EDIT REMOVAL END*/
 
 /obj/machinery/anomalous_crystal/theme_warp //Warps the area you're in to look like a new one
 	observer_desc = "This crystal warps the area around it to a theme."
@@ -584,7 +586,7 @@
 				P.yo = -20
 				P.xo = 0
 		P.fire()
-
+/* SKYRAT REMOVAL EDIT -- More generic roundremove/transformation shit
 /obj/machinery/anomalous_crystal/dark_reprise //Revives anyone nearby, but turns them into shadowpeople and renders them uncloneable, so the crystal is your only hope of getting up again if you go down.
 	observer_desc = "When activated, this crystal revives anyone nearby, but turns them into Shadowpeople and makes them unclonable, making the crystal their only hope of getting up again."
 	activation_method = ACTIVATE_TOUCH
@@ -605,6 +607,7 @@
 					H.revive(full_heal = TRUE, admin_revive = FALSE)
 					ADD_TRAIT(H, TRAIT_BADDNA, MAGIC_TRAIT) //Free revives, but significantly limits your options for reviving except via the crystal
 					H.grab_ghost(force = TRUE)
+SKYRAT REMOVAL EDIT END*/
 
 /obj/machinery/anomalous_crystal/helpers //Lets ghost spawn as helpful creatures that can only heal people slightly. Incredibly fragile and they can't converse with humans
 	observer_desc = "This crystal allows ghosts to turn into a fragile creature that can heal people."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the Clown Transformation, and Shadowperson Revival variants of the Anomalous Crystal dropped by the Colossus Megafauna.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Frankly, permanent transformation, especially non-consented transformation, and round-removal is garbage. What this PR does is remove 2 variants of the anomalous crystal that:

1) Turns people speaking nearby the crystal into clowns, this includes gear, irremovable clumsy trait, and brand new name.
2) Revives all nearby corpses as shadowpeople who are incapable of being cloned.

Both of these transformations are permanent, and the clown variant is especially NRP, so no longer needing to be fearful of a boss drop to the point of never opening the chest is a pretty good thing.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed the clown transformation Anomalous Crystal variant
del: Removed the shadowperson revival Anomalous Crystal variant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
