### PR TITLE
[MODULAR] Bumps Required Players For Families Up To 90, Moves ShipStation Max Players to 89

### DIFF
--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -3,7 +3,7 @@
 	config_tag = "families"
 	antag_flag = ROLE_FAMILIES
 	false_report_weight = 5
-	required_players = 40
+	required_players = 120 //SKYRAT EDIT CHANGE - Original: 40
 	required_enemies = 6
 	recommended_enemies = 6
 	announce_span = "danger"

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -3,7 +3,7 @@
 	config_tag = "families"
 	antag_flag = ROLE_FAMILIES
 	false_report_weight = 5
-	required_players = 120 //SKYRAT EDIT CHANGE - Original: 40
+	required_players = 40
 	required_enemies = 6
 	recommended_enemies = 6
 	announce_span = "danger"

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -44,6 +44,6 @@ endmap
 
 map shipstation
 	minplayers 0
-	maxplayers 39
+	maxplayers 119
 	votable
 endmap

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -44,6 +44,6 @@ endmap
 
 map shipstation
 	minplayers 0
-	maxplayers 119
+	maxplayers 89
 	votable
 endmap

--- a/modular_skyrat/modules/mapping/code/game/gamemodes/gang/gang.dm
+++ b/modular_skyrat/modules/mapping/code/game/gamemodes/gang/gang.dm
@@ -1,0 +1,2 @@
+/datum/game_mode/gang
+	required_players = 90

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3808,6 +3808,7 @@
 #include "modular_skyrat\modules\mapping\code\game\gamemodes\changeling\traitor_chan.dm"
 #include "modular_skyrat\modules\mapping\code\game\gamemodes\cult\cult.dm"
 #include "modular_skyrat\modules\mapping\code\game\gamemodes\devil\devil_game_mode.dm"
+#include "modular_skyrat\modules\mapping\code\game\gamemodes\gang\gang.dm"
 #include "modular_skyrat\modules\mapping\code\game\gamemodes\monkey\monkey.dm"
 #include "modular_skyrat\modules\mapping\code\game\gamemodes\revolution\revolution.dm"
 #include "modular_skyrat\modules\mapping\code\game\gamemodes\traitor\traitor.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What the title says. Makes ShipStation realistically playable on Skyrat, moves Families to require more people at the same time so they don't conflict.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't think anyone really //likes// Families anyways, honestly, but this is a good compromise between outright removing it and making the map realistically playable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Families requires more people (90) to roll.
tweak: ShipStation can roll with up to 89 people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
