### PR TITLE
More special examines: facehugger, ash flora

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -511,6 +511,9 @@
 	desc = "One of the more successful achievements of the Nanotrasen Corporate Warfare Division, their nuclear fission explosives are renowned for being cheap to produce and devastatingly effective. Signs explain that though this particular device has been decommissioned, every Nanotrasen station is equipped with an equivalent one, just in case. All Captains carefully guard the disk needed to detonate them - at least, the sign says they do. There seems to be a tap on the back."
 	proper_bomb = FALSE
 	var/obj/structure/reagent_dispensers/beerkeg/keg
+	special_desc_requirement = EXAMINE_CHECK_JOB //SKYRAT EDIT
+	special_desc_jobs = list("Captain, Bartender") //SKYRAT EDIT
+	special_desc = "This bomb has been converted into a beer keg. With the nuclear authentication disk and the right codes, though, you could have a party..." //SKYRAT EDIT
 
 /obj/machinery/nuclearbomb/beer/Initialize()
 	. = ..()

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -511,9 +511,6 @@
 	desc = "One of the more successful achievements of the Nanotrasen Corporate Warfare Division, their nuclear fission explosives are renowned for being cheap to produce and devastatingly effective. Signs explain that though this particular device has been decommissioned, every Nanotrasen station is equipped with an equivalent one, just in case. All Captains carefully guard the disk needed to detonate them - at least, the sign says they do. There seems to be a tap on the back."
 	proper_bomb = FALSE
 	var/obj/structure/reagent_dispensers/beerkeg/keg
-	special_desc_requirement = EXAMINE_CHECK_JOB //SKYRAT EDIT
-	special_desc_jobs = list("Captain, Bartender") //SKYRAT EDIT
-	special_desc = "This bomb has been converted into a beer keg. With the nuclear authentication disk and the right codes, though, you could have a party..." //SKYRAT EDIT
 
 /obj/machinery/nuclearbomb/beer/Initialize()
 	. = ..()

--- a/code/modules/mining/equipment/vendor_items.dm
+++ b/code/modules/mining/equipment/vendor_items.dm
@@ -9,6 +9,9 @@
 	real = 0
 	sterile = 1
 	tint = 3 //Makes it feel more authentic when it latches on
+	special_desc_requirement = EXAMINE_CHECK_ROLE //SKYRAT EDIT
+	special_desc_roles = list("ROLE_ALIEN") //SKYRAT EDIT
+	special_desc = "This appears to be a mechanical mockery of our young." //SKYRAT EDIT
 
 /obj/item/clothing/mask/facehugger/toy/Die()
 	return

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -183,6 +183,9 @@
 	pixel_y = base_pixel_y + rand(-4, 4)
 
 /obj/item/food/grown/ash_flora/shavings //So we can't craft bowls from everything.
+	special_desc_requirement = EXAMINE_CHECK_JOB //SKYRAT EDIT
+	special_desc_jobs = list("Botanist") //SKYRAT EDIT
+	special_desc = "You feel this flora would be unwise to consume while already full." //SKYRAT EDIT
 
 /obj/item/food/grown/ash_flora/mushroom_leaf
 	name = "mushroom leaf"
@@ -190,6 +193,9 @@
 	icon_state = "mushroom_leaf"
 	seed = /obj/item/seeds/lavaland/porcini
 	wine_power = 40
+	special_desc_requirement = EXAMINE_CHECK_JOB //SKYRAT EDIT
+	special_desc_jobs = list("Botanist") //SKYRAT EDIT
+	special_desc = "This flora is nutritious and healthy to eat, though slightly laced with nicotine." //SKYRAT EDIT
 
 /obj/item/food/grown/ash_flora/mushroom_cap
 	name = "mushroom cap"
@@ -197,6 +203,9 @@
 	icon_state = "mushroom_cap"
 	seed = /obj/item/seeds/lavaland/inocybe
 	wine_power = 70
+	special_desc_requirement = EXAMINE_CHECK_JOB //SKYRAT EDIT
+	special_desc_jobs = list("Botanist") //SKYRAT EDIT
+	special_desc = "This flora is poisonous and hallucinogenic." //SKYRAT EDIT
 
 /obj/item/food/grown/ash_flora/mushroom_stem
 	name = "mushroom stem"
