### PR TITLE
Self destruct terminal no longer makes an explosion when destroy() is called

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -47,7 +47,6 @@
 		// If we're not exploding, set the alert level back to normal
 		set_safety()
 	GLOB.nuke_list -= src
-	explosion(src, 50, 70, 80, 100, TRUE, TRUE) //SKYRAT EDIT ADDITION
 	QDEL_NULL(countdown)
 	QDEL_NULL(core)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

You're in the station and this blob shows up and slaps your self-destruct terminal, you die.

## Why It's Good For The Game

![dreamseeker_SvIAbWrJgn](https://user-images.githubusercontent.com/26494679/109621040-cf65d400-7af7-11eb-94f2-675abebbbaa0.png)

## Changelog
:cl:
del: removed a line from the self-destruct terminal code that causes it to blow up
/:cl:
