### PR TITLE
[NONMODULAR]Employs interns less.

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -52,15 +52,13 @@
 	report_message = "Something seems to be wrong with the PDAs issues to you all this shift. Nothing too bad though."
 	trait_to_give = STATION_TRAIT_PDA_GLITCHED
 
-/* SKYRAT EDIT BEGIN: - Removes intern trait
 /datum/station_trait/announcement_intern
 	name = "Announcement Intern"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 5
+	weight = 1 //SKYRAT EDIT: - CHANGES INTERN WEIGHT
 	show_in_report = TRUE
 	report_message = "Please be nice to him."
 
 /datum/station_trait/announcement_intern/New()
 	. = ..()
 	SSstation.announcer = /datum/centcom_announcer/intern
-*/ //SKYRAT EDIT END.

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -63,4 +63,4 @@
 /datum/station_trait/announcement_intern/New()
 	. = ..()
 	SSstation.announcer = /datum/centcom_announcer/intern
-*/ SKYRAT EDIT END.
+*/ //SKYRAT EDIT END.

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -52,6 +52,7 @@
 	report_message = "Something seems to be wrong with the PDAs issues to you all this shift. Nothing too bad though."
 	trait_to_give = STATION_TRAIT_PDA_GLITCHED
 
+/* SKYRAT EDIT BEGIN: - Removes intern trait
 /datum/station_trait/announcement_intern
 	name = "Announcement Intern"
 	trait_type = STATION_TRAIT_NEUTRAL
@@ -62,3 +63,4 @@
 /datum/station_trait/announcement_intern/New()
 	. = ..()
 	SSstation.announcer = /datum/centcom_announcer/intern
+*/ SKYRAT EDIT END.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Interns now roll less frequently due to their high chance of hiding priority alerts, such as CC Updates, blobs and radstorms

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Intern man rolls too often and causes serious damage to RP and the round itself.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Intern station trait now rolls much, much less frequently. 5 to 1 reduction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
