### PR TITLE
[Modular] Removes CQC+ From the uplink

### DIFF
--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -83,13 +83,14 @@
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //Blocked them because this just costs more than the version they get.
 	cost = 25
 	surplus = 20
-
-/datum/uplink_item/stealthy_weapons/cqcplus
+// Removed from the uplink for the time being.
+/*datum/uplink_item/stealthy_weapons/cqcplus
 	name = "CQC+ Manual"
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat and how to deflect projectiles before self-destructing."
 	item = /obj/item/book/granter/martial/cqc/plus
 	cost = 30
 	surplus = 20
+*/
 
 /datum/uplink_item/stealthy_weapons/telescopicbaton
 	name = "Telescopic Baton"


### PR DESCRIPTION

## About The Pull Request
Comments out CQC+ in a quick and dirty webedit

## Why It's Good For The Game
Various concerns, namely unbalance.
## Changelog
:cl:
CQC+ has been retired from the gorlex marauders arsenal
