### PR TITLE
Makes chameleon gear usable by furries and adds a slowdown button

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/chameleon.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/chameleon.dm
@@ -1,0 +1,55 @@
+/datum/action/chameleon_slowdown/
+	name = "Toggle Chameleon Slowdown"
+	button_icon_state = "chameleon_outfit"
+	var/savedslowdown = 0
+
+/datum/action/chameleon_slowdown/New(var/slowdown)
+	..()
+	savedslowdown = slowdown
+
+/datum/action/chameleon_slowdown/Trigger()
+	var/obj/item/clothing/T = target
+	var/slow = T.slowdown
+	T.slowdown = savedslowdown
+	savedslowdown = slow
+	owner.update_equipment_speed_mods()
+
+/datum/action/item_action/chameleon/change/
+	var/datum/action/chameleon_slowdown/slowtoggle
+
+/datum/action/item_action/chameleon/change/update_item(obj/item/picked_item)
+	. = ..()
+	if(istype(target, /obj/item/clothing/))
+		var/obj/item/clothing/T = target
+		var/obj/item/clothing/P = new picked_item
+		T.mutant_variants = P.mutant_variants
+		T.worn_icon_digi = P.worn_icon_digi
+		T.worn_icon_taur_snake = P.worn_icon_taur_snake
+		T.worn_icon_taur_paw = P.worn_icon_taur_paw
+		T.worn_icon_taur_hoof = P.worn_icon_taur_hoof
+		T.worn_icon_muzzled = P.worn_icon_muzzled
+		T.flags_inv = P.flags_inv
+		T.visor_flags_cover = P.visor_flags_cover
+		T.dynamic_hair_suffix = P.dynamic_hair_suffix
+		T.dynamic_fhair_suffix = P.dynamic_fhair_suffix
+		T.slowdown = 0
+		if(P.slowdown)
+			slowtoggle = new(P.slowdown, T)
+			slowtoggle.Grant(owner)
+			slowtoggle.target = T
+		else if(slowtoggle)
+			qdel(slowtoggle)
+		owner.regenerate_icons()
+		qdel(P)
+
+/datum/action/item_action/chameleon/change/Grant(mob/M)
+	. = ..()
+	if(M && (M == owner))
+		if(slowtoggle)
+			slowtoggle.Grant(M)
+
+/datum/action/item_action/chameleon/change/Remove(mob/M)
+	. = ..()
+	if(M && (M == owner))
+		if(slowtoggle)
+			slowtoggle.Remove(M)

--- a/modular_skyrat/master_files/code/modules/clothing/chameleon.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/chameleon.dm
@@ -21,26 +21,26 @@
 	. = ..()
 	if(istype(target, /obj/item/clothing/))
 		var/obj/item/clothing/T = target
-		var/obj/item/clothing/P = new picked_item
-		T.mutant_variants = P.mutant_variants
-		T.worn_icon_digi = P.worn_icon_digi
-		T.worn_icon_taur_snake = P.worn_icon_taur_snake
-		T.worn_icon_taur_paw = P.worn_icon_taur_paw
-		T.worn_icon_taur_hoof = P.worn_icon_taur_hoof
-		T.worn_icon_muzzled = P.worn_icon_muzzled
-		T.flags_inv = P.flags_inv
-		T.visor_flags_cover = P.visor_flags_cover
-		T.dynamic_hair_suffix = P.dynamic_hair_suffix
-		T.dynamic_fhair_suffix = P.dynamic_fhair_suffix
+		var/obj/item/clothing/P = picked_item
+		T.mutant_variants = initial(P.mutant_variants)
+		T.worn_icon_digi = initial(P.worn_icon_digi)
+		T.worn_icon_taur_snake = initial(P.worn_icon_taur_snake)
+		T.worn_icon_taur_paw = initial(P.worn_icon_taur_paw)
+		T.worn_icon_taur_hoof = initial(P.worn_icon_taur_hoof)
+		T.worn_icon_muzzled = initial(P.worn_icon_muzzled)
+		T.flags_inv = initial(P.flags_inv)
+		T.visor_flags_cover = initial(P.visor_flags_cover)
+		T.dynamic_hair_suffix = initial(P.dynamic_hair_suffix)
+		T.dynamic_fhair_suffix = initial(P.dynamic_fhair_suffix)
 		T.slowdown = 0
-		if(P.slowdown)
-			slowtoggle = new(P.slowdown, T)
+		var/slow = initial(P.slowdown)
+		if(slow)
+			slowtoggle = new(slow, T)
 			slowtoggle.Grant(owner)
 			slowtoggle.target = T
 		else if(slowtoggle)
 			qdel(slowtoggle)
 		owner.regenerate_icons()
-		qdel(P)
 
 /datum/action/item_action/chameleon/change/Grant(mob/M)
 	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3490,6 +3490,7 @@
 #include "modular_skyrat\master_files\code\modules\antagonists\ert\ert.dm"
 #include "modular_skyrat\master_files\code\modules\antagonists\nukeop\equipment\nuclearbomb.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\anthro_clothes.dm"
+#include "modular_skyrat\master_files\code\modules\clothing\chameleon.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\non_anthro_clothes.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\outfits\ert.dm"
 #include "modular_skyrat\master_files\code\modules\events\spider_infestation.dm"


### PR DESCRIPTION
Chameleon gear is now usable by furries fully, all mutant bodyparts are carried over. The only thing missing is tail colors. Currently chameleon hardsuits and ETC will just eat the tail rather than color it. This is due to how the hardsuit_tail_color code works. This is a very passable quirk(rather than your tail simply sticking out of the suit like nothing) but can be fixed by either moving the variable from hardsuits to just suits in general, or doing some very finnicky code with chameleons(might make the code non-modular. Aside from this chameleon gear is now indistinguishable from normal gear visually

This PR also adds a toggle slowdown button to gear that slowsdown by default.
Transforming your chameleon suit into a hardsuit(and anything else that slows) now adds a button to your HUD that you can click on to become slow, or click on again to start running at normal speed.

for the love of god merge this i had to make a furry in my private server to code this

## Changelog
:cl: GuppyLaxx
fix: Fixed chameleon gear for furries
add: Added a toggle slowdown button to chameleon clothing
/:cl:
