### PR TITLE
IDs show your age if you're not old enough to drink in the US.

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -106,7 +106,7 @@
 	if(Adjacent(user))
 		var/minor
 		if(registered_name && registered_age && registered_age < AGE_MINOR)
-			minor = " <b>(MINOR)</b>"
+			minor = " <b>[registered_age]</b>"
 		user.visible_message("<span class='notice'>[user] shows you: [icon2html(src, viewers(user))] [src.name][minor].</span>", "<span class='notice'>You show \the [src.name][minor].</span>")
 	add_fingerprint(user)
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -849,7 +849,8 @@ GLOBAL_LIST_EMPTY(vending_products)
 					say("You are not of legal age to purchase [R.name].")
 					if(!(usr in GLOB.narcd_underages))
 						Radio.set_frequency(FREQ_SECURITY)
-						Radio.talk_into(src, "SECURITY ALERT: Underaged crewmember [usr] recorded attempting to purchase [R.name] in [get_area(src)]. Please watch for substance abuse.", FREQ_SECURITY)
+						// SKYRAT EDIT: Original - Radio.talk_into(src, "SECURITY ALERT: Underaged crewmember [usr] recorded attempting to purchase [R.name] in [get_area(src)]. Please watch for substance abuse.", FREQ_SECURITY)
+						Radio.talk_into(src, "SECURITY ALERT: [usr] has attempted to purchase [R.name] in [get_area(src)] whilst not of legal age. Please watch for substance abuse.", FREQ_SECURITY)	// SKYRAT EDIT: Just worded slightly differently.
 						GLOB.narcd_underages += usr
 					flick(icon_deny,src)
 					vend_ready = TRUE

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -850,7 +850,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 					if(!(usr in GLOB.narcd_underages))
 						Radio.set_frequency(FREQ_SECURITY)
 						// SKYRAT EDIT: Original - Radio.talk_into(src, "SECURITY ALERT: Underaged crewmember [usr] recorded attempting to purchase [R.name] in [get_area(src)]. Please watch for substance abuse.", FREQ_SECURITY)
-						Radio.talk_into(src, "SECURITY ALERT: [usr] has attempted to purchase [R.name] in [get_area(src)] whilst not of legal age. Please watch for substance abuse.", FREQ_SECURITY)	// SKYRAT EDIT: Just worded slightly differently.
+						Radio.talk_into(src, "SECURITY ALERT: [usr] has attempted to purchase [R.name] in [get_area(src)] whilst not of legal drinking age. Please watch for substance abuse.", FREQ_SECURITY)	// SKYRAT EDIT: Just worded slightly differently.
 						GLOB.narcd_underages += usr
 					flick(icon_deny,src)
 					vend_ready = TRUE


### PR DESCRIPTION
## About The Pull Request
• Makes IDs show age instead of (MINOR) as we don't allow under 18s here anyway, so the wording is a bit scandalous.
• Rewords the security alert to say you aren't of legal age, instead of saying that you're underaged, since that gives bad vibes in a server where things happen that would confuse Hartmann very much.

## Why It's Good For The Game
Just a bit cooler than screaming (MINOR).

## Changelog
:cl:
tweak: You can now show your ID to the bartender and it'll say your age on it.
/:cl: