### PR TITLE
[Modular] Guts Ghostroles.

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/IceRuins/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/IceRuins/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -179,30 +179,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"aW" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"bc" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "bD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -225,47 +201,6 @@
 	dir = 5
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"bR" = (
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"bV" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"ck" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/table/wood,
-/obj/item/ammo_box/magazine/sniper_rounds,
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"cm" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"co" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "cA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -415,11 +350,6 @@
 "dE" = (
 /turf/open/floor/iron/white/corner,
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
-"dF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "dG" = (
 /obj/structure/lattice/catwalk,
 /turf/open/lava/plasma/ice_moon,
@@ -1906,9 +1836,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/mineral/equipment_vendor/golem{
-	name = "Syndie-Mine"
-	},
+/obj/structure/tank_dispenser/plasma,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "ho" = (
@@ -2945,8 +2873,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "jp" = (
@@ -3461,11 +3387,11 @@
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "ks" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
@@ -3934,7 +3860,6 @@
 	pixel_y = 12
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/construction/rcd/loaded,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "lq" = (
@@ -4611,9 +4536,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"mW" = (
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "mX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -5014,8 +4936,6 @@
 /obj/structure/rack,
 /obj/item/storage/belt/utility,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/circuitboard/machine/ore_silo,
-/obj/item/circuitboard/machine/ore_redemption,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "nP" = (
@@ -5085,47 +5005,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
-"nV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/door/airlock{
-	name = "Hydroponics";
-	req_access_txt = "150"
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"nW" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"nX" = (
-/obj/machinery/door/airlock/science{
-	name = "Research Division";
-	req_access_txt = "150"
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nZ" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -5133,7 +5012,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/structure/tank_dispenser/plasma,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "oa" = (
@@ -5179,19 +5057,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"og" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "oh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -5233,35 +5098,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
-"om" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"op" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"or" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/stamp/syndicate,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "ot" = (
 /obj/machinery/power/compressor{
 	comp_id = "syndie_lavaland_incineratorturbine";
@@ -5291,15 +5127,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow/ice/icemoon,
 /area/ruin/unpowered/syndicate_lava_base/main)
-"ow" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "oz" = (
 /obj/structure/chair{
 	dir = 4
@@ -5428,10 +5255,6 @@
 "oZ" = (
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"pp" = (
-/obj/structure/frame/machine,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "pu" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
@@ -5457,24 +5280,6 @@
 	},
 /turf/open/floor/circuit/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
-"pU" = (
-/obj/machinery/door/airlock{
-	name = "Deck Officer's Cabin"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"qt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/mob_spawn/human/lavaland_syndicate/shaftminer{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "qz" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
@@ -5496,13 +5301,6 @@
 	},
 /turf/open/floor/circuit/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
-"qV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "rg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -5530,19 +5328,6 @@
 "rp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"rq" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/frame/computer{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
 "ru" = (
 /obj/machinery/computer/arcade/orion_trail{
@@ -5600,12 +5385,6 @@
 /obj/structure/cable,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"sS" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "ta" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -5642,12 +5421,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/main)
-"to" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "tF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5658,15 +5431,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"tU" = (
-/obj/machinery/door/airlock{
-	name = "Shaft Miner Cabin 2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "tW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -5779,16 +5543,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"vS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "vU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5834,9 +5588,6 @@
 "wR" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/unpowered/syndicate_lava_base/telecomms)
-"xa" = (
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "xb" = (
 /obj/structure/closet/firecloset/full{
 	anchored = 1
@@ -5883,21 +5634,6 @@
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"xQ" = (
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "yd" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -5914,10 +5650,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"ye" = (
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "yg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -5928,15 +5660,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"yG" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Dormitories"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "zh" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6000,17 +5723,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/telecomms)
-"Bk" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "BC" = (
 /obj/machinery/portable_atmospherics/canister/tier_3,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -6045,42 +5757,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"Ch" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"Ci" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ore_box,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"Co" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/structure/ore_box,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"CC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "CG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -6089,23 +5765,6 @@
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"Df" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"Dt" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "DA" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -6120,15 +5779,6 @@
 /obj/item/taperecorder,
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"DQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/mob_spawn/human/lavaland_syndicate/deckofficer{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "Ec" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -6185,32 +5835,6 @@
 /obj/machinery/portable_atmospherics/canister/tier_3,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"FC" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/obj/machinery/button/door{
-	id = "lavalandsyndi_arrivals";
-	name = "Botany Blast Door Control";
-	pixel_y = -26;
-	req_access_txt = "150"
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"FF" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	id = "lavalandsyndisci"
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"FV" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Gd" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6262,26 +5886,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"GM" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"GN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"GP" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/closet/syndicate,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "GY" = (
 /obj/machinery/telecomms/relay/preset/ruskie{
 	use_power = 0
@@ -6301,20 +5905,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/telecomms)
-"Hc" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/storage/toolbox/syndicate,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Ho" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -6365,18 +5955,6 @@
 /obj/machinery/meter/turf,
 /turf/open/floor/engine/n2,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"Io" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Is" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -6420,13 +5998,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"Jm" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/machinery/chem_dispenser/mutagensaltpeter,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Jr" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "150"
@@ -6445,15 +6016,6 @@
 /obj/machinery/autolathe/hacked,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"Ko" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
-/obj/structure/grille,
-/obj/machinery/door/poddoor{
-	id = "lavalandsyndi_arrivals"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Ks" = (
 /obj/structure/chair{
 	dir = 8
@@ -6480,24 +6042,6 @@
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_lava_base/main)
-"KK" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/frame/machine,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"KY" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/closet/syndicate,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Lg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -6590,14 +6134,6 @@
 "MM" = (
 /turf/open/floor/engine/co2,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"MS" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/frame/machine,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Ng" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/visible{
 	name = "O2 to Mix"
@@ -6652,12 +6188,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"Or" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "ON" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album/syndicate,
@@ -6723,15 +6253,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"Qn" = (
-/obj/machinery/door/airlock{
-	name = "Shaft Miner Cabin 1"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "Qv" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -6753,36 +6274,9 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/icemoon,
 /area/icemoon/underground/explored)
-"QS" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"QT" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/structure/sign/poster/contraband/syndicate_recruitment{
-	pixel_x = 4;
-	pixel_y = 33
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Rl" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"Ro" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "Rq" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
@@ -6790,12 +6284,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"Rv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "RE" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_aux,
 /turf/open/floor/engine/vacuum,
@@ -6823,23 +6311,6 @@
 /obj/machinery/meter/turf,
 /turf/open/floor/engine/co2,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"ST" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"Th" = (
-/obj/structure/closet/firecloset/full{
-	anchored = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "Tp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -6874,11 +6345,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/main)
-"TT" = (
-/obj/structure/table/wood,
-/obj/item/ammo_box/magazine/sniper_rounds,
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "UE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6892,12 +6358,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"UP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "UZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -6956,12 +6416,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"Wj" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Wm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -6971,21 +6425,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"Wq" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Wt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7074,15 +6513,6 @@
 	dir = 4
 	},
 /area/ruin/unpowered/syndicate_lava_base/medbay)
-"WY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/mob_spawn/human/lavaland_syndicate/shaftminer{
-	dir = 8
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "Xa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7128,30 +6558,10 @@
 	dir = 6
 	},
 /area/ruin/unpowered/syndicate_lava_base/medbay)
-"Ye" = (
-/obj/machinery/button/door{
-	id = "lavalandsyndisci";
-	name = "Science Blast Door Control";
-	pixel_y = 26;
-	req_access_txt = "150"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Yf" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"Yq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "Yt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -8179,9 +7589,9 @@ mT
 mT
 mT
 Yf
-mT
-mT
-cm
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8232,11 +7642,11 @@ mu
 UE
 nr
 mT
-om
-Wj
-Wj
-Dt
-mT
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8287,11 +7697,11 @@ jy
 WK
 PO
 mT
-op
-xa
-xa
-FV
-Ko
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8342,11 +7752,11 @@ jy
 ah
 nu
 mT
-op
-xa
-xa
-FV
-Ko
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8397,11 +7807,11 @@ Rl
 ai
 jP
 mT
-op
-xa
-xa
-FV
-Ko
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8452,11 +7862,11 @@ jy
 vU
 nu
 mT
-Jm
-xa
-xa
-QS
-Ko
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8506,12 +7916,12 @@ jy
 Ww
 NJ
 nu
-nV
-to
-sS
-sS
-FC
 mT
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8562,11 +7972,11 @@ my
 oZ
 nu
 mT
-aW
-bR
-xQ
-Wq
-mT
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8616,12 +8026,12 @@ jy
 ah
 rp
 nu
-nX
-Io
-bc
-KY
-GP
-FF
+mT
+wi
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8672,11 +8082,11 @@ NT
 mX
 mT
 mT
-Ye
-xa
-xa
-nW
-FF
+wi
+wi
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8726,12 +8136,12 @@ WJ
 mz
 mY
 mT
-kQ
-Hc
-xa
-pp
-KK
-FF
+wi
+wi
+wi
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8782,11 +8192,11 @@ Lt
 UZ
 kQ
 kQ
-QT
-xa
-xa
-nW
-FF
+wi
+wi
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8800,10 +8210,10 @@ aa
 aa
 ab
 ab
-dy
-dy
-dy
-dy
+ab
+ab
+ab
+ab
 as
 as
 as
@@ -8837,11 +8247,11 @@ mA
 mZ
 ny
 kQ
-or
-ST
-MS
-rq
-FF
+wi
+wi
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8855,12 +8265,12 @@ aa
 aa
 ab
 ab
-dy
-TT
-DQ
-dy
-Co
-Ci
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 as
 as
@@ -8892,11 +8302,11 @@ mB
 na
 nz
 kQ
-mT
-GM
-mT
-mT
-mT
+wi
+wi
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8910,12 +8320,12 @@ aa
 aa
 aa
 ab
-dy
-mW
-Rv
-dy
-co
-Ch
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 iE
 iM
@@ -8947,9 +8357,9 @@ mC
 Xr
 mT
 mT
-lw
-GN
-mT
+wi
+wi
+ab
 ab
 ab
 ab
@@ -8965,12 +8375,12 @@ aa
 aa
 aa
 ab
-dy
-qV
-CC
-pU
-Ro
-gQ
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 iF
 iT
@@ -9001,10 +8411,10 @@ lI
 mD
 kQ
 mT
-lw
-GN
-GN
-mT
+wi
+wi
+ab
+ab
 ab
 ab
 ab
@@ -9020,12 +8430,12 @@ aa
 aa
 aa
 ab
-dy
-dy
-dy
-dy
-vS
-gQ
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 iI
 iV
@@ -9055,11 +8465,11 @@ lK
 WW
 mE
 kQ
-GN
-lw
-GN
-lw
-mT
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -9075,12 +8485,12 @@ aa
 aa
 aa
 ab
-dy
-TT
-qt
-dy
-ow
-ye
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 dy
 jl
@@ -9113,8 +8523,8 @@ Ho
 sP
 sP
 sP
-GN
-mT
+ab
+ab
 ab
 ab
 ab
@@ -9130,13 +8540,13 @@ aa
 aa
 aa
 ab
-dy
-qV
-CC
-tU
-dF
-gQ
-Ch
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 dy
 kg
@@ -9185,13 +8595,13 @@ aa
 aa
 ab
 ab
-dy
-dy
-dy
-dy
-ow
-kt
-kt
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 jn
 kh
@@ -9240,14 +8650,14 @@ aa
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 dy
-Or
-UP
-Qn
-og
-Df
-Yq
-yG
 jo
 ks
 ef
@@ -9295,13 +8705,13 @@ aa
 aa
 ab
 ab
-dy
-ck
-WY
-dy
-Bk
-Th
-bV
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 jq
 kt
@@ -9350,13 +8760,13 @@ aa
 aa
 ab
 ab
-dy
-dy
-dy
-dy
-dy
-dy
-dy
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 dy
 kF

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -114,13 +114,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
-"az" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "aE" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -189,39 +182,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"aW" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"bc" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"bl" = (
-/obj/machinery/door/airlock{
-	name = "Shaft Miner Cabin 2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "bD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -239,39 +199,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"bO" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Dormitories"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"bR" = (
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"bV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "cA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -282,35 +209,10 @@
 	dir = 4
 	},
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
-"cO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "cP" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"db" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"dd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/mob_spawn/human/lavaland_syndicate/deckofficer{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "dg" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -774,18 +676,6 @@
 /obj/machinery/processor/slime,
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"en" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ore_box,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eo" = (
 /obj/machinery/power/apc/syndicate{
 	name = "Experimentation Lab APC";
@@ -1937,9 +1827,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/mineral/equipment_vendor/golem{
-	name = "Syndie-Mine"
-	},
+/obj/structure/tank_dispenser/plasma,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "ho" = (
@@ -2826,14 +2714,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
-"iS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "iT" = (
 /obj/structure/closet/crate,
 /obj/item/storage/toolbox/electrical{
@@ -3002,8 +2882,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "jp" = (
@@ -3201,13 +3079,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"jK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "jL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3525,11 +3396,11 @@
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "ks" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
@@ -3998,7 +3869,6 @@
 	pixel_y = 12
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/construction/rcd/loaded,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "lq" = (
@@ -5076,8 +4946,6 @@
 /obj/structure/rack,
 /obj/item/storage/belt/utility,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/circuitboard/machine/ore_silo,
-/obj/item/circuitboard/machine/ore_redemption,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "nP" = (
@@ -5147,47 +5015,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
-"nV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/door/airlock{
-	name = "Hydroponics";
-	req_access_txt = "150"
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"nW" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"nX" = (
-/obj/machinery/door/airlock/science{
-	name = "Research Division";
-	req_access_txt = "150"
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nZ" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -5195,7 +5022,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/structure/tank_dispenser/plasma,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "oa" = (
@@ -5282,35 +5108,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
-"om" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"op" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"or" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/stamp/syndicate,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "ot" = (
 /obj/machinery/power/compressor{
 	comp_id = "syndie_lavaland_incineratorturbine";
@@ -5468,10 +5265,6 @@
 "oZ" = (
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"pp" = (
-/obj/structure/frame/machine,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "pu" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
@@ -5546,19 +5339,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"rq" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/frame/computer{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "ru" = (
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 1
@@ -5567,19 +5347,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"rw" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "rF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5626,18 +5393,12 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "st" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "sP" = (
 /obj/structure/cable,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"sS" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "ta" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -5674,12 +5435,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/main)
-"to" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "tF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5720,12 +5475,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"ug" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "uk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -5793,11 +5542,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"vg" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "vu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -5858,9 +5602,6 @@
 "wR" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/unpowered/syndicate_lava_base/telecomms)
-"xa" = (
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "xb" = (
 /obj/structure/closet/firecloset/full{
 	anchored = 1
@@ -5907,21 +5648,6 @@
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"xQ" = (
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "yd" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -5969,25 +5695,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"zK" = (
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"zO" = (
-/obj/machinery/door/airlock{
-	name = "Shaft Miner Cabin 1"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"zW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "Af" = (
 /obj/machinery/computer/camera_advanced,
 /obj/effect/turf_decal/tile/neutral{
@@ -6006,15 +5713,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"AL" = (
-/obj/machinery/door/airlock{
-	name = "Deck Officer's Cabin"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "AY" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications";
@@ -6063,12 +5761,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"Cd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/table/wood,
-/obj/item/ammo_box/magazine/sniper_rounds,
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "Cg" = (
 /obj/structure/grille,
 /obj/structure/window/plasma/reinforced/plastitanium,
@@ -6087,21 +5779,6 @@
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
-"CV" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"Dt" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "DA" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -6142,16 +5819,6 @@
 	dir = 9
 	},
 /area/ruin/unpowered/syndicate_lava_base/medbay)
-"Et" = (
-/obj/structure/closet/firecloset/full{
-	anchored = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "EH" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -6185,32 +5852,6 @@
 /obj/machinery/portable_atmospherics/canister/tier_3,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"FC" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/obj/machinery/button/door{
-	id = "lavalandsyndi_arrivals";
-	name = "Botany Blast Door Control";
-	pixel_y = -26;
-	req_access_txt = "150"
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"FF" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	id = "lavalandsyndisci"
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"FV" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Gd" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6262,17 +5903,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"GP" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/closet/syndicate,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "GY" = (
 /obj/machinery/telecomms/relay/preset/ruskie{
 	use_power = 0
@@ -6292,20 +5922,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/telecomms)
-"Hc" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/storage/toolbox/syndicate,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Ho" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -6356,18 +5972,6 @@
 /obj/machinery/meter/turf,
 /turf/open/floor/engine/n2,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"Io" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Is" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -6385,12 +5989,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"IC" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "IH" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos{
 	dir = 1
@@ -6417,13 +6015,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"Jm" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/machinery/chem_dispenser/mutagensaltpeter,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Jr" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "150"
@@ -6442,15 +6033,6 @@
 /obj/machinery/autolathe/hacked,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"Ko" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
-/obj/structure/grille,
-/obj/machinery/door/poddoor{
-	id = "lavalandsyndi_arrivals"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Ks" = (
 /obj/structure/chair{
 	dir = 8
@@ -6477,24 +6059,6 @@
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_lava_base/main)
-"KK" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/frame/machine,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"KY" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/closet/syndicate,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Lg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -6587,14 +6151,6 @@
 "MM" = (
 /turf/open/floor/engine/co2,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"MS" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/frame/machine,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Ng" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/visible{
 	name = "O2 to Mix"
@@ -6602,17 +6158,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"Nn" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "Np" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/syndicate,
@@ -6660,12 +6205,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"Om" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "ON" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album/syndicate,
@@ -6702,13 +6241,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"PU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "PX" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -6762,30 +6294,9 @@
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/lavaland/surface/outdoors)
-"QS" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"QT" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/structure/sign/poster/contraband/syndicate_recruitment{
-	pixel_x = 4;
-	pixel_y = 33
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Rl" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"Ro" = (
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "Rq" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
@@ -6806,11 +6317,6 @@
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"Se" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "St" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m9mm,
@@ -6821,36 +6327,10 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"Sx" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"SJ" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/structure/ore_box,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "SP" = (
 /obj/machinery/meter/turf,
 /turf/open/floor/engine/co2,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"ST" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Tp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -6962,17 +6442,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"Wd" = (
-/obj/structure/table/wood,
-/obj/item/ammo_box/magazine/sniper_rounds,
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"Wj" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Wm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -6982,21 +6451,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
-"Wq" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Wt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7133,37 +6587,6 @@
 	dir = 6
 	},
 /area/ruin/unpowered/syndicate_lava_base/medbay)
-"XG" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"XP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/mob_spawn/human/lavaland_syndicate/shaftminer{
-	dir = 8
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
-"Ye" = (
-/obj/machinery/button/door{
-	id = "lavalandsyndisci";
-	name = "Science Blast Door Control";
-	pixel_y = 26;
-	req_access_txt = "150"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Yf" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -7188,15 +6611,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/main)
-"Zr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/mob_spawn/human/lavaland_syndicate/shaftminer{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
 "ZN" = (
 /obj/structure/grille,
 /obj/structure/window/plasma/reinforced/plastitanium,
@@ -8204,9 +7618,9 @@ mT
 mT
 mT
 Yf
-mT
-mT
-db
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8257,11 +7671,11 @@ mu
 UE
 nr
 mT
-om
-Wj
-Wj
-Dt
-mT
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8312,11 +7726,11 @@ jy
 WK
 PO
 mT
-op
-xa
-xa
-FV
-Ko
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8367,11 +7781,11 @@ jy
 ah
 nu
 mT
-op
-xa
-xa
-FV
-Ko
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8422,11 +7836,11 @@ Rl
 ai
 jP
 mT
-op
-xa
-xa
-FV
-Ko
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8477,11 +7891,11 @@ jy
 vU
 nu
 mT
-Jm
-xa
-xa
-QS
-Ko
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8531,12 +7945,12 @@ jy
 Ww
 NJ
 nu
-nV
-to
-sS
-sS
-FC
 mT
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8587,11 +8001,11 @@ my
 oZ
 nu
 mT
-aW
-bR
-xQ
-Wq
-mT
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8641,12 +8055,12 @@ jy
 ah
 rp
 nu
-nX
-Io
-bc
-KY
-GP
-FF
+mT
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8697,11 +8111,11 @@ NT
 mX
 mT
 mT
-Ye
-xa
-xa
-nW
-FF
+wi
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8751,12 +8165,12 @@ WJ
 mz
 mY
 mT
-kQ
-Hc
-xa
-pp
-KK
-FF
+wi
+wi
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8807,11 +8221,11 @@ Lt
 UZ
 kQ
 kQ
-QT
-xa
-xa
-nW
-FF
+wi
+wi
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8825,10 +8239,10 @@ aa
 aa
 ab
 ab
-dy
-dy
-dy
-dy
+ab
+ab
+ab
+ab
 as
 as
 as
@@ -8862,11 +8276,11 @@ mA
 mZ
 ny
 kQ
-or
-ST
-MS
-rq
-FF
+wi
+wi
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8880,12 +8294,12 @@ aa
 aa
 ab
 ab
-dy
-Wd
-dd
-dy
-SJ
-en
+ab
+ab
+ab
+ab
+ab
+ab
 as
 as
 as
@@ -8917,11 +8331,11 @@ mB
 na
 nz
 kQ
-mT
-CV
-mT
-mT
-mT
+wi
+wi
+ab
+ab
+ab
 ab
 ab
 ab
@@ -8935,12 +8349,12 @@ aa
 aa
 aa
 ab
-dy
-Ro
-zW
-dy
-iS
-XG
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 iE
 iM
@@ -8972,9 +8386,9 @@ mC
 Xr
 kQ
 kQ
-lw
-st
-mT
+wi
+wi
+ab
 ab
 ab
 ab
@@ -8990,12 +8404,12 @@ aa
 aa
 aa
 ab
-dy
-jK
-PU
-AL
-Sx
-gQ
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 iF
 iT
@@ -9026,10 +8440,10 @@ lI
 mD
 kQ
 kQ
-lw
-st
-st
-mT
+wi
+wi
+ab
+ab
 ab
 ab
 ab
@@ -9045,12 +8459,12 @@ aa
 aa
 aa
 ab
-dy
-dy
-dy
-dy
-cO
-gQ
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 iI
 iV
@@ -9081,10 +8495,10 @@ WW
 mE
 kQ
 st
-lw
-st
-lw
-mT
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -9100,12 +8514,12 @@ aa
 aa
 aa
 ab
-dy
-Wd
-Zr
-dy
-bV
-zK
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 dy
 jl
@@ -9138,8 +8552,8 @@ Ho
 sP
 sP
 sP
-st
-mT
+ab
+ab
 ab
 ab
 ab
@@ -9155,13 +8569,13 @@ aa
 aa
 aa
 ab
-dy
-jK
-PU
-bl
-vg
-gQ
-XG
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 dy
 kg
@@ -9210,13 +8624,13 @@ aa
 aa
 ab
 ab
-dy
-dy
-dy
-dy
-bV
-kt
-kt
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 jn
 kh
@@ -9265,14 +8679,14 @@ aa
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 dy
-IC
-Om
-zO
-rw
-az
-Se
-bO
 jo
 ks
 ef
@@ -9320,13 +8734,13 @@ aa
 aa
 ab
 ab
-dy
-Cd
-XP
-dy
-Nn
-Et
-ug
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 jq
 kt
@@ -9375,13 +8789,13 @@ aa
 aa
 ab
 ab
-dy
-dy
-dy
-dy
-dy
-dy
-dy
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 dy
 dy
 kF

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/forgottenship_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/forgottenship_skyrat.dmm
@@ -1074,12 +1074,13 @@
 	},
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/storage/box/stockparts/deluxe,
-/obj/item/storage/box/rndboards,
 /obj/item/stack/sheet/glass{
 	amount = 10
 	},
 /obj/item/stack/cable_coil,
 /obj/item/storage/box/beakers,
+/obj/item/circuitboard/machine/protolathe/offstation,
+/obj/item/circuitboard/machine/circuit_imprinter/offstation,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "cU" = (
@@ -1591,11 +1592,11 @@
 /obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
 	},
-/obj/item/card/id/syndicate/anyone,
-/obj/item/card/id/syndicate/anyone,
-/obj/item/card/id/syndicate/anyone,
-/obj/item/card/id/syndicate/anyone,
-/obj/item/card/id/syndicate/anyone,
+/obj/item/card/id/advanced/chameleon,
+/obj/item/card/id/advanced/chameleon,
+/obj/item/card/id/advanced/chameleon,
+/obj/item/card/id/advanced/chameleon,
+/obj/item/card/id/advanced/chameleon,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
 "ss" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In light of _**recent events**_ it's become brazenly obvious to me that we cannot have nice things.
This removes RND and Botany from Interdyne, along with the Deck Officer and Shaft Miners. It also removes the RCD and Golem Vendor.
This PR also fixes the cybersun agent ID and removes their roundstart RND board, along with their destructive analyzer.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because Skyrat's changed since oldbase.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: RND From Interdyne.
fix: Agent IDs in Cybersun.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
