### PR TITLE
[DNM][MODULAR]I use the shotgun.

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
@@ -61,10 +61,10 @@
 /obj/item/storage/box/gunset/glock17/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/pistol/g17/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/g17/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/g17/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/g17/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/g17/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/g17(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/g17(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/g17(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/g17(src)
 
 //LADON
 /obj/item/storage/box/gunset/ladon
@@ -76,10 +76,10 @@
 /obj/item/storage/box/gunset/ladon/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/pistol/ladon/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/ladon/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/ladon/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/ladon/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/ladon/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/ladon(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/ladon(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/ladon(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/ladon(src)
 
 //PDH
 /obj/item/storage/box/gunset/pdh_peacekeeper
@@ -91,10 +91,10 @@
 /obj/item/storage/box/gunset/pdh_peacekeeper/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/pistol/pdh/peacekeeper/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper(src)
 
 // MK-58
 /obj/item/storage/box/gunset/ladon
@@ -106,10 +106,10 @@
 /obj/item/storage/box/gunset/mk58/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/pistol/mk58/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/mk58/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/mk58/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/mk58/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/mk58/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/mk58(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/mk58(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/mk58(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/mk58(src)
 
 //CROON
 /obj/item/storage/box/gunset/croon
@@ -121,10 +121,10 @@
 /obj/item/storage/box/gunset/croon/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/croon/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/croon/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/croon/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/croon/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/croon/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/croon(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/croon(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/croon(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/croon(src)
 
 //MAKAROV
 /obj/item/storage/box/gunset/makarov
@@ -136,10 +136,10 @@
 /obj/item/storage/box/gunset/makarov/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/pistol/makarov/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/makarov/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/makarov/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/makarov/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/makarov/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/makarov(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/makarov(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/makarov(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/makarov(src)
 
 //DOZER
 /obj/item/storage/box/gunset/dozer
@@ -151,10 +151,10 @@
 /obj/item/storage/box/gunset/dozer/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/dozer/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/dozer/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/dozer/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/dozer/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/dozer/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/dozer(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/dozer(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/dozer(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/dozer(src)
 
 //ZETA
 /obj/item/storage/box/gunset/zeta
@@ -163,8 +163,8 @@
 /obj/item/storage/box/gunset/zeta/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/revolver/zeta(src)
-	new /obj/item/ammo_box/revolver/multi_sprite/zeta/rubber(src)
-	new /obj/item/ammo_box/revolver/multi_sprite/zeta/rubber(src)
+	new /obj/item/ammo_box/revolver/multi_sprite/zeta(src)
+	new /obj/item/ammo_box/revolver/multi_sprite/zeta(src)
 
 //REVOLUTION
 /obj/item/storage/box/gunset/revolution
@@ -173,8 +173,8 @@
 /obj/item/storage/box/gunset/revolution/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/revolver/revolution(src)
-	new /obj/item/ammo_box/revolver/multi_sprite/revolution/rubber(src)
-	new /obj/item/ammo_box/revolver/multi_sprite/revolution/rubber(src)
+	new /obj/item/ammo_box/revolver/multi_sprite/revolution(src)
+	new /obj/item/ammo_box/revolver/multi_sprite/revolution(src)
 
 
 /////////////////
@@ -189,10 +189,10 @@
 /obj/item/storage/box/gunset/pcr/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/pcr/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pcr/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pcr/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pcr/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pcr/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pcr(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pcr(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pcr(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pcr(src)
 
 /obj/item/storage/box/gunset/norwind
 	name = "lg-2 norwind supply box"
@@ -203,10 +203,10 @@
 /obj/item/storage/box/gunset/norwind/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/norwind/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/norwind/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/norwind/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/norwind/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/norwind/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/norwind(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/norwind(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/norwind(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/norwind(src)
 
 /obj/item/storage/box/gunset/ostwind
 	name = "ostwind supply box"
@@ -217,10 +217,10 @@
 /obj/item/storage/box/gunset/ostwind/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/ostwind/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/ostwind/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/ostwind/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/ostwind/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/ostwind/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/ostwind(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/ostwind(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/ostwind(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/ostwind(src)
 
 /obj/item/storage/box/gunset/vintorez
 	name = "vintorez supply box"
@@ -231,10 +231,10 @@
 /obj/item/storage/box/gunset/vintorez/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/vintorez/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/vintorez/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/vintorez/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/vintorez/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/vintorez/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/vintorez(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/vintorez(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/vintorez(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/vintorez(src)
 
 /obj/item/storage/box/gunset/pitbull
 	name = "pitbull supply box"
@@ -245,10 +245,10 @@
 /obj/item/storage/box/gunset/pitbull/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/pitbull/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pitbull/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pitbull/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pitbull/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pitbull/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pitbull(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pitbull(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pitbull(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pitbull(src)
 
 /////////////////
 //JOB SPECIFIC GUNSETS
@@ -267,8 +267,8 @@
 	new /obj/item/gun/ballistic/automatic/pistol/pdh/alt/nomag(src)
 	new /obj/item/ammo_box/magazine/multi_sprite/pdh(src)
 	new /obj/item/ammo_box/magazine/multi_sprite/pdh(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh(src)
 
 //HOS
 /obj/item/storage/box/gunset/glock18_hos
@@ -282,8 +282,8 @@
 	new /obj/item/gun/ballistic/automatic/pistol/g18/nomag(src)
 	new /obj/item/ammo_box/magazine/multi_sprite/g18/hp(src)
 	new /obj/item/ammo_box/magazine/multi_sprite/g18/hp(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/g18/ihdf(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/g18/ihdf(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/g18(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/g18(src)
 
 //HOP
 /obj/item/storage/box/gunset/pdh_hop
@@ -295,9 +295,9 @@
 /obj/item/storage/box/gunset/pdh_hop/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/pistol/pdh/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src) //HOP gets one mag of rubbers.
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh(src)
 
 //CORPO
 /obj/item/storage/box/gunset/pdh_corpo
@@ -325,9 +325,9 @@
 /obj/item/storage/box/gunset/security_medic/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/pistol/firefly/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/firefly/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/firefly/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/firefly/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/firefly/ihdf(src) //Medic gets one mag of IHDF due to prisoners/etc being rowdy.
+	new /obj/item/ammo_box/magazine/multi_sprite/firefly/rubber(src) //Similar to the above
+	new /obj/item/ammo_box/magazine/multi_sprite/firefly(src)
 
 
 //Blaster

--- a/modular_skyrat/modules/sec_haul/code/misc/vending.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/vending.dm
@@ -80,15 +80,15 @@
 	icon_deny = "ammo-deny"
 	light_mask = "ammo-light-mask"
 	req_access = list(ACCESS_SECURITY)
-	products = list(/obj/item/ammo_box/advanced/b6mm/rubber = 10,
-					/obj/item/ammo_box/advanced/b9mm/rubber = 10,
-					/obj/item/ammo_box/advanced/b10mm/rubber = 10,
+	products = list(/obj/item/ammo_box/advanced/b6mm = 10,
+					/obj/item/ammo_box/advanced/b9mm = 10,
+					/obj/item/ammo_box/advanced/b10mm = 10,
 					/obj/item/storage/bag/ammo = 3,
 					/obj/item/gun_maintenance_supplies = 10
 					)
-	premium = list(/obj/item/ammo_box/advanced/b6mm/ihdf = 2,
-					/obj/item/ammo_box/advanced/b9mm/ihdf = 2,
-					/obj/item/ammo_box/advanced/b10mm/ihdf = 2)
+	premium = list(/obj/item/ammo_box/advanced/b12mm = 2,
+					/obj/item/ammo_box/advanced/b9mm/hp = 2,
+					/obj/item/ammo_box/advanced/b10mm/hp = 2)
 	refill_canister = /obj/item/vending_refill/security_ammo
 	default_price = PAYCHECK_MEDIUM
 	extra_price = PAYCHECK_HARD * 2


### PR DESCRIPTION
### AWAITING VERDICT BY STAFF AND POLICY PEOPLE

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
To quote Tyler1 'GET THIS SHIT OFF ME'

Complete and utter removal of non-lethals from the standard loadout of an Officer and Sergeant, along with the vending machines.

Why? You may ask.

This has been an idea long discussed between devs, people in #policy-talk and feedback team/other circles that might benefit security players and antagonists a like. The first and foremost issue.

Guns are being treated like they are **toys**.

People will draw their weapon as an officer and fire it for the smallest reason; because in the end? 'Its just rubbers or IHDF'. This is an utterly negligent attitude to have; and would wholly get you fired.
Now; while this may sound like an advanced shitpost - I want people to consider the actual effects. One. Security Officers /should not/ be drawing their weapon unless absolutely neccessary. They have other nonlethal options upon them. Flashes, Flashbangs, Pepperspray (the godawful baton I might make a normal one again), along with their actual body. By shifting importance away from the weapon itself; and more towards the officers behaviour, the (idea) is that we'll see an increase in overall RP, and maturity of security. No more shooting fellow officers with Rubbers/IHDF because its 'funny'.

Secondly. It gives Lawyers a thing to do.

If for some reason; an officer is acting like an absolute cocknocker and decides to negligently, or maliciously discharge his firearm in an improper fashion - this can lead to actual reasoning, reasoning that /cannot be discounted at face value/, to get a court case going - or even involve CC at a certain level; this, while seemingly tedious - somewhat gives power and importance back to Lawyers themselves.

Thirdly. It gives Staff an even easier time weeding out LRP shitters.

I've said it. It does; by giving security the means to potentially overesculate - it allows Staff to clearly see who's more likely to jump to mechanics first. I, myself; as a security player /do not like killing people./ I do not like wounding them, or taking them out of the round for any reason. I think it kills roleplay.

Sure, mechanics will still happen - but in our current state of antag VS security balance, it gives security some power back - while still giving them the /optional/ ability to take nonlethals from the armory lathe lategame.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Read reasons above.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Security are armed almost exclusively with non-lethals roundstart; while still retaining the ability to print nonlethals as neccessary.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
