### PR TITLE
Ghost Cafe plumbing area + small fixes

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -1902,7 +1902,7 @@
 /area/cruiser_dock/brig)
 "fl" = (
 /obj/machinery/jukebox{
-	req_one_access = null
+	req_access = "0"
 	},
 /obj/structure/sign/barsign{
 	pixel_y = 32;

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -295,6 +295,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/commons)
+"aP" = (
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "aQ" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 10;
@@ -1992,7 +1997,7 @@
 	pixel_y = 11
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "fz" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2248,11 +2253,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/commons)
-"gj" = (
-/turf/open/floor/plating/beach/coastline_b{
-	dir = 1
-	},
-/area/centcom/holding/cafepark)
 "gk" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -2418,6 +2418,14 @@
 	icon_state = "floor"
 	},
 /area/centcom/holding/cafe)
+"gH" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "gI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -3099,6 +3107,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/medical)
+"it" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "iu" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -3234,6 +3250,26 @@
 	icon_state = "floor"
 	},
 /area/centcom/holding/cafe)
+"iL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "iM" = (
 /obj/structure/showcase/fakeid{
 	dir = 4
@@ -3256,6 +3292,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/commons)
+"iP" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "iQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -3376,9 +3424,15 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/commons)
 "jh" = (
-/obj/structure/fence/door/opened,
-/turf/open/floor/plating/grass/planet,
-/area/centcom/holding/cafepark)
+/obj/machinery/door/airlock/wood{
+	name = "Plumbing"
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "ji" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/grass,
@@ -3669,7 +3723,15 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
+"jS" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "jT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -3873,6 +3935,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/research)
+"ky" = (
+/obj/item/kirbyplants/random,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "kz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -3880,6 +3948,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/vault)
+"kB" = (
+/obj/structure/table,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/plunger,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/plunger,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "kC" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -4045,6 +4129,21 @@
 	dir = 8
 	},
 /area/centcom/holding/cafepark)
+"kX" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "kY" = (
 /turf/open/floor/glass/reinforced,
 /area/cruiser_dock/research)
@@ -4162,6 +4261,17 @@
 	icon_state = "floor"
 	},
 /area/centcom/holding/cafe)
+"ln" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "lo" = (
 /obj/structure/flora/tree/jungle/small{
 	icon_state = "tree5"
@@ -4546,7 +4656,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "ml" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 10
@@ -4565,13 +4675,6 @@
 	},
 /turf/open/floor/wood,
 /area/cruiser_dock/commons/dorms)
-"mq" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
-	density = 0
-	},
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
 "mr" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -5496,13 +5599,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/research)
-"oN" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
-	density = 0
-	},
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
 "oO" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -5808,6 +5904,16 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/cruiser_dock/commons)
+"pz" = (
+/obj/structure/table,
+/obj/item/construction/plumbing,
+/obj/item/construction/plumbing,
+/obj/item/construction/plumbing,
+/obj/item/construction/plumbing,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "pA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -5995,7 +6101,7 @@
 	light_color = "#c1caff"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "pX" = (
 /turf/open/floor/plating/beach/coastline_t{
 	dir = 6
@@ -6158,7 +6264,7 @@
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "qx" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -6603,6 +6709,11 @@
 /obj/item/razor,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/commons)
+"rF" = (
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "rG" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/green{
@@ -7123,6 +7234,26 @@
 	},
 /turf/open/floor/plating/grass/planet,
 /area/centcom/holding/cafepark)
+"sY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "sZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/dark,
@@ -7210,10 +7341,6 @@
 /obj/item/storage/firstaid/brute,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/medical)
-"tk" = (
-/obj/structure/mineral_door/wood,
-/turf/closed/indestructible/wood,
-/area/centcom/holding/cafepark)
 "tl" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -7319,6 +7446,21 @@
 /obj/effect/spawner/lootdrop/gun/assaultops/ballistics,
 /turf/open/floor/carpet/royalblack,
 /area/cruiser_dock/commons)
+"tB" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "tC" = (
 /obj/effect/turf_decal/delivery/white{
 	color = "#7a5778"
@@ -7572,6 +7714,12 @@
 	planetary_atmos = 0
 	},
 /area/cruiser_dock/medical/virology)
+"ul" = (
+/obj/machinery/chem_heater,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "um" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -7602,6 +7750,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/research)
+"uq" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "ur" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -7804,7 +7960,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "uQ" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -7995,7 +8151,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "vu" = (
 /obj/vehicle/ridden/janicart/upgraded,
 /obj/item/key/janitor,
@@ -8407,7 +8563,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "wu" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 4
@@ -8423,11 +8579,6 @@
 /obj/structure/chair/sofa/corp/left,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafedorms)
-"ww" = (
-/turf/open/floor/plating/beach/coastline_b{
-	dir = 6
-	},
-/area/centcom/holding/cafepark)
 "wx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -9683,6 +9834,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/medical)
+"zS" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "zT" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -9924,7 +10083,7 @@
 	pixel_y = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "Aw" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
@@ -10606,6 +10765,25 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/bridge/hallway)
+"Cr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "Cs" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4
@@ -10697,12 +10875,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/research)
-"CH" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
-	},
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
 "CI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -11105,6 +11277,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/cruiser_dock/research)
+"DO" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "DP" = (
 /mob/living/simple_animal/chicken,
 /turf/open/floor/plating/grass/planet,
@@ -11221,11 +11400,6 @@
 	},
 /turf/open/floor/plating/grass/planet,
 /area/centcom/holding/cafepark)
-"Eg" = (
-/turf/open/floor/plating/beach/coastline_b{
-	dir = 8
-	},
-/area/centcom/holding/cafepark)
 "Eh" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 1
@@ -11257,7 +11431,13 @@
 	pixel_y = 7
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
+"Eo" = (
+/obj/machinery/light,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "Ep" = (
 /obj/structure/table/wood,
 /obj/machinery/smartfridge/disks{
@@ -11537,10 +11717,6 @@
 /obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/medical/virology)
-"Fe" = (
-/obj/machinery/light,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
 "Ff" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -11755,7 +11931,7 @@
 /obj/machinery/light,
 /obj/structure/table/wood,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "FL" = (
 /obj/structure/railing{
 	dir = 4
@@ -11982,12 +12158,6 @@
 	},
 /turf/open/floor/iron/vaporwave,
 /area/cruiser_dock/brig)
-"Gn" = (
-/obj/structure/chair/sofa/left{
-	dir = 8
-	},
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
 "Go" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -13293,7 +13463,7 @@
 	pixel_y = 2
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "JY" = (
 /obj/machinery/chem_dispenser/fullupgrade,
 /turf/open/indestructible/hoteltile{
@@ -13500,11 +13670,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/service)
-"KH" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien12"
-	},
-/area/centcom/holding/cafepark)
 "KI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/mech_bay_recharge_port{
@@ -13961,6 +14126,14 @@
 /obj/effect/turf_decal/bot_red/left,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/research)
+"LV" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/head/welding,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "LW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -14201,6 +14374,16 @@
 /obj/item/coin/silver,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
+"MF" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock/wood{
+	name = "Plumbing"
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "MG" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -14571,6 +14754,9 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafedorms)
+"NG" = (
+/turf/closed/indestructible/wood,
+/area/centcom/holding/cafeplumbing)
 "NH" = (
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/commons)
@@ -14637,7 +14823,7 @@
 	pixel_y = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "NU" = (
 /obj/structure/closet/crate/wooden/toy,
 /turf/open/floor/plating/dirt/planet,
@@ -14839,7 +15025,7 @@
 	set_obj_flags = "EMAGGED"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "Ou" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/delivery/white,
@@ -15362,6 +15548,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/research)
+"PM" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "PN" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -15679,7 +15878,7 @@
 	pixel_y = 2
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "QF" = (
 /obj/structure/table,
 /obj/item/folder/syndicate/blue,
@@ -16099,10 +16298,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/brig)
-"RF" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
 "RG" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -16772,7 +16967,7 @@
 "Tv" = (
 /obj/structure/dresser,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "Tw" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/paperframes/fifty,
@@ -16854,6 +17049,7 @@
 	id_tag = "ghostcafecabin3";
 	name = "Wooden Cabin"
 	},
+/obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafedorms)
 "TH" = (
@@ -17063,6 +17259,12 @@
 	},
 /turf/open/floor/iron,
 /area/cruiser_dock/brig)
+"Uh" = (
+/obj/machinery/chem_master,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "Ui" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 4
@@ -17120,6 +17322,24 @@
 	dir = 8
 	},
 /area/centcom/holding/cafepark)
+"Us" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "Ut" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -17231,6 +17451,21 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/medical)
+"UJ" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "UK" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -17385,6 +17620,7 @@
 	id_tag = "ghostcafecabin1";
 	name = "Wooden Cabin"
 	},
+/obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafedorms)
 "Vh" = (
@@ -17715,6 +17951,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/heads/cl)
+"We" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "Wf" = (
 /obj/machinery/light{
 	dir = 8
@@ -17858,6 +18110,12 @@
 /obj/item/radio/headset/assault,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/commons)
+"Wy" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "Wz" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -18103,6 +18361,22 @@
 	icon_state = "plating"
 	},
 /area/centcom/holding/cafe)
+"Xm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "Xn" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -18320,6 +18594,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/medical)
+"XQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "XR" = (
 /obj/machinery/button/door{
 	id = "ghostcafecabin3";
@@ -18512,6 +18795,21 @@
 "Yv" = (
 /turf/open/floor/iron/showroomfloor,
 /area/cruiser_dock/heads/admiral)
+"Yw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "Yx" = (
 /obj/machinery/rnd/destructive_analyzer,
 /turf/open/floor/iron/dark,
@@ -18536,6 +18834,21 @@
 /obj/effect/turf_decal/trimline/red/line,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/engineering)
+"YC" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "YD" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -18619,8 +18932,9 @@
 "YO" = (
 /obj/structure/spacevine,
 /obj/structure/mineral_door/wood,
+/obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "YP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -18841,6 +19155,12 @@
 	},
 /turf/open/floor/wood,
 /area/cruiser_dock/commons)
+"Zy" = (
+/obj/machinery/chem_dispenser/fullupgrade,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafeplumbing)
 "Zz" = (
 /obj/machinery/nanite_programmer,
 /obj/effect/turf_decal/bot,
@@ -18883,6 +19203,20 @@
 	},
 /turf/open/floor/engine,
 /area/cruiser_dock/research)
+"ZE" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "white"
+	},
+/area/centcom/holding/cafeplumbing)
 "ZF" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/rollingpapers,
@@ -18989,7 +19323,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafepark)
+/area/centcom/holding/cafedorms)
 "ZV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
@@ -55099,7 +55433,7 @@ Pf
 jj
 Um
 Vo
-gj
+Wi
 Wi
 OO
 Ur
@@ -55356,7 +55690,7 @@ yI
 HX
 Um
 Vo
-gj
+Wi
 Wi
 xY
 Wg
@@ -55613,7 +55947,7 @@ Pf
 jj
 xJ
 pX
-gj
+Wi
 Wi
 xa
 Um
@@ -55868,9 +56202,9 @@ jj
 jj
 jj
 jj
-Eg
-Eg
-ww
+Wi
+Wi
+Wi
 Wi
 xa
 Um
@@ -65654,20 +65988,20 @@ FP
 FP
 jj
 jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
 aa
 aa
 aa
@@ -65911,20 +66245,20 @@ aY
 Oz
 jj
 jj
-jj
-jj
-Ir
-Ir
-Ir
-Ir
-Ir
-Tp
-Ir
-Ir
-Ir
-Ir
-Ir
-jj
+NG
+kB
+rF
+it
+rF
+rF
+rF
+rF
+rF
+rF
+it
+rF
+rF
+NG
 aa
 aa
 aa
@@ -66168,20 +66502,20 @@ kp
 FP
 jj
 jj
-jj
-jj
-Ir
-Ir
-Ir
-Ir
-Ig
-Ig
-Ig
-Ir
-Ir
-Ir
-Ir
-jj
+NG
+DO
+Cr
+We
+We
+We
+We
+We
+We
+We
+We
+sY
+rF
+NG
 aa
 aa
 aa
@@ -66425,20 +66759,20 @@ gy
 FP
 jj
 jj
-jj
-jj
-Ir
-Ir
-Ir
-Ir
-Ig
-iM
-Ig
-Ir
-Ir
-Ir
-Ir
-jj
+NG
+pz
+Xm
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+PM
+rF
+NG
 aa
 aa
 aa
