### PR TITLE
The security medic's helmet can now have a flashlight attached

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/security_medic/secmed_clothes.dm
+++ b/modular_skyrat/modules/sec_haul/code/security_medic/secmed_clothes.dm
@@ -51,4 +51,3 @@
 	worn_icon_state = "secmed_helmet"
 	icon_state = "secmed_helmet"
 	mutant_variants = NONE
-	can_flashlight = FALSE


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

consistency

## Changelog
:cl:
fix: Sec medics can now see where they're going with the ability to put a flashlight on their helmet
/:cl: