### PR TITLE
[NON-MODULAR] Removes bananium drop from abandoned crates

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -188,7 +188,7 @@
 			/*
 			new /obj/item/stack/sheet/mineral/bananium(src, 10)
 			*/
-			new /obj/item/coin/titanium(src)
+			new /obj/item/stack/spacecash/c1000(src)
 			//SKYRAT EDIT REMOVAL END
 		if(81 to 82)
 			new /obj/item/bikehorn/airhorn(src)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -184,7 +184,12 @@
 		if(77 to 78)
 			new /obj/item/toy/plush/lizardplushie(src)
 		if(79 to 80)
+			//SKYRAT EDIT REMOVAL START
+			/*
 			new /obj/item/stack/sheet/mineral/bananium(src, 10)
+			*/
+			new /obj/item/coin/titanium(src)
+			//SKYRAT EDIT REMOVAL END
 		if(81 to 82)
 			new /obj/item/bikehorn/airhorn(src)
 		if(83 to 84)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. Replaces it with space cash.

## Why It's Good For The Game

Bananium bad.

## Changelog
:cl:
balance: Changes the abandoned crates' 79/80th drop from bananium to space cash.
/:cl:
