### PR TITLE
[NON-MODULAR] Makes the explosive hot potato not buyable

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1871,8 +1871,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 20
 	restricted_roles = list("Chaplain")
 	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
-*/
-//SKYRAT EDIT REMOVAL END
 
 /datum/uplink_item/role_restricted/explosive_hot_potato
 	name = "Exploding Hot Potato"
@@ -1882,6 +1880,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 4
 	surplus = 0
 	restricted_roles = list("Cook", "Botanist", "Clown", "Mime")
+*/
+//SKYRAT EDIT REMOVAL END
 
 /datum/uplink_item/role_restricted/ez_clean_bundle
 	name = "EZ Clean Grenade Bundle"


### PR DESCRIPTION

## About The Pull Request

Title.

## Why It's Good For The Game

LRP bullshit must go.

## Changelog
:cl:
del: removes the explosive hot potato from buyable antag items
/:cl: