### PR TITLE
re removes changeling head slugs from gold slime pool 

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -22,7 +22,6 @@
 	speak_emote = list("squeaks")
 	var/datum/mind/origin
 	var/egg_lain = 0
-	gold_core_spawnable = HOSTILE_SPAWN //SKYRAT EDIT ADDITION
 
 /mob/living/simple_animal/hostile/headcrab/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

re removes the changeling head slug from the gold slime pool, it really shouldnt be there

## Why It's Good For The Game

the headslug is supost to be a changeling power to escape via vent crawling as a last resort. being in the gold pool will lead to players without the changeling tag becoming a slug that dies if it bites a dead body due to more tg blockage to stop non changelings from becoming changelings 

## Changelog
:cl:
del: changeling headslug once again removed from the pool
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
