### PR TITLE
Adds polychromic gear to ClothesMates

### DIFF
--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -114,7 +114,19 @@
 		            /obj/item/clothing/under/rank/civilian/bartender/purple = 2,
 		            /obj/item/clothing/suit/toggle/suspenders/blue = 2,
 		            /obj/item/clothing/suit/toggle/suspenders/gray = 2,
-					/obj/item/clothing/under/costume/bathrobe = 5)	//SKYRAT EDIT ADDITION
+					/obj/item/clothing/under/costume/bathrobe = 5, //SKYRAT EDIT ADDITION
+					/obj/item/clothing/under/misc/poly_shirt = 3, // SKYRAT EDIT BEGIN - Adds polychromic gear to ClothesMates
+					/obj/item/clothing/under/misc/poly_kilt = 3,
+					/obj/item/clothing/under/misc/poly_tanktop = 3,
+					/obj/item/clothing/under/misc/poly_tanktop/female = 3,
+					/obj/item/clothing/under/misc/polyjumpsuit = 3,
+					/obj/item/clothing/under/dress/skirt/polychromic = 3,
+					/obj/item/clothing/under/dress/skirt/polychromic/pleated = 3,
+					/obj/item/clothing/suit/hooded/wintercoat/polychromic = 5,
+					/obj/item/clothing/neck/cloak/polychromic = 3,
+					/obj/item/clothing/neck/cloak/polychromic/veil = 3,
+					/obj/item/clothing/neck/cloak/polychromic/shroud = 3,
+					/obj/item/clothing/neck/cloak/polychromic/boat = 3)	// SKYRAT EDIT END - Adds polychromic gear to ClothesMates
 	contraband = list(/obj/item/clothing/under/syndicate/tacticool = 1,
 					  /obj/item/clothing/under/syndicate/tacticool/skirt = 1,
 		              /obj/item/clothing/mask/balaclava = 1,


### PR DESCRIPTION
## About The Pull Request

Adds every currently available piece of polychromic clothing to ClothesMates.

## Why It's Good For The Game

This stuff is currently all loadout-specific, meaning there's no way to get them on-station. Now they are available in ample supply.

## Changelog
:cl:
add: ClothesMates now stock polychromic clothes, which were previously only available as loadout items.
/:cl:
