### PR TITLE
[NONMODULAR]Spread Infestation removal

### DIFF
--- a/code/modules/antagonists/changeling/powers/spiders.dm
+++ b/code/modules/antagonists/changeling/powers/spiders.dm
@@ -1,3 +1,4 @@
+/*SKYRAT EDIT: Removes spread infestation ability due to increasing NRP usage.
 /datum/action/changeling/spiders
 	name = "Spread Infestation"
 	desc = "Our form divides, creating a cluster of eggs which will grow into a deadly arachnid. Costs 45 chemicals."
@@ -12,3 +13,4 @@
 	..()
 	new /obj/structure/spider/eggcluster/bloody(user.loc)
 	return TRUE
+*/

--- a/code/modules/antagonists/changeling/powers/spiders.dm
+++ b/code/modules/antagonists/changeling/powers/spiders.dm
@@ -1,4 +1,5 @@
-/*SKYRAT EDIT: Removes spread infestation ability due to increasing NRP usage.
+//SKYRAT EDIT REMOVAL BEGIN: Removes Spread Infestation due to NRP usage and abuse by changelings
+/*
 /datum/action/changeling/spiders
 	name = "Spread Infestation"
 	desc = "Our form divides, creating a cluster of eggs which will grow into a deadly arachnid. Costs 45 chemicals."
@@ -14,3 +15,4 @@
 	new /obj/structure/spider/eggcluster/bloody(user.loc)
 	return TRUE
 */
+//SKYRAT EDIT REMOVAL END


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After lengthy discussion in dev chats, player feedback, etc, it was decided that spread infestation overall contributes very little to the round - while taking lots away; especially with recent buffs to chem capacity, and regeneration

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more NRP spider spam; they've been abusing the role primary to drag welding tanks, water tanks, ecetera in order to cause massive damage; and have otherwise been abusing the point of the role. And the changelings themselves were not punished for spamming out spiders.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Spread Infestation has been removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