@@ -66682,20 +67016,20 @@ FP
 yd
 FP
 jj
-jj
-jj
-Ir
-Ir
-Ir
-qo
-DC
-Ny
-DC
-qo
-Ir
-Ir
-Ir
-jj
+NG
+LV
+Xm
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+PM
+rF
+NG
 aa
 aa
 aa
@@ -66939,20 +67273,20 @@ LH
 FP
 FP
 FP
-jj
-Ir
-Ir
-Ir
-Ir
-DC
-DC
-Si
-DC
-DC
-Ir
-Ir
-Ir
-jj
+NG
+XQ
+Xm
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+PM
+Eo
+NG
 aa
 aa
 aa
@@ -67196,20 +67530,20 @@ FP
 hs
 FP
 FP
-gU
-Ir
-Ir
-Ir
-Ir
-DC
-Yt
-Yt
-Yt
-Si
-GC
-Ir
-Ir
-jj
+NG
+rF
+Xm
+aP
+zS
+aP
+aP
+aP
+aP
+aP
+aP
+PM
+rF
+NG
 aa
 aa
 aa
@@ -67454,19 +67788,19 @@ FP
 FP
 FP
 jh
-Ir
-Ir
-uH
-DC
-DC
-kf
-Yt
-wA
-DC
-DC
-Vk
-Ir
-jj
+rF
+Xm
+aP
+tB
+kX
+kX
+kX
+kX
+iP
+aP
+PM
+rF
+NG
 aa
 aa
 aa
@@ -67710,20 +68044,20 @@ FP
 FP
 FP
 FP
-gU
-Ir
-GR
-DC
-DC
-DC
-ox
-Yt
-pn
-DC
-DC
-DC
-GR
-jj
+MF
+rF
+Xm
+aP
+UJ
+YC
+YC
+YC
+YC
+ZE
+aP
+PM
+rF
+NG
 aa
 aa
 aa
@@ -67967,20 +68301,20 @@ hQ
 FP
 FP
 FP
-jj
-Ir
-Ir
-Cs
-Cs
-DC
-kf
-Yt
-wA
-DC
-Cs
-Cs
-Ir
-jj
+NG
+rF
+Xm
+aP
+gH
+aP
+aP
+aP
+aP
+aP
+aP
+PM
+rF
+NG
 aa
 aa
 aa
@@ -68224,20 +68558,20 @@ sX
 hU
 FP
 jj
-jj
-jj
-Ir
-PU
-MR
-DC
-Yt
-Yt
-Yt
-DC
-PU
-MR
-Ir
-jj
+NG
+uq
+Xm
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+PM
+Eo
+NG
 aa
 aa
 aa
@@ -68481,20 +68815,20 @@ FP
 FP
 jj
 jj
-jj
-jj
-Ir
-Ir
-Ir
-DC
-Ny
-Ny
-Ny
-DC
-Ir
-Ir
-Ir
-jj
+NG
+ky
+Xm
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+PM
+rF
+NG
 aa
 aa
 aa
@@ -68738,20 +69072,20 @@ CM
 FB
 jj
 jj
-jj
-jj
-Ir
-Ir
-Ir
-DC
-DC
-Ig
-DC
-DC
-Ir
-Ir
-Ir
-jj
+NG
+ul
+Xm
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+PM
+rF
+NG
 aa
 aa
 aa
@@ -68995,20 +69329,20 @@ MJ
 FP
 jj
 jj
-jj
-jj
-Ir
-Ir
-Ir
-Ah
-Ir
-Ir
-Ir
-Ah
-Ir
-Ir
-Ir
-jj
+NG
+Zy
+iL
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Us
+rF
+NG
 aa
 aa
 aa
@@ -69250,22 +69584,22 @@ FP
 FP
 FP
 FP
-FP
 jj
 jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
-jj
+NG
+Uh
+ln
+jS
+rF
+rF
+rF
+rF
+rF
+rF
+jS
+rF
+rF
+NG
 aa
 aa
 aa
@@ -69507,22 +69841,22 @@ FB
 kp
 FP
 Br
-FP
-FP
 jj
 jj
-jj
-jj
-KH
-KH
-KH
-jj
-jj
-jj
-jj
-jj
-jj
-jj
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
 aa
 aa
 aa
@@ -69765,20 +70099,20 @@ FP
 FP
 FP
 FP
-FP
-FP
-Um
-Um
-Vo
-Lx
-Lx
-Lx
-xa
-Um
-Um
-Um
-Um
-Um
+jj
+jj
+jj
+jj
+jj
+jj
+jj
+jj
+jj
+jj
+jj
+jj
+jj
+jj
 jj
 aa
 aa
@@ -78202,15 +78536,15 @@ Pf
 Pf
 Pf
 Pf
-Fy
-Fy
-Fy
-Fy
+xA
+xA
+xA
+xA
 YO
-Fy
-Fy
-Fy
-Fy
+xA
+xA
+xA
+xA
 xA
 xA
 xA
@@ -78459,15 +78793,15 @@ Pf
 Pf
 Pf
 Pf
-Fy
+xA
 Av
-iA
-iA
-iA
+tF
+tF
+tF
 vt
 mk
-CH
-Fy
+SV
+xA
 xA
 Nd
 OY
@@ -78716,15 +79050,15 @@ Pf
 Pf
 Pf
 Pf
-Fy
+xA
 Ot
-iA
+tF
 Em
-iA
-RF
-RF
+tF
+bK
+bK
 FK
-Fy
+xA
 xA
 VC
 xA
@@ -78973,15 +79307,15 @@ Pf
 Pf
 Pf
 Pf
-Fy
-mq
-iA
+xA
+iD
+tF
 QE
-iA
-RF
-RF
+tF
+bK
+bK
 qw
-Fy
+xA
 xA
 xA
 xA
@@ -79230,15 +79564,15 @@ Pf
 Pf
 Pf
 Pf
-Fy
-oN
+xA
+xC
 JX
 NT
-iA
+tF
 ZU
 jR
-Gn
-Fy
+xF
+xA
 jj
 jj
 xA
@@ -79487,15 +79821,15 @@ Pf
 Pf
 Pf
 Pf
-Fy
-Fy
-Fy
-Fy
-tk
-Fy
-Fy
-Fy
-Fy
+xA
+xA
+xA
+xA
+Na
+xA
+xA
+xA
+xA
 jj
 jj
 xA
@@ -79744,15 +80078,15 @@ Pf
 Pf
 Pf
 Pf
-Fy
+xA
 wt
 Tv
-Fy
-iA
-Fy
+xA
+tF
+xA
 Tv
 wt
-Fy
+xA
 jj
 jj
 xA
@@ -80001,15 +80335,15 @@ Pf
 Pf
 Pf
 Pf
-Fy
-OZ
-iA
-Fy
-iA
-Fy
-iA
-Fe
-Fy
+xA
+Wy
+tF
+xA
+tF
+xA
+tF
+KX
+xA
 jj
 jj
 xA
@@ -80258,15 +80592,15 @@ Pf
 Pf
 Pf
 Pf
-Fy
+xA
 fy
-iA
-tk
+tF
+Na
 pW
-tk
-iA
+Na
+tF
 uP
-Fy
+xA
 jj
 jj
 xA
@@ -80515,15 +80849,15 @@ Pf
 Pf
 Pf
 Pf
-Fy
-Fy
-Fy
-Fy
-Fy
-Fy
-Fy
-Fy
-Fy
+xA
+xA
+xA
+xA
+xA
+xA
+xA
+xA
+xA
 jj
 jj
 xA

--- a/modular_skyrat/modules/ghostcafe/code/game/area/areas/centcom.dm
+++ b/modular_skyrat/modules/ghostcafe/code/game/area/areas/centcom.dm
@@ -21,3 +21,6 @@
 
 /area/centcom/holding/cafepark
 	name = "Ghost Cafe Outdoors"
+
+/area/centcom/holding/cafeplumbing
+	name = "Ghost Cafe Plumbing"


### PR DESCRIPTION
## About The Pull Request

Adds a plumbing area to the ghost cafe, replacing the secondary shuttle that had no purpose.

![image](https://user-images.githubusercontent.com/8881105/109503585-5f713280-7a92-11eb-8193-66948ca7c902.png)

## Why It's Good For The Game

More stuff to do = good

## Changelog
:cl:
add: New plumbing area in the ghost cafe
fix: Some ghost cafe doors are no longer occupied by walls
/:cl: