### PR TITLE
[NON-MODULAR] Disables the Grand Corporate Monastery shuttle

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -227,6 +227,7 @@
 	credit_cost = CARGO_CRATE_VALUE * 30
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
+/* SKYRAT EDIT BEGIN - Removes Monastery Shuttle
 /datum/map_template/shuttle/emergency/monastery
 	suffix = "monastery"
 	name = "Grand Corporate Monastery"
@@ -234,6 +235,7 @@
 	admin_notes = "WARNING: This shuttle WILL destroy a fourth of the station, likely picking up a lot of objects with it."
 	credit_cost = CARGO_CRATE_VALUE * 250
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 5)
+SKYRAT EDIT END - Removes Monastery Shuttle */
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"


### PR DESCRIPTION
## About The Pull Request

Exactly what it says on the tin.

## Why It's Good For The Game

Every time this shuttle is ordered, it grinds the server to a near-halt or outright crashes it. The shuttle subsystem just isn't able to handle a shuttle of this size at our population.

## Changelog
:cl:
del: The Grand Corporate Monastery shuttle is no longer able to be ordered.
/:cl: