### PR TITLE
[NONMODULAR] Increases sniper projectile speed

### DIFF
--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -2,7 +2,7 @@
 
 /obj/projectile/bullet/p50
 	name =".50 bullet"
-	speed = 0.4
+	speed = 0.2 //SKYRAT EDIT: Original value (0.4)
 	damage = 70
 	paralyze = 100
 	dismemberment = 50


### PR DESCRIPTION
## About The Pull Request

Sniper shots become hilariously slow at the TIDIs we tend to run at, so the speed they travel has been doubled.

## Why It's Good For The Game

Sniper is supposed to be an incredibly accurate and deadly weapon, but if people can just fucking sidestep the bullets it's uhhhhhhhhhh not as much of a precision gun?? 

## Changelog
:cl:
balance: Increased sniper projectile speed
/:cl: