### PR TITLE
Nerfs security into the ground

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
@@ -15,7 +15,7 @@
 
 /obj/projectile/bullet/advanced/b6mm
 	name = "6mm bullet"
-	damage = 15
+	damage = 10
 	speed = 0.5
 
 /obj/item/ammo_casing/b6mm/rubber
@@ -30,7 +30,7 @@
 	name = "6mm rubber bullet"
 	icon_state = "bullet_r"
 	damage = 5
-	stamina = 10
+	stamina = 5
 	ricochets_max = 6
 	ricochet_incidence_leeway = 0
 	ricochet_chance = 130
@@ -66,7 +66,7 @@
 
 /obj/projectile/bullet/advanced/b9mm
 	name = "9mm bullet"
-	damage = 20
+	damage = 15
 	speed = 0.7
 
 /obj/item/ammo_casing/b9mm/hp
@@ -80,10 +80,10 @@
 /obj/projectile/bullet/advanced/b9mm/hp
 	name = "9mm hollowpoint bullet"
 	icon_state = "bullet_h"
-	damage = 20
-	wound_bonus = 30
-	embedding = list(embed_chance=75, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=10)
-	armour_penetration = -30
+	damage = 15
+	wound_bonus = 15
+	embedding = list(embed_chance=30, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=10)
+	armour_penetration = -60
 
 /obj/item/ammo_casing/b9mm/rubber
 	name = "9mm rubber bullet casing"
@@ -97,7 +97,7 @@
 	name = "9mm rubber bullet"
 	icon_state = "bullet_r"
 	damage = 5
-	stamina = 20
+	stamina = 10
 	ricochets_max = 6
 	ricochet_incidence_leeway = 0
 	ricochet_chance = 130
@@ -117,7 +117,7 @@
 /obj/projectile/bullet/advanced/b9mm/ihdf
 	name = "9mm ihdf bullet"
 	icon_state = "bullet_i"
-	damage = 25
+	damage = 15
 	damage_type = STAMINA
 
 
@@ -134,7 +134,7 @@
 
 /obj/projectile/bullet/advanced/b10mm
 	name = "10mm bullet"
-	damage = 30
+	damage = 20
 	speed = 0.9
 
 /obj/item/ammo_casing/b10mm/hp
@@ -148,10 +148,10 @@
 /obj/projectile/bullet/advanced/b10mm/hp
 	name = "10mm hollowpoint bullet"
 	icon_state = "bullet_h"
-	damage = 30
-	wound_bonus = 30
-	embedding = list(embed_chance=75, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=10)
-	armour_penetration = -30
+	damage = 20
+	wound_bonus = 15
+	embedding = list(embed_chance=30, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=10)
+	armour_penetration = -60
 
 /obj/item/ammo_casing/b10mm/rubber
 	name = "10mm rubber bullet casing"
@@ -232,8 +232,8 @@
 /obj/projectile/bullet/advanced/b12mm/rubber
 	name = "12mm rubber bullet"
 	icon_state = "bullet_r"
-	damage = 13
-	stamina = 50
+	damage = 17
+	stamina = 30
 	ricochets_max = 6
 	ricochet_incidence_leeway = 0
 	ricochet_chance = 130

--- a/modular_skyrat/modules/sec_haul/code/guns/laser_hitscan.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/laser_hitscan.dm
@@ -11,7 +11,7 @@
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_BELT | ITEM_SLOT_SUITSTORE
 	w_class = WEIGHT_CLASS_BULKY
 	custom_materials = list(/datum/material/iron=4000)
-	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/hitscan)
+	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	ammo_x_offset = 0
 	shaded_charge = 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I put security on their high horse, and I'll rip them right back down.

After playing a few rounds as antagonist it's become very clear to me that I have overbuffed security by a mile. I was putting this off for a bit, but I have to.

All security rounds, aside from 12mm, have had a siginficant debuff.

I've also done away with that nasty hitscan gun.

## Changelog
:cl:
balance: Security weapons are no longer instant fight winners. Also yeeted the hitscan lasergun.
/:cl:
