### PR TITLE
[MODULAR] Ninja kit price hike.

### DIFF
--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -308,7 +308,7 @@
 	name = "Cyborg Ninja bundle"
 	desc = "Become a force of nature with this customized kit featuring next-generation syndicate technology in an efficient package."
 	item = /obj/item/storage/backpack/duffelbag/syndie/loadout/ninja
-	cost = 25
+	cost = 45
 
 /datum/uplink_item/loadout_skyrat/darklord
 	name = "Dark Lord bundle"


### PR DESCRIPTION
## About The Pull Request

vibro weapon has the carp bullet deflect iwthout needing to be in throwmode, it's fucking broken lmao.

Price hiked from 25 TC to 45 TC. Fuck it.

## Why It's Good For The Game

As much as I love FUCK SEC moments, the vibro blade is genuinely OP, especially at the price it was.

## Changelog
:cl:
balance: Adjusted the price of the ninja kit to better fit its value.
/:cl: