### PR TITLE
[MODULAR] Ninja kit fix thing

### DIFF
--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -308,7 +308,7 @@
 	name = "Cyborg Ninja bundle"
 	desc = "Become a force of nature with this customized kit featuring next-generation syndicate technology in an efficient package."
 	item = /obj/item/storage/backpack/duffelbag/syndie/loadout/ninja
-	cost = 25
+	cost = 45
 
 /datum/uplink_item/loadout_skyrat/darklord
 	name = "Dark Lord bundle"

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -308,7 +308,7 @@
 	name = "Cyborg Ninja bundle"
 	desc = "Become a force of nature with this customized kit featuring next-generation syndicate technology in an efficient package."
 	item = /obj/item/storage/backpack/duffelbag/syndie/loadout/ninja
-	cost = 45
+	cost = 25
 
 /datum/uplink_item/loadout_skyrat/darklord
 	name = "Dark Lord bundle"

--- a/modular_skyrat/modules/moretraitoritems/code/game/objects/items/weaponry.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/game/objects/items/weaponry.dm
@@ -1,2 +1,2 @@
 /obj/item/vibro_weapon/ninjasr
-    block_chance = 20
+    block_chance = 25

--- a/modular_skyrat/modules/moretraitoritems/code/game/objects/items/weaponry.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/game/objects/items/weaponry.dm
@@ -1,2 +1,2 @@
 /obj/item/vibro_weapon/ninjasr
-    block_chance = 75
+    block_chance = 20


### PR DESCRIPTION
## About The Pull Request

So.... the ninja sword was set to 75 block_chance, where the base vibro blade is only 40... you know why? Because when wielded we get this little thing called 
```
if(wielded)
	final_block_chance *= 2
```
which... clearly very much is not what the creator of the kit knew. As our wielding antags were sitting at a sweet 150% block chance. Amazing.

## Why It's Good For The Game

Lmao

## Changelog
:cl:
fix: Reduces ninja traitor kit  blade to be less than 100% block chance when wielded
/:cl: