### PR TITLE
[NON-MODULAR] Removes the banhammer drop from abandoned crates

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -212,11 +212,16 @@
 		if(95)
 			new /obj/item/toy/plush/nukeplushie(src)
 		if(96)
+			//SKYRAT EDIT START
+			/*
 			new /obj/item/banhammer(src)
 			for(var/i in 1 to 3)
 				var/obj/effect/mine/sound/bwoink/mine = new (src)
 				mine.set_anchored(FALSE)
 				mine.move_resist = MOVE_RESIST_DEFAULT
+			*/
+			new /obj/item/broken_bottle(src)
+			//SKYRAT EDIT END
 		if(97)
 			for(var/i in 1 to 4)
 				new /obj/item/clothing/mask/balaclava(src)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -220,7 +220,7 @@
 				mine.set_anchored(FALSE)
 				mine.move_resist = MOVE_RESIST_DEFAULT
 			*/
-			new /obj/item/broken_bottle(src)
+			new /obj/item/construction/rcd(src)
 			//SKYRAT EDIT END
 		if(97)
 			for(var/i in 1 to 4)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

## Why It's Good For The Game

Dumb OOC jokes in-game are bad, m'kay?

## Changelog
:cl:
balance: changed the abandoned crate's 96th drop from a banhammer to an RCD
/:cl: