### PR TITLE
[CONFIG] Disables the lavaland clown ruin from spawning

### DIFF
--- a/config/lavaruinblacklist.txt
+++ b/config/lavaruinblacklist.txt
@@ -6,7 +6,7 @@
 ##BIODOMES
 #_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
-#_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
 
 ##RESPAWN


### PR DESCRIPTION
## About The Pull Request

Changes the config to not spawn clown planet ruins.

## Why It's Good For The Game

> Nonsensical ruin that uses TG's clown "lore".
> Contains such wonderful items as: Staff of the Honkmother, Bananium, and ghetto Combat Clown Shoes.
> It simply isn't a ruin that belongs on a roleplay server

## Changelog
:cl:
config: disables the clown_planet ruin
/:cl: