### PR TITLE
[Modular] Yet More DS-1 Tweaks

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -5553,6 +5553,11 @@
 /obj/item/borg/upgrade/transform/syndicatejack,
 /obj/item/borg/upgrade/transform/syndicatejack,
 /obj/item/borg/upgrade/transform/syndicatejack,
+/obj/item/encryptionkey/headset_assault,
+/obj/item/encryptionkey/headset_assault,
+/obj/item/encryptionkey/headset_assault,
+/obj/item/encryptionkey/headset_assault,
+/obj/item/encryptionkey/headset_assault,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Cm" = (
@@ -8652,6 +8657,7 @@
 /obj/item/clothing/under/syndicate,
 /obj/item/clothing/under/syndicate/combat,
 /obj/item/clothing/under/syndicate/skirt,
+/obj/item/radio/headset/assault,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "WB" = (

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -42,11 +42,30 @@
 /area/cruiser_dock)
 "ah" = (
 /obj/structure/bed/maint,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/cruiser_dock/brig)
 "ai" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
+/obj/structure/closet/crate/freezer{
+	name = "universal blood storage"
+	},
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood/universal{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/blood/universal,
+/obj/item/reagent_containers/blood/universal{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/blood/universal,
+/obj/item/reagent_containers/blood/universal,
+/obj/item/reagent_containers/blood/universal,
+/obj/item/reagent_containers/blood/universal,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
@@ -94,6 +113,7 @@
 /area/cruiser_dock/brig)
 "ap" = (
 /obj/structure/table/wood,
+/obj/item/language_manual/codespeak_manual/unlimited,
 /turf/open/floor/iron/grimy,
 /area/cruiser_dock)
 "aq" = (
@@ -101,7 +121,8 @@
 /area/cruiser_dock)
 "ar" = (
 /obj/structure/table/wood,
-/obj/item/ship_in_a_bottle,
+/obj/item/folder/red,
+/obj/item/pen,
 /turf/open/floor/iron/grimy,
 /area/cruiser_dock)
 "as" = (
@@ -146,12 +167,12 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "aB" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Secure Airlock";
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry";
 	req_access_txt = "150"
 	},
-/obj/effect/turf_decal/delivery/red,
-/turf/open/floor/iron/dark/airless,
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "aC" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -168,13 +189,13 @@
 /turf/open/floor/iron,
 /area/cruiser_dock)
 "aE" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "security airlock";
-	req_access_txt = "150"
+/obj/structure/bed/maint,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 50
 	},
-/obj/structure/cable,
+/obj/item/toy/plush/plasmamanplushie,
 /turf/open/floor/plating,
-/area/cruiser_dock)
+/area/cruiser_dock/brig)
 "aF" = (
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plating,
@@ -198,6 +219,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/chair/pew{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/cruiser_dock)
 "aK" = (
@@ -209,12 +233,8 @@
 /area/cruiser_dock)
 "aL" = (
 /obj/structure/cable,
-/obj/machinery/power/port_gen/pacman/super,
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 50
-	},
-/turf/open/floor/plating,
-/area/cruiser_dock)
+/turf/open/floor/engine,
+/area/cruiser_dock/brig)
 "aM" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/engine,
@@ -301,16 +321,14 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "ba" = (
+/obj/effect/spawner/scatter/grime,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/cruiser_dock)
+/turf/open/floor/carpet/royalblack,
+/area/cruiser_dock/brig)
 "bb" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "security airlock";
-	req_access_txt = "150"
-	},
-/turf/open/floor/iron/checker,
-/area/cruiser_dock)
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/cruiser_dock/brig)
 "bc" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -320,6 +338,7 @@
 	name = "security airlock";
 	req_access_txt = "150"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/cruiser_dock/brig)
 "bf" = (
@@ -330,6 +349,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "docklockdown"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/cruiser_dock)
 "bg" = (
@@ -339,11 +359,11 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "bh" = (
-/obj/machinery/light/small/red{
-	dir = 1;
-	icon_state = "bulb"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/closet/crate/wooden,
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "bi" = (
 /turf/open/floor/iron,
@@ -539,16 +559,13 @@
 /turf/open/floor/iron,
 /area/cruiser_dock/brig)
 "bI" = (
+/obj/machinery/door/airlock/glass,
 /obj/structure/cable,
-/obj/machinery/power/smes/magical,
 /turf/open/floor/plating,
-/area/cruiser_dock)
+/area/cruiser_dock/brig)
 "bJ" = (
-/obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "bK" = (
 /turf/open/floor/glass/reinforced,
@@ -1457,9 +1474,6 @@
 "eb" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/spawner/scatter/grime,
-/obj/structure/sign/poster/contraband/syndicate_recruitment{
-	pixel_y = 32
-	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/brig)
 "ec" = (
@@ -1589,20 +1603,15 @@
 /turf/open/floor/glass/reinforced,
 /area/cruiser_dock/brig)
 "et" = (
-/obj/machinery/power/apc/auto_name/north{
-	cell_type = /obj/item/stock_parts/cell/infinite
+/obj/machinery/light/red{
+	dir = 1;
+	icon_state = "tube"
 	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "eu" = (
 /obj/machinery/power/apc/auto_name/north,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/cruiser_dock/brig)
@@ -1672,22 +1681,31 @@
 /turf/open/floor/grass,
 /area/cruiser_dock)
 "eH" = (
-/obj/structure/tank_dispenser/oxygen,
+/obj/structure/safe,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/item/storage/box/syndie_kit/chameleon,
+/obj/item/clothing/head/collectable/captain{
+	desc = "A collectable hat that'll make you look just like a real nuclear operative!";
+	name = "duffy brand collectable captain's hat"
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "eI" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/belt/utility/syndicate,
-/obj/item/storage/belt/utility/syndicate,
-/obj/item/storage/belt/utility/syndicate,
-/obj/item/storage/belt/utility/syndicate,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/caution{
+	dir = 8;
+	icon_state = "caution"
+	},
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/checker,
 /area/cruiser_dock)
 "eJ" = (
-/obj/machinery/door/airlock/atmos{
-	req_access_txt = "150"
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/ore_silo,
+/turf/open/floor/glass,
 /area/cruiser_dock)
 "eK" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -1707,26 +1725,21 @@
 /turf/open/floor/iron,
 /area/cruiser_dock)
 "eM" = (
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "eN" = (
-/obj/structure/safe,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/item/storage/box/syndie_kit/chameleon,
-/obj/item/clothing/head/collectable/captain{
-	desc = "A collectable hat that'll make you look just like a real nuclear operative!";
-	name = "duffy brand collectable captain's hat"
-	},
-/turf/open/floor/iron/dark,
-/area/cruiser_dock)
-"eO" = (
-/obj/structure/closet/crate/silvercrate,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
+/turf/open/floor/iron/checker,
+/area/cruiser_dock)
+"eO" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "docklockdown"
+	},
+/obj/effect/turf_decal/delivery/red,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "eP" = (
@@ -1742,6 +1755,13 @@
 "eR" = (
 /obj/machinery/light/warm,
 /turf/open/floor/wood,
+/area/cruiser_dock)
+"eV" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/water_source/puddle,
+/turf/open/floor/grass,
 /area/cruiser_dock)
 "fa" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
@@ -1781,18 +1801,15 @@
 /turf/open/floor/plating,
 /area/cruiser_dock)
 "fu" = (
-/obj/structure/closet/crate/goldcrate,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "fv" = (
-/obj/effect/turf_decal/trimline/red/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
-	},
-/obj/machinery/vending/medical{
-	pixel_x = -2
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
@@ -1860,23 +1877,18 @@
 /turf/open/floor/engine,
 /area/cruiser_dock)
 "fR" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 9
-	},
 /obj/structure/table/glass,
 /obj/item/storage/backpack/duffelbag/syndie/surgery,
 /obj/item/storage/firstaid/tactical,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "fT" = (
-/obj/machinery/door/airlock/vault{
-	req_access_txt = "150"
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/games,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "fW" = (
-/obj/structure/chair/sofa/corp/corner,
-/turf/open/floor/engine,
+/obj/machinery/skill_station,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "fX" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -1892,13 +1904,6 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 6
 	},
-/turf/open/floor/iron/dark,
-/area/cruiser_dock)
-"gb" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/obj/structure/bed/roller,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "gc" = (
@@ -2003,13 +2008,6 @@
 /obj/effect/spawner/lootdrop/space/fancytool,
 /turf/open/floor/engine,
 /area/cruiser_dock)
-"gt" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/dark,
-/area/cruiser_dock)
 "gv" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -2039,6 +2037,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"gB" = (
+/obj/machinery/light/warm{
+	dir = 1
+	},
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/cruiser_dock)
 "gC" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2087,18 +2093,18 @@
 /obj/structure/chair/sofa/corp{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "gX" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/indestructible/syndicate,
 /area/cruiser_dock)
 "gZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/dark,
+/obj/structure/chair/pew/left,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "ha" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2114,7 +2120,18 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "hb" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/vending/drugs{
+	name = "\improper SyndiDrug Plus"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"hd" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "he" = (
@@ -2139,12 +2156,10 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "docklockdown"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "hh" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
 /obj/machinery/stasis,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
@@ -2155,7 +2170,7 @@
 /turf/open/floor/wood,
 /area/cruiser_dock)
 "hl" = (
-/obj/machinery/vending/cigarette/syndicate,
+/obj/structure/chair/pew/right,
 /turf/open/floor/wood,
 /area/cruiser_dock)
 "hm" = (
@@ -2173,6 +2188,10 @@
 "hn" = (
 /obj/structure/sign/warning/xeno_mining,
 /turf/closed/indestructible/syndicate,
+/area/cruiser_dock)
+"hp" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "hq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -2259,16 +2278,24 @@
 /turf/open/floor/engine,
 /area/cruiser_dock)
 "hX" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/structure/closet/crate/silvercrate,
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/grass,
+/obj/item/stack/sheet/mineral/silver{
+	amount = 15
+	},
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "hZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+	dir = 8
 	},
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
+/obj/structure/table/glass,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "ia" = (
@@ -2291,17 +2318,6 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/stripes/red/corner,
 /turf/open/floor/iron/white,
-/area/cruiser_dock)
-"id" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "docklockdown"
-	},
-/obj/effect/turf_decal/caution/stand_clear/red,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "ig" = (
 /obj/structure/table/wood,
@@ -2378,7 +2394,13 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/cruiser_dock)
 "iq" = (
-/obj/machinery/portable_atmospherics/scrubber/huge/movable,
+/obj/structure/closet/crate/goldcrate,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/item/stack/sheet/mineral/gold{
+	amount = 10
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "iu" = (
@@ -2446,16 +2468,11 @@
 /obj/effect/turf_decal/stripes/red/box,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
-"iK" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/engine,
-/area/cruiser_dock)
 "iN" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "iS" = (
 /obj/structure/table/wood,
@@ -2563,16 +2580,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
-"jt" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/cruiser_dock)
 "ju" = (
 /obj/machinery/base_alarm{
 	pixel_x = 30
@@ -2625,6 +2632,10 @@
 /area/cruiser_dock)
 "jI" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/window/northleft{
+	name = "containment door";
+	req_access_txt = "150"
+	},
 /turf/open/floor/iron,
 /area/cruiser_dock)
 "jJ" = (
@@ -2663,7 +2674,10 @@
 /turf/open/floor/engine,
 /area/cruiser_dock)
 "jT" = (
-/turf/open/floor/light,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "jV" = (
 /obj/structure/chair/sofa/bench/corner,
@@ -2676,15 +2690,21 @@
 /obj/machinery/light/small/red{
 	dir = 1
 	},
-/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded{
+	desc = "A stun baton for incapacitating people with. Crudely scribbled on it is the words, 'BATONG'. Left click to stun, right click to harm.";
+	name = "stun batong"
+	},
 /obj/item/storage/firstaid/emergency,
+/obj/item/stack/sheet/mineral/titanium{
+	amount = 15
+	},
 /turf/open/floor/plating,
 /area/cruiser_dock/brig)
 "jZ" = (
-/obj/structure/chair/sofa/corp{
+/obj/structure/chair/pew/left{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "ka" = (
 /obj/effect/mob_spawn/human/syndicate/assops/facility_staff{
@@ -2797,6 +2817,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/checker,
 /area/cruiser_dock)
 "kI" = (
@@ -2866,11 +2887,11 @@
 /turf/open/floor/grass,
 /area/cruiser_dock)
 "li" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 1
-	},
 /obj/machinery/base_alarm{
 	pixel_y = 30
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
@@ -3013,13 +3034,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/cruiser_dock)
-"mu" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/engine,
-/area/cruiser_dock)
 "mw" = (
 /obj/effect/turf_decal/caution/stand_clear/red,
 /obj/effect/turf_decal/bot_red,
@@ -3122,6 +3136,13 @@
 /obj/item/storage/firstaid/advanced,
 /turf/open/floor/plating,
 /area/cruiser_dock/brig)
+"nj" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "nm" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -3145,7 +3166,7 @@
 /obj/machinery/light/cold{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/blue,
 /area/cruiser_dock)
 "nq" = (
 /obj/structure/grille/broken,
@@ -3157,7 +3178,7 @@
 	},
 /obj/machinery/door/airlock/hatch{
 	name = "Secure Pen";
-	req_access_txt = "55"
+	req_access_txt = "150"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine,
@@ -3183,6 +3204,9 @@
 /area/cruiser_dock)
 "nH" = (
 /obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -3214,7 +3238,8 @@
 "nQ" = (
 /obj/machinery/computer/cryopod{
 	dir = 4;
-	pixel_x = -32
+	pixel_x = -32;
+	req_one_access = list(150)
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -3244,8 +3269,8 @@
 /turf/open/floor/carpet/donk,
 /area/cruiser_dock)
 "nX" = (
-/obj/machinery/skill_station,
-/turf/open/floor/wood,
+/obj/structure/cable,
+/turf/open/floor/iron/checker,
 /area/cruiser_dock)
 "nZ" = (
 /obj/structure/table/reinforced,
@@ -3346,14 +3371,9 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "oH" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 8
+/obj/machinery/door/airlock/vault{
+	req_access_txt = "150"
 	},
-/obj/structure/table/glass,
-/obj/item/stack/medical/gauze{
-	pixel_x = 8
-	},
-/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "oI" = (
@@ -3464,18 +3484,14 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "pe" = (
-/obj/machinery/light/red{
-	dir = 1;
-	icon_state = "tube"
-	},
-/turf/open/floor/iron/dark,
-/area/cruiser_dock)
-"pf" = (
-/obj/effect/turf_decal/trimline/red/corner{
+/obj/structure/chair/sofa/corp/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/corner{
-	dir = 4
+/turf/open/floor/wood,
+/area/cruiser_dock)
+"pf" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
@@ -3587,11 +3603,8 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/cruiser_dock)
 "pI" = (
-/obj/effect/turf_decal/delivery/red,
-/obj/machinery/door/airlock/security/glass{
-	name = "Secure Airlock";
-	req_access_txt = "150"
-	},
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "pJ" = (
@@ -3693,6 +3706,13 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/cruiser_dock)
+"qs" = (
+/obj/structure/bed/roller,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "qu" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/iron/dark,
@@ -3747,28 +3767,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
-"qU" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/chem_pack{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/chem_pack{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/iron/dark,
-/area/cruiser_dock)
-"qV" = (
-/obj/effect/turf_decal/trimline/red/line,
-/obj/structure/sign/warning/bodysposal{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/dark,
-/area/cruiser_dock)
 "ra" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
@@ -3784,27 +3782,27 @@
 	},
 /turf/open/floor/holofloor/dark,
 /area/cruiser_dock)
-"rc" = (
+"rd" = (
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/obj/machinery/light/warm{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"rg" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/cruiser_dock)
-"rg" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/table/optable,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "ri" = (
-/obj/machinery/sleeper/syndie/fullupgrade,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/checker,
 /area/cruiser_dock)
 "rk" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -3820,7 +3818,7 @@
 	dir = 9
 	},
 /obj/machinery/chem_dispenser/fullupgrade,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/blue,
 /area/cruiser_dock)
 "rq" = (
 /obj/machinery/door/airlock/glass,
@@ -3839,6 +3837,9 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "rw" = (
@@ -3846,7 +3847,15 @@
 /turf/open/floor/iron/checker,
 /area/cruiser_dock)
 "rz" = (
-/obj/structure/table/reinforced,
+/obj/machinery/door/airlock/security/glass{
+	name = "security airlock";
+	req_access_txt = "150"
+	},
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/preopen{
+	id = "docklockdown"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "rB" = (
@@ -3869,12 +3878,7 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "rI" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "rM" = (
@@ -4091,9 +4095,8 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "tc" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
@@ -4166,6 +4169,7 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "tG" = (
@@ -4207,21 +4211,21 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "tZ" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 1
-	},
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
-"ud" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+"ua" = (
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"ud" = (
+/obj/structure/chair/pew/right{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "ue" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -4281,6 +4285,11 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/cruiser_dock/brig)
+"uw" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "uy" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -4309,8 +4318,11 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "uD" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
+/obj/machinery/sleeper/syndie/fullupgrade{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
@@ -4342,6 +4354,13 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"uS" = (
+/obj/machinery/door/airlock/engineering{
+	req_access_txt = "150"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "uT" = (
@@ -4451,15 +4470,6 @@
 /obj/structure/table,
 /turf/open/floor/carpet/royalblack,
 /area/cruiser_dock)
-"vG" = (
-/obj/effect/turf_decal/trimline/red/line,
-/obj/machinery/door/poddoor/preopen{
-	id = "docklockdown"
-	},
-/obj/effect/turf_decal/caution/stand_clear/red,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/dark,
-/area/cruiser_dock)
 "vH" = (
 /obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron/dark,
@@ -4476,6 +4486,13 @@
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 8
 	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"vQ" = (
+/obj/machinery/door/airlock/atmos{
+	req_access_txt = "150"
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "vT" = (
@@ -4519,12 +4536,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"wh" = (
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/grass,
+/area/cruiser_dock)
 "wi" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/machinery/light/cold{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
@@ -4722,11 +4747,11 @@
 /turf/open/floor/plating,
 /area/cruiser_dock/brig)
 "xr" = (
-/obj/machinery/computer/camera_advanced{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 8
+	},
+/obj/machinery/computer/camera_advanced/syndie{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/cruiser_dock)
@@ -4776,10 +4801,7 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "xK" = (
-/obj/effect/turf_decal/trimline/red/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/corner{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -4896,6 +4918,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/cafeteria,
 /area/cruiser_dock)
+"yw" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/cruiser_dock)
 "yz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -4954,8 +4982,7 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "yX" = (
-/obj/effect/turf_decal/trimline/red/corner,
-/obj/effect/turf_decal/trimline/red/corner{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -4985,6 +5012,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"ze" = (
+/obj/effect/turf_decal/trimline/red/line,
+/obj/machinery/light/warm,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "zi" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -5009,6 +5041,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "zp" = (
@@ -5059,6 +5092,12 @@
 /obj/item/stack/package_wrap,
 /obj/item/reagent_containers/food/condiment/mayonnaise,
 /turf/open/floor/iron/cafeteria,
+/area/cruiser_dock)
+"zD" = (
+/obj/machinery/light/warm{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "zE" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -5115,9 +5154,6 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "zQ" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 8
-	},
 /obj/machinery/stasis{
 	dir = 1
 	},
@@ -5142,6 +5178,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"Ab" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue";
+	req_access_txt = "150"
+	},
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "Ag" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/effect/turf_decal/siding/purple{
@@ -5157,6 +5201,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"Aj" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
 /area/cruiser_dock)
 "Am" = (
 /obj/structure/window/reinforced{
@@ -5200,6 +5251,10 @@
 /obj/item/gun/ballistic/automatic/sniper_rifle/modular/blackmarket,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"AF" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/cruiser_dock)
 "AG" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/grimy,
@@ -5224,13 +5279,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
-"AR" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/obj/machinery/computer/operating,
-/turf/open/floor/iron/dark,
-/area/cruiser_dock)
 "AS" = (
 /obj/structure/holosign/barrier,
 /turf/open/floor/iron/dark,
@@ -5240,38 +5288,34 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "AW" = (
-/obj/machinery/ore_silo,
-/turf/open/floor/glass,
+/obj/effect/turf_decal/trimline/red/line,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "AZ" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/freezer{
-	name = "universal blood storage"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood/universal{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 6;
+	pixel_y = 10
 	},
-/obj/item/reagent_containers/blood/universal,
-/obj/item/reagent_containers/blood/universal{
-	pixel_x = -4;
-	pixel_y = -4
+/obj/item/storage/box/beakers{
+	pixel_x = -1;
+	pixel_y = 5
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/item/reagent_containers/blood/universal,
-/obj/item/reagent_containers/blood/universal,
-/obj/item/reagent_containers/blood/universal,
-/obj/item/reagent_containers/blood/universal,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Bb" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"Be" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
 /area/cruiser_dock)
 "Bf" = (
 /obj/structure/table/reinforced,
@@ -5319,6 +5363,13 @@
 /obj/item/card/id/syndicate_command/crew_id,
 /obj/item/card/id/syndicate_command/crew_id,
 /turf/open/floor/mineral/plastitanium/red,
+/area/cruiser_dock)
+"Bw" = (
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "By" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
@@ -5427,38 +5478,8 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "BT" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -7;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 9
-	},
-/obj/item/storage/pill_bottle/mannitol{
-	pixel_y = 10
-	},
-/obj/item/storage/pill_bottle/mannitol{
-	pixel_y = 10
-	},
-/obj/item/storage/pill_bottle/mannitol{
-	pixel_y = 10
-	},
-/obj/item/storage/pill_bottle/mutadone,
-/obj/item/storage/pill_bottle/mutadone,
-/obj/item/storage/pill_bottle/mutadone,
+/obj/effect/turf_decal/trimline/red/line,
+/obj/effect/spawner/randomcolavend,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "BU" = (
@@ -5508,12 +5529,21 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Cd" = (
-/obj/machinery/light/small/blacklight,
-/turf/open/floor/iron/dark,
+/obj/machinery/power/rtg/advanced,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/cruiser_dock)
 "Ce" = (
 /obj/machinery/light/cold,
 /turf/open/floor/plating,
+/area/cruiser_dock)
+"Cg" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
 /area/cruiser_dock)
 "Ck" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -5534,15 +5564,6 @@
 	dir = 8
 	},
 /turf/open/floor/grass,
-/area/cruiser_dock)
-"Cx" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/light/small/red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "CA" = (
 /obj/effect/turf_decal/trimline/red/line{
@@ -5600,17 +5621,18 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/floor/plating,
 /area/cruiser_dock)
+"CT" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "CV" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/cruiser_dock)
 "CW" = (
-/obj/structure/chair/sofa/corp,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/engine,
+/obj/machinery/vending/cigarette/syndicate,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "CX" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -5630,6 +5652,13 @@
 /obj/machinery/recharger,
 /turf/open/floor/mineral/plastitanium/red,
 /area/cruiser_dock)
+"De" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/cruiser_dock)
 "Df" = (
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/caution/stand_clear/red,
@@ -5646,41 +5675,19 @@
 /obj/item/ammo_box/magazine/m16,
 /obj/item/ammo_box/magazine/m16,
 /obj/item/ammo_box/magazine/m16,
+/obj/item/stack/sheet/mineral/diamond{
+	amount = 15
+	},
 /turf/open/floor/plating,
 /area/cruiser_dock/brig)
 "Ds" = (
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 50
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 50
+/obj/structure/chair/pew/left{
+	dir = 1
 	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 50
-	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 50
-	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 50
-	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 50
-	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 50
-	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 50
-	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 50
-	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 50
-	},
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "Dt" = (
 /obj/effect/turf_decal/trimline/red/line{
@@ -5721,6 +5728,10 @@
 	dir = 5
 	},
 /turf/open/floor/engine,
+/area/cruiser_dock)
+"DG" = (
+/obj/effect/turf_decal/trimline/red/warning,
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "DI" = (
 /obj/structure/sign/warning/securearea{
@@ -5794,6 +5805,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
+/area/cruiser_dock)
+"Er" = (
+/obj/machinery/power/smes/magical{
+	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. Produces power through an unstable bluespace pocket.";
+	name = "bluespace-powered power storage unit"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Eu" = (
 /obj/machinery/mineral/ore_redemption,
@@ -5915,20 +5934,10 @@
 /turf/open/floor/plating,
 /area/cruiser_dock/brig)
 "Fk" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
+/obj/structure/chair/pew/right{
+	dir = 1
 	},
-/obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/syndie/surgery,
-/obj/item/storage/firstaid/tactical,
-/turf/open/floor/iron/dark,
-/area/cruiser_dock)
-"Fl" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 8
-	},
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "Fm" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -5976,9 +5985,6 @@
 /turf/open/floor/iron,
 /area/cruiser_dock)
 "Fz" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 8
-	},
 /obj/machinery/stasis{
 	dir = 1
 	},
@@ -5987,6 +5993,10 @@
 "FA" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/iron/showroomfloor,
+/area/cruiser_dock)
+"FC" = (
+/obj/machinery/portable_atmospherics/scrubber/huge/movable,
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "FD" = (
 /obj/effect/turf_decal/trimline/red/line{
@@ -6082,9 +6092,6 @@
 /turf/open/floor/engine,
 /area/cruiser_dock)
 "Ge" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
 /obj/structure/table/glass,
 /obj/item/stack/medical/gauze{
 	pixel_x = 8
@@ -6150,11 +6157,10 @@
 /turf/open/floor/plating,
 /area/cruiser_dock)
 "Gu" = (
-/obj/machinery/light/red{
-	dir = 1;
-	icon_state = "tube"
+/obj/structure/table/glass,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Gz" = (
@@ -6169,6 +6175,11 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/cruiser_dock)
+"GF" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/cruiser_dock)
 "GG" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -6182,8 +6193,8 @@
 /turf/open/floor/glass,
 /area/cruiser_dock)
 "GI" = (
-/obj/structure/table/glass,
-/turf/open/floor/engine,
+/obj/structure/table,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "GJ" = (
 /obj/structure/window/reinforced{
@@ -6195,14 +6206,14 @@
 /turf/open/floor/engine,
 /area/cruiser_dock)
 "GM" = (
-/obj/effect/turf_decal/delivery/red,
-/obj/machinery/door/airlock/security/glass{
-	name = "Secure Airlock";
-	req_access_txt = "150"
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "docklockdown"
 	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay";
+	req_access_txt = "150"
+	},
+/obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "GY" = (
@@ -6226,6 +6237,9 @@
 "Hf" = (
 /obj/machinery/skill_station,
 /turf/open/floor/engine,
+/area/cruiser_dock)
+"Hg" = (
+/turf/open/floor/grass,
 /area/cruiser_dock)
 "Hi" = (
 /obj/machinery/light/broken,
@@ -6255,11 +6269,13 @@
 /turf/open/floor/iron/white,
 /area/cruiser_dock)
 "Hq" = (
-/obj/machinery/computer/secure_data/syndie{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 8
+	},
+/obj/machinery/computer/security{
+	dir = 4;
+	name = "syndicate camera console";
+	network = list("fsci")
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/cruiser_dock)
@@ -6278,16 +6294,19 @@
 /turf/open/floor/glass/reinforced,
 /area/cruiser_dock/brig)
 "Hv" = (
-/obj/machinery/light/red{
-	dir = 8;
-	icon_state = "tube"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/structure/table/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Hw" = (
 /obj/effect/mob_spawn/human/syndicate/assops/facility_staff,
 /turf/open/floor/iron/cafeteria,
+/area/cruiser_dock)
+"Hx" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
 /area/cruiser_dock)
 "HB" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -6355,11 +6374,9 @@
 /turf/open/floor/glass,
 /area/cruiser_dock)
 "Ik" = (
-/obj/effect/spawner/randomsnackvend,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/cruiser_dock)
 "Io" = (
 /obj/structure/table/reinforced,
@@ -6476,10 +6493,8 @@
 /area/cruiser_dock)
 "IR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
+	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/syndie/surgery,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "IS" = (
@@ -6503,7 +6518,9 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Je" = (
-/obj/machinery/firealarm,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/cruiser_dock/brig)
 "Jf" = (
@@ -6516,7 +6533,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/computer/med_data/syndie{
+/obj/machinery/computer/aifixer{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -6528,7 +6545,10 @@
 /turf/open/floor/iron/checker,
 /area/cruiser_dock)
 "Jj" = (
-/obj/machinery/vending/medical/syndicate_access,
+/obj/machinery/vending/medical{
+	name = "\improper SyndiMed Plus";
+	pixel_x = -2
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Jk" = (
@@ -6575,12 +6595,11 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Ju" = (
-/obj/machinery/light/red{
-	dir = 4;
-	icon_state = "tube"
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/preopen{
+	id = "docklockdown"
 	},
-/obj/machinery/recharge_station,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/cruiser_dock)
 "Jw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6697,19 +6716,17 @@
 /turf/open/floor/wood,
 /area/cruiser_dock)
 "Kb" = (
-/obj/effect/turf_decal/delivery/red,
-/obj/machinery/door/airlock/security{
-	name = "Secure Airlock";
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Kk" = (
-/obj/machinery/light/red{
-	dir = 8;
-	icon_state = "tube"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/obj/machinery/portable_atmospherics/scrubber/huge/movable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Ko" = (
@@ -6726,11 +6743,10 @@
 /turf/open/floor/engine,
 /area/cruiser_dock)
 "Kq" = (
-/obj/effect/turf_decal/trimline/red/line{
+/obj/machinery/light/cold{
 	dir = 8
 	},
-/obj/machinery/iv_drip,
-/obj/machinery/light/cold{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -6747,7 +6763,9 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Ky" = (
-/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Kz" = (
@@ -6785,9 +6803,7 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "KJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "KK" = (
@@ -6921,13 +6937,48 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Ln" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/storage/pill_bottle/mannitol{
+	pixel_y = 10
+	},
+/obj/item/storage/pill_bottle/mannitol{
+	pixel_y = 10
+	},
+/obj/item/storage/pill_bottle/mannitol{
+	pixel_y = 10
+	},
+/obj/item/storage/pill_bottle/mutadone,
+/obj/item/storage/pill_bottle/mutadone,
+/obj/item/storage/pill_bottle/mutadone,
 /obj/structure/sign/warning/coldtemp{
 	pixel_y = 32
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Lp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/sleeper/syndie/fullupgrade{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -6938,6 +6989,10 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"Lw" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/cruiser_dock)
 "Ly" = (
 /obj/structure/table/wood,
@@ -6962,6 +7017,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"LC" = (
+/obj/machinery/door/airlock/engineering{
+	req_access_txt = "150"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "LE" = (
@@ -6992,10 +7055,12 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "LM" = (
-/obj/machinery/door/airlock/security{
-	name = "Brig";
-	req_access_txt = "150"
-	},
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/floor/grass,
+/area/cruiser_dock)
+"LP" = (
+/obj/machinery/light/warm,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "LR" = (
@@ -7061,16 +7126,23 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Mj" = (
-/obj/effect/turf_decal/trimline/red/line{
+/obj/machinery/light/cold{
 	dir = 4
 	},
-/obj/machinery/light/cold{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Ml" = (
 /obj/structure/table/glass,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"Mo" = (
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Mq" = (
@@ -7084,6 +7156,10 @@
 	dir = 8
 	},
 /turf/open/floor/glass,
+/area/cruiser_dock)
+"Mv" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "My" = (
 /obj/effect/turf_decal/caution/red{
@@ -7105,10 +7181,9 @@
 /turf/open/floor/iron/white/side,
 /area/cruiser_dock)
 "MC" = (
-/obj/effect/turf_decal/trimline/red/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/bed/roller,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "MD" = (
@@ -7125,11 +7200,9 @@
 /turf/open/floor/iron,
 /area/cruiser_dock)
 "MK" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/tactical,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "MM" = (
@@ -7162,11 +7235,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/cruiser_dock)
 "Nc" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/engine,
+/obj/structure/fluff/hedge/opaque,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "Nf" = (
 /obj/machinery/door/poddoor/preopen{
@@ -7176,7 +7246,9 @@
 /turf/open/floor/plating,
 /area/cruiser_dock)
 "Nl" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Np" = (
@@ -7188,8 +7260,11 @@
 /turf/open/floor/engine,
 /area/cruiser_dock)
 "Ns" = (
-/obj/structure/table/glass,
-/obj/item/instrument/guitar,
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "containment door";
+	req_access_txt = "150"
+	},
 /turf/open/floor/engine,
 /area/cruiser_dock)
 "Nt" = (
@@ -7197,8 +7272,9 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "NA" = (
-/obj/item/flashlight/lamp,
-/obj/structure/table,
+/obj/structure/chair/office{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "NB" = (
@@ -7252,17 +7328,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/cruiser_dock)
 "NX" = (
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/engine,
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "NZ" = (
-/obj/effect/turf_decal/trimline/red/line,
 /obj/machinery/light/cold,
-/obj/machinery/door/poddoor/preopen{
-	id = "docklockdown"
-	},
-/obj/effect/turf_decal/caution/stand_clear/red,
-/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Oa" = (
@@ -7361,6 +7432,7 @@
 	dir = 1;
 	icon_state = "tube"
 	},
+/obj/structure/closet/crate/wooden,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Ow" = (
@@ -7394,9 +7466,6 @@
 /turf/open/floor/iron,
 /area/cruiser_dock)
 "OF" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
 /obj/machinery/stasis,
 /obj/machinery/light/cold{
 	dir = 4
@@ -7457,17 +7526,21 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Pg" = (
-/obj/structure/table,
-/obj/item/kitchen/knife/combat,
-/obj/item/scalpel,
+/obj/structure/table/optable,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Pk" = (
 /mob/living/simple_animal/hostile/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/brig)
+"Pl" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "Pm" = (
-/obj/structure/closet/crate/wooden,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Pn" = (
@@ -7518,6 +7591,14 @@
 	dir = 6
 	},
 /obj/machinery/light/cold/no_nightlight,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"Pu" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/utility/syndicate,
+/obj/item/storage/belt/utility/syndicate,
+/obj/item/storage/belt/utility/syndicate,
+/obj/item/storage/belt/utility/syndicate,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Pw" = (
@@ -7588,7 +7669,11 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "PT" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Centre";
+	req_access_txt = "150"
+	},
+/obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Qb" = (
@@ -7625,6 +7710,10 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/cruiser_dock)
+"Qk" = (
+/obj/machinery/light/small/blacklight,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "Qm" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -7656,7 +7745,6 @@
 /area/cruiser_dock)
 "Qq" = (
 /obj/structure/table/wood,
-/obj/item/language_manual/codespeak_manual/unlimited,
 /turf/open/floor/iron/grimy,
 /area/cruiser_dock)
 "Qr" = (
@@ -7669,12 +7757,7 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Qv" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Qx" = (
@@ -7717,6 +7800,13 @@
 /obj/item/folder/syndicate/blue,
 /turf/open/floor/carpet/royalblack,
 /area/cruiser_dock)
+"QG" = (
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "QH" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/turf_decal/bot,
@@ -7736,6 +7826,11 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
+/area/cruiser_dock)
+"QO" = (
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/cruiser_dock)
 "QS" = (
 /obj/machinery/light/cold/no_nightlight,
@@ -7777,7 +7872,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/blue,
 /area/cruiser_dock)
 "Rf" = (
 /obj/effect/turf_decal/stripes/line{
@@ -7791,7 +7886,7 @@
 /obj/machinery/light/cold{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/blue,
 /area/cruiser_dock)
 "Rl" = (
 /obj/structure/sign/warning/vacuum,
@@ -7822,6 +7917,16 @@
 	},
 /obj/effect/turf_decal/trimline/red/line,
 /turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"RJ" = (
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/blue,
 /area/cruiser_dock)
 "RN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -7873,17 +7978,19 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Sd" = (
-/obj/effect/turf_decal/trimline/red/line,
-/obj/effect/spawner/randomsnackvend,
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/effect/turf_decal/delivery/red,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Si" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "151"
-	},
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/door/poddoor/preopen{
 	id = "docklockdown"
+	},
+/obj/machinery/door/airlock/vault{
+	name = "Armory";
+	req_access_txt = "151"
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
@@ -7954,7 +8061,8 @@
 "SD" = (
 /obj/machinery/computer/cryopod{
 	dir = 4;
-	pixel_x = -32
+	pixel_x = -32;
+	req_one_access = list(150)
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/brig)
@@ -7986,8 +8094,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/cruiser_dock)
 "SN" = (
-/obj/structure/table,
-/obj/item/gun/energy/decloner/unrestricted,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"SO" = (
+/obj/structure/table/glass,
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "SR" = (
@@ -8001,8 +8115,11 @@
 /turf/closed/indestructible/syndicate,
 /area/cruiser_dock)
 "ST" = (
-/obj/machinery/vending/games,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "SW" = (
 /obj/effect/turf_decal/stripes/line{
@@ -8053,14 +8170,23 @@
 	},
 /turf/open/floor/engine,
 /area/cruiser_dock)
+"Tm" = (
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/yellow,
+/area/cruiser_dock)
 "Tn" = (
 /obj/item/flashlight/seclite,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Tq" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/tactical,
-/obj/item/kitchen/knife/rainbowknife,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Ts" = (
@@ -8089,6 +8215,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"TE" = (
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "TH" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/rock,
@@ -8100,11 +8233,10 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/brig)
 "TJ" = (
-/obj/effect/turf_decal/trimline/red/line,
-/obj/structure/sign/warning/bodysposal{
-	pixel_y = -32
-	},
 /obj/machinery/light/cold,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "TK" = (
@@ -8158,8 +8290,10 @@
 /turf/open/floor/iron/checker,
 /area/cruiser_dock)
 "TU" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "TY" = (
 /obj/structure/window/reinforced,
@@ -8208,17 +8342,20 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Un" = (
-/turf/open/space/basic,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/light/cold{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Ut" = (
 /mob/living/simple_animal/hostile/russian/ranged/trooper,
 /turf/open/floor/plating,
 /area/cruiser_dock/brig)
 "Ux" = (
-/obj/effect/spawner/randomcolavend,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/gun/energy/decloner/unrestricted,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "UB" = (
@@ -8255,11 +8392,12 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "UO" = (
-/obj/structure/chair{
+/obj/machinery/light/small/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot_red,
-/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/computer/operating{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "UP" = (
@@ -8335,6 +8473,14 @@
 /obj/item/storage/box/contractor/fulton_extraction,
 /turf/open/floor/engine,
 /area/cruiser_dock)
+"Vq" = (
+/obj/structure/bed/roller,
+/obj/structure/window/reinforced/spawner,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "Vr" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
@@ -8342,9 +8488,8 @@
 /turf/open/floor/carpet/donk,
 /area/cruiser_dock)
 "Vt" = (
-/obj/machinery/light/cold{
-	dir = 8
-	},
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Vu" = (
@@ -8361,10 +8506,11 @@
 /turf/open/floor/engine,
 /area/cruiser_dock)
 "VD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/chair/office{
-	dir = 1
+/obj/machinery/door/airlock/medical{
+	name = "Unit A";
+	req_access_txt = "150"
 	},
+/obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "VE" = (
@@ -8401,6 +8547,10 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
+/area/cruiser_dock)
+"VQ" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/grass,
 /area/cruiser_dock)
 "VT" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -8497,8 +8647,11 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Wx" = (
-/obj/structure/closet/syndicate/personal,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/closet/syndicate,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/under/syndicate/skirt,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "WB" = (
@@ -8513,6 +8666,13 @@
 "WD" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/light/cold/no_nightlight,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"WI" = (
+/obj/structure/closet/radiation,
+/obj/machinery/light/warm{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "WJ" = (
@@ -8622,7 +8782,7 @@
 /obj/structure/chair/sofa/corp/corner{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/wood,
 /area/cruiser_dock)
 "Xx" = (
 /obj/machinery/door/airlock/research{
@@ -8637,9 +8797,6 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "XC" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 5
-	},
 /obj/structure/table/glass,
 /obj/item/reagent_containers/chem_pack{
 	pixel_x = 1;
@@ -8652,8 +8809,12 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "XE" = (
-/obj/structure/fluff/hedge/opaque,
-/turf/open/floor/wood,
+/obj/machinery/door/airlock/medical{
+	name = "Unit B";
+	req_access_txt = "150"
+	},
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "XF" = (
 /obj/structure/fluff/broken_flooring,
@@ -8663,6 +8824,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
+/obj/structure/closet/crate/wooden,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "XL" = (
@@ -8738,10 +8900,7 @@
 /turf/open/floor/plating,
 /area/cruiser_dock)
 "Yl" = (
-/obj/effect/turf_decal/trimline/red/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/corner,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Ym" = (
@@ -8801,6 +8960,10 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"YG" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "YH" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -8837,6 +9000,11 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
+/area/cruiser_dock)
+"YN" = (
+/obj/effect/turf_decal/trimline/red/warning,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "YT" = (
 /obj/vehicle/sealed/mecha/working/ripley/deathripley/real,
@@ -8975,6 +9143,15 @@
 /mob/living/simple_animal/hostile/rat,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/brig)
+"ZP" = (
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 5
+	},
+/obj/machinery/light/warm{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "ZZ" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -23346,9 +23523,9 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
+aa
+aa
+aa
 aa
 aa
 aa
@@ -23601,11 +23778,11 @@ NV
 Rv
 Ld
 fO
-fO
-Vt
-aA
-SN
+Un
 ak
+aa
+aa
+aa
 aa
 aa
 aa
@@ -23829,10 +24006,10 @@ aa
 aa
 aa
 aa
-ak
-ak
-ak
-ak
+aa
+aa
+aa
+aa
 ak
 ak
 ak
@@ -23858,11 +24035,11 @@ Ym
 Ym
 pk
 aA
-aA
-aA
-aA
-aA
+Ux
 ak
+aa
+aa
+aa
 aa
 aa
 aa
@@ -24086,10 +24263,10 @@ aa
 aa
 aa
 aa
-ak
-aL
-aL
-aL
+aa
+aa
+aa
+aa
 ak
 nm
 jN
@@ -24115,11 +24292,11 @@ aA
 aA
 aA
 aA
-aA
-aA
-aA
-Jj
+Vt
 ak
+aa
+aa
+aa
 aa
 aa
 aa
@@ -24343,10 +24520,10 @@ aa
 aa
 aa
 aa
-ak
-ab
-ba
-ab
+aa
+aa
+aa
+aa
 ak
 KA
 pJ
@@ -24600,12 +24777,12 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
 ak
-bh
-ba
-ab
-bb
-vV
+nF
 af
 Ll
 aU
@@ -24620,19 +24797,19 @@ aC
 af
 af
 rw
-uX
-aO
+Ju
+Kk
 MC
 Kq
 xK
-aO
-aO
-aO
-ml
+MC
+MC
+MC
+Tq
 ak
-eM
 aA
-aA
+Qv
+SO
 ak
 aa
 aa
@@ -24857,10 +25034,10 @@ aa
 aa
 aa
 aa
-ak
-et
-ba
-ab
+aa
+aa
+aa
+aa
 ak
 kI
 af
@@ -24876,17 +25053,17 @@ ap
 aC
 af
 af
-af
+Ll
 GM
+pf
 aA
 aA
 aA
 aA
 aA
 aA
-aA
-Zv
-Kb
+Yl
+VD
 aA
 aA
 NA
@@ -25114,10 +25291,10 @@ aP
 aP
 aP
 aa
-ak
-Ds
-ba
-ab
+aa
+aa
+aa
+aa
 ak
 KA
 pJ
@@ -25134,17 +25311,17 @@ aR
 af
 af
 rw
-uX
-Pz
-Pz
-Pz
-gt
-gb
-aT
+Ju
+Ky
+IR
+IR
+IR
+IR
+SN
 aA
-Zv
+KJ
 ak
-aA
+RJ
 UO
 Pg
 ak
@@ -25371,22 +25548,22 @@ SD
 An
 aP
 aa
-ak
-bI
-bJ
-ab
+aa
+aa
+aa
+aa
 ak
 lO
 an
 zl
 Nf
 XV
-an
-GG
-GG
+eI
+eN
+eN
 kD
-af
-af
+nX
+nX
 Zl
 GG
 GG
@@ -25397,13 +25574,13 @@ ak
 ak
 ak
 ak
-id
-pO
+Nl
+aA
 NZ
 ak
-aA
-aA
-aA
+ak
+ak
+ak
 ak
 aa
 aa
@@ -25628,10 +25805,10 @@ aS
 An
 aP
 aa
-ak
-ak
-aE
-ak
+aP
+aP
+aP
+aP
 ak
 uX
 Ot
@@ -25643,7 +25820,7 @@ Nf
 Nf
 nF
 af
-af
+nX
 rw
 jl
 ak
@@ -25654,13 +25831,13 @@ hZ
 wi
 AZ
 ak
-bg
+Nl
 aA
-Zv
+KJ
 ak
-uX
+GF
 LM
-uX
+Be
 ak
 aa
 aa
@@ -25887,7 +26064,7 @@ aP
 aa
 aP
 Je
-bc
+aG
 aG
 aP
 aI
@@ -25895,29 +26072,29 @@ eE
 av
 eB
 aI
-av
+aL
 av
 Nf
 nF
 af
-af
+nX
 rw
 uX
 ro
 QZ
 np
 Nl
-MK
-gZ
+aA
+aA
 KJ
 uX
-bg
+Nl
 aA
-Zv
+KJ
 ak
-aZ
+aA
 Qv
-XJ
+SO
 ak
 aa
 aa
@@ -26144,7 +26321,7 @@ aP
 aa
 aP
 br
-bc
+aG
 aG
 aP
 av
@@ -26152,29 +26329,29 @@ eE
 av
 eB
 av
-av
+aL
 av
 Nf
 nF
 af
-af
+nX
 rw
 uX
 Ml
 nH
+MC
+MK
 aA
-Nl
-rg
-VD
-KJ
+aA
+Yl
 aB
 pf
 aA
 Yl
-Kb
-rI
-Tq
-KV
+XE
+aA
+aA
+NA
 ak
 aa
 aa
@@ -26402,36 +26579,36 @@ aa
 aP
 eu
 bc
-aG
+bc
 bd
-av
-eF
-eE
-aF
-av
+aL
+ba
+bb
+bI
+aL
 ah
 av
 ak
 PK
 af
-af
+nX
 rw
 uX
-Ml
+Gu
 rv
-aA
-Nl
-AR
 IR
-KJ
+IR
+IR
+IR
+fv
 uX
-bg
+Nl
 aA
-Zv
+KJ
 ak
-dN
-Cx
-xG
+RJ
+UO
+Pg
 ak
 aa
 aa
@@ -26671,7 +26848,7 @@ am
 ak
 jg
 at
-at
+ri
 DI
 uX
 ro
@@ -26682,9 +26859,9 @@ Lp
 Lp
 uD
 ak
-id
-pO
-vG
+Nl
+aA
+KJ
 ak
 ak
 ak
@@ -26699,9 +26876,9 @@ ak
 ak
 ak
 ak
-aa
-aa
-aa
+ak
+ak
+ak
 aa
 aa
 aa
@@ -26928,7 +27105,7 @@ aP
 ak
 ak
 tg
-tg
+rz
 ak
 ak
 ak
@@ -26941,24 +27118,24 @@ ak
 ak
 li
 aA
-tD
-MC
-MC
-aO
-ml
+TU
+qs
+Vq
+Bw
+ua
 ak
 qb
 qb
 qb
-qb
-qb
-qb
-qb
-qb
 ak
-aa
-aa
-aa
+QO
+QO
+QO
+Cd
+rI
+rI
+aA
+ak
 aa
 aa
 aa
@@ -27190,32 +27367,32 @@ ml
 ak
 fR
 zQ
-Fl
+Qv
 Fz
-qU
+XC
 zQ
-Fl
-oH
-FY
+Qv
+uX
+Nl
 aA
 aA
 aA
-aA
-aA
+TU
+MC
 TJ
 ak
 UI
 aA
 aA
+ak
+ab
+ab
+ab
+Lw
 aA
-aA
-aA
-aA
+rI
 aA
 ak
-aa
-aa
-aa
 aa
 aa
 aa
@@ -27442,37 +27619,37 @@ bo
 ak
 bg
 aA
-aA
+rI
 Zv
 ak
-bg
-aA
-qa
-LJ
-LJ
-LJ
-vo
 aA
 aA
+aA
+aA
+aA
+aA
+aA
+uX
+Nl
 aA
 aA
 aA
 aA
 aA
 Yl
-Kb
+Ab
 aA
 aA
-aA
-aA
-aA
-aA
-UI
-Cd
+Qk
 ak
-aa
-aa
-aa
+gB
+QO
+QO
+Cd
+rI
+rI
+LP
+ak
 aa
 aa
 aa
@@ -27699,37 +27876,37 @@ bi
 ak
 bg
 aA
-aA
+rI
 FT
 ak
 tZ
 aA
-Nt
-ri
-ri
-ri
-YV
 aA
 aA
 aA
 aA
 aA
+PT
+pf
 aA
 aA
-qV
+aA
+aA
+aA
+KJ
 ak
-aA
-aA
-UI
-aA
-aA
 aA
 aA
 aA
 ak
-aa
-aa
-aa
+ab
+ab
+ab
+Lw
+aA
+rI
+aA
+ak
 aa
 aa
 aa
@@ -27956,16 +28133,9 @@ aG
 ak
 qS
 aA
-aA
+rI
 Zx
 ak
-bg
-aA
-fX
-SW
-SW
-SW
-HB
 aA
 aA
 aA
@@ -27973,20 +28143,27 @@ aA
 aA
 aA
 aA
-Zv
+uX
+Nl
+aA
+aA
+aA
+aA
+aA
+KJ
 ak
 uO
 uO
 uO
-uO
-uO
-uO
-uO
-uO
 ak
-aa
-aa
-aa
+QO
+QO
+QO
+Cd
+rI
+rI
+aA
+ak
 aa
 aa
 aa
@@ -28213,23 +28390,23 @@ ak
 ak
 FY
 aA
-aA
+rI
 Zx
 ak
 XC
 OF
-gt
+Qv
 hh
 Ge
 OF
-gt
-Fk
-gb
-gb
+Qv
+uX
+Ky
+IR
 Mj
 yX
-Pz
-Pz
+IR
+IR
 fv
 ak
 ak
@@ -28241,9 +28418,9 @@ ak
 ak
 ak
 ak
-aa
-aa
-aa
+uS
+ak
+ak
 aa
 aa
 aa
@@ -28470,7 +28647,7 @@ aA
 CP
 aA
 aA
-aA
+rI
 Zx
 ak
 ak
@@ -28481,26 +28658,26 @@ ak
 ak
 ak
 ak
-ak
-ak
+uX
+uX
 ak
 pI
 ak
+uX
+uX
 ak
+Ax
+ml
 ak
+Aj
+De
+yw
 ak
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Er
+nj
+rI
+aA
+ak
 aa
 aa
 aa
@@ -28727,7 +28904,7 @@ aA
 Zv
 aA
 aA
-aA
+rI
 Ry
 ak
 Xn
@@ -28742,22 +28919,22 @@ fa
 eK
 aA
 aA
-BT
+aA
 kT
 qu
 ak
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+bg
+Zv
+ak
+YG
+WI
+aA
+ak
+uw
+aA
+aA
+aA
+ak
 aa
 aa
 aa
@@ -28984,8 +29161,8 @@ Pz
 Iq
 aA
 aA
-aA
-Sd
+rI
+Zv
 ak
 eC
 aA
@@ -29003,18 +29180,18 @@ jc
 kT
 xB
 ak
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+QG
+YN
+LC
+rI
+rI
+rI
+LC
+rI
+aA
+aA
+LP
+ak
 aa
 aa
 aa
@@ -29241,10 +29418,10 @@ Yu
 PH
 aA
 aA
-aA
+rI
 tD
 hg
-NL
+Hv
 aA
 Zn
 rE
@@ -29260,18 +29437,18 @@ nG
 BV
 Xi
 ak
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+QG
+Zv
+ak
+Tm
+aA
+aA
+ak
+Mo
+aA
+aA
+aA
+ak
 aa
 aa
 aa
@@ -29501,7 +29678,7 @@ aA
 aA
 uW
 qm
-NL
+Hv
 aA
 Jt
 Bb
@@ -29511,24 +29688,24 @@ Wx
 ak
 ak
 ak
+uX
+uX
+uX
+ak
+ak
+ak
+QG
+ze
 ak
 ak
 ak
 ak
 ak
 ak
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ak
+ak
+ak
+ak
 aa
 aa
 aa
@@ -29756,36 +29933,36 @@ ml
 aA
 aA
 aA
-Zv
+AW
 ak
 zo
-aA
-aA
-aA
-aA
-aA
-KV
-ft
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+rI
+rI
+rI
+rI
+rI
+Pm
+Sd
+ST
+ST
+ST
+ST
+ST
+ST
+ST
+hd
+TE
+Zv
+uX
+Hg
+Hx
+AF
 ak
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+FC
+FC
+FC
+hp
+ak
 aa
 aa
 aa
@@ -30013,36 +30190,36 @@ Zv
 aA
 aA
 aA
-Zv
+BT
 ak
 AN
 Fm
 Fm
 Fm
-tc
-Ux
-Ik
+Fm
+Fm
+xG
+ES
+Pz
+Pz
+Pz
+rd
+Pz
+Pz
+Pz
+ES
+aT
+Zv
+uX
+wh
+Hg
+VQ
 ak
-TU
-ab
-ab
-ab
-ab
-ab
-ab
+aA
+aA
+aA
+aA
 ak
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -30286,20 +30463,20 @@ ak
 ak
 ak
 ak
-ab
+ft
 ak
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+bg
+Zv
+ak
+eV
+Cg
+yw
+ak
+CT
+aA
+aA
+aA
+ak
 aa
 aa
 aa
@@ -30545,18 +30722,18 @@ lI
 ak
 ab
 ak
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+bg
+Zv
+ak
+aA
+zD
+aA
+ak
+CT
+aA
+aA
+Pl
+ak
 aa
 aa
 aa
@@ -30802,18 +30979,18 @@ eQ
 ak
 ab
 ak
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+bg
+DG
+vQ
+aA
+aA
+aA
+vQ
+aA
+aA
+aA
+Pl
+ak
 aa
 aa
 aa
@@ -31059,18 +31236,18 @@ QC
 ak
 ab
 ak
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ZP
+Iq
+ak
+aA
+aA
+aA
+ak
+Mv
+aA
+Pu
+Pl
+ak
 aa
 aa
 aa
@@ -31316,18 +31493,18 @@ ak
 ak
 ab
 ak
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+ak
 aa
 aa
 aa
@@ -31803,9 +31980,9 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
+uX
+uX
+uX
 ak
 ak
 ak
@@ -32004,7 +32181,7 @@ aa
 aa
 aa
 aP
-aG
+aE
 aG
 aG
 aP
@@ -32059,17 +32236,17 @@ xt
 xt
 NB
 ak
-Kk
-aA
-aA
-eI
-Hv
-ak
-Un
-Un
-Un
-Un
-Un
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ak
 US
 BD
@@ -32316,17 +32493,17 @@ xt
 xt
 su
 ak
-iq
-aA
-aA
-aA
-rz
-ak
-Un
-Un
-Un
-Un
-Un
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ak
 uy
 BD
@@ -32573,18 +32750,18 @@ xt
 xt
 fG
 ak
-iq
-aA
-aA
-aA
-rz
-ak
-Un
-Un
-Un
-Un
-Un
-ak
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+uX
 py
 hj
 BD
@@ -32830,18 +33007,18 @@ xt
 xt
 gs
 ak
-iN
-aA
-aA
-aA
-aA
-ak
-Un
-Un
-Un
-Un
-Un
-ak
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+uX
 Ec
 BD
 BD
@@ -33087,18 +33264,18 @@ xt
 xt
 EL
 ak
-Ky
-aA
-aA
-aA
-aA
+aa
+aa
 ak
-Un
-Un
-Un
-Un
-Un
 ak
+ak
+ak
+ak
+ak
+ak
+aa
+aa
+uX
 py
 BD
 BD
@@ -33344,17 +33521,17 @@ xt
 xt
 JC
 ak
-Ky
-aA
-aA
-aA
-aA
+aa
+aa
 ak
+bJ
+Fm
+Fm
+Fm
+hX
 ak
-uX
-uX
-uX
-ak
+aa
+aa
 ak
 uX
 zV
@@ -33601,17 +33778,17 @@ xt
 xt
 Pq
 ak
-eH
-aA
-aA
-aA
-aA
+aa
+aa
 ak
-aA
-aA
-aA
-aA
-aA
+KV
+Gq
+Gq
+Gq
+NL
+ak
+uX
+uX
 ak
 TY
 BD
@@ -33858,18 +34035,18 @@ xt
 xt
 iv
 ak
-Ju
-aA
-aA
-aA
-aA
+aa
+aa
+ak
+et
+Gq
 eJ
+Gq
+NL
+oH
 aA
 aA
-aA
-aA
-aA
-eJ
+oH
 BD
 BD
 BD
@@ -34118,14 +34295,14 @@ ak
 ak
 ak
 ak
-pe
-aA
+KV
+Gq
+Gq
+Gq
+NL
 ak
-aA
-aA
-uI
-aA
-aA
+uX
+uX
 ak
 kr
 BD
@@ -34375,14 +34552,14 @@ xt
 ko
 Ix
 ak
-aA
-aA
+eH
+hq
+hq
+hq
+iq
 ak
-ak
-ak
-ak
-ak
-ak
+aa
+aa
 ak
 eG
 BD
@@ -34632,15 +34809,15 @@ xt
 ko
 Ix
 ak
-aA
-aA
 ak
-PT
-Fm
-Fm
-Fm
-eO
 ak
+ak
+ak
+ak
+ak
+aa
+aa
+uX
 py
 BD
 BD
@@ -34889,16 +35066,16 @@ xt
 ko
 eD
 ak
-aA
-aA
-ak
-KV
-Gq
-Gq
-Gq
-NL
-ak
-hX
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+uX
+MU
 BD
 BD
 BD
@@ -35146,16 +35323,16 @@ xt
 ko
 Ix
 ak
-aA
-aA
-ak
-Gu
-Gq
-AW
-Gq
-NL
-fT
-BD
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+uX
+Ik
 BD
 BD
 BD
@@ -35403,16 +35580,16 @@ xt
 ko
 Ix
 ak
-pe
-aA
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ak
-KV
-Gq
-Gq
-Gq
-NL
-ak
-kr
+py
 BD
 BD
 BD
@@ -35660,14 +35837,14 @@ ju
 ko
 Ix
 ak
-aA
-aA
-ak
-eN
-hq
-hq
-hq
-fu
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ak
 le
 BD
@@ -36172,17 +36349,17 @@ gl
 kc
 ak
 Ov
-hq
-hq
-hq
+bh
+bh
+bh
 XJ
 ak
 Xr
 gW
-gW
-gW
+pe
+ak
 Nc
-XE
+BD
 UY
 BD
 UY
@@ -36190,9 +36367,9 @@ BD
 UY
 lY
 BD
-nX
-ST
-hl
+BD
+BD
+BD
 lY
 BD
 UY
@@ -36436,10 +36613,10 @@ KV
 ak
 NX
 GI
-GI
-GI
-iK
-XE
+rg
+ak
+Nc
+BD
 BD
 BD
 BD
@@ -36691,12 +36868,12 @@ aA
 aA
 KV
 ak
-CW
-GI
-jT
-GI
-iK
-XE
+BD
+BD
+BD
+ak
+Nc
+BD
 BD
 DP
 DP
@@ -36948,12 +37125,12 @@ aA
 aA
 BZ
 ak
-NX
-GI
 jT
-Gq
-rc
-XE
+jT
+jT
+ak
+Nc
+BD
 BD
 Rr
 ig
@@ -37203,13 +37380,13 @@ ET
 aA
 aA
 aA
-KV
-ak
-NX
-Gq
-Gq
-Gq
-xt
+eM
+eO
+Hk
+hq
+hq
+tc
+BD
 BD
 BD
 lS
@@ -37460,13 +37637,13 @@ SF
 aA
 aA
 aA
+eM
+eO
+PH
+aA
+aA
 KV
-ak
-NX
-Gq
-Gq
-Gq
-ud
+BD
 BD
 BD
 BD
@@ -37715,15 +37892,15 @@ BP
 YI
 gi
 aA
-Pm
 aA
-KV
-ak
-NX
-Gq
-Gq
-Gq
-xt
+aA
+eM
+eO
+Lm
+Fm
+Fm
+xG
+BD
 BD
 BD
 DP
@@ -37972,16 +38149,16 @@ aA
 oQ
 gi
 aA
-Pm
+aA
 aA
 KV
 ak
-NX
-GI
-jT
-Gq
-jt
-XE
+fu
+iN
+iN
+ak
+Nc
+BD
 BD
 ig
 ig
@@ -38229,16 +38406,16 @@ aA
 oQ
 gi
 aA
-Pm
+aA
 aA
 Fq
 ak
 CW
-GI
-jT
-GI
-iK
-XE
+BD
+BD
+ak
+Nc
+BD
 BD
 lS
 lS
@@ -38486,16 +38663,16 @@ aA
 oQ
 gi
 aA
-Pm
+aA
 aA
 KV
 ak
-NX
-Ns
-GI
-GI
-iK
-XE
+fT
+BD
+BD
+ak
+Nc
+BD
 BD
 BD
 BD
@@ -38743,16 +38920,16 @@ aA
 oQ
 gi
 aA
-Pm
+aA
 aA
 KV
 ak
 fW
-jZ
-jZ
-jZ
-mu
-XE
+BD
+BD
+ak
+Nc
+BD
 XX
 XX
 XX
@@ -39000,7 +39177,7 @@ Oo
 Gj
 gi
 aA
-Pm
+aA
 aA
 KV
 ak
@@ -39518,11 +39695,11 @@ aA
 aA
 KV
 ak
-BD
-BD
-BD
-BD
-BD
+gZ
+iN
+iN
+iN
+Ds
 ak
 Hs
 Qc
@@ -39775,11 +39952,11 @@ aA
 aA
 KV
 ak
-BD
+hl
 ay
 BD
 ay
-BD
+Fk
 ak
 Qc
 aA
@@ -40032,11 +40209,11 @@ Fm
 Fm
 xG
 ak
-BD
-BD
+ig
+jZ
 aJ
-BD
-BD
+ud
+ig
 ak
 lP
 Fx
@@ -47237,7 +47414,7 @@ Gq
 pa
 Nt
 jI
-xt
+Ns
 xt
 xt
 xt

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -2084,6 +2084,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/cruiser_dock)
+"gR" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "gS" = (
 /obj/effect/turf_decal/stripes/red/box,
 /obj/machinery/nuclearbomb,
@@ -2191,6 +2197,9 @@
 /area/cruiser_dock)
 "hp" = (
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "hq" = (
@@ -2968,6 +2977,13 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"lQ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "lS" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -3141,7 +3157,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/cruiser_dock)
 "nm" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -3345,6 +3364,12 @@
 /area/cruiser_dock)
 "oq" = (
 /obj/structure/spider/stickyweb,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"os" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "oA" = (
@@ -3767,6 +3792,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"qZ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "ra" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
@@ -4094,6 +4125,10 @@
 /obj/effect/turf_decal/trimline/red/line,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"sZ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "tc" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -4150,6 +4185,12 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/grimy,
+/area/cruiser_dock)
+"tn" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "tp" = (
 /obj/machinery/light/red{
@@ -4288,6 +4329,9 @@
 "uw" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "uy" = (
@@ -4361,6 +4405,7 @@
 	req_access_txt = "150"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "uT" = (
@@ -4437,6 +4482,12 @@
 "vo" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"vq" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
@@ -4767,6 +4818,10 @@
 "xt" = (
 /turf/open/floor/engine,
 /area/cruiser_dock)
+"xv" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "xA" = (
 /obj/machinery/status_display,
 /turf/closed/indestructible/syndicate,
@@ -4858,6 +4913,13 @@
 	},
 /turf/open/floor/iron,
 /area/cruiser_dock)
+"xX" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "ya" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
@@ -4911,6 +4973,11 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"ys" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "yu" = (
@@ -5097,6 +5164,9 @@
 /obj/machinery/light/warm{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "zE" = (
@@ -5209,6 +5279,13 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/cruiser_dock)
+"Al" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "Am" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -5258,6 +5335,13 @@
 "AG" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/grimy,
+/area/cruiser_dock)
+"AI" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "AN" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -5347,6 +5431,12 @@
 "Bq" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/mob_spawn/human/syndicate/assops/syndicate_scientist,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"Bu" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Bv" = (
@@ -5628,6 +5718,9 @@
 /area/cruiser_dock)
 "CT" = (
 /obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "CV" = (
@@ -5656,6 +5749,13 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /turf/open/floor/mineral/plastitanium/red,
+/area/cruiser_dock)
+"Db" = (
+/obj/machinery/portable_atmospherics/scrubber/huge/movable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "De" = (
 /obj/structure/window/reinforced{
@@ -5817,7 +5917,10 @@
 	name = "bluespace-powered power storage unit"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/cruiser_dock)
 "Eu" = (
 /obj/machinery/mineral/ore_redemption,
@@ -6001,6 +6104,9 @@
 /area/cruiser_dock)
 "FC" = (
 /obj/machinery/portable_atmospherics/scrubber/huge/movable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "FD" = (
@@ -7066,6 +7172,7 @@
 /area/cruiser_dock)
 "LP" = (
 /obj/machinery/light/warm,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "LR" = (
@@ -7148,6 +7255,9 @@
 /area/cruiser_dock)
 "Mo" = (
 /obj/machinery/recharge_station,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Mq" = (
@@ -7164,6 +7274,9 @@
 /area/cruiser_dock)
 "Mv" = (
 /obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "My" = (
@@ -7347,6 +7460,12 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"Ob" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
@@ -7535,12 +7654,21 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"Pi" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "Pk" = (
 /mob/living/simple_animal/hostile/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/brig)
 "Pl" = (
 /obj/structure/table/reinforced,
+/obj/machinery/light/warm,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Pm" = (
@@ -7604,6 +7732,9 @@
 /obj/item/storage/belt/utility/syndicate,
 /obj/item/storage/belt/utility/syndicate,
 /obj/item/storage/belt/utility/syndicate,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "Pw" = (
@@ -7916,6 +8047,12 @@
 /obj/item/storage/firstaid/tactical,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"Rw" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "Ry" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
@@ -8147,6 +8284,11 @@
 	},
 /turf/open/floor/engine,
 /area/cruiser_dock)
+"Tc" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "Td" = (
 /turf/open/floor/glass/reinforced,
 /area/cruiser_dock)
@@ -8227,6 +8369,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"TF" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "TH" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/rock,
@@ -8297,6 +8445,13 @@
 "TU" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"TX" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
@@ -8669,6 +8824,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"WC" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "WD" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/light/cold/no_nightlight,
@@ -8677,6 +8839,9 @@
 "WI" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light/warm{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -8968,6 +9133,9 @@
 /area/cruiser_dock)
 "YG" = (
 /obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "YH" = (
@@ -9155,6 +9323,13 @@
 	},
 /obj/machinery/light/warm{
 	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
+"ZS" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
@@ -27138,9 +27313,9 @@ QO
 QO
 QO
 Cd
-rI
-rI
-aA
+AI
+ZS
+Bu
 ak
 aa
 aa
@@ -27395,9 +27570,9 @@ ab
 ab
 ab
 Lw
-aA
+Rw
 rI
-aA
+sZ
 ak
 aa
 aa
@@ -27652,7 +27827,7 @@ gB
 QO
 QO
 Cd
-rI
+xX
 rI
 LP
 ak
@@ -27909,9 +28084,9 @@ ab
 ab
 ab
 Lw
-aA
+Rw
 rI
-aA
+sZ
 ak
 aa
 aa
@@ -28166,9 +28341,9 @@ QO
 QO
 QO
 Cd
-rI
-rI
-aA
+lQ
+TX
+vq
 ak
 aa
 aa
@@ -28681,8 +28856,8 @@ yw
 ak
 Er
 nj
-rI
-aA
+Al
+Bu
 ak
 aa
 aa
@@ -28934,12 +29109,12 @@ Zv
 ak
 YG
 WI
-aA
+Bu
 ak
 uw
-aA
-aA
-aA
+tn
+Ob
+sZ
 ak
 aa
 aa
@@ -29189,11 +29364,11 @@ ak
 QG
 YN
 LC
+WC
 rI
-rI
-rI
+ys
 LC
-rI
+WC
 aA
 aA
 LP
@@ -29447,13 +29622,13 @@ QG
 Zv
 ak
 Tm
-aA
-aA
+qZ
+vq
 ak
 Mo
-aA
-aA
-aA
+qZ
+qZ
+vq
 ak
 aa
 aa
@@ -29965,8 +30140,8 @@ Hx
 AF
 ak
 FC
-FC
-FC
+Db
+Db
 hp
 ak
 aa
@@ -30221,10 +30396,10 @@ wh
 Hg
 VQ
 ak
+Rw
 aA
 aA
-aA
-aA
+sZ
 ak
 aa
 aa
@@ -30481,7 +30656,7 @@ ak
 CT
 aA
 aA
-aA
+sZ
 ak
 aa
 aa
@@ -30731,9 +30906,9 @@ ak
 bg
 Zv
 ak
-aA
+os
 zD
-aA
+Bu
 ak
 CT
 aA
@@ -30988,14 +31163,14 @@ ak
 bg
 DG
 vQ
+TF
 aA
-aA
-aA
+xv
 vQ
+TF
 aA
 aA
-aA
-Pl
+Tc
 ak
 aa
 aa
@@ -31245,14 +31420,14 @@ ak
 ZP
 Iq
 ak
-aA
-aA
-aA
+gR
+qZ
+vq
 ak
 Mv
-aA
+qZ
 Pu
-Pl
+Pi
 ak
 aa
 aa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Inspired by my previous DS-1 Tweak PR and people deriding the place for being only good for ERP and Assault Ops, but even more drastic. Opens up the bar to cargo, reorganizes medbay and gives chemistry beakers, moves atmospherics and power generation, changes power generation to RTGs, Removes the syndiecomms keys, replaced with more DS-1 keys. Warden's records consoles are gone in favor of an AI restorer and syndicate network camera console. Spreads more materials out across the entire station. Renamed the NanoMed to SyndiMed. Added NanoDrug.
I debated making the prisoners functional ghostroles too rather than catatonic monkies, but decided against it. I feel it'd ruin the chill vibe of the place.
![image](https://user-images.githubusercontent.com/50649185/107576830-af5d8780-6bbf-11eb-85a7-5a48946ca117.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People don't really like DS-1 in it's current state, with it being treated as a syndicate-themed ghost cafe. While I like that it's disconnected from the main game, it's probably best to give the place things to do for those who.. don't. This partially helps, by adding more materials so more things can be printed from the lathe.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: DS-1 Has been opened up somewhat, with new materials inside.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
