### PR TITLE
Consistency in Loadout for plushies

### DIFF
--- a/modular_skyrat/modules/customization/game/objects/items/plushes.dm
+++ b/modular_skyrat/modules/customization/game/objects/items/plushes.dm
@@ -84,7 +84,7 @@
 	squeak_override = list('sound/machines/beep.ogg' = 1)
 
 
-/obj/item/toy/plush/mammal/fox
+/obj/item/toy/plush/fox
 	name = "Fox plushie"
 	desc = "An adorable stuffed toy of a Fox."
 	icon = 'modular_skyrat/modules/customization/icons/obj/plushes.dmi'

--- a/modular_skyrat/modules/customization/modules/client/loadout/backpack.dm
+++ b/modular_skyrat/modules/customization/modules/client/loadout/backpack.dm
@@ -110,22 +110,6 @@
 	name = "Playing cards"
 	path = /obj/item/toy/cards/deck
 
-/datum/loadout_item/backpack/toy/plushcarp
-	name = "Space carp plushie"
-	path = /obj/item/toy/plush/carpplushie
-
-/datum/loadout_item/backpack/toy/plushliz
-	name = "Lizard plushie"
-	path = /obj/item/toy/plush/lizardplushie
-
-/datum/loadout_item/backpack/toy/plushsnek
-	name = "Snake plushie"
-	path = /obj/item/toy/plush/snakeplushie
-
-/datum/loadout_item/backpack/toy/plushslime
-	name = "Slime plushie"
-	path = /obj/item/toy/plush/slimeplushie
-
 /datum/loadout_item/backpack/toy/tennis
 	name = "Classic Tennis Ball"
 	path = /obj/item/toy/tennis
@@ -163,12 +147,6 @@
 	name = "Box of crayons"
 	path = /obj/item/storage/crayons
 
-/datum/loadout_item/backpack/toy/narplush
-	name = "Narsie Plushie"
-	path = /obj/item/toy/plush/narplush
-	cost = 5
-	restricted_roles = list("Chaplain")
-
 /datum/loadout_item/backpack/cross
 	name = "Ornate Cross"
 	path = /obj/item/crucifix
@@ -179,6 +157,50 @@
 //Plushies
 /datum/loadout_item/backpack/plushies
 	subcategory = LOADOUT_SUBCATEGORY_BACKPACK_PLUSHIES
+	
+/datum/loadout_item/backpack/plushies/plushcarp
+	name = "Space carp plushie"
+	path = /obj/item/toy/plush/carpplushie
+
+/datum/loadout_item/backpack/plushies/plushliz
+	name = "Lizard plushie"
+	path = /obj/item/toy/plush/lizardplushie
+
+/datum/loadout_item/backpack/plushies/plushsnek
+	name = "Snake plushie"
+	path = /obj/item/toy/plush/snakeplushie
+
+/datum/loadout_item/backpack/plushies/plushslime
+	name = "Slime plushie"
+	path = /obj/item/toy/plush/slimeplushie
+	
+/datum/loadout_item/backpack/plushies/bubbleplush
+	name = "Bubblegum plushie"
+	path = /obj/item/toy/plush/bubbleplush
+	
+/datum/loadout_item/backpack/plushies/nukeplushie
+	name = "Operative plushie"
+	path = /obj/item/toy/plush/nukeplushie
+	
+/datum/loadout_item/backpack/plushies/plasmamanplushie
+	name = "Plasmaman plushie"
+	path = /obj/item/toy/plush/plasmamanplushie
+	
+/datum/loadout_item/backpack/plushies/beeplushie //the best one
+	name = "Bee plushie"
+	path = /obj/item/toy/plush/beeplushie
+	
+/datum/loadout_item/backpack/plushies/goatplushie
+	name = "Strange Goat plushie"
+	path = /obj/item/toy/plush/goatplushie
+	
+/datum/loadout_item/backpack/plushies/moth
+	name = "Moth plushie"
+	path = /obj/item/toy/plush/moth
+	
+/datum/loadout_item/backpack/plushies/pkplush
+	name = "Peacekeeper plushie"
+	path = /obj/item/toy/plush/pkplush
 
 /datum/loadout_item/backpack/plushies/sechound
 	name = "Sechound plushie"
@@ -207,6 +229,14 @@
 /datum/loadout_item/backpack/plushies/deer
 	name = "Deer plushie"
 	path = /obj/item/toy/plush/deer
+	
+/datum/loadout_item/backpack/plushies/fermis
+	name = "Medcat plushie"
+	path = /obj/item/toy/plush/fermis
+	
+/datum/loadout_item/backpack/plushies/fox
+	name = "Fox plushie"
+	path = /obj/item/toy/plush/fox
 
 /datum/loadout_item/backpack/plushies/duffmoff
 	name = "Suspicious moth plushie"
@@ -219,3 +249,15 @@
 /datum/loadout_item/backpack/plushies/leaplush
 	name = "Suspicious deer plushie"
 	path = /obj/item/toy/plush/leaplush
+	
+/datum/loadout_item/backpack/plushies/narplush
+	name = "Narsie Plushie"
+	path = /obj/item/toy/plush/narplush
+	cost = 5
+	restricted_roles = list("Chaplain")
+	
+/datum/loadout_item/backpack/plushies/ratplush
+	name = "Ratvar Plushie"
+	path = /obj/item/toy/plush/ratplush
+	cost = 5
+	restricted_roles = list("Chaplain")


### PR DESCRIPTION
## About The Pull Request

Moves all plushies currently in loadout to the new Plushies category. Adds in the remaining non-special ones (awakened specifically and some map-exclusive ones) to the category.

This will break loadout for anyone currently using one of the previous "toy" category plushies.

Ratvar plushie added as a chaplain-only toy. Careful not to loadout with both a Narsie and Ratvar toy.

## Why It's Good For The Game

Consistency. I could just port the choice box, but in Rome, do as the Romans do.

## Changelog
:cl: YakumoChen
tweak: You can now have choose any available plushie as a loadout item, aside from a few special ones.
server: This will break loadout for some people. If you were using a slime, lizard, snake, or the Nar-sie plushie, you may need to reset your loadout points.
/:cl:

