### PR TITLE
[TM-ONLY] Disables jukeboxes as orderable cargo crates.

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -214,6 +214,7 @@
 					/obj/item/storage/box/matches)
 	crate_name = "candle crate"
 
+/*
 /datum/supply_pack/misc/jukebox
 	name = "Jukebox Crate"
 	desc = "Contains a regular old jukebox. It can play music!"
@@ -227,6 +228,7 @@
 	cost = CARGO_CRATE_VALUE * 50
 	contains = list(/obj/machinery/jukebox/disco)
 	crate_name = "dance machine crate"
+*/
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Food Stuff //////////////////////////////////////


### PR DESCRIPTION
Apparently the echo and sound falloffs got really bonked and the jukebox is very loud across the entire z-level.
Let's disable them while we work it out.