### PR TITLE
[MODULAR] Adds item outline glow

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -152,11 +152,17 @@
 /atom/movable/screen/inventory/MouseEntered()
 	..()
 	add_overlays()
+	//SKYRAT EDIT ADDITION START - ITEM_OUTLINE - Apply the outline effect
+	add_stored_outline()
+	//SKYRAT EDIT END
 
 /atom/movable/screen/inventory/MouseExited()
 	..()
 	cut_overlay(object_overlay)
 	QDEL_NULL(object_overlay)
+	//SKYRAT EDIT ADDITION START - ITEM_OUTLINE - Remvoe the outline effect
+	remove_stored_outline()
+	//SKYRAT EDIT END
 
 /atom/movable/screen/inventory/update_icon_state()
 	if(!icon_empty)

--- a/code/datums/components/storage/concrete/_concrete.dm
+++ b/code/datums/components/storage/concrete/_concrete.dm
@@ -122,11 +122,22 @@
 	var/list/seeing_mobs = can_see_contents()
 	for(var/mob/M in seeing_mobs)
 		M.client.screen -= AM
+	/* SKYRAT EDIT CHANGE - ITEM_OUTLINE - ORIGINAL
 	if(ismob(parent.loc) && isitem(AM))
 		var/obj/item/I = AM
 		var/mob/M = parent.loc
 		I.dropped(M, TRUE)
 		I.item_flags &= ~IN_STORAGE
+	*/
+	//SKYRAT EDIT CHANGE START - ITEM_OUTLINE
+	if(isitem(AM))
+		var/obj/item/I = AM
+		I.item_flags &= ~IN_STORAGE
+		I.remove_outline()
+		if(ismob(parent.loc))
+			var/mob/M = parent.loc
+			I.dropped(M)
+	//SKYRAT EDIT END
 	if(new_location)
 		//Reset the items values
 		_removal_reset(AM)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -558,6 +558,12 @@
 
 	set waitfor = FALSE
 	. = COMPONENT_NO_MOUSEDROP
+	//SKYRAT EDIT ADDITON START - ITEM_OUTLINE
+	var/atom/A = parent
+	if(istype(A, /obj/item))
+		var/obj/item/I = A
+		I.remove_outline()	//Removes the outline when we drag
+	//SKRYAT EDIT END
 	if(!ismob(M))
 		return
 	if(!over_object)
@@ -566,7 +572,7 @@
 		return
 	if(M.incapacitated() || !M.canUseStorage())
 		return
-	var/atom/A = parent
+	//var/atom/A = parent SKYRAT EDIT REMOVAL
 	A.add_fingerprint(M)
 	// this must come before the screen objects only block, dunno why it wasn't before
 	if(over_object == M)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -192,6 +192,8 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 
 	var/canMouseDown = FALSE
 
+	var/outline_filter //SKYRAT EDIT ADDITION - ITEM_OUTLINE - the outline filter on hover
+
 /obj/item/Initialize()
 
 	if(attack_verb_continuous)
@@ -208,6 +210,14 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 
 	if(force_string)
 		item_flags |= FORCE_STRING_OVERRIDE
+
+	//SKYRAT EDIT ADDITION BEGIN - ITEM_OUTLINE
+	if(istype(loc, /obj/item/storage))
+		item_flags |= IN_STORAGE
+
+	if(istype(loc, /obj/item/robot_model))
+		item_flags |= IN_INVENTORY
+	//SKYRAT EDIT END
 
 	if(!hitsound)
 		if(damtype == BURN)
@@ -397,6 +407,8 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 			return
 
 	. = FALSE
+
+	remove_outline() //SKYRAT EDIT ADDITION - ITEM_OUTLINE
 	pickup(user)
 	add_fingerprint(user)
 	if(!user.put_in_active_hand(src, FALSE, FALSE))
@@ -470,6 +482,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 		qdel(src)
 	item_flags &= ~IN_INVENTORY
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED,user)
+	remove_outline() //SKYRAT EDIT ADDITION - ITEM_OUTLINE
 	if(!silent)
 		playsound(src, drop_sound, DROP_SOUND_VOLUME, ignore_walls = FALSE)
 	user?.update_equipment_speed_mods()
@@ -829,11 +842,22 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 		var/timedelay = usr.client.prefs.tip_delay/100
 		var/user = usr
 		tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), timedelay, TIMER_STOPPABLE)//timer takes delay in deciseconds, but the pref is in milliseconds. dividing by 100 converts it.
