### PR TITLE
[NONMODULAR]Lavaland swarmer ruin change

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_swarmer_crash.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_swarmer_crash.dmm
@@ -20,7 +20,7 @@
 /turf/template_noop,
 /area/ruin/unpowered)
 "f" = (
-/mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon,
+/obj/structure/swarmer_beacon,
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the beacon to now exclusively print sentient swarmers.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Another lavaland ghost role is excellent; and as it stood - Swarmers act differently between the NPC and Sentient variant; including the ability to devour walls that may breach things, as it stands, the NPC version would commonly spawn too close to the mining base, and begin eating it; this isnt an issue with sentient swarmers - since they're capable of both understanding player behaviour, and are mechanically restricted from doing so.

Also, factorio but with small robits is fun.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Swarmer beacon is now an actual swarmer beacon (LAVALAND RUIN CHANGE)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
