### PR TITLE
[Non-modular]Examining a syndicate bomb no longer tells you how much it has left before it blows

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -63,7 +63,7 @@
 			if(0 to 5)
 				volume = 50
 				for(var/i,i<3,i++)
-					addtimer(CALLBACK(src, .proc/play_fearsome_ping), i*10)
+					addtimer(CALLBACK(src, .proc/play_fearsome_ping), i*5)
 			if(5 to 10)
 				volume = 40
 			if(10 to 15)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -98,7 +98,7 @@
 
 /obj/machinery/syndicatebomb/examine(mob/user)
 	. = ..()
-	. += {"A digital display on it reads "[seconds_remaining()]"."}
+	// . += {"A digital display on it reads "[seconds_remaining()]"."} Skyrat change - commented out to make people fear it more.
 
 /obj/machinery/syndicatebomb/update_icon_state()
 	icon_state = "[initial(icon_state)][active ? "-active" : "-inactive"][open_panel ? "-wires" : ""]"

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -62,6 +62,8 @@
 		switch(seconds_remaining())
 			if(0 to 5)
 				volume = 50
+				for(var/i,i<3,i++)
+					addtimer(CALLBACK(src, .proc/play_fearsome_ping), i*10)
 			if(5 to 10)
 				volume = 40
 			if(10 to 15)
@@ -80,6 +82,9 @@
 		timer_set = initial(timer_set)
 		update_appearance()
 		try_detonate(TRUE)
+
+/obj/machinery/syndicatebomb/proc/play_fearsome_ping()
+	playsound(loc, beepsound, 80, FALSE)
 
 /obj/machinery/syndicatebomb/Initialize()
 	. = ..()

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -98,7 +98,7 @@
 
 /obj/machinery/syndicatebomb/examine(mob/user)
 	. = ..()
-	// . += {"A digital display on it reads "[seconds_remaining()]"."} Skyrat change - commented out to make people fear it more.
+	// . += {"A digital display on it reads "[seconds_remaining()]"."} SKYRAT EDIT : - commented out to make people fear it more.
 
 /obj/machinery/syndicatebomb/update_icon_state()
 	icon_state = "[initial(icon_state)][active ? "-active" : "-inactive"][open_panel ? "-wires" : ""]"


### PR DESCRIPTION

## About The Pull Request
Makes it so syndicate bombs don't display their timer on examine anymore
## Why It's Good For The Game
If you know how much a bomb has left , there is no element of urgency or fear. If the player doesn't know how much the bomb has left , security will be encouraged to get a bomb suit as fast and possible and defuse it , and all non-security jobs will run.
Also makes it viable for antags to set bombs with 60000 seconds timer and complete their stuff while everyone is panicking because they don't know how much it has left until it blows.
## Changelog
:cl:
balance: Syndicate minibombs no longer show how much time they have left until they blow.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