+//SKYRAT EDIT ADDITON BEGIN - ITEM_OUTLINE
+	var/mob/living/L = usr
+	if(istype(L) && L.incapacitated())
+		apply_outline(COLOR_RED_GRAY)
+	else
+		apply_outline()
+
+/obj/item/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	. = ..()
+	remove_outline()
+//SKYRAT EDIT END
 
 /obj/item/MouseExited()
 	deltimer(tip_timer)//delete any in-progress timer if the mouse is moved off the item before it finishes
 	closeToolTip(usr)
-
+	remove_outline() //SKYRAT EDIT ADDITION - ITEM_OUTLINE
 
 /// Called when a mob tries to use the item as a tool. Handles most checks.
 /obj/item/proc/use_tool(atom/target, mob/living/user, delay, amount=0, volume=0, datum/callback/extra_checks)

--- a/modular_skyrat/modules/customization/modules/client/preferences.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences.dm
@@ -141,6 +141,11 @@ GLOBAL_LIST_INIT(food, list(
 	///Color of screentips at top of screen
 	var/screentip_color = "#ffd391"
 
+	//Do we want to show item glow?
+	var/outline_enabled = TRUE
+	//Colour of said glow
+	var/outline_color = COLOR_BLUE_GRAY
+
 	var/ambientocclusion = TRUE
 	///Should we automatically fit the viewport?
 	var/auto_fit_viewport = FALSE
@@ -1013,6 +1018,9 @@ GLOBAL_LIST_INIT(food, list(
 
 			dat += "<b>Set screentip mode:</b> <a href='?_src_=prefs;preference=screentipmode'>[screentip_pref ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>Screentip color:</b><span style='border: 1px solid #161616; background-color: [screentip_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=screentipcolor'>Change</a><BR>"
+
+			dat += "<b>Set item outline mode:</b> <a href='?_src_=prefs;preference=outline_enabled'>[outline_enabled ? "Enabled" : "Disabled"]</a><br>"
+			dat += "<b>Item outline Color:</b> <span style='border:1px solid #161616; background-color: [outline_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=outline_color'>Change</a><BR>"
 
 			dat += "<b>Ambient Occlusion:</b> <a href='?_src_=prefs;preference=ambientocclusion'>[ambientocclusion ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>Fit Viewport:</b> <a href='?_src_=prefs;preference=auto_fit_viewport'>[auto_fit_viewport ? "Auto" : "Manual"]</a><br>"
@@ -2686,6 +2694,14 @@ GLOBAL_LIST_INIT(food, list(
 					var/new_screentipcolor = input(user, "Choose your screentip color:", "Character Preference", screentip_color) as color|null
 					if(new_screentipcolor)
 						screentip_color = sanitize_ooccolor(new_screentipcolor)
+
+				if("outline_enabled")
+					outline_enabled = !outline_enabled
+
+				if("outline_color")
+					var/pickedOutlineColor = input(user, "Choose your outline color.", "General Preference", outline_color) as color|null
+					if(pickedOutlineColor)
+						outline_color = pickedOutlineColor
 
 				if("ambientocclusion")
 					ambientocclusion = !ambientocclusion

--- a/modular_skyrat/modules/item_outline/code/outline_procs.dm
+++ b/modular_skyrat/modules/item_outline/code/outline_procs.dm
@@ -14,7 +14,7 @@
 			inv_item.remove_outline()
 
 /obj/item/proc/apply_outline(colour = null)
-	if(!Adjacent(usr) || QDELETED(src))
+	if(!Adjacent(usr) || QDELETED(src) || || isobserver(usr))
 		return
 	if(usr.client)
 		if(!usr.client.prefs.outline_enabled)

--- a/modular_skyrat/modules/item_outline/code/outline_procs.dm
+++ b/modular_skyrat/modules/item_outline/code/outline_procs.dm
@@ -1,0 +1,37 @@
+/obj/screen/inventory/proc/add_stored_outline()
+	if(hud?.mymob && slot_id)
+		var/obj/item/inv_item = hud.mymob.get_item_by_slot(slot_id)
+		if(inv_item)
+			if(hud?.mymob.incapacitated())
+				inv_item.apply_outline(COLOR_RED_GRAY)
+			else
+				inv_item.apply_outline()
+
+/obj/screen/inventory/proc/remove_stored_outline()
+	if(hud?.mymob && slot_id)
+		var/obj/item/inv_item = hud.mymob.get_item_by_slot(slot_id)
+		if(inv_item)
+			inv_item.remove_outline()
+
+/obj/item/proc/apply_outline(colour = null)
+	if(!(item_flags & IN_INVENTORY || item_flags & IN_STORAGE) || QDELETED(src))
+		return
+	if(usr.client)
+		if(!usr.client.prefs.outline_enabled)
+			return
+	if(!colour)
+		if(usr.client)
+			colour = usr.client.prefs.outline_color
+			if(!colour)
+				colour = COLOR_BLUE_GRAY
+		else
+			colour = COLOR_BLUE_GRAY
+	if(outline_filter)
+		filters -= outline_filter
+	outline_filter = filter(type="outline", size=1, color=colour)
+	filters += outline_filter
+
+/obj/item/proc/remove_outline()
+	if(outline_filter)
+		filters -= outline_filter
+		outline_filter = null

--- a/modular_skyrat/modules/item_outline/code/outline_procs.dm
+++ b/modular_skyrat/modules/item_outline/code/outline_procs.dm
@@ -1,4 +1,4 @@
-/obj/screen/inventory/proc/add_stored_outline()
+/atom/movable/screen/inventory/proc/add_stored_outline()
 	if(hud?.mymob && slot_id)
 		var/obj/item/inv_item = hud.mymob.get_item_by_slot(slot_id)
 		if(inv_item)
@@ -7,7 +7,7 @@
 			else
 				inv_item.apply_outline()
 
-/obj/screen/inventory/proc/remove_stored_outline()
+/atom/movable/screen/inventory/proc/remove_stored_outline()
 	if(hud?.mymob && slot_id)
 		var/obj/item/inv_item = hud.mymob.get_item_by_slot(slot_id)
 		if(inv_item)

--- a/modular_skyrat/modules/item_outline/code/outline_procs.dm
+++ b/modular_skyrat/modules/item_outline/code/outline_procs.dm
@@ -14,7 +14,7 @@
 			inv_item.remove_outline()
 
 /obj/item/proc/apply_outline(colour = null)
-	if(!Adjacent(usr) || QDELETED(src) || || isobserver(usr))
+	if(!Adjacent(usr) || QDELETED(src) || isobserver(usr))
 		return
 	if(usr.client)
 		if(!usr.client.prefs.outline_enabled)

--- a/modular_skyrat/modules/item_outline/code/outline_procs.dm
+++ b/modular_skyrat/modules/item_outline/code/outline_procs.dm
@@ -14,7 +14,7 @@
 			inv_item.remove_outline()
 
 /obj/item/proc/apply_outline(colour = null)
-	if(!(item_flags & IN_INVENTORY || item_flags & IN_STORAGE) || QDELETED(src))
+	if(!Adjacent(usr) || QDELETED(src))
 		return
 	if(usr.client)
 		if(!usr.client.prefs.outline_enabled)

--- a/modular_skyrat/modules/item_outline/code/readme.md
+++ b/modular_skyrat/modules/item_outline/code/readme.md
@@ -1,0 +1,32 @@
+## Title: Item outlines
+
+MODULE ID: ITEM_OUTLINE
+
+### Description:
+
+Creates an outline over any items you move your mouse over, very nice!
+
+### TG Proc Changes:
+
+- /datum/component/storage/concrete/remove_from_storage
+- /atom/movable/screen/inventory/MouseEntered()
+- /atom/movable/screen/inventory/MouseExited()
+- /datum/component/storage/proc/mousedrop_onto()
+- /obj/item/proc/dropped()
+- /obj/item/attack_hand()
+- /obj/item/Initialize()
+
+### Defines:
+
+- N/A
+
+### Master file additions
+
+- N/A
+
+### Included files that are not contained in this module:
+
+- N/A
+
+### Credits:
+Gandalf2k15 - Porting

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3853,6 +3853,7 @@
 #include "modular_skyrat\modules\implants\code\research\designs\medical_designs.dm"
 #include "modular_skyrat\modules\implants\code\research\techweb\medical_nodes.dm"
 #include "modular_skyrat\modules\inflatables\code\inflatable.dm"
+#include "modular_skyrat\modules\item_outline\code\outline_procs.dm"
 #include "modular_skyrat\modules\jukebox\code\controllers\subsystem\jukeboxes.dm"
 #include "modular_skyrat\modules\jukebox\code\controllers\subsystem\game\machinery\dance_machine.dm"
 #include "modular_skyrat\modules\jungle\code\game\objects\structures\flora.dm"


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/BeeStation/BeeStation-Hornet/pull/2086

![image](https://i.imgur.com/ZGjEY62.png)

This basically adds a nice soft glow around items that you hover your mouse over. It provides nice user feedback.

You can toggle it on and off in preferences, and also set the colour!

Indicates if you can access an item in the game world too. 

![image](https://i.imgur.com/FXp4Cun.gif)

## Changelog
:cl:
add: A unique looking item outline glow to most items, you can toggle it on and off in preferences and also set the colour!
/:cl:

