### PR TITLE
[Modular] Replaces advanced defib with compact defib on cargo list.

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -80,13 +80,13 @@
 	contains = list(/obj/item/clothing/suit/space/hardsuit/medical)
 	crate_name = "medical hardsuit crate"
 
-/datum/supply_pack/medical/advanced_defib
-	name = "Advanced Defibrillator Crate"
-	desc = "Contains a single high-tech NT defibrillator, capable of self-charging and applying reviving shocks through thick clothing materials."
-	cost = CARGO_CRATE_VALUE * 25
-	access = ACCESS_CMO
-	contains = list(/obj/item/defibrillator/compact/combat/loaded/nanotrasen)
-	crate_name = "advanced defibrillator crate"
+/datum/supply_pack/medical/compact_defib
+	name = "Compact Defibrillator Crate"
+	desc = "Contains a single compact defibrillator. Capable of being worn as a belt."
+	cost = CARGO_CRATE_VALUE * 5
+	access = ACCESS_MEDICAL
+	contains = list(/obj/item/defibrillator/compact)
+	crate_name = "compact defibrillator crate"
 
 /datum/supply_pack/medical/medigun
 	name = "Experimental Medical Beam Crate"


### PR DESCRIPTION
## About The Pull Request

Replaces the advanced defib with the compact defib at cargo

## Why It's Good For The Game

They don't need this. ERTs can have it, sure. Medical doesn't. THey get the beam gun. They have no reason to have the advanced defib that is literally a one click right click win against a majority of antagonists. Give them the compact.

I remember when some people found out that we had the advanced defib on our cargo list for normal purchase they were like "wtf why?? it's broken!" and they were freaking right, wish I had removed it earlier.

## Changelog
:cl:
fix: Replaces advanced defib with compact defib at cargo
/:cl: