### PR TITLE
[NON-MODULAR] Golden Bike Horn no longer flips everyone on-screen

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -220,6 +220,8 @@
 	icon_state = "gold_horn"
 	inhand_icon_state = "gold_horn"
 	worn_icon_state = "horn_gold"
+	//SKYRAT EDIT REMOVAL START
+	/*
 	COOLDOWN_DECLARE(golden_horn_cooldown)
 
 /obj/item/bikehorn/golden/attack()
@@ -238,6 +240,8 @@
 		if(M.can_hear())
 			M.emote("flip")
 	COOLDOWN_START(src, golden_horn_cooldown, 1 SECONDS)
+*/
+//SKYRAT EDIT REMOVAL END
 
 //canned laughter
 /obj/item/reagent_containers/food/drinks/soda_cans/canned_laughter


### PR DESCRIPTION

## About The Pull Request

Read the title.

## Why It's Good For The Game

Flipping is dumb - especially force-flipping.
Why would a bike horn flip you, even?

## Changelog
:cl:
del: removes the flip_mobs() proc from golden bike horns
/:cl:
