### PR TITLE
Memento Mori is now better, and more punishing in ways.

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -240,6 +240,9 @@
 		ADD_TRAIT(user, TRAIT_NODEATH, "memento_mori")
 		ADD_TRAIT(user, TRAIT_NOHARDCRIT, "memento_mori")
 		ADD_TRAIT(user, TRAIT_NOCRITDAMAGE, "memento_mori")
+		//Skyrat Edit. Once you put it on, it wont be coming back off, not without great effort.
+		ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
+		//Skyrat Edit End
 		icon_state = "memento_mori_active"
 		active_owner = user
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Memento Mori is now impossible to remove without beheading the target.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You can currently game memento mori through a decently fun meme. For example, if you equip it, and get clonescanned; something can cause the traits itself to bug out - and transfer to your clone after you remove it (likely because removing it doesnt actually remove the traits).

Also, its dumb that others can just yeet you from the round by grabbing your funny necklace pendant, and I've been stripped as a shaft miner prisoner with it on.
Not gamer.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Memento Mori can no longer be removed willingly, or by force, truly taking its place as a cursed item. No more suiciding to get out of brig and into your autocloners, prisoners.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
