### PR TITLE
[MODULAR] Reduces ninja kit vibro sword damage

### DIFF
--- a/modular_skyrat/modules/moretraitoritems/code/game/objects/items/weaponry.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/game/objects/items/weaponry.dm
@@ -1,2 +1,3 @@
 /obj/item/vibro_weapon/ninjasr
     block_chance = 25
+	force = 13

--- a/modular_skyrat/modules/moretraitoritems/code/game/objects/items/weaponry.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/game/objects/items/weaponry.dm
@@ -1,3 +1,3 @@
 /obj/item/vibro_weapon/ninjasr
-    block_chance = 25
+	block_chance = 25
 	force = 13


### PR DESCRIPTION
## About The Pull Request

Reduces the damage on the vibro sword for the ninja kit from 20 to 13. This seems awful, but remember, when wielded the weapon does twice the damage, effectively reducing the damage output from 40 to 26 per hit. Against unarmored targets the vibro sword was absolutely broken. This will fix up some of the issues I and others who have used it and had it used on them had. 

Also fixes space indentation to be tab indentation instead.

## Why It's Good For The Game

Less broken, but still cool weapon.

## Changelog
:cl:
balance: Reduced damage on the vibro sword from the cyborg ninja kit by 35%.
/:cl: