### PR TITLE
Sets the monastery shuttle to be unpurchasable

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -234,6 +234,7 @@
 	admin_notes = "WARNING: This shuttle WILL destroy a fourth of the station, likely picking up a lot of objects with it."
 	credit_cost = CARGO_CRATE_VALUE * 250
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 5)
+	can_be_bought = FALSE //SKYRAT EDIT: Addition
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"


### PR DESCRIPTION
## About The Pull Request

Currently the monastery shuttle has the ability to crash the server during highpop shifts. This is not something that players should be able to do.

## Why It's Good For The Game

No crash

## Changelog
:cl:
del: Monastery Shuttle can't be purchased anymore
/:cl: