### PR TITLE
Lighting runtime fix

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -665,6 +665,10 @@
 // true if area has power and lightswitch is on
 /obj/machinery/light/proc/has_power()
 	var/area/A = get_area(src)
+	//SKYRAT EDIT ADDITION BEGIN
+	if(isnull(A))
+		return FALSE
+	//SKYRAT EDIT END
 	return A.lightswitch && A.power_light
 
 // returns whether this light has emergency power


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Possibly fixes a big lightswitch runtime, for some reason, the get power proc was being called for many lights without an area.

Due to the fact this can happen in real time(light being pulled out of it's area) I've put a null check there and returned false if it doesn't have an area. No area = no power.

## Changelog
:cl:
fix: A big lighting runtime.
/:cl:

