### PR TITLE
[MODULAR] Adds skillchip to chief engineering officer of DS1

### DIFF
--- a/modular_skyrat/modules/assaultops/code/assaultops_spawners.dm
+++ b/modular_skyrat/modules/assaultops/code/assaultops_spawners.dm
@@ -275,6 +275,8 @@
 	id = /obj/item/card/id/syndicate_command/chief_engineering_officer
 	backpack_contents = list(/obj/item/melee/classic_baton/telescopic)
 
+	skillchips = list(/obj/item/skillchip/job/engineer)
+
 /obj/item/card/id/syndicate_command/chief_engineering_officer
 	assignment = "Chief Engineering Officer"
 	access = list(ACCESS_ENGINE_EQUIP,ACCESS_SYNDICATE)


### PR DESCRIPTION
## About The Pull Request

Adds an engineering skillchip to the Chief Engineering Officer at DS1, from issue https://github.com/Skyrat-SS13/Skyrat-tg/issues/3569.

## Why It's Good For The Game

It makes complete sense, tbh.

## Changelog
:cl:
qol: Adds engineering skillchip to chief engineering officer on DS1
/:cl: