### PR TITLE
Makes power tools half as fast as they were on oldbase

### DIFF
--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -64,14 +64,14 @@
 	custom_materials = list(/datum/material/iron=150,/datum/material/silver=50,/datum/material/titanium=25)
 	usesound = 'sound/items/jaws_pry.ogg'
 	force = 15
-	toolspeed = 0.7
+	toolspeed = 0.5	// SKYRAT EDIT: Buffs toolspeed to half of what it was on oldbase - Original value (0.7)
 	force_opens = TRUE
 
 /obj/item/crowbar/power/syndicate
 	name = "Syndicate jaws of life"
 	desc = "A re-engineered copy of Nanotrasen's standard jaws of life. Can be used to force open airlocks in its crowbar configuration."
 	icon_state = "jaws_pry_syndie"
-	toolspeed = 0.5
+	toolspeed = 0.25	// SKYRAT EDIT: Keeps this relevant, buffs to oldbase speed - Original value (0.5)
 	force_opens = TRUE
 
 /obj/item/crowbar/power/examine()

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -107,7 +107,7 @@
 	attack_verb_simple = list("drill", "screw", "jab", "whack")
 	hitsound = 'sound/items/drill_hit.ogg'
 	usesound = 'sound/items/drill_use.ogg'
-	toolspeed = 0.7
+	toolspeed = 0.5	// SKYRAT EDIT: Buffs toolspeed to half of what it was on oldbase - Original value (0.7)
 	random_color = FALSE
 
 /obj/item/screwdriver/power/examine()


### PR DESCRIPTION
## About The Pull Request
• Changes power tool toolspeed to half of what it was on oldbase. From 0.7 to 0.5, oldbase was 0.25 which was lovely.
• Buffs syndie jaws to 0.25, so it's still faster than it's non-syndicate counterpart. You have to pay TC for this thing.

## Why It's Good For The Game
Have you ever used a drill in real life? Do you know how much faster that is than a regular screwdriver?
This is a QoL change for engineering. At the moment, power tools are only really useful for prying airlocks and saving belt space. It's an expensive tech node and very expensive crafting recipe. Changing the speed to 0.5 isn't enough to reflect its cost and that... it's a power tool.

Also paves the way for in-between tools, like electric screwdrivers, which are just slightly faster screwdrivers.

## Changelog
:cl:
qol: Power tools are now slightly faster, reflecting the fact that they are indeed electrically assisted tools. They're now twice as fast as regular tools, instead of only slightly faster.
/:cl:
