### PR TITLE
Removes the lrp suicide verbs.

### DIFF
--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -21,6 +21,8 @@
 		if(mmi.brainmob)
 			mmi.brainmob.suiciding = suicide_state
 
+//SKYRAT EDIT REMOVAL BEGIN - SUICIDE_VERB
+/*
 /mob/living/carbon/human/verb/suicide()
 	set hidden = TRUE
 	if(!canSuicide())
@@ -214,6 +216,8 @@
 
 		death(FALSE)
 		ghostize(FALSE)	// Disallows reentering body and disassociates mind
+*/
+//SKYRAT EDIT REMOVAL END
 
 /mob/living/proc/suicide_log()
 	log_message("committed suicide as [src.type]", LOG_ATTACK)

--- a/modular_skyrat/modules/suicide_verb/readme.md
+++ b/modular_skyrat/modules/suicide_verb/readme.md
@@ -1,0 +1,45 @@
+https://github.com/Skyrat-SS13/Skyrat-tg/pull/3194
+
+## Title: Suicide verb removal <!--Title of your addition-->
+
+MODULE ID: SUICIDE_VERB
+
+
+### Description:
+
+Removes the LRP suicide verb, in the same manner as most RP servers.
+
+
+### TG Proc/File Changes:
+
+Modified:
+- `code/modules/client/verbs/suicide.dm`
+
+Removed:
+- `/mob/living/carbon/human/verb/suicide()`
+- `/mob/living/brain/verb/suicide()`
+- `/mob/living/silicon/ai/verb/suicide()`
+- `/mob/living/silicon/robot/verb/suicide()`
+- `/mob/living/silicon/pai/verb/suicide()`
+- `/mob/living/carbon/alien/humanoid/verb/suicide()`
+- `/mob/living/simple_animal/verb/suicide()`
+
+
+### Defines:
+
+- N/A
+
+
+### Master file additions
+
+- N/A
+
+
+### Included files that are not contained in this module:
+
+- N/A
+
+
+### Credits:
+
+Rohesie

--- a/modular_skyrat/modules/suicide_verb/readme.md
+++ b/modular_skyrat/modules/suicide_verb/readme.md
@@ -1,6 +1,6 @@
 https://github.com/Skyrat-SS13/Skyrat-tg/pull/3194
 
-## Title: Suicide verb removal <!--Title of your addition-->
+## Title: Suicide verb removal
 
 MODULE ID: SUICIDE_VERB
 


### PR DESCRIPTION
## Title: Suicide verb removal <!--Title of your addition-->

MODULE ID: SUICIDE_VERB <!-- uppercase, underscore_connected name of your module, that you use to mark files-->

### Description:

Removes the "comedy"-based LRP suicide verb, in the same manner as most RP servers.
<!-- Here, try to describe what your PR does, what features it provides and any other directly useful information -->

### TG Proc/File Changes:

Modified:
- `code/modules/client/verbs/suicide.dm`

Removed:
- `/mob/living/carbon/human/verb/suicide()`
- `/mob/living/brain/verb/suicide()`
- `/mob/living/silicon/ai/verb/suicide()`
- `/mob/living/silicon/robot/verb/suicide()`
- `/mob/living/silicon/pai/verb/suicide()`
- `/mob/living/carbon/alien/humanoid/verb/suicide()`
- `/mob/living/simple_animal/verb/suicide()`
<!-- If you had to edit, or append to any core procs in the process of making this PR, list them here. APPEND: Also, please include any files that you've changed. .DM files that is. -->

### Defines:

- N/A
<!-- If you needed to add any defines, mention the files you added those defines in -->

### Master file additions

- N/A
<!-- Any master file changes you've made to existing master files or if you've added a new master file. Please mark either as #NEW or #CHANGE -->

### Included files that are not contained in this module:

- N/A
<!-- Likewise, be it a non-modular file or a modular one that's not contained within the folder belonging to this specific module, it should be mentioned here -->

### Credits:

<!-- Here go the credits to you, dear coder, and in case of collaborative work or ports, credits to the original source of the code -->
Me.