### PR TITLE
CQC+

### DIFF
--- a/code/__DEFINES/melee.dm
+++ b/code/__DEFINES/melee.dm
@@ -7,4 +7,5 @@
 #define MARTIALART_MUSHPUNCH "mushroom punch"
 #define MARTIALART_KRAVMAGA "krav maga"
 #define MARTIALART_CQC "CQC"
+#define MARTIALART_CQC_PLUS "CQCPLUS" //SKYRAT EDIT ADDITION
 #define MARTIALART_PLASMAFIST "plasma fist"

--- a/modular_skyrat/master_files/code/datums/martial/cqcplus.dm
+++ b/modular_skyrat/master_files/code/datums/martial/cqcplus.dm
@@ -25,6 +25,4 @@
 	name = "old but gold manual"
 	martialname = "close quarters combat plus"
 	desc = "A small, black manual. There are drawn instructions of tactical hand-to-hand combat. This includes how to defelct projectiles too."
-	greet = "<span class='boldannounce'>You've mastered the basics of CQC.</span>"
-	icon_state = "cqcmanual"
-	remarks = list("Kick... Slam...", "Lock... Kick...", "Strike their abdomen, neck and back for critical damage...", "Slam... Lock...", "I could probably combine this with some other martial arts!", "Words that kill...", "The last and final moment is yours...")
+	greet = "<span class='boldannounce'>You've mastered the basics of CQC+.</span>"

--- a/modular_skyrat/master_files/code/datums/martial/cqcplus.dm
+++ b/modular_skyrat/master_files/code/datums/martial/cqcplus.dm
@@ -1,7 +1,7 @@
 /datum/martial_art/cqc/plus
 	name = "CQC+"
 	id = MARTIALART_CQC_PLUS
-	block_chance = 90
+	block_chance = 85
 
 /datum/martial_art/cqc/plus/on_projectile_hit(mob/living/A, obj/projectile/P, def_zone)
 	. = ..()

--- a/modular_skyrat/master_files/code/datums/martial/cqcplus.dm
+++ b/modular_skyrat/master_files/code/datums/martial/cqcplus.dm
@@ -1,0 +1,30 @@
+/datum/martial_art/cqc/plus
+	name = "CQC+"
+	id = MARTIALART_CQC_PLUS
+	block_chance = 95
+
+/datum/martial_art/cqc/plus/on_projectile_hit(mob/living/A, obj/projectile/P, def_zone)
+	. = ..()
+	if(A.incapacitated(FALSE, TRUE)) //NO STUN
+		return BULLET_ACT_HIT
+	if(!(A.mobility_flags & MOBILITY_USE)) //NO UNABLE TO USE
+		return BULLET_ACT_HIT
+	var/datum/dna/dna = A.has_dna()
+	if(dna?.check_mutation(HULK)) //NO HULK
+		return BULLET_ACT_HIT
+	if(!isturf(A.loc)) //NO MOTHERFLIPPIN MECHS!
+		return BULLET_ACT_HIT
+	A.visible_message("<span class='danger'>[A] effortlessly swats the projectile aside! They can block bullets with their bare hands!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
+	playsound(get_turf(A), pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
+	P.firer = A
+	P.set_angle(rand(0, 360))//SHING
+	return BULLET_ACT_FORCE_PIERCE
+
+/obj/item/book/granter/martial/cqc/plus
+	martial = /datum/martial_art/cqc/plus
+	name = "old but gold manual"
+	martialname = "close quarters combat plus"
+	desc = "A small, black manual. There are drawn instructions of tactical hand-to-hand combat. This includes how to defelct projectiles too."
+	greet = "<span class='boldannounce'>You've mastered the basics of CQC.</span>"
+	icon_state = "cqcmanual"
+	remarks = list("Kick... Slam...", "Lock... Kick...", "Strike their abdomen, neck and back for critical damage...", "Slam... Lock...", "I could probably combine this with some other martial arts!", "Words that kill...", "The last and final moment is yours...")

--- a/modular_skyrat/master_files/code/datums/martial/cqcplus.dm
+++ b/modular_skyrat/master_files/code/datums/martial/cqcplus.dm
@@ -1,7 +1,7 @@
 /datum/martial_art/cqc/plus
 	name = "CQC+"
 	id = MARTIALART_CQC_PLUS
-	block_chance = 95
+	block_chance = 90
 
 /datum/martial_art/cqc/plus/on_projectile_hit(mob/living/A, obj/projectile/P, def_zone)
 	. = ..()

--- a/modular_skyrat/master_files/code/datums/martial/cqcplus.dm
+++ b/modular_skyrat/master_files/code/datums/martial/cqcplus.dm
@@ -14,11 +14,13 @@
 		return BULLET_ACT_HIT
 	if(!isturf(A.loc)) //NO MOTHERFLIPPIN MECHS!
 		return BULLET_ACT_HIT
-	A.visible_message("<span class='danger'>[A] effortlessly swats the projectile aside! They can block bullets with their bare hands!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
-	playsound(get_turf(A), pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
-	P.firer = A
-	P.set_angle(rand(0, 360))//SHING
-	return BULLET_ACT_FORCE_PIERCE
+	if(A.in_throw_mode)
+		A.visible_message("<span class='danger'>[A] effortlessly swats the projectile aside! They can block bullets with their bare hands!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
+		playsound(get_turf(A), pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
+		P.firer = A
+		P.set_angle(rand(0, 360))//SHING
+		return BULLET_ACT_FORCE_PIERCE
+	return BULLET_ACT_HIT
 
 /obj/item/book/granter/martial/cqc/plus
 	martial = /datum/martial_art/cqc/plus

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -65,7 +65,14 @@
 	item = /obj/item/book/granter/martial/cqc
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //Blocked them because this just costs more than the version they get.
 	cost = 25
-	surplus = 0
+	surplus = 20
+
+/datum/uplink_item/stealthy_weapons/cqcplus
+	name = "CQC+ Manual"
+	desc = "A manual that teaches a single user tactical Close-Quarters Combat and how to deflect projectiles before self-destructing."
+	item = /obj/item/book/granter/martial/cqc/plus
+	cost = 35
+	surplus = 20
 
 /datum/uplink_item/stealthy_weapons/telescopicbaton
 	name = "Telescopic Baton"

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -71,7 +71,7 @@
 	name = "CQC+ Manual"
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat and how to deflect projectiles before self-destructing."
 	item = /obj/item/book/granter/martial/cqc/plus
-	cost = 35
+	cost = 30
 	surplus = 20
 
 /datum/uplink_item/stealthy_weapons/telescopicbaton

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3412,6 +3412,7 @@
 #include "modular_skyrat\master_files\code\_globalvars\~maint_loot.dm"
 #include "modular_skyrat\master_files\code\controllers\configuration\entries.dm"
 #include "modular_skyrat\master_files\code\datums\ert.dm"
+#include "modular_skyrat\master_files\code\datums\martial\cqcplus.dm"
 #include "modular_skyrat\master_files\code\datums\traits\good.dm"
 #include "modular_skyrat\master_files\code\datums\traits\negative.dm"
 #include "modular_skyrat\master_files\code\datums\traits\neutral.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new traitor item, CQC+, this costs a whopping 30 TC but combines the best of CQC with sleeping carp. Considering it costs most of your TC, you'd expect it to be good. And it is, you'll be able to do all of the CQC moves without the disadvantage of being downed in 3.2 seconds because "FIRE AT WILL". 

Part of the traitor buff.

## Changelog
:cl:
add:  Added a new martial arts book, CQC+, capable of standard CQC moves as well as projectile deflection.
/:cl:

