### PR TITLE
[NONMODULAR]Removes RESTRICTED_GAS roll chance for both lavaland and icebox

### DIFF
--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -35,12 +35,12 @@
 	normal_gases = list(
 		/datum/gas/oxygen=10,
 		/datum/gas/nitrogen=10,
-		/datum/gas/carbon_dioxide=10,
+		/datum/gas/carbon_dioxide=1, //turned this down so it hopefully doesnt nuke our air alarms. Still dangerous.
 	)
 	restricted_gases = list(
-		/datum/gas/plasma=0.1,
+		///datum/gas/plasma=0.1, removed temporarily to see if this helps
 		/datum/gas/water_vapor=0.1,
-		/datum/gas/miasma=1.2,
+		/datum/gas/miasma=0.1,//Changed so disease spam is no longer as high, also should reduce TIDI lag from miasma spamming diseases and other nasty stuff
 	)
 	restricted_chance = 20
 

--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -42,7 +42,7 @@
 		/datum/gas/water_vapor=0.1,
 		/datum/gas/miasma=0.1,//Changed so disease spam is no longer as high, also should reduce TIDI lag from miasma spamming diseases and other nasty stuff
 	)
-	restricted_chance = 20
+	restricted_chance = 0 //changed on maintainer request. Skyrat edit
 
 	minimum_pressure = HAZARD_LOW_PRESSURE + 10
 	maximum_pressure = LAVALAND_EQUIPMENT_EFFECT_PRESSURE - 1

--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -17,9 +17,8 @@
 		/datum/gas/miasma=1.2,
 		/datum/gas/water_vapor=0.1,
 	)
-	//SKYRAT EDIT. REMOVE RESTRICTED GASES FROM SPAWNING
-	restricted_chance = 0
-	//EDIT END
+	restricted_chance = 0	// SKYRAT EDIT: Disables restricted gases from rolling - Original value (30)
+
 	minimum_pressure = HAZARD_LOW_PRESSURE + 10
 	maximum_pressure = LAVALAND_EQUIPMENT_EFFECT_PRESSURE - 1
 
@@ -43,9 +42,8 @@
 		/datum/gas/water_vapor=0.1,
 		/datum/gas/miasma=1.2,
 	)
-	//SKYRAT EDIT. REMOVES RESTRICTED GASES
-	restricted_chance = 0
-	//EDIT END
+	restricted_chance = 0	// SKYRAT EDIT: Disables restricted gases from rolling - Original value (20)
+
 	minimum_pressure = HAZARD_LOW_PRESSURE + 10
 	maximum_pressure = LAVALAND_EQUIPMENT_EFFECT_PRESSURE - 1
 

--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -17,8 +17,9 @@
 		/datum/gas/miasma=1.2,
 		/datum/gas/water_vapor=0.1,
 	)
-	restricted_chance = 30
-
+	//SKYRAT EDIT. REMOVE RESTRICTED GASES FROM SPAWNING
+	restricted_chance = 0
+	//EDIT END
 	minimum_pressure = HAZARD_LOW_PRESSURE + 10
 	maximum_pressure = LAVALAND_EQUIPMENT_EFFECT_PRESSURE - 1
 
@@ -35,15 +36,16 @@
 	normal_gases = list(
 		/datum/gas/oxygen=10,
 		/datum/gas/nitrogen=10,
-		/datum/gas/carbon_dioxide=1, //turned this down so it hopefully doesnt nuke our air alarms. Still dangerous.
+		/datum/gas/carbon_dioxide=10,
 	)
 	restricted_gases = list(
-		///datum/gas/plasma=0.1, removed temporarily to see if this helps
+		/datum/gas/plasma=0.1,
 		/datum/gas/water_vapor=0.1,
-		/datum/gas/miasma=0.1,//Changed so disease spam is no longer as high, also should reduce TIDI lag from miasma spamming diseases and other nasty stuff
+		/datum/gas/miasma=1.2,
 	)
-	restricted_chance = 0 //changed on maintainer request. Skyrat edit
-
+	//SKYRAT EDIT. REMOVES RESTRICTED GASES
+	restricted_chance = 0
+	//EDIT END
 	minimum_pressure = HAZARD_LOW_PRESSURE + 10
 	maximum_pressure = LAVALAND_EQUIPMENT_EFFECT_PRESSURE - 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes egregious plasma and miasma spam, along with changing the co2 concentration down a bit.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Icebox currently lags whenever the station has been breached due to miasma continually throwing up new diseases and other negative effects, along with massive wildfires (that if no adminbus is taken to stop it, will consume the map)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Removes roll_chance from all restricted gases on lavaland and icemoon. Weh!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
