### PR TITLE
[NONMODULAR] Removes Xray and Thermal eyes from research tree

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -401,6 +401,8 @@
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
+//SKYRAT EDIT REMOVAL BEGIN - Noxray
+/*
 /datum/design/cyberimp_xray
 	name = "X-ray Eyes"
 	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
@@ -422,6 +424,8 @@
 	build_path = /obj/item/organ/eyes/robotic/thermals
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+*/
+//SKYRAT EDIT REMOVAL END - Noxray
 
 /datum/design/cyberimp_antidrop
 	name = "Anti-Drop Implant"

--- a/modular_skyrat/modules/implants/code/research/techweb/medical_nodes.dm
+++ b/modular_skyrat/modules/implants/code/research/techweb/medical_nodes.dm
@@ -6,6 +6,6 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 
 /datum/techweb_node/combat_cyber_implants
-	design_ids = list("ci-xray", "ci-thermals", "ci-nv", "ci-antidrop", "ci-antistun", "ci-antisleep", "ci-thrusters", "ci-mantis", "ci-flash")
+	design_ids = list("ci-nv", "ci-antidrop", "ci-antistun", "ci-antisleep", "ci-thrusters", "ci-mantis", "ci-flash")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12000)
 


### PR DESCRIPTION
## About The Pull Request

At admin request (infrey), I have removed xray and thermal eyes from the research pool, they can no longer be researched and printed by the crew.

![image](https://user-images.githubusercontent.com/26744576/110232696-dd936600-7ee4-11eb-9e27-004a391d10eb.png)
![image](https://user-images.githubusercontent.com/26744576/110232698-e71cce00-7ee4-11eb-95ec-1603da161109.png)


## Why It's Good For The Game

Often these things get given to security by unscrupulous roboticists or doctors, and it can create unfun situations considering security's already strong position in terms of what they get. I dunno. Xray and thermals is just pretty fucking bonkers strong y'know?

![image](https://user-images.githubusercontent.com/26744576/110232653-9907ca80-7ee4-11eb-8c3c-711f7c0002cb.png)


## Changelog
:cl:
del: Removed xray and thermal eyes from the research pool.
/:cl: