### PR TITLE
Fixes for integrated circuit printer

### DIFF
--- a/modular_skyrat/modules/integrated_circuits/code/integrated_electronics/core/printer.dm
+++ b/modular_skyrat/modules/integrated_circuits/code/integrated_electronics/core/printer.dm
@@ -167,7 +167,7 @@
 	else
 		HTML += " Load Program"
 	if(!program)
-		HTML += " [fast_clone ? "Print" : "Begin Printing"] Assembly"
+		HTML += " [fast_clone ? "Print" : "Begin Printing"] Assembly<br>"
 	else if(cloning)
 		HTML += " <A href='?src=[REF(src)];print=cancel'>Cancel Print</a>"
 	else
@@ -264,7 +264,8 @@
 			if("load")
 				if(cloning)
 					return
-				var/input = stripped_multiline_input(usr, "Put your code there:", "loading", max_length = MAX_SIZE_CIRCUIT)
+				// We want this trimmed through stripped_multiline_input, but we don't want the result to be html encoded otherwise there will be json decode errors.
+				var/input = html_decode(stripped_multiline_input(usr, "Put your code there:", "loading", max_length = MAX_SIZE_CIRCUIT))
 				if(!check_interactivity(usr) || cloning)
 					return
 				if(!input)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
There was a json parsing error happening because `proc/stripped_multiline_input` html encodes text passed into it as part of its sanitization steps. This was the cause behind the inability to clone circuits. Additionally there was a missing newline in the UI that I put into place while I was at it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Without functional circuit cloning creating interesting and complex circuits is severely discouraged. 
It can take nearly an entire round to set up something truly unique. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: 0xEFF
fix: The integrated circuit printer can now clone circuits as originally intended.
fix: Integrated circuit printer UI given a linebreak where it was needed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
