### PR TITLE
[MODULAR] RPDs can install the unwrench upgrade by interacting with the disk

### DIFF
--- a/modular_skyrat/modules/cyborg/code/rpd_upgrade_thing.dm
+++ b/modular_skyrat/modules/cyborg/code/rpd_upgrade_thing.dm
@@ -1,0 +1,11 @@
+/obj/item/pipe_dispenser/pre_attack(atom/target, mob/user, params)
+	if(istype(target, /obj/item/rpd_upgrade/unwrench))
+		install_upgrade(target, user)
+		return TRUE
+	return ..()
+
+/obj/item/pipe_dispenser/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/rpd_upgrade/unwrench))
+		install_upgrade(W, user)
+		return TRUE
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3832,6 +3832,7 @@
 #include "modular_skyrat\modules\cyborg\code\borgpowertools.dm"
 #include "modular_skyrat\modules\cyborg\code\mechafabricator_designs.dm"
 #include "modular_skyrat\modules\cyborg\code\robot_upgrades.dm"
+#include "modular_skyrat\modules\cyborg\code\rpd_upgrade_thing.dm"
 #include "modular_skyrat\modules\cyborgpda\code\_onclick\hud\robot.dm"
 #include "modular_skyrat\modules\digi_bloodsole\code\modules\clothing\shoes\_shoes.dm"
 #include "modular_skyrat\modules\emotes\code\dna_screams.dm"


### PR DESCRIPTION
## About The Pull Request

I guess to better explain interacting the upgrade disk with the RPD now applies it like the RCD's

## Why It's Good For The Game

Suppose the only good thing this brings is allowing engie borgs to apply the unwrench upgrade to their RPDs

Honestly surprised this wasn't a thing already

## Changelog
:cl:
add: RPDs can install their upgrades by interacting with the upgrade disk like RCDs can
/:cl: