### PR TITLE
Disables flipping and spinning, removes dabbing, adjusts blepping

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -28,6 +28,7 @@
 	//SKYRAT EDIT ADDITION BEGIN - EMOTES
 	var/sound_volume = 25 //Emote volume
 	var/list/allowed_species
+	var/blacklisted = FALSE
 	//SKYRAT EDIT ADDITION END
 
 /datum/emote/New()
@@ -48,6 +49,10 @@
 	. = TRUE
 	if(!can_run_emote(user, TRUE, intentional))
 		return FALSE
+	//SKYRAT EDIT ADDITION START
+	if(blacklisted && intentional)
+		return FALSE
+	//SKYRAT EDIT END
 	var/msg = select_message_type(user, intentional)
 	if(params && message_param)
 		msg = select_param(user, params)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -60,6 +60,9 @@
 	hands_use_check = TRUE
 	mob_type_allowed_typecache = list(/mob/living, /mob/dead/observer)
 	mob_type_ignore_stat_typecache = list(/mob/dead/observer, /mob/living/silicon/ai)
+	//SKYRAT EDIT ADDITION START
+	blacklisted = TRUE
+	//SKYRAT EDIT END
 
 /datum/emote/flip/run_emote(mob/user, params , type_override, intentional)
 	. = ..()
@@ -94,6 +97,9 @@
 	hands_use_check = TRUE
 	mob_type_allowed_typecache = list(/mob/living, /mob/dead/observer)
 	mob_type_ignore_stat_typecache = list(/mob/dead/observer)
+	//SKYRAT EDIT ADDITION START
+	blacklisted = TRUE
+	//SKYRAT EDIT END
 
 /datum/emote/spin/run_emote(mob/user, params ,  type_override, intentional)
 	. = ..()

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -391,6 +391,12 @@
 	message_AI = "shows an image of a random blepping animal."
 	message_robot = "bleps their robo-tongue out."
 
+/datum/emote/living/carbon/twirl
+	key = "twirl"
+	key_third_person = "twirls"
+	message = "twirls around on their foot!"
+	mob_type_allowed_typecache = list(/mob/living/carbon))
+
 /datum/emote/living/bork
 	key = "bork"
 	key_third_person = "borks"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -173,13 +173,6 @@
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/weh.ogg'
 
-/datum/emote/living/dab
-	key = "dab"
-	key_third_person = "dabs"
-	message = "suddenly hits a dab!"
-	emote_type = EMOTE_AUDIBLE
-	hands_use_check = TRUE
-
 /datum/emote/living/mothsqueak
 	key = "msqueak"
 	key_third_person = "lets out a tiny squeak"
@@ -394,9 +387,9 @@
 /datum/emote/living/blep
 	key = "blep"
 	key_third_person = "bleps"
-	message = "bleps their tongue out. Blep."
-	message_AI = "shows an image of a random blepping animal. Blep."
-	message_robot = "bleps their robo-tongue out. Blep."
+	message = "bleps their tongue out."
+	message_AI = "shows an image of a random blepping animal."
+	message_robot = "bleps their robo-tongue out."
 
 /datum/emote/living/bork
 	key = "bork"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -395,7 +395,7 @@
 	key = "twirl"
 	key_third_person = "twirls"
 	message = "twirls around on their foot!"
-	mob_type_allowed_typecache = list(/mob/living/carbon))
+	mob_type_allowed_typecache = list(/mob/living/carbon)
 
 /datum/emote/living/bork
 	key = "bork"


### PR DESCRIPTION
Title.
Adds a check for if an emote is "blacklisted" - if it is, you cannot use it intentionally. Makes flip and spin blacklisted. Dabbing was already fully modular, so I just removed it. Also makes it so blepping emote doesn't end with "Blep."


also now replaces spinning with twirling
because salt