### PR TITLE
[Modular] Removes the explosive walls from Interdyne

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/IceRuins/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/IceRuins/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -1088,9 +1088,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
-"eY" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eZ" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,
@@ -1577,9 +1574,6 @@
 	dir = 5
 	},
 /area/ruin/unpowered/syndicate_lava_base/virology)
-"gs" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/virology)
 "gt" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/decal/cleanable/dirt,
@@ -1807,9 +1801,6 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "ha" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
-"hb" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "hc" = (
 /obj/machinery/light/small{
@@ -2497,9 +2488,6 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/icemoon,
 /area/icemoon/underground/explored)
-"iw" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
 "ix" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
@@ -2814,9 +2802,6 @@
 	pixel_y = 24
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
-"iY" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -5831,9 +5816,6 @@
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"wR" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "xa" = (
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
@@ -6554,12 +6536,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"Mb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
 "Mc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/corner{
@@ -6771,9 +6747,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"Rl" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/bar)
 "Ro" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7825,7 +7798,7 @@ lR
 mb
 mF
 eh
-gs
+eh
 eh
 eh
 ab
@@ -7843,7 +7816,7 @@ dG
 Fj
 mn
 mn
-wR
+mn
 AY
 mn
 mn
@@ -8273,7 +8246,7 @@ ha
 ha
 ha
 ha
-Rl
+jy
 uH
 jN
 jZ
@@ -8321,7 +8294,7 @@ ae
 fk
 nH
 ha
-hb
+ha
 ha
 iN
 oz
@@ -8393,7 +8366,7 @@ kL
 lj
 lB
 lY
-Rl
+jy
 ai
 jP
 mT
@@ -8477,7 +8450,7 @@ ae
 ae
 ae
 hM
-iw
+ae
 ae
 ae
 ae
@@ -8877,7 +8850,7 @@ hz
 ie
 uB
 hz
-iY
+hz
 hz
 hz
 zh
@@ -9032,7 +9005,7 @@ iV
 dM
 ec
 ez
-eY
+dy
 ft
 gN
 gN
@@ -9105,7 +9078,7 @@ jT
 IJ
 IJ
 IJ
-Mb
+IJ
 IJ
 IJ
 IJ

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -1125,9 +1125,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
-"eY" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eZ" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,
@@ -1608,9 +1605,6 @@
 	dir = 5
 	},
 /area/ruin/unpowered/syndicate_lava_base/virology)
-"gs" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/virology)
 "gt" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/decal/cleanable/dirt,
@@ -1838,9 +1832,6 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "ha" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
-"hb" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "hc" = (
 /obj/machinery/light/small{
@@ -2546,9 +2537,6 @@
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/lavaland/surface/outdoors)
-"iw" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
 "ix" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
@@ -2871,9 +2859,6 @@
 	pixel_y = 24
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
-"iY" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -5855,9 +5840,6 @@
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"wR" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "xa" = (
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
@@ -6551,12 +6533,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"Mb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
 "Mc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/corner{
@@ -6780,9 +6756,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"Rl" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/bar)
 "Ro" = (
 /turf/open/floor/iron/grimy,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
@@ -7850,7 +7823,7 @@ lR
 mb
 mF
 eh
-gs
+eh
 eh
 eh
 ab
@@ -7868,7 +7841,7 @@ dG
 Fj
 mn
 mn
-wR
+mn
 AY
 mn
 mn
@@ -8298,7 +8271,7 @@ ha
 ha
 ha
 ha
-Rl
+jy
 uH
 jN
 jZ
@@ -8346,7 +8319,7 @@ ae
 fk
 nH
 ha
-hb
+ha
 ha
 iN
 oz
@@ -8418,7 +8391,7 @@ kL
 lj
 lB
 lY
-Rl
+jy
 ai
 jP
 mT
@@ -8502,7 +8475,7 @@ ae
 ae
 ae
 hM
-iw
+ae
 ae
 ae
 ae
@@ -8902,7 +8875,7 @@ hz
 ie
 uB
 hz
-iY
+hz
 hz
 hz
 zh
@@ -9057,7 +9030,7 @@ iV
 dM
 ec
 ez
-eY
+dy
 ft
 gN
 gN
@@ -9130,7 +9103,7 @@ jT
 IJ
 IJ
 IJ
-Mb
+IJ
 IJ
 IJ
 IJ

--- a/modular_skyrat/modules/mapping/code/modules/ruins/lavaland_ruin_code.dm
+++ b/modular_skyrat/modules/mapping/code/modules/ruins/lavaland_ruin_code.dm
@@ -1,4 +1,7 @@
 //SPAWNERS//
+/obj/effect/mob_spawn/human/lavaland_syndicate
+	important_info = "The base is rigged with a self-destruct, DO NOT abandon it or let it fall into enemy hands!"
+
 /obj/effect/mob_spawn/human/lavaland_syndicate/shaftminer
 	name = "Syndicate Shaft Miner"
 	short_desc = "You are a syndicate shaft miner, employed in a top secret research facility developing biological weapons."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cloning is gone, accidentally round removing people 4noraisin should be too. Besides, these are literally only in place to make the explosion from when mining raids the base (which is against the rules anyways, honk) cooler and more complete.
This doesn't remove the self-destruct bomb.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
RR bad. RR on Ghostroles is especially bad. Accidental RR On Ghostroles is e s p e c i a l l y bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Interdyne is no longer laced with explosive walls. Only a self-destruct remains.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
