### PR TITLE
[NONMODULAR] Gives Engineering Borgs Holofans

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -248,6 +248,7 @@
 		/obj/item/t_scanner,
 		/obj/item/analyzer,
 		/obj/item/geiger_counter/cyborg,
+		/obj/item/holosign_creator/atmos, // Skyrat Edit - Adds Holofans to engineering borgos
 		/obj/item/assembly/signaler/cyborg,
 		/obj/item/areaeditor/blueprints/cyborg,
 		/obj/item/electroadaptive_pseudocircuit,


### PR DESCRIPTION
## About The Pull Request

Gives Engineering borgs the holofan, to combat their enemy, atmospherics!

## Why It's Good For The Game

Allows borgs to effectively combat gas leaks or breaches
inb4 borg powercreep

## Changelog
:cl:
add: Engineering Cyborgs can now use holofans!
/:cl:
