### PR TITLE
[NON-MODULAR] Makes the teleprod weight class bulky

### DIFF
--- a/code/game/objects/items/teleprod.dm
+++ b/code/game/objects/items/teleprod.dm
@@ -1,7 +1,7 @@
 /obj/item/melee/baton/cattleprod/teleprod
 	name = "teleprod"
 	desc = "A prod with a bluespace crystal on the end. The crystal doesn't look too fun to touch."
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY	// SKYRAT EDIT CHANGE - ORIGINAL: w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "teleprod"
 	inhand_icon_state = "teleprod"
 	slot_flags = null


### PR DESCRIPTION
## About The Pull Request

Changes the teleprod from normal weight class to bulky

## Why It's Good For The Game

Brings it in line with the other prods, as well as it making very little sense that the most powerful one is not bulky while the others are. It is a beyond free escape tool as it stands, this will keep its power while stopping it from having absolutely zero downsides.
As it stands, it's basically impossible to get a teleprod away from someone that is using it, as they can just pull it out their bag and zap themselves before you can react. Now it's possible for them to actually drop it, letting you have a little more counterplay.

## Changelog
:cl:
balance: Teleprods are now bulky
/:cl: