### PR TITLE
[SPEEDMERGE FOR NOOBS AND CAPTAINS] Adds memo for new ID system to HoP offices + Cap's spare safe

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -46830,6 +46830,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon,
 /obj/item/stamp/hop,
+/obj/item/paper/fluff/ids_for_dummies,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "bWS" = (

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -35854,10 +35854,6 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "bBG" = (
-/obj/item/radio/intercom{
-	pixel_x = -26;
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -35867,6 +35863,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/item/storage/secure/safe/caps_spare{
+	pixel_x = -26;
+	pixel_y = 26
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -22892,6 +22892,7 @@
 	},
 /obj/item/pen,
 /obj/item/stamp/hop,
+/obj/item/paper/fluff/ids_for_dummies,
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "btE" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -12749,6 +12749,10 @@
 /obj/structure/table/reinforced,
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
+/obj/machinery/bounty_board{
+	dir = 4;
+	pixel_x = -32
+	},
 /turf/open/floor/iron,
 /area/command/bridge)
 "aSw" = (
@@ -12827,10 +12831,6 @@
 "aSE" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
-/obj/machinery/bounty_board{
-	dir = 8;
-	pixel_x = 32
-	},
 /turf/open/floor/iron,
 /area/command/bridge)
 "aSF" = (
@@ -13254,6 +13254,10 @@
 "aUc" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
+/obj/item/storage/secure/safe/caps_spare{
+	pixel_x = 32;
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/command/bridge)
 "aUd" = (

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -10440,6 +10440,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/item/paper/fluff/ids_for_dummies,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hop)
 "ats" = (

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -47430,10 +47430,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32;
-	pixel_y = 32
-	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "bzK" = (
@@ -47464,6 +47460,10 @@
 	},
 /obj/item/healthanalyzer,
 /obj/item/hand_labeler,
+/obj/item/storage/secure/safe/caps_spare{
+	pixel_x = 5;
+	pixel_y = 32
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "bzM" = (

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -53891,6 +53891,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
+/obj/item/paper/fluff/ids_for_dummies,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "mDz" = (

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -34317,6 +34317,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/item/storage/secure/safe/caps_spare{
+	pixel_x = -26;
+	pixel_y = 32
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "eNR" = (
@@ -39590,9 +39594,6 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "gOe" = (
-/obj/item/radio/intercom{
-	pixel_y = 29
-	},
 /obj/machinery/modular_computer/console/preset/engineering,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -54743,6 +54744,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = 32
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)


### PR DESCRIPTION
## About The Pull Request

Adds a memo about the new ID system to the HoP office on icebox, meta, kilo, and delta

![image](https://user-images.githubusercontent.com/8881105/109817994-7054ac00-7c2a-11eb-8290-436c712cd6fe.png)

Gives the captain the spare once again. As well as a neat safe to hold it in.

## Why It's Good For The Game

Imagine giving any instruction on a new system by default

## Changelog
:cl:
add: Adds a memo instructing on the new ID system to the HoP's office
add: Snaps the Cap's Spare ID back into existence, along with an ugly golden safe to keep it in
/:cl: