### PR TITLE
Assops Update

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -49,7 +49,7 @@
 		return
 
 	if(SSticker.mode.type in excluded_gamemodes)
-		to_chat(user, "span class='warning'>Error, unable to spawn.</span>")
+		to_chat(user, "<span class='warning'>Error, unable to spawn.</span>")
 		return
 	//SKYRAT EDIT ADDITION END
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -48,7 +48,7 @@
 	if(!extra_prompts(user))
 		return
 
-	if(SSticker.mode in excluded_gamemodes)
+	if(SSticker.mode.type in excluded_gamemodes)
 		to_chat(user, "span class='warning'>Error, unable to spawn.</span>")
 		return
 	//SKYRAT EDIT ADDITION END

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -35,6 +35,7 @@
 	var/show_flavour = TRUE
 	var/banType = ROLE_LAVALAND
 	var/ghost_usable = TRUE
+	var/list/excluded_gamemodes
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
 /obj/effect/mob_spawn/attack_ghost(mob/user)
@@ -46,7 +47,12 @@
 	//SKYRAT EDIT ADDITION BEGIN
 	if(!extra_prompts(user))
 		return
+
+	if(SSticker.mode in excluded_gamemodes)
+		to_chat(user, "span class='warning'>Error, unable to spawn.</span>")
+		return
 	//SKYRAT EDIT ADDITION END
+
 	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(flags_1 & ADMIN_SPAWNED_1))
 		to_chat(user, "<span class='warning'>An admin has temporarily disabled non-admin ghost roles!</span>")
 		return

--- a/modular_skyrat/modules/assaultops/code/assaultops_misc.dm
+++ b/modular_skyrat/modules/assaultops/code/assaultops_misc.dm
@@ -4,6 +4,7 @@
 	req_access = list(ACCESS_SYNDICATE)
 	faction = list(ROLE_SYNDICATE)
 	mode = TURRET_STUN
+	uses_stored = FALSE
 	max_integrity = 200
 	base_icon_state = "syndie"
 	stun_projectile = /obj/projectile/energy/electrode
@@ -26,9 +27,6 @@
 /obj/machinery/porta_turret/assaultops/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF | EMP_PROTECT_WIRES)
-
-/obj/machinery/porta_turret/assaultops/setup(obj/item/gun/turret_gun)
-	return
 
 /obj/machinery/porta_turret/syndicate/assess_perp(mob/living/carbon/human/perp)
 	return 10 //Syndicate turrets shoot everything not in their faction

--- a/modular_skyrat/modules/assaultops/code/assaultops_misc.dm
+++ b/modular_skyrat/modules/assaultops/code/assaultops_misc.dm
@@ -15,6 +15,9 @@
 /obj/machinery/porta_turret/assaultops/assess_perp(mob/living/carbon/human/perp)
 	return 10
 
+/obj/machinery/porta_turret/assaultops/setup(obj/item/gun/turret_gun)
+	return
+
 /obj/machinery/porta_turret/assaultops/shuttle
 	scan_range = 9
 	lethal_projectile = /obj/projectile/bullet/p50/penetrator/shuttle
@@ -28,8 +31,6 @@
 	. = ..()
 	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF | EMP_PROTECT_WIRES)
 
-/obj/machinery/porta_turret/syndicate/assess_perp(mob/living/carbon/human/perp)
-	return 10 //Syndicate turrets shoot everything not in their faction
 
 //VENDING MACHINES>>>>>>>>>>>>>>>>>>>>>>>>>
 /obj/machinery/vending/assaultops_ammo

--- a/modular_skyrat/modules/assaultops/code/assaultops_outfits.dm
+++ b/modular_skyrat/modules/assaultops/code/assaultops_outfits.dm
@@ -11,7 +11,7 @@
 	back = /obj/item/storage/backpack/fireproof
 	ears = /obj/item/radio/headset/syndicate/alt/assault
 	l_pocket = /obj/item/modular_computer/tablet/nukeops
-	id = /obj/item/card/id/syndicate/nuke_leader
+	id = /obj/item/card/id/syndicate_command/assault_operative
 	suit = /obj/item/clothing/suit/space/hardsuit/syndi
 	suit_store = /obj/item/gun/ballistic/automatic/pistol/aps
 	r_pocket = /obj/item/ammo_box/magazine/m9mm_aps
@@ -20,6 +20,8 @@
 	var/command_radio = FALSE
 	var/cqc = FALSE
 
+/obj/item/card/id/syndicate_command/assault_operative
+	assignment = "Assault Operative"
 /datum/outfit/assaultops/cqb
 	name = "Assault Operative - CQB"
 

--- a/modular_skyrat/modules/assaultops/code/assaultops_spawners.dm
+++ b/modular_skyrat/modules/assaultops/code/assaultops_spawners.dm
@@ -9,6 +9,7 @@
 	permanent = FALSE
 	can_use_alias = TRUE
 	any_station_species = TRUE
+	excluded_gamemodes = list(/datum/game_mode/assaultops)
 
 /obj/effect/mob_spawn/human/assops_prisoner
 	name = "Syndicate Prisoner"
@@ -18,10 +19,12 @@
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper_s"
 	outfit = /datum/outfit/prisoner
+	roundstart = FALSE
 	permanent = FALSE
 	death = FALSE
 	can_use_alias = TRUE
 	any_station_species = TRUE
+	excluded_gamemodes = list(/datum/game_mode/assaultops)
 
 /obj/effect/mob_spawn/human/syndicate/assops/prison_guard
 	name = "Syndicate Prison Guard"
@@ -29,6 +32,7 @@
 	flavour_text = "Your job is to keep the prisoners in check and ensure they do not cause trouble. Patrol the prison, DO NOT TAKE ITEMS FROM THE ARMORY."
 	important_info = "The armory is not a candy store, and your role is not to assault the station directly, leave that work to the assault operatives."
 	outfit = /datum/outfit/syndicate_empty/prison_guard
+	excluded_gamemodes = list(/datum/game_mode/assaultops)
 
 /datum/outfit/syndicate_empty/prison_guard
 	name = "Syndicate Prison Guard"
@@ -56,6 +60,8 @@
 	flavour_text = "Your job is to oversee facility operations and ensure a smooth running prison. You deal with executions and sentencing."
 	important_info = "The armory is not a candy store, and your role is not to assault the station directly, leave that work to the assault operatives."
 	outfit = /datum/outfit/syndicate_empty/prison_warden
+	excluded_gamemodes = list()
+
 
 /datum/outfit/syndicate_empty/prison_warden
 	name = "Syndicate Prison Warden"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes assops to be in a useable state, we've disabled ghost role spawners if the gamemode is running.

Also enabled prison spawners.

Fixes their IDs.

Turrets now work again.
## Changelog
:cl:
tweak: DS1 spawners are smart.
fix: Assops ID cards.
fix: DS1 turrets.
/:cl:

