### PR TITLE
[NON-MODULAR] Makes clown PDA's not slip/laugh

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -7,10 +7,14 @@
 	desc = "A portable microcomputer by Thinktronic Systems, LTD. The surface is coated with polytetrafluoroethylene and banana drippings."
 	ttone = "honk"
 
+//SKYRAT EDIT REMOVAL START
+/*
 /obj/item/pda/clown/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/slippery/clowning, 120, NO_SLIP_WHEN_WALKING, CALLBACK(src, .proc/AfterSlip))
 	AddComponent(/datum/component/wearertargeting/sitcomlaughter, CALLBACK(src, .proc/after_sitcom_laugh))
+*/
+//SKYRAT EDIT REMOVAL END
 
 /obj/item/pda/clown/proc/AfterSlip(mob/living/carbon/human/M)
 	if (istype(M) && (M.real_name != owner))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.
Also you can get the PDA's from legion corpses, I'm not just removing something not-in-use.

## Why It's Good For The Game

Both of these traits are pretty nonsensical for a PDA. No, I don't buy that it's "covered in micro-bananium".
## Changelog
:cl:
del: Removes the slippery/clowning and sitcomlaughter components from clown PDA's
/:cl:
