### PR TITLE
[MODULAR] Removes beesease from the bee loadout

### DIFF
--- a/modular_skyrat/modules/moretraitoritems/code/game/objects/items/storage/syndicate_loadout.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/game/objects/items/storage/syndicate_loadout.dm
@@ -145,7 +145,6 @@
 	new /obj/item/storage/belt/fannypack/yellow(src)
 	new /obj/item/grenade/spawnergrenade/buzzkill(src)
 	new /obj/item/grenade/spawnergrenade/buzzkill(src)
-	new /obj/item/reagent_containers/glass/bottle/beesease(src)
 	new /obj/item/melee/beesword(src)
 
 /obj/item/storage/backpack/duffelbag/syndie/loadout/cryomancer/PopulateContents()


### PR DESCRIPTION
## About The Pull Request

Removes it from the bee loadout.

## Why It's Good For The Game

The creator of the loadout asked for it to be removed.

## Changelog
:cl:
del: Removed beesease from the traitor loadout
/:cl: