### PR TITLE
[NON-MODULAR] Removes the bananium sword drop from abandoned crates

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -196,7 +196,12 @@
 		if(88)
 			new /obj/item/reagent_containers/food/drinks/bottle/lizardwine(src)
 		if(89)
+			//SKYRAT EDIT START
+			/*
 			new /obj/item/melee/transforming/energy/sword/bananium(src)
+			*/
+			new /obj/item/stack/sheet/mineral/gold(src, 5)
+			//SKYRAT EDIT END
 		if(90)
 			new /obj/item/dnainjector/wackymut(src)
 		if(91)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
removes bananium sword drop
replaces with gold
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fuck bananium
all my homies hate bananium
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Changes the abandoned crates to not drop bananium swords - replaced with gold
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
