### PR TITLE
[MODULAR] Tramstation Medical Storage APC is now connected to the grid 

### DIFF
--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -34,11 +34,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"aag" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/brown/tom,
-/turf/open/floor/plating,
-/area/security/prison)
 "aah" = (
 /obj/structure/bed/dogbed/mcgriff,
 /obj/structure/cable,
@@ -9504,6 +9499,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/gun/syringe,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "ato" = (
@@ -106960,7 +106956,7 @@ aGF
 ccM
 abE
 acP
-aag
+ooT
 ccM
 ljx
 oho


### PR DESCRIPTION
## About The Pull Request

This map makes me so depressed

## Why It's Good For The Game

Medical Storage APC is missing a single damn wire to connect it to the grid which this adds.
I have also removed a mouse from the prison APC room that'd eat the wires connecting to the APC without fail every round since it sits in a room by itself with it's dinner date, the APC wires

:cl:
fix: Tramstation Medical Storage APC is now connected to the grid
/:cl: