### PR TITLE
[NonModular] Sepia/lightpink rebalance

### DIFF
--- a/code/modules/movespeed/modifiers/status_effects.dm
+++ b/code/modules/movespeed/modifiers/status_effects.dm
@@ -5,7 +5,7 @@
 	multiplicative_slowdown = 3
 
 /datum/movespeed_modifier/status_effect/lightpink
-	multiplicative_slowdown = -0.5
+	multiplicative_slowdown = -0.25 //SKYRAT EDIT: Oiriginal value (-0.5)
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/status_effect/tarfoot

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -683,11 +683,11 @@
 /datum/status_effect/stabilized/sepia/tick()
 	if(prob(50) && mod > -1)
 		mod--
-		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, multiplicative_slowdown = -0.5)
+		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, multiplicative_slowdown = -0.2) //SKYRAT EDIT: Original value (-0.5)
 	else if(mod < 1)
 		mod++
 		// yeah a value of 0 does nothing but replacing the trait in place is cheaper than removing and adding repeatedly
-		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, multiplicative_slowdown = 0)
+		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, multiplicative_slowdown = -0.1) //SKYRAT EDIT: Original value (0)
 	return ..()
 
 /datum/status_effect/stabilized/sepia/on_remove()


### PR DESCRIPTION
## About The Pull Request

REMAKE OF https://github.com/Skyrat-SS13/Skyrat-tg/pull/3612

lightpink down to 25% speed buff from 50%, sepia speed buff down to 20% from 50%, wth a possible slowdown of 10%

I totally FUCKERED my last PR https://github.com/Skyrat-SS13/Skyrat-tg/pull/3612 of this, like, utterly annihilated it. All that's left is a smoldering crater. Don't go there.

- Lightpink speed buff reduced from 50% to 25%
- Sepia speedbuff reduced 50% to 20%
- Sepia, instead of doing nothing if it doesn't roll the speedbuff, now applies a 10% slowdown.

## Why It's Good For The Game

No lightspeed sec, or other people, adds a potential, and slight, downside if you don't roll the speed buff on the stabilized sepias. It's not as bad as the possible good.

## Changelog
:cl:
balance: Balanced stabilized Light pink and sepia extracts to not create lightspeed characters
/:cl:
