### PR TITLE
Unrestricts job jackets

### DIFF
--- a/modular_skyrat/modules/customization/modules/client/loadout/suit.dm
+++ b/modular_skyrat/modules/customization/modules/client/loadout/suit.dm
@@ -131,6 +131,36 @@
 	name = "Flak Jacket"
 	path = /obj/item/clothing/suit/flakjack
 	cost = 2
+	
+/datum/loadout_item/suit/job/security_jacket
+	name = "Security Jacket"
+	path = /obj/item/clothing/suit/toggle/jacket/sec
+	/* restricted_roles = list("Head of Security", "Security Officer", "Warden", "Detective", "Security Medic", "Security Sergeant")
+	restricted_desc = "All Security Personnel" */
+
+/datum/loadout_item/suit/job/engi_jacket
+	name = "Engineering Jacket"
+	path = /obj/item/clothing/suit/toggle/jacket/engi
+	/* restricted_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
+	restricted_desc = "All Engineering Personnel" */
+
+/datum/loadout_item/suit/job/sci_jacket
+	name = "Science Jacket"
+	path = /obj/item/clothing/suit/toggle/jacket/sci
+	/* restricted_roles = list("Research Director", "Scientist", "Roboticist", "Geneticist")
+	restricted_desc = "All Science Personnel" */
+
+/datum/loadout_item/suit/job/med_jacket
+	name = "Medbay Jacket"
+	path = /obj/item/clothing/suit/toggle/jacket/med
+	/* restricted_roles = list("Chief Medical Officer", "Medical Doctor", "Paramedic", "Chemist", "Virologist")
+	restricted_desc = "All Medical Personnel" */
+
+/datum/loadout_item/suit/job/supply_jacket
+	name = "Supply Jacket"
+	path = /obj/item/clothing/suit/toggle/jacket/supply
+	/* restricted_roles = list("Quartermaster", "Cargo Technician", "Miner")
+	restricted_desc = "All Cargo Personnel" */
 
 //HOODIES
 /datum/loadout_item/suit/hoodie
@@ -256,36 +286,6 @@
 	name = "warden navyblue jacket"
 	path = /obj/item/clothing/suit/armor/vest/warden/navyblue
 	restricted_roles = list("Warden")
-
-/datum/loadout_item/suit/job/security_jacket
-	name = "Security Jacket"
-	path = /obj/item/clothing/suit/toggle/jacket/sec
-	restricted_roles = list("Head of Security", "Security Officer", "Warden", "Detective", "Security Medic", "Security Sergeant")
-	restricted_desc = "All Security Personnel"
-
-/datum/loadout_item/suit/job/engi_jacket
-	name = "Engineering Jacket"
-	path = /obj/item/clothing/suit/toggle/jacket/engi
-	restricted_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
-	restricted_desc = "All Engineering Personnel"
-
-/datum/loadout_item/suit/job/sci_jacket
-	name = "Science Jacket"
-	path = /obj/item/clothing/suit/toggle/jacket/sci
-	restricted_roles = list("Research Director", "Scientist", "Roboticist", "Geneticist")
-	restricted_desc = "All Science Personnel"
-
-/datum/loadout_item/suit/job/med_jacket
-	name = "Medbay Jacket"
-	path = /obj/item/clothing/suit/toggle/jacket/med
-	restricted_roles = list("Chief Medical Officer", "Medical Doctor", "Paramedic", "Chemist", "Virologist")
-	restricted_desc = "All Medical Personnel"
-
-/datum/loadout_item/suit/job/supply_jacket
-	name = "Supply Jacket"
-	path = /obj/item/clothing/suit/toggle/jacket/supply
-	restricted_roles = list("Quartermaster", "Cargo Technician", "Miner")
-	restricted_desc = "All Cargo Personnel"
 
 /datum/loadout_item/suit/job/supply_head_jacket
 	name = "Quartermaster's Jacket"

--- a/modular_skyrat/modules/customization/modules/clothing/under/utility_port/suits_port.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/under/utility_port/suits_port.dm
@@ -62,7 +62,7 @@
 	name = "security jacket"
 	desc = "A comfortable jacket in security blue. Probably against uniform regulations."
 	icon_state = "sec_dep_jacket"
-	armor = list(MELEE = 20, BULLET = 10, LASER = 25, ENERGY = 5, BOMB = 20, BIO = 0, RAD = 0, FIRE = 0, ACID = 40, WOUND = 0)
+	armor = list(MELEE = 5, BULLET = 0, LASER = 0, ENERGY = 5, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 15, WOUND = 0)
 
 /obj/item/clothing/suit/toggle/jacket/sec/old	//Oldsec (Red)
 	icon_state = "sec_dep_jacket_old"

--- a/modular_skyrat/modules/customization/modules/clothing/under/utility_port/suits_port.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/under/utility_port/suits_port.dm
@@ -33,20 +33,20 @@
 	name = "engineering jacket"
 	desc = "A comfortable jacket in engineering yellow."
 	icon_state = "engi_dep_jacket"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 20, FIRE = 30, ACID = 45, WOUND = 0)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 15, FIRE = 25, ACID = 40, WOUND = 0)
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/t_scanner, /obj/item/construction/rcd, /obj/item/pipe_dispenser, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter)
 
 /obj/item/clothing/suit/toggle/jacket/sci
 	name = "science jacket"
 	desc = "A comfortable jacket in science purple."
 	icon_state = "sci_dep_jacket"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 10, BIO = 0, RAD = 0, FIRE = 0, ACID = 0, WOUND = 0)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 5, BIO = 0, RAD = 0, FIRE = 0, ACID = 0, WOUND = 0)
 
 /obj/item/clothing/suit/toggle/jacket/med
 	name = "medbay jacket"
 	desc = "A comfortable jacket in medical blue."
 	icon_state = "med_dep_jacket"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 50, RAD = 0, FIRE = 0, ACID = 45, WOUND = 0)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 45, RAD = 0, FIRE = 0, ACID = 40, WOUND = 0)
 
 /obj/item/clothing/suit/toggle/jacket/supply
 	name = "cargo jacket"
@@ -62,7 +62,7 @@
 	name = "security jacket"
 	desc = "A comfortable jacket in security blue. Probably against uniform regulations."
 	icon_state = "sec_dep_jacket"
-	armor = list(MELEE = 25, BULLET = 15, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 0, RAD = 0, FIRE = 0, ACID = 45, WOUND = 0)
+	armor = list(MELEE = 20, BULLET = 10, LASER = 25, ENERGY = 5, BOMB = 20, BIO = 0, RAD = 0, FIRE = 0, ACID = 40, WOUND = 0)
 
 /obj/item/clothing/suit/toggle/jacket/sec/old	//Oldsec (Red)
 	icon_state = "sec_dep_jacket_old"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Unrestricts departmental jackets in the loadout screen, now you can rep your favorite department whenever you want!
Also gently reduces some of the armor values of said jackets, seeing as anyone could get them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Assistants are commonly seen as "off-duty," and this would allow them to represent their department when they are so.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Removes job restrictions for departmental jackets, rep your department while off duty!
balance: Balanced armor for the stated jackets accordingly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
