### PR TITLE
Removes several meme shuttles.

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -212,12 +212,15 @@
 	admin_notes = "For player punishment."
 	can_be_bought = FALSE
 
+//SKYRAT EDIT REMOVAL START
+/* Sidenote, this COULD be accomplished by setting these shuttles' can_be_bought to false. Buuuut this is faster.
 /datum/map_template/shuttle/emergency/russiafightpit
 	suffix = "russiafightpit"
 	name = "Mother Russia Bleeds"
 	description = "Dis is a high-quality shuttle, da. Many seats, lots of space, all equipment! Even includes entertainment! Such as lots to drink, and a fighting arena for drunk crew to have fun! If arena not fun enough, simply press button of releasing bears. Do not worry, bears trained not to break out of fighting pit, so totally safe so long as nobody stupid or drunk enough to leave door open. Try not to let asimov babycons ruin fun!"
 	admin_notes = "Includes a small variety of weapons. And bears. Only captain-access can release the bears. Bears won't smash the windows themselves, but they can escape if someone lets them."
 	credit_cost = CARGO_CRATE_VALUE * 10 // While the shuttle is rusted and poorly maintained, trained bears are costly.
+
 
 /datum/map_template/shuttle/emergency/meteor
 	suffix = "meteor"
@@ -234,6 +237,7 @@
 	admin_notes = "WARNING: This shuttle WILL destroy a fourth of the station, likely picking up a lot of objects with it."
 	credit_cost = CARGO_CRATE_VALUE * 250
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 5)
+*/
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"
@@ -243,6 +247,7 @@
 	admin_notes = "Due to the limited space for non paying crew, this shuttle may cause a riot."
 	credit_cost = CARGO_CRATE_VALUE * 20
 
+/*
 /datum/map_template/shuttle/emergency/medisim
 	suffix = "medisim"
 	name = "Medieval Reality Simulation Dome"
@@ -283,6 +288,7 @@
 /datum/map_template/arena
 	name = "The Arena"
 	mappath = "_maps/templates/the_arena.dmm"
+*/
 
 /datum/map_template/shuttle/emergency/birdboat
 	suffix = "birdboat"
@@ -303,6 +309,7 @@
 	admin_notes = "Has airlocks on both sides of the shuttle and will probably intersect near the front on some stations that build past departures."
 	credit_cost = CARGO_CRATE_VALUE * 5
 
+/*
 /datum/map_template/shuttle/emergency/clown
 	suffix = "clown"
 	name = "Snappop(tm)!"
@@ -313,6 +320,8 @@
 	Have a fun ride!"
 	admin_notes = "Brig is replaced by anchored greentext book surrounded by lavaland chasms, stationside door has been removed to prevent accidental dropping. No brig."
 	credit_cost = CARGO_CRATE_VALUE * 16
+*/
+//SKYRAT EDIT REMOVAL END
 
 /datum/map_template/shuttle/emergency/cramped
 	suffix = "cramped"

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -229,9 +229,13 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 
 	spawned = template.created_atoms //populate the spawned list with the atoms belonging to the holodeck
 
+	//SKYRAT EDIT REMOVAL START
+	/*
 	if(istype(template, /datum/map_template/holodeck/thunderdome1218) && !SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_MEDISIM])
 		say("Special note from \"1218 AD\" developer: I see you too are interested in the REAL dark ages of humanity! I've made this program also unlock some interesting shuttle designs on any communication console around. Have fun!")
 		SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_MEDISIM] = TRUE
+	*/
+	//SKYRAT EDIT REMOVAL END
 
 	nerf(!(obj_flags & EMAGGED))
 	finish_spawn()


### PR DESCRIPTION
This should have been done a long time ago.


Comments out several shuttle datums - making them unavailable to be purchased, or even to be set as. The shuttle maps themselves remain in the code, to avoid potential conflicts.

Removed shuttles:
"Mother Russia Bleeds"
"Asteroid With Engines Strapped To It"
"Grand Corporate Monastery"
"Medieval Reality Simulation Dome" (medisim.dm is untouched, since commenting it would require changing the map too)
"Disco Inferno"
"The Arena"
"Snappop(tm)!"