### PR TITLE
Fixed "Safeguard" run time error in game options config

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -355,7 +355,8 @@ DEFAULT_LAWS 0
 ## See datums\ai_laws.dm for the full law lists
 
 ## standard-ish laws. These are fairly ok to run
-#RANDOM_LAWS safeguard #Currently not coded
+#SKYRAT EDIT ADDITION BEGIN
+RANDOM_LAWS armadyne_safeguard
 RANDOM_LAWS asimov
 RANDOM_LAWS asimovpp
 RANDOM_LAWS paladin
@@ -388,7 +389,9 @@ RANDOM_LAWS corporate
 LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
-#LAW_WEIGHT safeguard,40 #Currently not coded
+#SKYRAT EDIT ADDITION BEGIN
+LAW_WEIGHT armadyne_safeguard,40
+#SKYRAT EDIT ADDITION END
 LAW_WEIGHT asimov,32
 LAW_WEIGHT asimovpp,12
 LAW_WEIGHT paladin,12

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -355,7 +355,7 @@ DEFAULT_LAWS 0
 ## See datums\ai_laws.dm for the full law lists
 
 ## standard-ish laws. These are fairly ok to run
-RANDOM_LAWS safeguard
+#RANDOM_LAWS safeguard #Currently not coded
 RANDOM_LAWS asimov
 RANDOM_LAWS asimovpp
 RANDOM_LAWS paladin
@@ -388,7 +388,7 @@ RANDOM_LAWS corporate
 LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
-LAW_WEIGHT safeguard,40
+#LAW_WEIGHT safeguard,40 #Currently not coded
 LAW_WEIGHT asimov,32
 LAW_WEIGHT asimovpp,12
 LAW_WEIGHT paladin,12


### PR DESCRIPTION
Game Options config file was pointing to a "safeguard" law which does not exist. changed it to armadyne_safeguard to clear run time error.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Was debugging my own down stream when i found a run time error saying an AI law did not exist.
AI law referred to was "safeguard". this does not exist in the tg upstream version of the file. Eventually found the proper AI law in modular_skyrat/modules/sec_haul/code/misc/ai_module.dm. Further, ss13 loads the random AI list and weighted random AI law list even when this ai selection type is disabled by the config options

## Why It's Good For The Game

run time errors slow things down. killing them speeds things up.

## Changelog
:cl:
fix: Run time error from Invalid AI law in game_options.txt
config: config/game_options.txt
server: Config File Modified
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
