### PR TITLE
[MODULAR] Ling Horror Bugfix

### DIFF
--- a/modular_skyrat/modules/horrorform/code/modules/mob/hostile/true_changeling.dm
+++ b/modular_skyrat/modules/horrorform/code/modules/mob/hostile/true_changeling.dm
@@ -109,8 +109,6 @@
 		stored_changeling.Paralyze(10 SECONDS) //Make them helpless for 10 seconds
 		stored_changeling.adjustBruteLoss(30, TRUE, TRUE)
 		stored_changeling.status_flags &= ~GODMODE
-		var/datum/antagonist/changeling/C = mind.has_antag_datum(/datum/antagonist/changeling)
-		C.true_form_death = world.time
 		qdel(src)
 	else
 		visible_message("<span class='warning'>[src] lets out a waning scream as it falls, twitching, to the floor.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changeling horror forms used to just respawn after 30 seconds or so of death, now they just spit out the changeling as they should. All I did was remove 2 redundant lines of code

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Changeling Horror forms no longer respawn 30 seconds after death

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
