### PR TITLE
Small medbay and chemistry changes

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -25827,6 +25827,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/machinery/computer/crew{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bwO" = (
@@ -26091,7 +26094,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/computer/crew,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -48540,6 +48542,9 @@
 "mMH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
+	},
+/obj/machinery/computer/med_data{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -19750,6 +19750,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bhi" = (
@@ -25798,6 +25801,9 @@
 /area/medical/chemistry)
 "bwF" = (
 /obj/effect/landmark/start/medical_doctor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bwG" = (
@@ -25824,13 +25830,20 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "bwI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/machinery/computer/crew{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron,
 /area/medical/medbay/central)
 "bwO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -26104,11 +26117,11 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "bxT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -26117,14 +26130,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bxV" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -27475,6 +27491,9 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bCR" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bCS" = (
@@ -44971,6 +44990,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"hHl" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "hHq" = (
 /obj/machinery/button/door{
 	id = "xenobiomain";
@@ -48540,13 +48568,20 @@
 /turf/open/floor/iron,
 /area/commons/storage/mining)
 "mMH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/medical/medbay/central)
 "mNa" = (
 /obj/item/target,
@@ -55448,6 +55483,13 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
+"woB" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "wpg" = (
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
@@ -93679,7 +93721,7 @@ bpv
 pBF
 bfG
 btV
-kvh
+woB
 bwF
 bhh
 eIN
@@ -93936,7 +93978,7 @@ aKK
 jib
 bsx
 jsH
-jEe
+bAt
 bwI
 bxT
 fBp
@@ -94450,7 +94492,7 @@ hjZ
 bwz
 bsx
 btZ
-eIN
+bAt
 mMH
 bxV
 kvh
@@ -94707,7 +94749,7 @@ boc
 bpP
 bfG
 uGw
-fBp
+hHl
 bCR
 bxU
 jEe

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -20827,7 +20827,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "bjT" = (
@@ -47120,14 +47119,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = 8
-	},
-/obj/item/book/manual/wiki/grenades,
-/obj/item/book/manual/wiki/plumbing{
-	pixel_x = 5
-	},
-/obj/structure/table,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "kGQ" = (
@@ -50624,9 +50615,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -46651,10 +46651,6 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "jPL" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Paramedic Dispatch Room";
-	req_access_txt = "5"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -46667,6 +46663,10 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/medical{
+	name = "Paramedic Dispatch Room";
+	req_access_txt = "5"
+	},
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "jPR" = (

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -22320,8 +22320,6 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "chc" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -22329,6 +22327,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood/o_minus,
+/obj/item/reagent_containers/blood/o_minus,
+/obj/item/reagent_containers/blood/o_minus,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "chd" = (
@@ -22590,7 +22592,6 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "cix" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -22598,14 +22599,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "ciy" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -23709,7 +23711,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "cnK" = (
@@ -36106,6 +36110,21 @@
 /obj/effect/turf_decal/box/white{
 	color = "#EFB341"
 	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/bottle/multiver{
+	pixel_x = 7;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "fvb" = (
@@ -66733,20 +66752,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "rTC" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/glass/bottle/multiver{
-	pixel_x = 7;
-	pixel_y = 12
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -36106,10 +36106,6 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "fuY" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/box/white{
-	color = "#EFB341"
-	},
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/multiver{
 	pixel_x = 7;
@@ -47352,6 +47348,10 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "kge" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/box/white{
+	color = "#EFB341"
+	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "kgg" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces the door to the paramedic dispatch on metastation with a non-see through one for privacy. Adds a medical records computer to icebox station as unlike the other maps there was none that regular medbay staff could access. 
On metastation each chemistry station now has disposals unit like on delta. In the spot where the upper unit used to be I've added a blood pack of O- blood to be used to help restore blood lost from chemists during synthflesh production.
On Iceboxstation I've removed several small internal windows inside of their chemistry lab to allow the chemists access to each of the two chemistry fridges without having to push the other chemist out of the way.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The new medical records computer adds the same RP opportunities provided by one to Icebox station as it has previously been lacking it. The non-see through door was added so paramedics could better relax when waiting for injured to run out and treat.
This also makes having 2 chemists in the department much easier and they'll end up getting in each other's way much less. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added medical records computer to icebox station medbay. Added new disposals unit and blood bag to chemistry on metastation
del: Removed 2 internal windows blocking chem fridge access on icebox.
tweak: Replaced glass paramedic dispatch door on metastation with a non see-through one. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
