### PR TITLE
[Semi-Modular] Add more miner slots.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -26104,6 +26104,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bgO" = (
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bgP" = (
@@ -26970,13 +26971,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bir" = (
-/obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bis" = (
@@ -27776,6 +27777,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bjY" = (
@@ -27820,6 +27822,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bkc" = (
@@ -28631,12 +28634,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "blY" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "blZ" = (
@@ -99527,6 +99530,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"fMw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "fMV" = (
 /obj/structure/chair/stool,
 /obj/structure/cable,
@@ -106621,6 +106630,22 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"pLd" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "pLw" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -110778,6 +110803,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"vsQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/shaft_miner,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "vti" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/toilet{
@@ -157241,7 +157271,7 @@ bfy
 aCy
 bim
 bjX
-bgP
+fMw
 aig
 boY
 aig
@@ -158266,7 +158296,7 @@ aQP
 bcC
 bee
 bfC
-bgP
+vsQ
 biq
 bjZ
 blX
@@ -158781,7 +158811,7 @@ bcE
 beg
 bfE
 bfD
-bfD
+pLd
 bkc
 blZ
 aig

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -15796,6 +15796,7 @@
 /area/maintenance/port)
 "aWv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aWx" = (
@@ -24071,6 +24072,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bsg" = (
@@ -76900,7 +76902,7 @@ avD
 ofT
 awE
 azU
-byE
+bEQ
 aWC
 aXB
 bsf

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -37714,9 +37714,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants{
-	icon_state = "plant-05"
-	},
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bko" = (
@@ -40968,17 +40966,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bpv" = (
-/obj/structure/closet/wardrobe/miner,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/clothing/suit/hooded/wintercoat/miner,
-/obj/item/clothing/suit/hooded/wintercoat/miner,
-/obj/item/clothing/suit/hooded/wintercoat/miner,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningoffice)
 "bpw" = (
@@ -43358,6 +43353,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bsX" = (
@@ -50681,6 +50677,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bFf" = (

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -8097,12 +8097,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aAK" = (
-/obj/structure/table,
-/obj/item/toy/cards/deck,
-/obj/item/storage/fancy/cigarettes/cigpack_robust{
-	pixel_x = -4;
-	pixel_y = 6
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -8112,6 +8106,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aAL" = (
@@ -8543,17 +8538,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aBY" = (
-/obj/structure/table,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/item/storage/pill_bottle/dice,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aBZ" = (
@@ -8913,6 +8907,7 @@
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aDi" = (
@@ -99660,7 +99655,7 @@ dne
 dne
 ayj
 cSF
-aAC
+aAF
 aFH
 aDi
 ayj

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -2,8 +2,8 @@
 	title = "Shaft Miner"
 	department_head = list("Head of Personnel")
 	faction = "Station"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 5 //SKYRAT EDIT: Original value (3)
+	spawn_positions = 5 //SKYRAT EDIT: Original value (3)
 	supervisors = "the quartermaster and the head of personnel"
 	selection_color = "#dcba97"
 

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -15,7 +15,7 @@ Prisoner=0,2
 
 Quartermaster=1,1
 Cargo Technician=3,2
-Shaft Miner=3,3
+Shaft Miner=5,5
 
 Bartender=1,1
 Cook=2,1


### PR DESCRIPTION
## About The Pull Request

Adds more miner slots, miner spawns, and miner lockers to all maps in rotation.

Miner slots set to 5.
Number of spawns increased to 5.
Every station now has at least 5 Miner lockers.

## Why It's Good For The Game

we don't have enough miner slots right now, shit's tough.

## Changelog
:cl:
add: Added more miner slots, material leeches rejoice!
/:cl:


