### PR TITLE
[QUESTIONABLY MODULAR] Changes the cargopack armor vests to the appropriate type

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -286,7 +286,7 @@
 	crate_name = "ammo crate"
 
 /datum/supply_pack/security/armor
-/* Moved to Bloat.dm	name = "Armor Crate"
+	name = "Armor Crate"
 	desc = "Three vests of well-rounded, decently-protective armor. Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -285,6 +285,7 @@
 					/obj/item/ammo_box/c38/iceblox)
 	crate_name = "ammo crate"
 
+/* SKYRAT EDIT: Moved to Bloat.dm	name = "Armor Crate"
 /datum/supply_pack/security/armor
 	name = "Armor Crate"
 	desc = "Three vests of well-rounded, decently-protective armor. Requires Security access to open."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -286,14 +286,14 @@
 	crate_name = "ammo crate"
 
 /datum/supply_pack/security/armor
-	name = "Armor Crate"
+/* Moved to Bloat.dm	name = "Armor Crate"
 	desc = "Three vests of well-rounded, decently-protective armor. Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest)
-	crate_name = "armor crate"
+	crate_name = "armor crate" */
 
 /* - SKYRAT EDIT REMOVAL - SEC_HAUL
 /datum/supply_pack/security/disabler

--- a/modular_skyrat/modules/cargo/code/bloat.dm
+++ b/modular_skyrat/modules/cargo/code/bloat.dm
@@ -36,6 +36,16 @@
 					/obj/item/ammo_box/magazine/wt550m9/wtic)
 	crate_name = "WT550 Ammo Variety Pack"
 
+/datum/supply_pack/security/armor
+	name = "Armor Crate"
+	desc = "Three vests of well-rounded, decently-protective armor. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 2
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/clothing/suit/armor/vest/alt,
+					/obj/item/clothing/suit/armor/vest/alt,
+					/obj/item/clothing/suit/armor/vest/alt)
+	crate_name = "armor crate"
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Science /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## About The Pull Request
Moves the armor cargo pack to bloat file, and changes the vest type to the much more identifiable one(and subjectively better looking), with the same stats (Tg changed the icons around at some point, but didn't update this)
(I expect cobalt will save me from my fantastic web edit practices)
## Why It's Good For The Game
No more pondering if that's an armor vest, or a waistcoat
old:
![image](https://user-images.githubusercontent.com/62520989/112368108-1b4c0900-8cb1-11eb-982c-c3f076b2a91f.png)
new:
![image](https://user-images.githubusercontent.com/62520989/112368252-40d91280-8cb1-11eb-93f4-334972d23e3d.png)


## Changelog
:cl:
code: Cargo now sells an appropriate armor vest, instead of surplus bartender ones.
/:cl:
