### PR TITLE
[NONMODULAR] Lets Janitors throw mops and buckets on their belts

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -578,7 +578,10 @@
 		/obj/item/melee/flyswatter,
 		/obj/item/assembly/mousetrap,
 		/obj/item/paint/paint_remover,
-		/obj/item/pushbroom
+		/obj/item/pushbroom, //SKYRAT EDIT - Comma.....
+		/obj/item/mop, //SKYRAT EDIT - For when you're lazy to use soap
+		/obj/item/mop/advanced, //SKYRAT EDIT For when you're lazy to use a bucket
+		/obj/item/reagent_containers/glass/bucket //SKYRAT EDIT - Bucket
 		))
 
 /obj/item/storage/belt/janitor/full/PopulateContents()


### PR DESCRIPTION
## About The Pull Request

Adds the mop, advanced mop and **bucket** to the belt

## Why It's Good For The Game

If the Janitor can somehow lug a fucking broom on a belt around, surely he can lug a mop (and **bucket**)
Essentially just keeps their tools of trade in one confined space

## Changelog
:cl:
qol: Allows the Janitor to store mops and buckets to their jannibelt for easy access!
/:cl:
