### PR TITLE
Traitor Uplink Update #1

### DIFF
--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -11,15 +11,53 @@
 			with suppressors. The gun fires in three round bursts."
 	item = /obj/item/gun/ballistic/automatic/pistol/aps
 	cost = 13
-	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear) //They don't need this since it is just a version that costs more than the original.
-
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
 /datum/uplink_item/dangerous/foamsmg_traitor
 	name = "Toy Submachine Gun"
 	desc = "A fully-loaded Donksoft bullpup submachine gun that fires riot grade darts with a 20-round magazine."
 	item = /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot
 	cost = 5
-	surplus = 0
 
+/datum/uplink_item/dangerous/smgc20r_traitor
+	name = "C-20r Submachine Gun"
+	desc = "A fully-loaded Scarborough Arms bullpup submachine gun. The C-20r fires .45 rounds with a \
+			24-round magazine and is compatible with suppressors."
+	item = /obj/item/gun/ballistic/automatic/c20r
+	cost = 17
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/dangerous/shotgun_traitor
+	name = "Bulldog Shotgun"
+	desc = "A fully-loaded semi-automatic drum-fed shotgun. Compatible with all 12g rounds. Designed for close \
+			quarter anti-personnel engagements."
+	item = /obj/item/gun/ballistic/shotgun/bulldog
+	cost = 15
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/dangerous/shield_traitor
+	name = "Energy Shield"
+	desc = "An incredibly useful personal shield projector, capable of reflecting energy projectiles and defending \
+			against other attacks. Pair with an Energy Sword for a killer combination."
+	item = /obj/item/shield/energy
+	cost = 15
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+//BUNDLES
+
+/datum/uplink_item/bundles_tc/bulldog
+	name = "Bulldog bundle"
+	desc = "Lean and mean: Optimized for people that want to get up close and personal. Contains the popular \
+			Bulldog shotgun, two 12g buckshot drums, and a pair of Thermal imaging goggles."
+	item = /obj/item/storage/backpack/duffelbag/syndie/bulldogbundle
+	cost = 20 // normally 16
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/bundles_tc/c20r_traitor
+	name = "C-20r bundle"
+	desc = "Old Faithful: The classic C-20r, bundled with two magazines and a (surplus) suppressor at discount price."
+	item = /obj/item/storage/backpack/duffelbag/syndie/c20rbundle
+	cost = 25
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
 
 //STEALTHY WEAPONS
 /datum/uplink_item/stealthy_weapons/cqc_traitor
@@ -76,7 +114,58 @@
 	desc = "An additional 15-round 9mm magazine, compatible with the Stechkin APS machine pistol."
 	item = /obj/item/ammo_box/magazine/m9mm_aps
 	cost = 2
-	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/smg_traitor
+	name = ".45 SMG Magazine"
+	desc = "An additional 24-round .45 magazine suitable for use with the C-20r submachine gun."
+	item = /obj/item/ammo_box/magazine/smgm45
+	cost = 3
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/smgap_traitor
+	name = ".45 Armor Piercing SMG Magazine"
+	desc = "An additional 24-round .45 magazine suitable for use with the C-20r submachine gun.\
+			These rounds are less effective at injuring the target but penetrate protective gear."
+	item = /obj/item/ammo_box/magazine/smgm45/ap
+	cost = 5
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/smgfire_traitor
+	name = ".45 Incendiary SMG Magazine"
+	desc = "An additional 24-round .45 magazine suitable for use with the C-20r submachine gun.\
+			Loaded with incendiary rounds which inflict little damage, but ignite the target."
+	item = /obj/item/ammo_box/magazine/smgm45/incen
+	cost = 4
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/shotgun/buck_traitor
+	name = "12g Buckshot Drum"
+	desc = "An additional 8-round buckshot magazine for use with the Bulldog shotgun. Front towards enemy."
+	item = /obj/item/ammo_box/magazine/m12g
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/shotgun/dragon_traitor
+	name = "12g Dragon's Breath Drum"
+	desc = "An alternative 8-round dragon's breath magazine for use in the Bulldog shotgun. \
+			'I'm a fire starter, twisted fire starter!'"
+	item = /obj/item/ammo_box/magazine/m12g/dragon
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/shotgun/meteor_traitor
+	name = "12g Meteorslug Shells"
+	desc = "An alternative 8-round meteorslug magazine for use in the Bulldog shotgun. \
+		Great for blasting airlocks off their frames and knocking down enemies."
+	item = /obj/item/ammo_box/magazine/m12g/meteor
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/shotgun/slug_traitor
+	name = "12g Slug Drum"
+	desc = "An additional 8-round slug magazine for use with the Bulldog shotgun. \
+			Now 8 times less likely to shoot your pals."
+	cost = 3
+	item = /obj/item/ammo_box/magazine/m12g/slug
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
 
 //SUITS
 /datum/uplink_item/suits/hardsuit/elite_traitor


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

# Base TC now 45

This PR adds 3 items to the traitor uplink along with their respective bundles:

- C20R SMG:
Bundle: 25
Stand alone: 17
Ammo: Standard nukeops.

- Bulldog:
Bundle: 20
Stand alone: 15
Ammo: Standard nukeops.

- Armor Vest
3 TC

- Syndicate Helmet
6 TC

- Syndicate jaw-o-life
4 TC

- Viscerator grenade
7 TC

- Buzzkill Grenade
15 TC

- Energy shield:
5 TC

- CQC
20 TC



## Why It's Good For The Game

We buffed security to heaven, we need to bring traitors back upto scratch.

## Changelog
:cl:
add: Traitors now get access to the bulldog, C20R and energy shield.
tweak: Some old stats have been changed regarding uplink items.
/:cl:

