### PR TITLE
Nerfs Double Bladed Energy Sword TC cost

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -412,7 +412,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			all energy projectiles, but requires two hands to wield."
 	item = /obj/item/dualsaber
 	player_minimum = 25
-	cost = 34
+	cost = 25
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/dangerous/doublesword/get_discount()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -412,7 +412,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			all energy projectiles, but requires two hands to wield."
 	item = /obj/item/dualsaber
 	player_minimum = 25
-	cost = 16
+	cost = 34
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/dangerous/doublesword/get_discount()


### PR DESCRIPTION
## About The Pull Request

Nerfs the cost of the DE-sword in the traitor uplink from 16 to 34 (about 75% of your TC), making it on-par with the cost of the formerly great CQC+.

EDIT: 16 to 25 at request of TF4.

## Why It's Good For The Game

Stops people on going from "epic gamer" rampages and forces people to be more resourceful with their TC.

Disclaimer: Making this PR on behalf of IsaacTheSharkWolf#3811, I don't really believe in the points I make here.

## Changelog
:cl:
balance: The Syndicate has upped the cost of the double bladed energy sword due to production costs.
/:cl: