### PR TITLE
[NON-MODULAR] Someone complained about non-RP friendly deathsquad names

### DIFF
--- a/strings/names/death_commando.txt
+++ b/strings/names/death_commando.txt
@@ -1,91 +1,33 @@
-A whole bunch of spiders in a SWAT suit
-Al "Otta" Gore
-AMERICA
-Beat Punchbeef
-Beef Manmuscle
-Beef Slab
-Benny Bloodmulch
-Bicep McTricep
-Billy Herrington
-Blast Hardcheese
-Blast Thickneck
-Bob Johnson
-Bold Bigflank
-Bolt Vanderhuge
-Brawn Hugeneck
-Brick Hardmeat
-Buck Plankchest
-Buff Drinklots
-Buff Hardback
-Buff Slamchest
-Butch Deadlift
-Chombo Cromagnum
-Crud Bonemeal
-Crunch Buttsteak
-Crush McStompbones
-Diego Diefist
-Dirk Hardpeck
-Duke Killington
-Evil Bob Marley
-Evil Martin Luther King
-Fist Rockbone
-Flint Ironstag
-Ford Spinetwist
-Fridge Largemeat
-George Melons
-Gibbs McLargehuge
-GORE Vidal
-Gristle McThornBody
-Hank Chesthair
-Hans Testosteroneson
-Killiam Shakespeare
-Killing McKillingalot
-Jet Handblood
-Lance Killiam
-Leonardo Da Viking
-Lump Beefrock
-Lunge Crushheel
-Mancrush McBrorape
-Max Pain
-Maximilian Murderface
-Maxx Power
-Noam Bombsky
-Norb Chrometaint
-Oats Squatzon
-Pack Blowfist
-Punch Rockgroin
-Punch Sideiron
-Punt Speedchunk
-Reef Blastbody
-Rex Dudekiller VII
-Rip Sidecheek
-Rip Steakface
-Rock Vangranite
-Roid Swolebod
-Roll Fizzlebeef
-Ronnie Roidready
-Sarah Pain
-Seamus McTosterone
-Sgt Slaughter
-Shred Gluteflex
-Sir Killaslot
-Slab Bulkhead
-Slab Squatthrust
-Slake Fistcrunch
-Slate Slabrock
-Smash Lampjaw
-Smoke Manmuscle
-Splint Chesthair
-Stabby McGee
-Stump Beefgnaw
-Stump Chunkman
-THAT DAMN GRIEFING TRAITOR GEORGE MELONS
-Theodore Pain
-Thick McRunfast
-Thrust Vanderhuge
-Trent Tightshirt
-Toolboxl Rose
-Touch Rustrod
-Trunk Slamchest
-Van Darkholme
-Zombie Gandhi
+Red Menace
+Black Mamba
+Anaconda
+Cerberus
+Foehammer
+Ghost
+Phantom
+Chief
+Snake-Eyes
+Stormrider
+Black Baron
+Lion
+Panther
+Diamond-Dog
+Magnumtip
+Winter
+Reznov
+Dubbo
+2-2-8
+Headhunter
+Destroyer
+Firestorm
+Thunder
+Wallbreacher
+Rookie
+Hall-Sweeper
+Steelnerve
+John-Rat
+Nuke'em
+Corp Slayer
+Goldenbolt
+Price
+Recker


### PR DESCRIPTION
## About The Pull Request

Changes deathsquad names to be more believable for the setting.

## Why It's Good For The Game

Something about increasing RP quality or something. Also vidya references.

## Changelog
:cl:
tweak: A whole bunch of spiders in a SWAT suit (and others) can no longer be a Deathsquad Trooper.
/:cl: