### PR TITLE
[NON-MODULAR] Removes ability to edit QM and shuttle pilot job slots

### DIFF
--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -28,7 +28,9 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		"Security Medic",
 		"Clown",
 		"Blueshield",
-		"Chief Medical Officer")
+		"Chief Medical Officer",
+		"Quartermaster",
+		"Shuttle Pilot")
 
 	//The scaling factor of max total positions in relation to the total amount of people on board the station in %
 	var/max_relative_positions = 30 //30%: Seems reasonable, limit of 6 @ 20 players


### PR DESCRIPTION
## About The Pull Request

Removes the ability to edit Quartermaster and Shuttle Pilot job slots in an ID console

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/8881105/108612151-b1082600-73dd-11eb-947e-8606008fa753.png)

## Changelog
:cl:
fix: You can no longer open and close QM and shuttle pilot job slots
/:cl: