### PR TITLE
Deathsquads don't exist

### DIFF
--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -582,7 +582,7 @@
 
 /obj/structure/sign/poster/official/enlist
 	name = "Enlist" // but I thought deathsquad was never acknowledged
-	desc = "Enlist in the Nanotrasen Deathsquadron reserves today!"
+	desc = "Enlist in Nanotrasen's Elite squadron today!" //SKYRAT EDIT: original: 	desc = "Enlist in the Nanotrasen Deathsquadron reserves today!"
 	icon_state = "poster29_legit"
 
 /obj/structure/sign/poster/official/nanomichi_ad


### PR DESCRIPTION
## About The Pull Request

I change the description on the swat mk 3 enlist poster to something more subtle.

## Why It's Good For The Game

People shouldn't know what a deathsquad is or why it's come to the station to kill everyone, because everyone who encounters them should be dead.

## Changelog
:cl:
fix: You've never heard of a deathsquadron.
/:cl: