### PR TITLE
[Nonmodular]Disables Distributed Neuron blob strain

### DIFF
--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -141,7 +141,7 @@
 	humanize_pod(user)
 
 /mob/living/simple_animal/hostile/blob/blobspore/proc/humanize_pod(mob/user)
-	if((!overmind || istype(src, /mob/living/simple_animal/hostile/blob/blobspore/weak) && !is_zombie)
+	if((!overmind || istype(src, /mob/living/simple_animal/hostile/blob/blobspore/weak)) && !is_zombie)
 		return
 	if(key || stat)
 		return

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -120,7 +120,7 @@
 	if(istype(linked_node))
 		factory = linked_node
 		factory.spores += src
-		if(linked_node.overmind && istype(linked_node.overmind.blobstrain, /datum/blobstrain/reagent/distributed_neurons) && !istype(src, /mob/living/simple_animal/hostile/blob/blobspore/weak))
+		if(linked_node.overmind && !istype(src, /mob/living/simple_animal/hostile/blob/blobspore/weak))
 			notify_ghosts("A controllable spore has been created in \the [get_area(src)].", source = src, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Sentient Spore Created")
 		add_cell_sample()
 
@@ -141,7 +141,7 @@
 	humanize_pod(user)
 
 /mob/living/simple_animal/hostile/blob/blobspore/proc/humanize_pod(mob/user)
-	if((!overmind || istype(src, /mob/living/simple_animal/hostile/blob/blobspore/weak) || !istype(overmind.blobstrain, /datum/blobstrain/reagent/distributed_neurons)) && !is_zombie)
+	if((!overmind || istype(src, /mob/living/simple_animal/hostile/blob/blobspore/weak) && !is_zombie)
 		return
 	if(key || stat)
 		return

--- a/code/modules/antagonists/blob/blobstrains/distributed_neurons.dm
+++ b/code/modules/antagonists/blob/blobstrains/distributed_neurons.dm
@@ -1,4 +1,5 @@
 //kills unconscious targets and turns them into blob zombies, produces fragile spores when killed.  Spore produced by factories are sentient.
+/* SKYRAT EDIT: - DISABLES DISTRIBUTED NEURONS DUE TO BALANCING
 /datum/blobstrain/reagent/distributed_neurons
 	name = "Distributed Neurons"
 	description = "will do medium-low toxin damage and turns unconscious targets into blob zombies."
@@ -39,3 +40,4 @@
 			spore.Zombify(exposed_mob)
 			overmind.add_points(-5)
 			to_chat(overmind, "<span class='notice'>Spent 5 resources for the zombification of [exposed_mob].</span>")
+*/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Requested by staff somewhat, either a change or an outright disable during the time we figure out how to adjust it to be less gamer

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
DN is currently the strongest strain in the game. This is a fact. Every blob spore can be player-controlled; while not an issue on /tg/ - we get much higher instasnces of engine sabotage, welderbombing, general balance issues involving some of our maps (such as Tramstation); even against multiple ERTs and otherwise admin interference, it can still /easily/ win short of a literal Deathsquad with 12 people.

This is due to how it spreads. Distributed Neurons has a reagent that /literally changes whoever it hits/ if they're meeting the following pre-requisites

1) They're dead or unconcious
2) The blob has 5 resource points

This makes it extremely unbalanced; see - the thing is, the reagent also instantly kills anyone unconcious or in hardcrit, meaning if a blobbernaut or blob zombie were to hit someone, they get knocked unconcious from an explosion or go into crit, it instantly kills and zombifies them, allowing a new ghost, or the same person; to immediately take control of that new blob zombie.

There is no way to counter this against an experienced blob player, with the increased difficulty in making X-Ray weapons, beam rifles, ecetera; overall making it harder for players to counter this strain; it was decided that, after two rounds of similar occurances, that it would be removed for playabilities sake. It will likely be changed, and possibly PR'd upstream.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Distributed Neurons is gone, for now. Good-bye zergo blob.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
