### PR TITLE
[NON-MODULAR] Changes the charged pyrite extract not to spawn bananium

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/charged.dm
+++ b/code/modules/research/xenobiology/crossbreeding/charged.dm
@@ -143,11 +143,22 @@ Charged extracts:
 
 /obj/item/slimecross/charged/pyrite
 	colour = "pyrite"
+	//SKYRAT EDIT START
+	/*
 	effect_desc = "Creates bananium. Oh no."
+	*/
+	effect_desc = "Creates a rainbow crayon."
+	//SKYRAT EDIT END
 
 /obj/item/slimecross/charged/pyrite/do_effect(mob/user)
+	//SKYRAT EDIT START
+	/*
 	new /obj/item/stack/sheet/mineral/bananium(get_turf(user), 10)
 	user.visible_message("<span class='warning'>[src] solidifies with a horrifying banana stench!</span>")
+	*/
+	new /obj/item/toy/crayon/rainbow(get_turf(user))
+	user.visible_message("<span class='notice'>[src] morphs it's shape into a narrow cylinder, gaining a rainbow color!</span>")
+	//SKYRAT EDIT END
 	..()
 
 /obj/item/slimecross/charged/red


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes the charged pyrite crossbreed so it doesn't spawn bananium anymore - instead, it creates a rainbow crayon.

## Why It's Good For The Game

Bananium is bad.

## Changelog
:cl:
balance: replaces bananium spawn with a rainbow crayon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