@@ -204,6 +213,9 @@
 	icon_state = "mushroom_stem"
 	seed = /obj/item/seeds/lavaland/ember
 	wine_power = 60
+	special_desc_requirement = EXAMINE_CHECK_JOB //SKYRAT EDIT
+	special_desc_jobs = list("Botanist") //SKYRAT EDIT
+	special_desc = "This flora contains psychoactive drugs and will also make you glow." //SKYRAT EDIT
 
 /obj/item/food/grown/ash_flora/cactus_fruit
 	name = "cactus fruit"
@@ -211,6 +223,9 @@
 	icon_state = "cactus_fruit"
 	seed = /obj/item/seeds/lavaland/cactus
 	wine_power = 50
+	special_desc_requirement = EXAMINE_CHECK_JOB //SKYRAT EDIT
+	special_desc_jobs = list("Botanist") //SKYRAT EDIT
+	special_desc = "This flora is very nutritious and medicinal." //SKYRAT EDIT
 
 //SEEDS
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -22,9 +22,9 @@
 	layer = MOB_LAYER
 	max_integrity = 100
 	item_flags = XENOMORPH_HOLDABLE
-	special_desc_requirement = EXAMINE_CHECK_JOB
-	special_desc_jobs = list("Scientist, RD")
-	special_desc = "This alien is an extremely dangerous life form capable of creating a xenomorph. You would know well not to approach without full body biological protection."
+	special_desc_requirement = EXAMINE_CHECK_JOB //SKYRAT EDIT
+	special_desc_jobs = list("Scientist, RD") //SKYRAT EDIT
+	special_desc = "This alien is an extremely dangerous life form capable of creating a xenomorph. You would know well not to approach without full body biological protection." //SKYRAT EDIT
 	var/stat = CONSCIOUS //UNCONSCIOUS is the idle state in this case
 
 	var/sterile = FALSE

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -23,7 +23,7 @@
 	max_integrity = 100
 	item_flags = XENOMORPH_HOLDABLE
 	special_desc_requirement = EXAMINE_CHECK_JOB //SKYRAT EDIT
-	special_desc_jobs = list("Scientist, RD") //SKYRAT EDIT
+	special_desc_jobs = list("Scientist, Research Director") //SKYRAT EDIT
 	special_desc = "This alien is an extremely dangerous life form capable of creating a xenomorph. You would know well not to approach without full body biological protection." //SKYRAT EDIT
 	var/stat = CONSCIOUS //UNCONSCIOUS is the idle state in this case
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -22,6 +22,9 @@
 	layer = MOB_LAYER
 	max_integrity = 100
 	item_flags = XENOMORPH_HOLDABLE
+	special_desc_requirement = EXAMINE_CHECK_JOB
+	special_desc_jobs = list("Scientist, RD")
+	special_desc = "This alien is an extremely dangerous life form capable of creating a xenomorph. You would know well not to approach without full body biological protection."
 	var/stat = CONSCIOUS //UNCONSCIOUS is the idle state in this case
 
 	var/sterile = FALSE
@@ -37,6 +40,9 @@
 /obj/item/clothing/mask/facehugger/lamarr
 	name = "Lamarr"
 	desc = "The Research Director's pet, a domesticated and debeaked xenomorph facehugger. Friendly, but may still try to couple with your head."
+	special_desc_requirement = EXAMINE_CHECK_ROLE //SKYRAT EDIT
+	special_desc_roles = list("ROLE_ALIEN") //SKYRAT EDIT
+	special_desc = "This young one has been cruelly mutilated. It lacks the capability to fill a host with our sisters." //SKYRAT EDIT
 	sterile = 1
 
 /obj/item/clothing/mask/facehugger/dead


### PR DESCRIPTION
## About The Pull Request
* Adds some various examines for facehuggers and their variants. Scientists get a very clear warning about what the real deal is. Aliens get funny examine text if they happen to look at Lamarr or a toy.
* Added special examines for lavaland plants, as a small bonus for any botanists who change jobs and can't remember what each one does.
<s>* Captain and Bartender both get an extra-obvious message when examining a beer nuke, that also hints at the beer-splosion</s> removed because you can't do this with machines yet


## Why It's Good For The Game
A proof of concept. Special examines have more uses beyond just hiding antag items. They can be used to give useful or insightful information for a relevant role.

## Changelog
Very minor changes so not really needed.