### PR TITLE
Adjusts job slots for Prisoner, AI, Cyborgs & Adds latejoin Prisoner spawns

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -65,6 +65,12 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	name = "Prisoner"
 	icon_state = "Prisoner"
 
+// SKYRAT EDIT: Start - Latejoin prisoners!
+/obj/effect/landmark/start/prisoner/latejoin
+	name = "Latejoin Prisoner"
+	jobspawn_override = TRUE
+	delete_after_roundstart = FALSE
+// SKYRAT EDIT: End - Latejoin prisoners!
 /obj/effect/landmark/start/janitor
 	name = "Janitor"
 	icon_state = "Janitor"

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -2,8 +2,8 @@
 	title = "Cyborg"
 	auto_deadmin_role_flags = DEADMIN_POSITION_SILICON
 	faction = "Station"
-	total_positions = 0
-	spawn_positions = 1
+	total_positions = 3		// SKYRAT EDIT: Original value (0)
+	spawn_positions = 3		// SKYRAT EDIT: Original value (1)
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#ddffdd"
 	minimal_player_age = 21

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -2,7 +2,7 @@
 	title = "Prisoner"
 	department_head = list("The Security Team")
 	faction = "Station"
-	total_positions = 0
+	total_positions = 12		// SKYRAT EDIT: Original value (0)
 	spawn_positions = 2
 	supervisors = "the security team"
 	selection_color = "#ffe1c3"

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -2,8 +2,8 @@
 	title = "Shaft Miner"
 	department_head = list("Head of Personnel")
 	faction = "Station"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 5		//SKYRAT EDIT: Original value (3)
+	spawn_positions = 5		//SKYRAT EDIT: Original value (3)
 	supervisors = "the quartermaster and the head of personnel"
 	selection_color = "#dcba97"
 

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -49,4 +49,4 @@ Security Officer=5,5
 Security Medic=1,1
 
 AI=1,1
-Cyborg=3,1
+Cyborg=3,3

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -11,11 +11,11 @@ Chief Medical Officer=1,1
 Blueshield=1,1
 
 Assistant=-1,-1
-Prisoner=0,2
+Prisoner=12,2
 
 Quartermaster=1,1
 Cargo Technician=3,2
-Shaft Miner=3,3
+Shaft Miner=5,5
 
 Bartender=1,1
 Cook=2,1
@@ -48,5 +48,5 @@ Detective=1,1
 Security Officer=5,5
 Security Medic=1,1
 
-AI=0,1
-Cyborg=0,1
+AI=1,1
+Cyborg=3,1


### PR DESCRIPTION
## About The Pull Request
• Adds a special marker for prisoners to spawn into the prisoner via latejoining instead of going onto the arrivals shuttle.
• You can now spawn as a prisoner roundstart.
• You can now spawn as an AI roundstart.
• You can now spawn as a Cyborg roundstart.
• You can now have up to five miners.
• Closes #3197 again.

## Why It's Good For The Game
Because we get ahelps for this every damn round. AI mains can't really play anymore, nor can borg mains. Prisoners also ahelp for that they rolled sec officer when they wanted to be a prisoner.
Swiftfeather also wanted more miners. Yeah sure, I'm getting a tad tired of an empty ore silo to be honest.

## Changelog
:cl:
fix: AIs can now spawn roundstart again..
fix: Cyborgs can now spawn roundstart again.
fix: Prisoners can now spawn roundstart again.
tweak: Miners now have five slots. See #3197, Swiftfeather.
/:cl:
