### PR TITLE
[Modular Item] Alien monkeycube

### DIFF
--- a/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
@@ -6,3 +6,9 @@
 	force = 2
 	throwforce = 3
 	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/food/monkeycube/beno
+	name = "alien cube"
+	desc = "Don't let corporate crooks slip this into your lunch."
+	tastes = list("the jungle" = 1, "acid" = 1)
+	spawned_mob = /mob/living/carbon/alien/humanoid/hunter //This is catatonic.


### PR DESCRIPTION
## About The Pull Request

I hope I'm doing this right I've never used git before oh god oh fuck

This adds an offshoot of monkey cubes called the _alien cube_, AKA "beno" cube from Citadel-Station code, fixed and tested to work here. It spawns a catatonic alien, which used to be a drone on Cit, but I altered it into a hunter because this removes the risk of evolution abuse, and the potential organs would be less exploitable than sentinels.

There is no dedicated way to make an alien cube, which means the only way to obtain it is through randomization. Essentially only doable with Xenobiology, which is fitting.

The risk of powergame is minimal, because the hunter is catatonic and cannot be used like the gorilla cube can. Making it conscious would require a volunteer for a brain transplant, which takes 2-person effort and leaves one person unable to use items or comprehend common.
That just leaves us with the organs, which come in their weakest form on the hunter. Small plasma vessel, no neurotoxin, no resin spinner, etc.

## Why It's Good For The Game

Allows Xenobio to get their hands on aliens to research for actual roleplay without risking trying to deal with a permanent mechanic-based xeno foe.
This means we get to research something in detail beyond slimes.
The potential is similar to existing tricks with gold core monster spawns and transfer potions, but this requires extra luck with RNG to produce. But unlike gold core monsters, there's a greater degree of dynamics to using this for roleplay.

## Changelog
:cl:
add: Added an alien cube from Citadel-Station to randomized food.
/:cl: