### PR TITLE
[NON-MODULAR] Nerfs plasma sheet generation in the crystalliser

### DIFF
--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -126,7 +126,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	max_temp = 140
 	reaction_type = ENDOTHERMIC_REACTION
 	energy_release = 15000
-	requirements = list(/datum/gas/plasma = 300)	// SKYRAT EDIT - ORIGINAL VALUE: 25
+	requirements = list(/datum/gas/plasma = 150, /datum/gas/bz = 15)	// SKYRAT EDIT - ORIGINAL: list(/datum/gas/plasma = 25)
 	products = list(/obj/item/stack/sheet/mineral/plasma = 1)
 
 /datum/gas_recipe/crystallizer/crystal_cell

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -126,7 +126,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	max_temp = 140
 	reaction_type = ENDOTHERMIC_REACTION
 	energy_release = 15000
-	requirements = list(/datum/gas/plasma = 25)
+	requirements = list(/datum/gas/plasma = 300)
 	products = list(/obj/item/stack/sheet/mineral/plasma = 1)
 
 /datum/gas_recipe/crystallizer/crystal_cell

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -126,7 +126,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	max_temp = 140
 	reaction_type = ENDOTHERMIC_REACTION
 	energy_release = 15000
-	requirements = list(/datum/gas/plasma = 300)
+	requirements = list(/datum/gas/plasma = 300)	// SKYRAT EDIT - ORIGINAL VALUE: 25
 	products = list(/obj/item/stack/sheet/mineral/plasma = 1)
 
 /datum/gas_recipe/crystallizer/crystal_cell


### PR DESCRIPTION
## About The Pull Request

Increases mols needed per sheet from 25 to 150 plus 15 mols of BZ. Honestly might need to be raised more but we'll see.

## Why It's Good For The Game

Haha gas miner goes brrrr. Free money bad

## Changelog
:cl:
balance: Plasma sheets made in the crystalliser require 150 mols per sheet, up from 25, as well as 15 mols of BZ. 
/:cl: