### PR TITLE
[MODULAR] Gives Paramedics access to the prescription health hud glasses

### DIFF
--- a/modular_skyrat/modules/huds/code/loadout/glasses_loadout.dm
+++ b/modular_skyrat/modules/huds/code/loadout/glasses_loadout.dm
@@ -6,7 +6,7 @@
 /datum/loadout_item/glasses/medhud_glasses
 	name = "Prescription Medical Hud"
 	path = /obj/item/clothing/glasses/hud/health/prescription
-	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Geneticist", "Chemist", "Virologist")
+	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Geneticist", "Chemist", "Virologist", "Paramedic")
 
 /datum/loadout_item/glasses/diaghud_glasses
 	name = "Prescription Diagnostic Hud"


### PR DESCRIPTION
## About The Pull Request
Adds paramedics to the loadout job requirements 

## Why It's Good For The Game
Allows Paramedics who are nearsighted to now spawn with prescription health hud glasses so they can see what they're doing

## Changelog
:cl:
fix: Nearsighted Paramedics can now elect to spawn with prescription health hud glasses in the loadout menu
/:cl: