### PR TITLE
[NONMODULAR] Removes AI lawset station trait

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -21,7 +21,7 @@
 	show_in_report = TRUE
 	report_message = "For experimental purposes, this station AI might show divergence from default lawset. Do not meddle with this experiment."
 	trait_to_give = STATION_TRAIT_UNIQUE_AI
-*/	SKYRAT EDIT: End - DISABLES LAWSET RANDOMISATION
+*/	//SKYRAT EDIT: End - DISABLES LAWSET RANDOMISATION
 
 /datum/station_trait/ian_adventure
 	name = "Ian's Adventure"

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -13,7 +13,7 @@
 	report_message = "System's local planet has irregular atmospherical properties"
 	trait_to_give = STATION_TRAIT_UNNATURAL_ATMOSPHERE
 
-/* SKYRAT EDIT: DISABLES LAWSET RANDOMISATION
+/*	SKYRAT EDIT: Start - DISABLES LAWSET RANDOMISATION
 /datum/station_trait/unique_ai
 	name = "Unique AI"
 	trait_type = STATION_TRAIT_NEUTRAL
@@ -21,7 +21,7 @@
 	show_in_report = TRUE
 	report_message = "For experimental purposes, this station AI might show divergence from default lawset. Do not meddle with this experiment."
 	trait_to_give = STATION_TRAIT_UNIQUE_AI
-*///EDIT END
+*/	SKYRAT EDIT: End - DISABLES LAWSET RANDOMISATION
 
 /datum/station_trait/ian_adventure
 	name = "Ian's Adventure"

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -13,6 +13,7 @@
 	report_message = "System's local planet has irregular atmospherical properties"
 	trait_to_give = STATION_TRAIT_UNNATURAL_ATMOSPHERE
 
+/* SKYRAT EDIT: DISABLES LAWSET RANDOMISATION
 /datum/station_trait/unique_ai
 	name = "Unique AI"
 	trait_type = STATION_TRAIT_NEUTRAL
@@ -20,6 +21,7 @@
 	show_in_report = TRUE
 	report_message = "For experimental purposes, this station AI might show divergence from default lawset. Do not meddle with this experiment."
 	trait_to_give = STATION_TRAIT_UNIQUE_AI
+*///EDIT END
 
 /datum/station_trait/ian_adventure
 	name = "Ian's Adventure"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We disabled this in server config for a reason; we dont want AI lawsets being randomised to potentially dangerous lawsets, such as antimov and/or asiimov depending.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Randomised lawsets due to station traits are no longer possible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
