### PR TITLE
[NONMODULAR] [FUCK] FIX FOR BLOBS BLOWING UP STATION WITH NUKE VORE

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -47,7 +47,6 @@
 		// If we're not exploding, set the alert level back to normal
 		set_safety()
 	GLOB.nuke_list -= src
-	//explosion(src, 50, 70, 80, 100, TRUE, TRUE) //SKYRAT EDIT ADDITION -Removed to prevent 'fun' blob events involving nukes
 	QDEL_NULL(countdown)
 	QDEL_NULL(core)
 	. = ..()
@@ -492,7 +491,7 @@
 	if(off_station < 2)
 		SSshuttle.registerHostileEnvironment(src)
 		SSshuttle.lockdown = TRUE
-
+	explosion(src, 50, 70, 80, 100, TRUE, TRUE) //SKYRAT EDIT ADDITION
 	INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnZLevel, z) //SKYRAT EDIT ADDITION
 
 	//Cinematic

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -47,7 +47,7 @@
 		// If we're not exploding, set the alert level back to normal
 		set_safety()
 	GLOB.nuke_list -= src
-	explosion(src, 50, 70, 80, 100, TRUE, TRUE) //SKYRAT EDIT ADDITION
+	//explosion(src, 50, 70, 80, 100, TRUE, TRUE) //SKYRAT EDIT ADDITION -Removed to prevent 'fun' blob events involving nukes
 	QDEL_NULL(countdown)
 	QDEL_NULL(core)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Blobs can yeet half the station by eating the nuke in the vault. Who'd have thought?

This still does a massive explosion when the nuke is triggered by conventional means, but the blob won't nuke the station anymore.

## Why It's Good For The Game

Blobs aren't nukies.

## Changelog
:cl:
fix: Blobs voring the station nuke no longer detonates the nuke.
/:cl: