### PR TITLE
[NONMODULAR] fixes material issues with metal hydrogen armor and buffs it

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -377,10 +377,13 @@
 	desc = "A superb helmet made with the toughest and rarest materials available to man."
 	icon_state = "h2helmet"
 	inhand_icon_state = "h2helmet"
-	armor = list(MELEE = 15, BULLET = 10, LASER = 30, ENERGY = 30, BOMB = 10, BIO = 10, RAD = 20, FIRE = 65, ACID = 40, WOUND = 15)
-	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS //Can change color and add prefix
+	armor = list(MELEE = 40, BULLET = 20, LASER = 30, ENERGY = 30, BOMB = 10, BIO = 10, RAD = 70, FIRE = 100, ACID = 100, WOUND = 30)
+	custom_materials = list(/datum/material/metalhydrogen = 10000)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	heat_protection = HEAD
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
+	
 
 //monkey sentience caps
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -299,11 +299,12 @@
 	desc = "A superb armor made with the toughest and rarest materials available to man."
 	icon_state = "h2armor"
 	inhand_icon_state = "h2armor"
-	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS//Can change color and add prefix
-	armor = list(MELEE = 15, BULLET = 10, LASER = 30, ENERGY = 30, BOMB = 10, BIO = 10, RAD = 20, FIRE = 65, ACID = 40, WOUND = 15)
+	custom_materials = list(/datum/material/metalhydrogen = 16000)
+	armor = list(MELEE = 40, BULLET = 20, LASER = 30, ENERGY = 30, BOMB = 10, BIO = 10, RAD = 70, FIRE = 100, ACID = 100, WOUND = 30)
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 
 /obj/item/clothing/suit/armor/vest/centcom_formal
 	name = "\improper CentCom Formal Coat"


### PR DESCRIPTION
## About The Pull Request

Metal hydrogen armor has a few issues with it's material datums. This pr fixes those and gives it a slight buff, as it currently lacks any value as armor.

## Why It's Good For The Game

Not broken! Also, it's actually worth getting as an armor now, rather than making it once and realizing it's shit.

## Changelog
:cl:
fix: elder atmosian armor material datums not wacky
add: new elder atmosian armor stats
/:cl: