### PR TITLE
[Modular] Ports speech impediments from old base

### DIFF
--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -34,3 +34,70 @@
 	medical_record_text = "Patient is a DNR, and cannot be revived in any way."
 	value = 0
 	mob_trait = TRAIT_DNR
+
+//Speech impediments
+/datum/quirk/speech_impediment_rl
+	name = "Speech impediment (r as l)"
+	desc = "You mispronounce \"r\" as \"l\""
+	value = 0
+	medical_record_text = "Patient experiences difficulty in pronouncing certain phonemes."
+
+/datum/quirk/speech_impediment_rl/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		H.enable_speech_mod(/datum/speech_mod/impediment_rl)
+
+/datum/quirk/speech_impediment_rl/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		H.disable_speech_mod(/datum/speech_mod/impediment_rl)
+
+
+/datum/quirk/speech_impediment_lw
+	name = "Speech impediment (l as w)"
+	desc = "You mispronounce \"l\" as \"w\""
+	value = 0
+	medical_record_text = "Patient experiences difficulty in pronouncing certain phonemes."
+
+/datum/quirk/speech_impediment_lw/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		H.enable_speech_mod(/datum/speech_mod/impediment_lw)
+
+/datum/quirk/speech_impediment_lw/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		H.disable_speech_mod(/datum/speech_mod/impediment_lw)
+
+
+/datum/quirk/speech_impediment_rw
+	name = "Speech impediment (r as w)"
+	desc = "You mispronounce \"r\" as \"w\""
+	value = 0
+	medical_record_text = "Patient experiences difficulty in pronouncing certain phonemes."
+
+/datum/quirk/speech_impediment_rw/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		H.enable_speech_mod(/datum/speech_mod/impediment_rw)
+
+/datum/quirk/speech_impediment_rw/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		H.disable_speech_mod(/datum/speech_mod/impediment_rw)
+
+/datum/quirk/speech_impediment_rw_lw
+	name = "Speech impediment (r and l as w)"
+	desc = "You mispronounce \"r\" and \"l\" as \"w\""
+	value = 0
+	medical_record_text = "Patient experiences difficulty in pronouncing certain phonemes."
+
+/datum/quirk/speech_impediment_rw_lw/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		H.enable_speech_mod(/datum/speech_mod/impediment_rw_lw)
+
+/datum/quirk/speech_impediment_rw_lw/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		H.disable_speech_mod(/datum/speech_mod/impediment_rw_lw)

--- a/modular_skyrat/master_files/code/datums/traits/speech_mod/_speech_mod.dm
+++ b/modular_skyrat/master_files/code/datums/traits/speech_mod/_speech_mod.dm
@@ -1,0 +1,51 @@
+/mob/living/carbon/human/var/list/speech_mods = list()
+
+/mob/living/carbon/human/proc/toggle_speech_mod(datumtype)
+	var/checkbool = TRUE
+	for(var/datum/speech_mod/S in speech_mods)
+		if(istype(S,datumtype))
+			S.remove_speech_mod()
+			qdel(S)
+			checkbool = FALSE
+			break
+	if(checkbool)
+		var/datum/speech_mod/speech = new datumtype
+		speech.add_speech_mod(src)
+
+/mob/living/carbon/human/proc/enable_speech_mod(datumtype)
+	for(var/datum/speech_mod/S in speech_mods)
+		if(istype(S,datumtype))
+			return
+	var/datum/speech_mod/speech = new datumtype
+	speech.add_speech_mod(src)
+
+/mob/living/carbon/human/proc/disable_speech_mod(datumtype)
+	for(var/datum/speech_mod/S in speech_mods)
+		if(istype(S,datumtype))
+			S.remove_speech_mod()
+			qdel(S)
+
+/datum/speech_mod
+	var/soundtext = ""
+	var/mob/living/carbon/human/affected_mob = null
+
+/datum/speech_mod/proc/handle_speech(datum/source, list/speech_args)
+	return
+
+/datum/speech_mod/proc/after_add()
+	RegisterSignal(affected_mob, COMSIG_MOB_SAY, .proc/handle_speech)
+	if(soundtext)
+		to_chat(affected_mob, "You start [soundtext].")
+	return
+
+/datum/speech_mod/proc/add_speech_mod(mob/living/carbon/human/M)
+	affected_mob = M
+	affected_mob.speech_mods += src
+	after_add()
+
+/datum/speech_mod/proc/remove_speech_mod()
+	if(soundtext)
+		to_chat(affected_mob, "You stop [soundtext].")
+	UnregisterSignal(affected_mob, COMSIG_MOB_SAY)
+	affected_mob.speech_mods -= src
+	affected_mob = null

