### PR TITLE
Modularizes ERT loadouts

### DIFF
--- a/code/modules/clothing/outfits/ert_skyrat.dm
+++ b/code/modules/clothing/outfits/ert_skyrat.dm
@@ -1,5 +1,3 @@
-/* //SKYRAT EDIT: Made modular. in ert_skyrat.dm
-
 /datum/outfit/centcom/ert
 	name = "ERT Common"
 
@@ -429,5 +427,3 @@
 	backpack_contents = list(/obj/item/storage/box/survival/engineer=1,\
 		/obj/item/storage/box/fireworks=3,\
 		/obj/item/food/cake/birthday=1)
-
-*/ //SKYRAT EDIT END

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1910,6 +1910,7 @@
 #include "code\modules\clothing\masks\miscellaneous.dm"
 #include "code\modules\clothing\neck\_neck.dm"
 #include "code\modules\clothing\outfits\ert.dm"
+#include "code\modules\clothing\outfits\ert_skyrat.dm"
 #include "code\modules\clothing\outfits\event.dm"
 #include "code\modules\clothing\outfits\plasmaman.dm"
 #include "code\modules\clothing\outfits\standard.dm"


### PR DESCRIPTION
## About The Pull Request

Modularizes our ERT outfit file, so that others can begin modifying ert loadouts to better suit our server. Tested and working after enabling the ert_skyrat.dm through dream maker.

## Why It's Good For The Game

Currently there are several issues with the ERT loadouts, including that security's base loadouts tend to be better than the ERT's red alert loadout. This makes them wholly impractical for our uses, making them modular will allow many people to contribute different changes to suit our server without interfering with any upstream changes.

## Changelog

- Replaces /modules/clothing/outfits/ert.dm with /modules/clothing/outfits/ert_skyrat.dm in order to facilitate future modular changes to our ERT loadouts with minimal upstream interference.
