### PR TITLE
45 TC traitor update

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -78,7 +78,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge,list(/datum/eldritch_knowledge/spell/ba
 
 /// How many telecrystals a normal traitor starts with
 //#define TELECRYSTALS_DEFAULT 20 //ORIGINAL
-#define TELECRYSTALS_DEFAULT 30 //SKYRAT EDIT CHANGE
+#define TELECRYSTALS_DEFAULT 45 //SKYRAT EDIT CHANGE - ORIGINAL: 20
 /// How many telecrystals mapper/admin only "precharged" uplink implant
 #define TELECRYSTALS_PRELOADED_IMPLANT 10
 /// The normal cost of an uplink implant; used for calcuating how many

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -78,7 +78,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge,list(/datum/eldritch_knowledge/spell/ba
 
 /// How many telecrystals a normal traitor starts with
 //#define TELECRYSTALS_DEFAULT 20 //ORIGINAL
-#define TELECRYSTALS_DEFAULT 40 //SKYRAT EDIT CHANGE - ORIGINAL: 20
+#define TELECRYSTALS_DEFAULT 45 //SKYRAT EDIT CHANGE - ORIGINAL: 20
 /// How many telecrystals mapper/admin only "precharged" uplink implant
 #define TELECRYSTALS_PRELOADED_IMPLANT 10
 /// The normal cost of an uplink implant; used for calcuating how many

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -78,7 +78,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge,list(/datum/eldritch_knowledge/spell/ba
 
 /// How many telecrystals a normal traitor starts with
 //#define TELECRYSTALS_DEFAULT 20 //ORIGINAL
-#define TELECRYSTALS_DEFAULT 45 //SKYRAT EDIT CHANGE - ORIGINAL: 20
+#define TELECRYSTALS_DEFAULT 40 //SKYRAT EDIT CHANGE - ORIGINAL: 20
 /// How many telecrystals mapper/admin only "precharged" uplink implant
 #define TELECRYSTALS_PRELOADED_IMPLANT 10
 /// The normal cost of an uplink implant; used for calcuating how many

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -239,9 +239,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Super Surplus Crate"
 	desc = "A dusty SUPER-SIZED from the back of the Syndicate warehouse. Rumored to contain a valuable assortment of items, \
 			but you never know. Contents are sorted to always be worth 125 TC."
-	cost = 40
+	cost = 50 //SKYRAT EDIT CHANGE - ORIGINAL: 40
 	player_minimum = 40
-	starting_crate_value = 125
+	starting_crate_value = 145 //SKYRAT EDIT CHANGE - ORIGINAL: 125
 
 /datum/uplink_item/bundles_tc/surplus/purchase(mob/user, datum/component/uplink/U)
 	var/list/uplink_items = get_uplink_items(SSticker && SSticker.mode? SSticker.mode : null, FALSE)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -431,7 +431,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An incredibly useful personal shield projector, capable of reflecting energy projectiles and defending \
 			against other attacks. Pair with an Energy Sword for a killer combination."
 	item = /obj/item/shield/energy
-	cost = 16
+	cost = 5 //SKYRAT EDIT CHANGE: ORIGINAL: 16
 	surplus = 20
 	include_modes = list(/datum/game_mode/nuclear)
 

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -11,15 +11,53 @@
 			with suppressors. The gun fires in three round bursts."
 	item = /obj/item/gun/ballistic/automatic/pistol/aps
 	cost = 13
-	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear) //They don't need this since it is just a version that costs more than the original.
-
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
 /datum/uplink_item/dangerous/foamsmg_traitor
 	name = "Toy Submachine Gun"
 	desc = "A fully-loaded Donksoft bullpup submachine gun that fires riot grade darts with a 20-round magazine."
 	item = /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot
 	cost = 5
-	surplus = 0
 
+/datum/uplink_item/dangerous/smgc20r_traitor
+	name = "C-20r Submachine Gun"
+	desc = "A fully-loaded Scarborough Arms bullpup submachine gun. The C-20r fires .45 rounds with a \
+			24-round magazine and is compatible with suppressors."
+	item = /obj/item/gun/ballistic/automatic/c20r
+	cost = 17
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/dangerous/shotgun_traitor
+	name = "Bulldog Shotgun"
+	desc = "A fully-loaded semi-automatic drum-fed shotgun. Compatible with all 12g rounds. Designed for close \
+			quarter anti-personnel engagements."
+	item = /obj/item/gun/ballistic/shotgun/bulldog
+	cost = 15
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/dangerous/shield_traitor
+	name = "Energy Shield"
+	desc = "An incredibly useful personal shield projector, capable of reflecting energy projectiles and defending \
+			against other attacks. Pair with an Energy Sword for a killer combination."
+	item = /obj/item/shield/energy
+	cost = 15
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+//BUNDLES
+
+/datum/uplink_item/bundles_tc/bulldog
+	name = "Bulldog bundle"
+	desc = "Lean and mean: Optimized for people that want to get up close and personal. Contains the popular \
+			Bulldog shotgun, two 12g buckshot drums, and a pair of Thermal imaging goggles."
+	item = /obj/item/storage/backpack/duffelbag/syndie/bulldogbundle
+	cost = 20 // normally 16
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/bundles_tc/c20r_traitor
+	name = "C-20r bundle"
+	desc = "Old Faithful: The classic C-20r, bundled with two magazines and a (surplus) suppressor at discount price."
+	item = /obj/item/storage/backpack/duffelbag/syndie/c20rbundle
+	cost = 25
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
 
 //STEALTHY WEAPONS
 /datum/uplink_item/stealthy_weapons/cqc_traitor
@@ -76,7 +114,58 @@
 	desc = "An additional 15-round 9mm magazine, compatible with the Stechkin APS machine pistol."
 	item = /obj/item/ammo_box/magazine/m9mm_aps
 	cost = 2
-	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/smg_traitor
+	name = ".45 SMG Magazine"
+	desc = "An additional 24-round .45 magazine suitable for use with the C-20r submachine gun."
+	item = /obj/item/ammo_box/magazine/smgm45
+	cost = 3
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/smgap_traitor
+	name = ".45 Armor Piercing SMG Magazine"
+	desc = "An additional 24-round .45 magazine suitable for use with the C-20r submachine gun.\
+			These rounds are less effective at injuring the target but penetrate protective gear."
+	item = /obj/item/ammo_box/magazine/smgm45/ap
+	cost = 5
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/smgfire_traitor
+	name = ".45 Incendiary SMG Magazine"
+	desc = "An additional 24-round .45 magazine suitable for use with the C-20r submachine gun.\
+			Loaded with incendiary rounds which inflict little damage, but ignite the target."
+	item = /obj/item/ammo_box/magazine/smgm45/incen
+	cost = 4
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/shotgun/buck_traitor
+	name = "12g Buckshot Drum"
+	desc = "An additional 8-round buckshot magazine for use with the Bulldog shotgun. Front towards enemy."
+	item = /obj/item/ammo_box/magazine/m12g
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/shotgun/dragon_traitor
+	name = "12g Dragon's Breath Drum"
+	desc = "An alternative 8-round dragon's breath magazine for use in the Bulldog shotgun. \
+			'I'm a fire starter, twisted fire starter!'"
+	item = /obj/item/ammo_box/magazine/m12g/dragon
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/shotgun/meteor_traitor
+	name = "12g Meteorslug Shells"
+	desc = "An alternative 8-round meteorslug magazine for use in the Bulldog shotgun. \
+		Great for blasting airlocks off their frames and knocking down enemies."
+	item = /obj/item/ammo_box/magazine/m12g/meteor
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/shotgun/slug_traitor
+	name = "12g Slug Drum"
+	desc = "An additional 8-round slug magazine for use with the Bulldog shotgun. \
+			Now 8 times less likely to shoot your pals."
+	cost = 3
+	item = /obj/item/ammo_box/magazine/m12g/slug
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
 
 //SUITS
 /datum/uplink_item/suits/hardsuit/elite_traitor

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -18,6 +18,15 @@
 	item = /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot
 	cost = 5
 
+/datum/uplink_item/dangerous/revolver_alt
+	name = "Unica Six Revolver"
+	desc = "A retro high-powered autorevolver typically used by officers of the New Russia military. Uses .357 ammo."
+	item = /obj/item/gun/ballistic/revolver/mateba
+	cost = 13
+	surplus = 50
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
+
+
 /datum/uplink_item/dangerous/smgc20r_traitor
 	name = "C-20r Submachine Gun"
 	desc = "A fully-loaded Scarborough Arms bullpup submachine gun. The C-20r fires .45 rounds with a \

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -211,13 +211,19 @@
 	cost = 14
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //It's exactly same as the one that costs 8 TC for nukies, so they have no reason to buy it for more.
 
-/datum/uplink_item/suits/armor/standard_armor
+/datum/uplink_item/suits/standard_armor
 	name = "Standard Armor Vest"
 	desc = "A slim Type I armored vest that provides decent protection against most types of damage."
 	item = /obj/item/clothing/suit/armor/vest
 	cost = 1
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //It's exactly same as the one that costs 8 TC for nukies, so they have no reason to buy it for more.
 
+/datum/uplink_item/suits/standard_armor
+	name = "Bulletproof Armor Vest"
+	desc = "A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent."
+	item = /obj/item/clothing/suit/armor/bulletproof
+	cost = 6
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //It's exactly same as the one that costs 8 TC for nukies, so they have no reason to buy it for more.
 
 //HELMETS
 /datum/uplink_item/suits/hardsuit/swathelmet_traitor

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -39,7 +39,7 @@
 	desc = "An incredibly useful personal shield projector, capable of reflecting energy projectiles and defending \
 			against other attacks. Pair with an Energy Sword for a killer combination."
 	item = /obj/item/shield/energy
-	cost = 15
+	cost = 5
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
 
 //BUNDLES
@@ -65,7 +65,7 @@
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing."
 	item = /obj/item/book/granter/martial/cqc
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //Blocked them because this just costs more than the version they get.
-	cost = 24
+	cost = 20
 	surplus = 0
 
 /datum/uplink_item/stealthy_weapons/telescopicbaton
@@ -82,6 +82,32 @@
 	desc = "A balaclava that muffles your voice, masking your identity. Also provides flash immunity!"
 	item = /obj/item/clothing/mask/infiltrator
 	cost = 2
+
+//EXPLOSIVES
+/datum/uplink_item/explosives/buzzkill_traitor
+	name = "Buzzkill Grenade Box"
+	desc = "A box with three grenades that release a swarm of angry bees upon activation. These bees indiscriminately attack friend or foe \
+			with random toxins. Courtesy of the BLF and Tiger Cooperative."
+	item = /obj/item/storage/box/syndie_kit/bee_grenades
+	cost = 15
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+
+/datum/uplink_item/explosives/viscerators_traitor
+	name = "Viscerator Delivery Grenade"
+	desc = "A unique grenade that deploys a swarm of viscerators upon activation, which will chase down and shred \
+			any non-operatives in the area."
+	item = /obj/item/grenade/spawnergrenade/manhacks
+	cost = 7
+	surplus = 35
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+
+/datum/uplink_item/device_tools/syndie_jaws_of_life_traitor
+	name = "Syndicate Jaws of Life"
+	desc = "Based on a Nanotrasen model, this powerful tool can be used as both a crowbar and a pair of wirecutters. \
+	In its crowbar configuration, it can be used to force open airlocks. Very useful for entering the station or its departments."
+	item = /obj/item/crowbar/power/syndicate
+	cost = 4
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
 //DEVICE TOOLS
 /datum/uplink_item/device_tools/medkit_traitor
@@ -174,6 +200,22 @@
 			provides the user with superior armor and mobility compared to the standard Syndicate hardsuit."
 	item = /obj/item/clothing/suit/space/hardsuit/syndi/elite
 	cost = 14
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //It's exactly same as the one that costs 8 TC for nukies, so they have no reason to buy it for more.
+
+/datum/uplink_item/suits/armor/standard_armor
+	name = "Standard Armor Vest"
+	desc = "A slim Type I armored vest that provides decent protection against most types of damage."
+	item = /obj/item/clothing/suit/armor/vest
+	cost = 3
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //It's exactly same as the one that costs 8 TC for nukies, so they have no reason to buy it for more.
+
+
+//HELMETS
+/datum/uplink_item/suits/hardsuit/swathelmet_traitor
+	name = "Syndicate Helmet"
+	desc = "An extremely robust, space-worthy helmet in a nefarious red and black stripe pattern."
+	item = /obj/item/clothing/head/helmet/swat
+	cost = 6
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //It's exactly same as the one that costs 8 TC for nukies, so they have no reason to buy it for more.
 
 //IMPLANTS

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -31,7 +31,7 @@
 	name = "C-20r Submachine Gun"
 	desc = "A fully-loaded Scarborough Arms bullpup submachine gun. The C-20r fires .45 rounds with a \
 			24-round magazine and is compatible with suppressors."
-	item = /obj/item/gun/ballistic/automatic/c20r
+	item = /obj/item/gun/ballistic/automatic/c20r/unrestricted
 	cost = 17
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
 
@@ -39,7 +39,7 @@
 	name = "Bulldog Shotgun"
 	desc = "A fully-loaded semi-automatic drum-fed shotgun. Compatible with all 12g rounds. Designed for close \
 			quarter anti-personnel engagements."
-	item = /obj/item/gun/ballistic/shotgun/bulldog
+	item = /obj/item/gun/ballistic/shotgun/bulldog/unrestricted
 	cost = 15
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
 
@@ -56,23 +56,6 @@
 	desc = "An incredibly sharp sword used by Samurais. Woefully underpowered in D20."
 	item = /obj/item/katana
 	cost = 12
-	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
-
-//BUNDLES
-
-/datum/uplink_item/bundles_tc/bulldog
-	name = "Bulldog bundle"
-	desc = "Lean and mean: Optimized for people that want to get up close and personal. Contains the popular \
-			Bulldog shotgun, two 12g buckshot drums, and a pair of Thermal imaging goggles."
-	item = /obj/item/storage/backpack/duffelbag/syndie/bulldogbundle
-	cost = 20 // normally 16
-	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
-
-/datum/uplink_item/bundles_tc/c20r_traitor
-	name = "C-20r bundle"
-	desc = "Old Faithful: The classic C-20r, bundled with two magazines and a (surplus) suppressor at discount price."
-	item = /obj/item/storage/backpack/duffelbag/syndie/c20rbundle
-	cost = 25
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
 
 //STEALTHY WEAPONS

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -51,7 +51,7 @@
 	cost = 5
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
 
-/datum/uplink_item/dangerous/shield_traitor
+/datum/uplink_item/dangerous/katana_traitor
 	name = "Katana"
 	desc = "An incredibly sharp sword used by Samurais. Woefully underpowered in D20."
 	item = /obj/item/katana

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -81,7 +81,7 @@
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing."
 	item = /obj/item/book/granter/martial/cqc
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //Blocked them because this just costs more than the version they get.
-	cost = 20
+	cost = 25
 	surplus = 0
 
 /datum/uplink_item/stealthy_weapons/telescopicbaton
@@ -148,7 +148,6 @@
 	desc = "A small yet large enough pouch that can fit in your pocket, and has room for three magazines."
 	item = /obj/item/storage/bag/ammo
 	cost = 1
-
 
 //AMMO
 /datum/uplink_item/ammo/pistolaps_traitor

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -219,7 +219,7 @@
 	name = "Syndicate Helmet"
 	desc = "An extremely robust, space-worthy helmet in a nefarious red and black stripe pattern."
 	item = /obj/item/clothing/head/helmet/swat
-	cost = 64
+	cost = 4
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //It's exactly same as the one that costs 8 TC for nukies, so they have no reason to buy it for more.
 
 //IMPLANTS

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -215,7 +215,7 @@
 	name = "Standard Armor Vest"
 	desc = "A slim Type I armored vest that provides decent protection against most types of damage."
 	item = /obj/item/clothing/suit/armor/vest
-	cost = 3
+	cost = 1
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //It's exactly same as the one that costs 8 TC for nukies, so they have no reason to buy it for more.
 
 
@@ -224,7 +224,7 @@
 	name = "Syndicate Helmet"
 	desc = "An extremely robust, space-worthy helmet in a nefarious red and black stripe pattern."
 	item = /obj/item/clothing/head/helmet/swat
-	cost = 6
+	cost = 64
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //It's exactly same as the one that costs 8 TC for nukies, so they have no reason to buy it for more.
 
 //IMPLANTS

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -51,6 +51,13 @@
 	cost = 5
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
 
+/datum/uplink_item/dangerous/shield_traitor
+	name = "Katana"
+	desc = "An incredibly sharp sword used by Samurais. Woefully underpowered in D20."
+	item = /obj/item/katana
+	cost = 12
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/nuclear)
+
 //BUNDLES
 
 /datum/uplink_item/bundles_tc/bulldog

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -207,7 +207,7 @@
 	cost = 1
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //It's exactly same as the one that costs 8 TC for nukies, so they have no reason to buy it for more.
 
-/datum/uplink_item/suits/standard_armor
+/datum/uplink_item/suits/standard_armor_traitor
 	name = "Bulletproof Armor Vest"
 	desc = "A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent."
 	item = /obj/item/clothing/suit/armor/bulletproof


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

# Base TC now 40

This PR adds 3 items to the traitor uplink along with their respective bundles:

- C20R SMG:
Bundle: 25
Stand alone: 17
Ammo: Standard nukeops.

- Bulldog:
Bundle: 20
Stand alone: 15
Ammo: Standard nukeops.

- Armor Vest
1 TC

- Bulletproof Armor Vest
6 TC

- Syndicate Helmet
4 TC

- Syndicate jaw-o-life
4 TC

- Viscerator grenade
7 TC

- Buzzkill Grenade
15 TC

- Energy shield:
5 TC

- Katana:
12 TC

- CQC
25 TC

The super surplus crate is now 50 TC, and comes with 145 TC of stuff.

Probably more to come.

## Why It's Good For The Game

We buffed security to heaven, we need to bring traitors back upto scratch.

## Changelog
:cl:
add: Traitors now get access to the bulldog, C20R, buzzkill grenade, viscerator grenade, syndie-jaws-o-life, energy shield, armor, helmet, katana, and an alternative revolver.
tweak; Traitors now come with 40 TC as standard.
tweak: Some old stats have been changed regarding uplink items.
/:cl:
