### PR TITLE
[Modular] Adds Anti-drop implant autosurgeon to traitor uplink

### DIFF
--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -230,3 +230,11 @@
 	cost = 12
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
+
+/datum/uplink_item/implants/anti_drop
+	name = "Anti-Drop Implant"
+	desc = "This cybernetic brain implant will allow you to force your hand muscles to contract, preventing item dropping at will. Comes in an autosurgeon."
+	item = /obj/item/autosurgeon/organ/syndicate/no_drop
+	cost = 5
+	surplus = 0
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)

--- a/modular_skyrat/modules/implants/code/organs/augments_internal.dm
+++ b/modular_skyrat/modules/implants/code/organs/augments_internal.dm
@@ -32,4 +32,10 @@
 
 /obj/item/organ/cyberimp/brain/anti_sleep/proc/reboot()
 	organ_flags &= ~ORGAN_FAILING
-	cooldown = FALSE 
+	cooldown = FALSE
+
+//Autosurgeon for anti-drop implant
+/obj/item/autosurgeon/organ/syndicate/no_drop
+	desc = "A single use autosurgeon that contains an anti-drop implant. A screwdriver can be used to remove it, but implants can't be placed back in."
+	uses = 1
+	starting_organ = /obj/item/organ/cyberimp/brain/anti_drop


### PR DESCRIPTION
## About The Pull Request

Simple. Adds an anti drop implant autosurgeon object, and that object to the traitor uplink list.

## Why It's Good For The Game

Sometimes you drop something by accident, sometimes you throw it, sometimes you fall to the next z level, and sometimes you get stam critted. Wouldn't be amazing if you DIDN'T drop your items when this happened? Well now you don't have to worry! Clench your fists so tight nobody will ever be able to get the things out without CUTTING YOUR ARM OFF!

## Changelog
:cl:
add: Added anti-drop implant to traitor uplink.
/:cl: