### PR TITLE
[Modular] Restores Half-Shaved Hairstyle

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/hair.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/hair.dm
@@ -212,7 +212,7 @@
 	icon_state = "hair_gloomy_long"
 
 /datum/sprite_accessory/hair/skyrat/halfshave
-	name = "Half-shaved"
+	name = "Half-shaved 2"
 	icon_state = "hair_halfshave"
 
 /datum/sprite_accessory/hair/skyrat/manbun


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#4236 overwrote the upstream Half-Shaved hairstyle by adding a new datum with the same `name`. This renames the ported hairstyle to "Half-shaved 2", allowing the original upstream hairstyle to be used again.

## Why It's Good For The Game

Best not to overwrite tg assets, especially if you have characters developed around them.

## Changelog
:cl:
fix: restores original half-shaved hairstyle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