--- a/modular_skyrat/master_files/code/datums/traits/speech_mod/impediments.dm
+++ b/modular_skyrat/master_files/code/datums/traits/speech_mod/impediments.dm
@@ -1,0 +1,29 @@
+/datum/speech_mod/impediment_rl
+	soundtext = "mispronouncing \"r\" as \"l\""
+
+/datum/speech_mod/impediment_rl/handle_speech(datum/source, list/speech_args)
+	speech_args[SPEECH_MESSAGE] = replacetext(speech_args[SPEECH_MESSAGE], "r", "l")
+	speech_args[SPEECH_MESSAGE] = replacetext(speech_args[SPEECH_MESSAGE], "R", "L")
+
+/datum/speech_mod/impediment_lw
+	soundtext = "mispronouncing \"l\" as \"w\""
+
+/datum/speech_mod/impediment_lw/handle_speech(datum/source, list/speech_args)
+	speech_args[SPEECH_MESSAGE] = replacetext(speech_args[SPEECH_MESSAGE], "l", "w")
+	speech_args[SPEECH_MESSAGE] = replacetext(speech_args[SPEECH_MESSAGE], "L", "W")
+
+/datum/speech_mod/impediment_rw
+	soundtext = "mispronouncing \"r\" as \"w\""
+
+/datum/speech_mod/impediment_rw/handle_speech(datum/source, list/speech_args)
+	speech_args[SPEECH_MESSAGE] = replacetext(speech_args[SPEECH_MESSAGE], "r", "w")
+	speech_args[SPEECH_MESSAGE] = replacetext(speech_args[SPEECH_MESSAGE], "R", "W")
+
+/datum/speech_mod/impediment_rw_lw
+	soundtext = "mispronouncing \"r\" and \"l\" as \"w\""
+
+/datum/speech_mod/impediment_rw_lw/handle_speech(datum/source, list/speech_args)
+	speech_args[SPEECH_MESSAGE] = replacetext(speech_args[SPEECH_MESSAGE], "r", "w")
+	speech_args[SPEECH_MESSAGE] = replacetext(speech_args[SPEECH_MESSAGE], "R", "W")
+	speech_args[SPEECH_MESSAGE] = replacetext(speech_args[SPEECH_MESSAGE], "l", "w")
+	speech_args[SPEECH_MESSAGE] = replacetext(speech_args[SPEECH_MESSAGE], "L", "W")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3397,6 +3397,8 @@
 #include "modular_skyrat\master_files\code\datums\traits\good.dm"
 #include "modular_skyrat\master_files\code\datums\traits\negative.dm"
 #include "modular_skyrat\master_files\code\datums\traits\neutral.dm"
+#include "modular_skyrat\master_files\code\datums\traits\speech_mod\_speech_mod.dm"
+#include "modular_skyrat\master_files\code\datums\traits\speech_mod\impediments.dm"
 #include "modular_skyrat\master_files\code\game\objects\ghost_role_spawners.dm"
 #include "modular_skyrat\master_files\code\game\objects\items\oxygen_candle.dm"
 #include "modular_skyrat\master_files\code\game\objects\items\devices\radio\encryption_key.dm"


### PR DESCRIPTION
## About The Pull Request

Code ripped directly from https://github.com/Skyrat-SS13/Skyrat13/pull/1958's speech impediment addons.

Adds the speech impediments from oldbase. [Tested](https://i.gyazo.com/449aa0deb22358c31d7c1c93d9aafea0.png) [and](https://i.gyazo.com/76169dfc1c591b0f3da0f960d49a23d0.png) [fully](https://i.gyazo.com/657f2cb28ade049b2fcc8e17a8889f1b.png) [working](https://i.gyazo.com/436f95c585a124f0da4ab87fcd3aecff.png). <-(Four links by the way)

## Why It's Good For The Game

More character customization, these  gave a little more uniqueness to some characters, and I felt their absence from the server. This also allows users of all tongues to have the impediments, rather than making a bunch of tongues.

## Changelog
:cl:
add: Added speech impediments.
/:cl:
