### PR TITLE
[Not  Modular] LRP Clown Ruin Removals Part 1

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -20,12 +20,14 @@
 	description = "For those getaways where you want to get back to nature, but you don't want to leave the fortified military compound where you spend your days. \
 	Includes a unique(*) laser pistol display case, and the recently introduced I.C.E(tm)."
 	suffix = "lavaland_surface_biodome_winter.dmm"
-
+//SKYRAT EDIT REMOVAL BEGIN - Clownshit Removals
+/*
 /datum/map_template/ruin/lavaland/biodome/clown
 	name = "Biodome Clown Planet"
 	id = "biodome-clown"
 	description = "WELCOME TO CLOWN PLANET! HONK HONK HONK etc.!"
 	suffix = "lavaland_biodome_clown_planet.dmm"
+*/
 
 /datum/map_template/ruin/lavaland/cube
 	name = "The Wishgranter Cube"

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -188,12 +188,15 @@
 	description = "In space construction the teleporter is often the first system brought online. \
 	This lonely, half-built teleporter is a sign of a proposed structure that for one reason or another just never got built."
 
+//SKYRAT EDIT REMOVAL BEGIN - Clownshit Removals
+/*
 /datum/map_template/ruin/space/crashedclownship
 	id = "crashedclownship"
 	suffix = "crashedclownship.dmm"
 	name = "Crashed Clown Ship"
 	description = "For centuries the promise of a new clown homeworld has been the siren call for countless clown vessels. \
 	Alas, the clown's lust for shenanigans means that successful voyages are almost unheard of, with most vessels falling to hilarious consequences almost immediately."
+*/
 
 /datum/map_template/ruin/space/crashedship
 	id = "crashedship"
@@ -283,11 +286,14 @@ suffix = "whiteshipruin_box.dmm"*/
 	name = "Hilbert Research Facility"
 	description = "A research facility of great bluespace discoveries. Long since abandoned, willingly or not..."
 
+//SKYRAT EDIT REMOVAL BEGIN - Clownshit Removals
+/*
 /datum/map_template/ruin/space/clownplanet
 	id = "clownplanet"
 	suffix = "clownplanet.dmm"
 	name = "Clown Planet"
 	description = "Thought lost in 2552, this minor planet has recently been rediscovered."
+*/
 
 /datum/map_template/ruin/space/clericden
 	id = "clericden"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Just comments out 3 different clown ruins, until they can be replaced with clown-free replacements.
Todo: Part 2 to prevent bananium from spawning on icebox/remove clown research from sci?

## Why It's Good For The Game

With the removal of clowns from even being in the game (0 Job Slots Open), it's time that we crack down on these space ruins too. Clown Bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Clown Planet, Crashed Clown Ship, and Clown Biodome ruins can no longer spawn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
