### PR TITLE
Adjusts stamina damage of contractor batons.

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -422,7 +422,7 @@
 	force = 5
 
 	cooldown = 25
-	stamina_damage = 30 //SKYRAT EDIT CHANGE - ORIGINAL: 85
+	stamina_damage = 65 //SKYRAT EDIT CHANGE - ORIGINAL: 85 // SKYRAT EDIT CHANGE - SKYRAT ORIGINAL POST-NERF: 30
 	affect_silicon = TRUE
 	on_sound = 'sound/weapons/contractorbatonextend.ogg'
 	on_stun_sound = 'sound/effects/contractorbatonhit.ogg'


### PR DESCRIPTION
Makes contractor batons useful again by reverting the damage to something closer to the original damage so that it remains an effective tool.

## About The Pull Request

This PR buffs the contractor baton closer to what it originally was so it remains true to the original intent of the weapon, that being to be a relatively reliable way for traitors with the Contractor kit to acquire their targets if they could catch them off guard. It makes a loud, distrinctive noise that is easily identifyable as a contractor baton, to equal out the risk reward of using it to subdue people rather than coerce them, or to make unruly contract targets a little easier to manage.

## Why It's Good For The Game

I am in the firm belief that Contractors are in need of a bit of a buff when it comes to their baton, for the current damage makes it equal to telebatons that Heads get, i.e, 30 stamina damage. This means that it would take on average six or seven hits for a contractor to subdue a target, at which point they would be better off using a martial art such as CQC or an electric stun baton to subdue their target rather than the purpose built tool that came with their kit. I believe that the 3-4 hit knockdown is much more fair to contractors, compared to the original harsh value of 85 stamina damage from TG, leading to a 2 hit guarenteed knockout.

## Changelog
:cl:
balance: Syndicate contractors will notice that their batons have recieved some upgrades, and are now more capable of subduing targets more effectively, only taking three to four hits to crit rather than six to seven.
/:cl:
