### PR TITLE
Changes beakers to be like oldbase

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -569,7 +569,7 @@
 	icon_state = "shaker"
 	custom_materials = list(/datum/material/iron=1500)
 	amount_per_transfer_from_this = 10
-	volume = 100
+	volume = 120 //SKYRAT EDIT: Original value: (100)
 	isGlass = FALSE
 
 /obj/item/reagent_containers/food/drinks/flask

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -130,12 +130,14 @@
 
 /obj/item/reagent_containers/glass/beaker
 	name = "beaker"
-	desc = "A beaker. It can hold up to 50 units."
+	desc = "A beaker. It can hold up to 60 units." //SKYRAT EDIT: Used to say can hold up to 50 units.
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "beaker"
 	inhand_icon_state = "beaker"
 	worn_icon_state = "beaker"
 	custom_materials = list(/datum/material/glass=500)
+	volume = 60 //SKYRAT EDIT: Addition
+	possible_transfer_amounts = list(5,10,15,20,30,60) //SKYRAT EDIT: Addition
 	fill_icon_thresholds = list(0, 10, 25, 50, 75, 80, 90)
 
 /obj/item/reagent_containers/glass/beaker/Initialize()
@@ -153,22 +155,24 @@
 
 /obj/item/reagent_containers/glass/beaker/large
 	name = "large beaker"
-	desc = "A large beaker. Can hold up to 100 units."
+	desc = "A large beaker. Can hold up to 120 units." //SKYRAT EDIT: Used to say Can hold up to 100 units.
 	icon_state = "beakerlarge"
 	custom_materials = list(/datum/material/glass=2500)
-	volume = 100
+	volume = 120 //SKYRAT EDIT: Original value (100)
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100)
+	//possible_transfer_amounts = list(5,10,15,20,25,30,50,100) //SKYRAT EDIT: Original Values
+	possible_transfer_amounts = list(5,10,15,20,30,40,60,120) //SKYRAT EDIT: New Values
 
 /obj/item/reagent_containers/glass/beaker/plastic
 	name = "x-large beaker"
-	desc = "An extra-large beaker. Can hold up to 120 units."
+	desc = "An extra-large beaker. Can hold up to 150 units." //SKYRAT EDIT: Used to say Can hold up to 120 units
 	icon_state = "beakerwhite"
 	fill_icon_state = "beakerlarge"
 	custom_materials = list(/datum/material/glass=2500, /datum/material/plastic=3000)
-	volume = 120
+	volume = 150 //SKYRAT EDIT: Original Value (120)
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,25,30,60,120)
+	//possible_transfer_amounts = list(5,10,15,20,25,30,60,120) //SKYRAT EDIT: Original values
+	possible_transfer_amounts = list(5,10,15,20,25,30,50,75,150) //SKYRAT EDIT: New Values
 
 /obj/item/reagent_containers/glass/beaker/meta
 	name = "metamaterial beaker"


### PR DESCRIPTION
## About The Pull Request

Beaker set to 60u, large beaker set to 120u, x large beaker set to 150u, bartending shaker set to 120u as well.


## Why It's Good For The Game

On oldbase these were the beaker values, making a lot of mathematical things a lot easier, since 120 and 60 are both divisible by 3, 4, 5, and 6, they can have mixtures fit the beaker sizes a lot better. This adds more versatility to the beakers and makes an allround better experience for those mixing things.

## Changelog
:cl:
tweak: beakers and shakers now hold more.
/:cl:
