### PR TITLE
Makes Quad-Sec only work inside /area/security

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1562,7 +1562,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			M.heal_bodypart_damage(brute = 1, burn = 1)
 			M.adjustBruteLoss(-2,0)
 			. = 1
-		return ..() // Skyrat edit - end
+		return ..() // SKYRAT EDIT: End - This line and the above few have only indentation changes.
 	return ..()
 
 /datum/reagent/consumable/ethanol/quintuple_sec
@@ -2337,4 +2337,3 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_icon_state = "godmother"
 	glass_name = "Godmother"
 	glass_desc = "A lovely fresh smelling cocktail, a true Sicilian delight."
-

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1558,9 +1558,11 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes
 	var/obj/item/organ/liver/liver = M.getorganslot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		M.heal_bodypart_damage(brute = 1, burn = 1)
-		M.adjustBruteLoss(-2,0)
-		. = 1
+		if(istype(/area/security, get_area(M)))
+			M.heal_bodypart_damage(brute = 1, burn = 1)
+			M.adjustBruteLoss(-2,0)
+			. = 1
+		return ..()
 	return ..()
 
 /datum/reagent/consumable/ethanol/quintuple_sec

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1558,7 +1558,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes
 	var/obj/item/organ/liver/liver = M.getorganslot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		if(istype(/area/security, get_area(M)))
+		if(istype(get_area(M), /area/security))
 			M.heal_bodypart_damage(brute = 1, burn = 1)
 			M.adjustBruteLoss(-2,0)
 			. = 1

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1558,11 +1558,11 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes
 	var/obj/item/organ/liver/liver = M.getorganslot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		if(istype(get_area(M), /area/security))
+		if(istype(get_area(M), /area/security)) // Skyrat edit , it checks for area now - Start
 			M.heal_bodypart_damage(brute = 1, burn = 1)
 			M.adjustBruteLoss(-2,0)
 			. = 1
-		return ..()
+		return ..() // Skyrat edit - end
 	return ..()
 
 /datum/reagent/consumable/ethanol/quintuple_sec


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes quad-sec only have its healing effects apply in security areas
## Why It's Good For The Game
Security uses quad-sec to powergame mid-combat because it has no downsides that other cobbychems have to prevent powergaming.

## Changelog
:cl:
balance: Quadruple Security now only heals inside security areas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
