### PR TITLE
[NON-MODULAR] Gives Engie Borgs Light Replacers

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -255,7 +255,8 @@
 		/obj/item/stack/sheet/rglass/cyborg,
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/iron,
-		/obj/item/stack/cable_coil)
+		/obj/item/stack/cable_coil,
+		/obj/item/lightreplacer/cyborg) // Skyrat Edit - Surprised Engie borgs don't get these
 	radio_channels = list(RADIO_CHANNEL_ENGINEERING)
 	emag_modules = list(/obj/item/borg/stun)
 	cyborg_base_icon = "engineer"


### PR DESCRIPTION
## About The Pull Request

Honestly dunno why they don't get light replacers

## Why It's Good For The Game

Allows engie borgs to replace broken or build lights without wanting to kill themselves via lack of hands

## Changelog
:cl:
add: Added light replacers to the engie borg
/:cl: