### PR TITLE
Links CI to combat mode

### DIFF
--- a/code/__DEFINES/~skyrat_defines/keybindings.dm
+++ b/code/__DEFINES/~skyrat_defines/keybindings.dm
@@ -1,4 +1,3 @@
 #define COMSIG_KB_MOB_PIXELSHIFT "keybinding_mob_pixelshift"
 #define COMSIG_KB_CLIENT_LOOC_DOWN "keybinding_client_looc_down"
 #define COMSIG_KB_CLIENT_WHISPER_DOWN "keybinding_client_whisper_down"
-#define COMSIG_KB_LIVING_COMBAT_INDICATOR "keybinding_living_combat_indicator"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -87,11 +87,10 @@
 				G.toggle_safety(src, "off")
 			else
 				G.toggle_safety(src, "on")
-	if(!ishuman(src))
-		if(combat_mode)
-			set_combat_indicator(TRUE)
-		else
-			set_combat_indicator(FALSE)
+	if(combat_mode)
+		set_combat_indicator(TRUE)
+	else
+		set_combat_indicator(FALSE)
 	//SKYRAT EDIT ADDITION END
 
 	if(silent || !(client?.prefs.toggles & SOUND_COMBATMODE))

--- a/modular_skyrat/modules/combat_indicator/code/combat_indicator.dm
+++ b/modular_skyrat/modules/combat_indicator/code/combat_indicator.dm
@@ -44,17 +44,3 @@ GLOBAL_VAR_INIT(combat_indicator_overlay, GenerateCombatOverlay())
 	set_combat_indicator(!combat_indicator)
 
 #undef COMBAT_NOTICE_COOLDOWN
-
-/datum/keybinding/living/combat_indicator
-	hotkey_keys = list("C")
-	name = "combat_indicator"
-	full_name = "Combat Indicator"
-	description = "Indicates that you're escalating to mechanics. YOU NEED TO USE THIS"
-	keybind_signal = COMSIG_KB_LIVING_COMBAT_INDICATOR
-
-/datum/keybinding/living/combat_indicator/down(client/user)
-	. = ..()
-	if(.)
-		return
-	var/mob/living/L = user.mob
-	L.user_toggle_combat_indicator()


### PR DESCRIPTION
Links the CI to combat mode for policy ease of use.

## Changelog
:cl:
tweak: The combat indicator is now linked to combat mode.
/:cl:

