### PR TITLE
[Modular] Adds Hypnotic Stupor back as neutral trait

### DIFF
--- a/modular_skyrat/modules/customization/datums/traits/neutral.dm
+++ b/modular_skyrat/modules/customization/datums/traits/neutral.dm
@@ -1,0 +1,13 @@
+/datum/quirk/hypnotic_stupor
+	name = "Hypnotic Stupor"
+	desc = "Your prone to episodes of extreme stupor that leaves you extremely suggestible."
+	value = 0
+	human_only = TRUE
+	gain_text = null // Handled by trauma.
+	lose_text = null
+	medical_record_text = "Patient has an untreatable condition with their brain, wiring them to be extreamly suggestible..."
+
+/datum/quirk/hypnotic_stupor/add()
+	var/datum/brain_trauma/severe/hypnotic_stupor/T = new()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(T, TRAUMA_RESILIENCE_ABSOLUTE)

--- a/modular_skyrat/modules/customization/datums/traits/neutral.dm
+++ b/modular_skyrat/modules/customization/datums/traits/neutral.dm
@@ -1,6 +1,6 @@
 /datum/quirk/hypnotic_stupor
 	name = "Hypnotic Stupor"
-	desc = "Your prone to episodes of extreme stupor that leaves you extremely suggestible."
+	desc = "You're prone to episodes of extreme stupor that leave you extremely suggestible."
 	value = 0
 	human_only = TRUE
 	gain_text = null // Handled by trauma.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3613,6 +3613,7 @@
 #include "modular_skyrat\modules\customization\datums\elements\polychromic.dm"
 #include "modular_skyrat\modules\customization\datums\keybinding\communication.dm"
 #include "modular_skyrat\modules\customization\datums\traits\negative.dm"
+#include "modular_skyrat\modules\customization\datums\traits\neutral.dm"
 #include "modular_skyrat\modules\customization\game\objects\items\balls.dm"
 #include "modular_skyrat\modules\customization\game\objects\items\plushes.dm"
 #include "modular_skyrat\modules\customization\game\objects\items\devices\ttsdevice.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This trait was pre-rebase so.
Good to have it back


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Your mind is obsessed  with "You want sex"
Jokes aside more traits more goods

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: add: Hypnotic Stupor back in neutral trait selection

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
