### PR TITLE
[NON-MODULAR] Disables OCD Device

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1968,6 +1968,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/autosurgeon/organ/syndicate/laser_arm
 	//restricted_roles = list("Roboticist", "Research Director") //SKYRAT EDIT: Removal
 
+// SKYRAT EDIT REMOVAL BEGIN
+/*
 /datum/uplink_item/role_restricted/ocd_device
 	name = "Organic Resources Disturbance Inducer"
 	desc = "A device that raises hell in organic resources indirectly. Single use."
@@ -1975,6 +1977,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	limited_stock = 2 //SKYRAT EDIT: Original Value: (1)
 	item = /obj/item/devices/ocd_device
 	//restricted_roles = list("Head of Personnel", "Quartermaster") //SKYRAT EDIT: Removal
+*/
+// SKYRAT EDIT REMOVAL END
 
 /datum/uplink_item/role_restricted/meathook
 	name = "Butcher's Meat Hook"


### PR DESCRIPTION
## About The Pull Request

Removes organic resources disturber from the uplink. Can't really be role locked as we don't have head antags and no other roles make a lot of sense. Can't be hugely balanced around price, as either people buy it and it's a pain in the ass, or it's too expensive so a terrible idea to buy.

## Why It's Good For The Game

It causes LRP and memey situations, as well as headaches for staff. It adds nothing of particular value RP wise.

## Changelog
:cl:
del: removes organic resources disturber from the uplink
/:cl: