### PR TITLE
[MODULAR]Blueshield now has a proper gun.

### DIFF
--- a/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
@@ -33,7 +33,7 @@
 	shoes = /obj/item/clothing/shoes/jackboots
 	ears = /obj/item/radio/headset/heads/blueshield/alt
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
-	backpack_contents = list(,/obj/item/melee/baton/blueshieldprod = 1)
+	backpack_contents = list(/obj/item/storage/box/gunset/pdh_blueshield,/obj/item/melee/baton/blueshieldprod = 1)
 	implants = list(/obj/item/implant/mindshield)
 	backpack = /obj/item/storage/backpack/blueshield
 	satchel = /obj/item/storage/backpack/satchel/blueshield

--- a/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
@@ -29,12 +29,11 @@
 	uniform = /obj/item/clothing/under/rank/security/blueshield
 	id = /obj/item/card/id/silver
 	suit = /obj/item/clothing/suit/armor/vest/blueshield
-	suit_store = /obj/item/gun/ballistic/automatic/pistol/m1911
 	gloves = /obj/item/clothing/gloves/krav_maga/combatglovesplus
 	shoes = /obj/item/clothing/shoes/jackboots
 	ears = /obj/item/radio/headset/heads/blueshield/alt
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
-	backpack_contents = list(/obj/item/ammo_box/magazine/m45 = 3,/obj/item/melee/baton/blueshieldprod = 1)
+	backpack_contents = list(,/obj/item/melee/baton/blueshieldprod = 1)
 	implants = list(/obj/item/implant/mindshield)
 	backpack = /obj/item/storage/backpack/blueshield
 	satchel = /obj/item/storage/backpack/satchel/blueshield

--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -138,6 +138,40 @@
 	can_flashlight = TRUE
 	emp_damageable = FALSE
 
+/obj/item/gun/ballistic/automatic/pistol/pdh/blueshield
+	name = "\improper Armadyne PDH-6D 'SOCOM'"
+	desc = "A rugged, 10mm three-round burst modified SOCOM, usually found in the hands of CC Special Operatives. Supports extended magazines."
+	icon_state = "pdh_alt"
+	w_class = WEIGHT_CLASS_NORMAL
+	mag_type = /obj/item/ammo_box/magazine/multi_sprite/pdh
+	can_suppress = FALSE
+	fire_sound = 'sound/weapons/gun/pistol/shot_suppressed.ogg'
+	fire_delay = 8
+	fire_sound_volume = 30
+	spread = 1
+	realistic = TRUE
+	dirt_modifier = 0.1
+	can_flashlight = TRUE
+	emp_damageable = FALSE
+
+/obj/item/ammo_box/magazine/multi_sprite/pdh_blueshield
+	name = "pdh handgun magazine (10mm)"
+	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'
+	icon_state = "pdh"
+	ammo_type = /obj/item/ammo_casing/b10mm
+	caliber = "10mm"
+	max_ammo = 14
+	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
+	possible_types = list("lethal" = AMMO_TYPE_LETHAL, "hollowpoint" = AMMO_TYPE_HOLLOWPOINT, "rubber" = AMMO_TYPE_RUBBER)
+
+/obj/item/ammo_box/magazine/multi_sprite/pdh_blueshield/hp
+	ammo_type = /obj/item/ammo_casing/b10mm/hp
+	round_type = AMMO_TYPE_HOLLOWPOINT
+
+/obj/item/ammo_box/magazine/multi_sprite/pdh_blueshield/rubber
+	ammo_type = /obj/item/ammo_casing/b10mm/rubber
+	round_type = AMMO_TYPE_RUBBER
+
 /obj/item/ammo_box/magazine/multi_sprite/pdh
 	name = "pdh handgun magazine (12mm)"
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'

--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -143,11 +143,12 @@
 	desc = "A rugged, 10mm three-round burst modified SOCOM, usually found in the hands of CC Special Operatives. Supports extended magazines."
 	icon_state = "pdh_alt"
 	w_class = WEIGHT_CLASS_NORMAL
-	mag_type = /obj/item/ammo_box/magazine/multi_sprite/pdh
+	mag_type = /obj/item/ammo_box/magazine/multi_sprite/pdh_blueshield
 	can_suppress = FALSE
 	fire_sound = 'sound/weapons/gun/pistol/shot_suppressed.ogg'
-	fire_delay = 8
+	fire_delay = 3
 	fire_sound_volume = 30
+	burst_size = 3
 	spread = 1
 	realistic = TRUE
 	dirt_modifier = 0.1

--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
@@ -253,6 +253,19 @@
 /////////////////
 //JOB SPECIFIC GUNSETS
 ////////////////
+//BLUESHIELD
+/obj/item/storage/box/gunset/pdh_blueshield
+
+/obj/item/gun/ballistic/automatic/pistol/pdh/blueshield/nomag
+	spawnwithmagazine = FALSE
+
+/obj/item/storage/box/gunset/pdh_blueshield/PopulateContents()
+	. = ..()
+	new /obj/item/gun/ballistic/automatic/pistol/pdh/blueshield/nomag(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh_blueshield(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh_blueshield(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh_blueshield/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh_blueshield/rubber(src)
 
 //CAPTAIN
 /obj/item/storage/box/gunset/pdh_captain
@@ -289,6 +302,7 @@
 /obj/item/storage/box/gunset/pdh_hop
 	name = "pdh 'osprey' supply box"
 	w_class = WEIGHT_CLASS_NORMAL
+
 /obj/item/gun/ballistic/automatic/pistol/pdh/nomag
 	spawnwithmagazine = FALSE
 

--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
@@ -255,6 +255,8 @@
 ////////////////
 //BLUESHIELD
 /obj/item/storage/box/gunset/pdh_blueshield
+	name = "PDH 'SOCOM-D' Supply Box"
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/gun/ballistic/automatic/pistol/pdh/blueshield/nomag
 	spawnwithmagazine = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Blueshield now gets a 10mm variant of the SOCOM, with the same statistics, spread, etc as the captains pistol.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The blueshields .45 is entirely out of place; its so bad the Krav-maga gloves are unironically more effective than it, ammo is scarce; and distasteful to get - requiring hacking an autolathe, and then manually printing the rounds - which dont come in a box; but instead each individual bullet.
This gives them a reliable sidearm with more than the 3 spare mags they get; along with proper nonlethal and HP options - and standardises the mags they use to be sec-lathe compatible.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Blueshield PDH variant, ammo types and gun box.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
