### PR TITLE
[MODULAR] Buffs the shit out of .50 and adds a bullet rebalance module

### DIFF
--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -1,6 +1,6 @@
 // .50 (Sniper)
 
-/obj/projectile/bullet/p50
+/obj/projectile/bullet/p50    /////OVERRIDEN IN MODULAR > BULLETREBALANCE
 	name =".50 bullet"
 	speed = 0.4
 	damage = 70

--- a/modular_skyrat/modules/aesthetics/guns/code/guns.dm
+++ b/modular_skyrat/modules/aesthetics/guns/code/guns.dm
@@ -142,6 +142,9 @@
 
 /obj/item/ammo_casing/energy/laser/accelerator
 	fire_sound = 'modular_skyrat/modules/aesthetics/guns/sound/laser_cannon_fire.ogg'
+	
+/obj/item/gun/ballistic/automatic/sniper_rifle
+	fire_delay = 60
 
 /obj/item/gun/ballistic/automatic/sniper_rifle/modular
 	name = "AUS-107 anti-materiel rifle"
@@ -159,7 +162,7 @@
 	icon_state = "sysniper"
 	fire_sound = 'modular_skyrat/modules/aesthetics/guns/sound/sniperrifle.ogg'
 	suppressed_sound = 'modular_skyrat/modules/aesthetics/guns/sound/sniperrifle_s.ogg'
-	fire_delay = 20 //Delay halved thanks to recoil absorption
+	fire_delay = 40 //Delay reduced thanks to recoil absorption
 	burst_size = 0.5
 	recoil = 1
 	can_suppress = TRUE
@@ -182,7 +185,7 @@
 	recoil = 1.8
 	weapon_weight = WEAPON_HEAVY
 	mag_type = /obj/item/ammo_box/magazine/sniper_rounds
-	fire_delay = 35 //Slightly smaller than standard sniper
+	fire_delay = 55 //Slightly smaller than standard sniper
 	burst_size = 1
 	zoomable = TRUE
 	zoom_amt = 10 //Long range, enough to see in front of you, but no tiles behind you.

--- a/modular_skyrat/modules/bulletrebalance/sniper.dm
+++ b/modular_skyrat/modules/bulletrebalance/sniper.dm
@@ -2,8 +2,7 @@
 	name =".50 BMG bullet"
 	speed = 0.2
 	damage = 110  //You have 120 health, not a guaranteed instant critical. Unless....
-	paralyze = 0 //Knocks you on your ass hard enough as-is
+	paralyze = 0 //Knocks you on your ass hard enough as-is, we won't need the paralyze stat
 	dismemberment = 30
 	armour_penetration = 61 //Bulletproof armor alone will not stop this
-  wound_bonus = 95 //Guaranteed wound, why would it not fuck you up royally?
-	var/breakthings = TRUE
+  wound_bonus = 90 //Pretty much guaranteed wound

--- a/modular_skyrat/modules/bulletrebalance/sniper.dm
+++ b/modular_skyrat/modules/bulletrebalance/sniper.dm
@@ -1,9 +1,9 @@
 /obj/projectile/bullet/p50
 	name =".50 BMG bullet"
-	speed = 1
+	speed = 0.2
 	damage = 110  //You have 120 health, not a guaranteed instant critical. Unless....
-	paralyze = 100
+	paralyze = 1 //Knocks you on your ass hard enough as-is, paralyze super nerfed
 	dismemberment = 60
-	armour_penetration = 80 //Stacking tactical sec armor and a bulletproof vest won't stop your insides from becoming play-doh
+	armour_penetration = 61 //Bulletproof armor alone will not stop this
   wound_bonus = 100 //Guaranteed wound, why would it not fuck you up royally?
 	var/breakthings = TRUE

--- a/modular_skyrat/modules/bulletrebalance/sniper.dm
+++ b/modular_skyrat/modules/bulletrebalance/sniper.dm
@@ -2,8 +2,8 @@
 	name =".50 BMG bullet"
 	speed = 0.2
 	damage = 110  //You have 120 health, not a guaranteed instant critical. Unless....
-	paralyze = 1 //Knocks you on your ass hard enough as-is, paralyze super nerfed
-	dismemberment = 60
+	paralyze = 0 //Knocks you on your ass hard enough as-is
+	dismemberment = 30
 	armour_penetration = 61 //Bulletproof armor alone will not stop this
-  wound_bonus = 100 //Guaranteed wound, why would it not fuck you up royally?
+  wound_bonus = 95 //Guaranteed wound, why would it not fuck you up royally?
 	var/breakthings = TRUE

--- a/modular_skyrat/modules/bulletrebalance/sniper.dm
+++ b/modular_skyrat/modules/bulletrebalance/sniper.dm
@@ -1,0 +1,9 @@
+/obj/projectile/bullet/p50
+	name =".50 BMG bullet"
+	speed = 1
+	damage = 110  //You have 120 health, not a guaranteed instant critical. Unless....
+	paralyze = 100
+	dismemberment = 60
+	armour_penetration = 80 //Stacking tactical sec armor and a bulletproof vest won't stop your insides from becoming play-doh
+  wound_bonus = 100 //Guaranteed wound, why would it not fuck you up royally?
+	var/breakthings = TRUE


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin.

## Why It's Good For The Game
.50 in its current state is hilariously underpowered, and you can see cases of jacked up people simply brushing two shots off. I mean, fuck man, a .357 is more effective right now. I don't want to live in a world where blind firing with a pistol is more effective than hitting a clean shot with an anti-materiel rifle

Edit: Inherits bullet speed from pull #3816
Edit 2: Add firing delay changes to changelog

## Changelog
balance: After a mean lawsuit, Scarborough Arms is now placing the correct powder load on .50 casings, and are producing them with high quality materials. They are faster and much, much more lethal now!
balance: Sniper rifles have been fitted with heavier plasteel bolts to ensure proper function. Their firing delay has been increased!
tweak: .50 renamed to .50 BMG
/:cl: