### PR TITLE
Removes mindshield from blueshield's baton

### DIFF
--- a/modular_skyrat/modules/blueshield/code/game/objects/items/melee/misc.dm
+++ b/modular_skyrat/modules/blueshield/code/game/objects/items/melee/misc.dm
@@ -16,9 +16,3 @@
 	w_class = WEIGHT_CLASS_SMALL //small but packs a PUNCH.
 	preload_cell_type = /obj/item/stock_parts/cell/high/plus
 	convertible = FALSE //SKYRAT EDIT ADDITION
-
-/obj/item/melee/baton/blueshieldprod/attack(mob/M, mob/living/carbon/human/user)
-	if(!HAS_TRAIT(user, TRAIT_MINDSHIELD))
-		to_chat(user, "<span class='danger'>A red light on the baton flashes!</span>")
-		return TRUE
-	..()


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin

## Why It's Good For The Game

There would be consequences for losing your baton as Blueshield.

## Changelog
:cl:
balance: blueshield electric prod mindshield BTFO'd
/:cl: