### PR TITLE
[NON-MODULAR] Removes the "Bananium Shipment" station trait

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -1,9 +1,13 @@
+//SKYRAT EDIT REMOVAL START
+/*
 /datum/station_trait/bananium_shipment
 	name = "Bananium Shipment"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 5
 	report_message = "Rumors has it that the clown planet has been sending support packages to clowns in this system"
 	trait_to_give = STATION_TRAIT_BANANIUM_SHIPMENTS
+*/
+//SKYRAT EDIT END
 
 /datum/station_trait/unnatural_atmosphere
 	name = "Unnatural atmospherical properties"


### PR DESCRIPTION
## About The Pull Request

Title. Only removes the datum that rolls it.

## Why It's Good For The Game

Yes, we don't have clowns. But it still rolls and takes the station's trait without even doing anything. So why not just.. remove it?

## Changelog
:cl:
del: removes the bananium_shipment station trait datum
/:cl: