### PR TITLE
Removes the Job Overflow Station Trait.

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -85,7 +85,7 @@
 /datum/station_trait/overflow_job_bureacracy
 	name = "Overflow bureacracy mistake"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 5
+	weight = 0 //SKYRAT EDIT: - CHANGES WEIGHT FROM FIVE TO ZERO
 	show_in_report = TRUE
 	var/list/jobs_to_use = list("Clown", "Bartender", "Cook", "Botanist", "Cargo Technician", "Mime", "Janitor", "Prisoner")
 	var/chosen_job


### PR DESCRIPTION
## About The Pull Request

Makes it so the Job Overflow Station Trait can't roll anymore.

## Why It's Good For The Game

Because every time it happens there are like five ahelps made about "Why can I play assistant???!?! then the staff online go ahead and fix it anyway, so it might as well not exist. This is just saving admins work, while allowing the chance for something that actually matters to be rolled. It could allow allow for the **CLOWN SLOT** to open up, thus turning Skyrat into HippieStation in only a matter of seconds, thus it is important this PR gets speed-merged right away.

## Changelog
:cl:
del: Job Overflow Station Trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
