### PR TITLE
[NONMODULAR]Brings Noc regen in line with starlight and fleshmend

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -184,14 +184,14 @@
 	level = 6
 	passive_message = "<span class='notice'>You feel tingling on your skin as light passes over it.</span>"
 	threshold_descs = list(
-		"Stage Speed 7" = "Doubles healing speed.",
+		"Stage Speed 7" = "Doubles healing speed.", //SKYRAT EDIT: Brings Noc regen into line with the rest of the healing symptoms.
 	)
 
 /datum/symptom/heal/darkness/Start(datum/disease/advance/A)
 	. = ..()
 	if(!.)
 		return
-	if(A.totalStageSpeed() >= 7)
+	if(A.totalStageSpeed() >= 7)//SKYRAT EDIT: Brings Noc regen into line with the rest of the healing symptoms.
 		power = 2
 
 /datum/symptom/heal/darkness/CanHeal(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -184,14 +184,14 @@
 	level = 6
 	passive_message = "<span class='notice'>You feel tingling on your skin as light passes over it.</span>"
 	threshold_descs = list(
-		"Stage Speed 8" = "Doubles healing speed.",
+		"Stage Speed 7" = "Doubles healing speed.",
 	)
 
 /datum/symptom/heal/darkness/Start(datum/disease/advance/A)
 	. = ..()
 	if(!.)
 		return
-	if(A.totalStageSpeed() >= 8)
+	if(A.totalStageSpeed() >= 7)
 		power = 2
 
 /datum/symptom/heal/darkness/CanHeal(datum/disease/advance/A)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the symptom threshold from 8 to 7 like every other tier 6 healing symptom.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency and more freedom to avoid 'minmax' diseases, mcbruh.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Nocturnal regen is now in line with every tier 6 healing symptom, in terms of thresholds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
