### PR TITLE
[NONMODULAR] Adds a manual override to firelocks

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -78,12 +78,14 @@
 	. = ..()
 	INVOKE_ASYNC(src, .proc/latetoggle)
 
-/obj/machinery/door/firedoor/attack_hand(mob/user, list/modifiers)
+/obj/machinery/door/firedoor/attack_hand(mob/living/user, list/modifiers) //SKYRAT EDIT - ORIGINAL "mob/user" w/o 'living'
 	. = ..()
 	if(.)
 		return
 	if(operating || !density)
 		return
+	if(!user.combat_mode && try_manual_override(user)) // SKYRAT EDIT - MANUAL FIRELOCKS
+		return // SKYRAT EDIT - MANUAL FIRELOCKS
 	user.changeNext_move(CLICK_CD_MELEE)
 
 	user.visible_message("<span class='notice'>[user] bangs on \the [src].</span>", \
@@ -132,6 +134,7 @@
 
 /obj/machinery/door/firedoor/try_to_crowbar(obj/item/I, mob/user)
 	if(welded || operating)
+		to_chat(user, "<span class='warning'>[src] refuses to budge!</span>") // SKYRAT EDIT ADDITION - Makes flavour text apparent, manual override
 		return
 
 	if(density)
@@ -210,7 +213,15 @@
 		if(FIREDOOR_CLOSED)
 			nextstate = null
 			close()
-
+// SKYRAT EDIT BEGIN - MANUAL FIRELOCK OVERRIDE
+/obj/machinery/door/proc/try_manual_override(mob/user)
+	if(density)
+		to_chat(user, "<span class='notice'>You begin working the manual override mechanism...</span>")
+		if(do_after(user, 15 SECONDS, target = src))
+			try_to_crowbar(null, user)
+			return TRUE
+	return FALSE
+// SKYRAT EDIT END - MANUAL FIRELOCK OVERRIDE
 /obj/machinery/door/firedoor/border_only
 	icon = 'icons/obj/doors/edge_Doorfire.dmi'
 	can_crush = FALSE

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -137,7 +137,6 @@
 		new /obj/item/tank/internals/emergency_oxygen(src)
 	//SKYRAT EDIT END
 	new /obj/item/oxygen_candle(src) //SKYRAT EDIT ADDITION
-	new /obj/item/crowbar/red(src) //SKYRAT EDIT ADDITION
 
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
 		new /obj/item/flashlight/flare(src)

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -137,6 +137,7 @@
 		new /obj/item/tank/internals/emergency_oxygen(src)
 	//SKYRAT EDIT END
 	new /obj/item/oxygen_candle(src) //SKYRAT EDIT ADDITION
+	new /obj/item/crowbar/red(src) //SKYRAT EDIT ADDITION
 
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
 		new /obj/item/flashlight/flare(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title says it all.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Icebox.

But seriously, being trapped behind a firelock because of depressurization sucks, and as scummy as NT is lore-wise, they probably wouldn't skimp on a really cheap way to prevent deaths. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: After repeated incidents on their "Icebox" line of standardized research stations, NanoTrasen has added a manual override lever to their emergency shutter designs!
add: Added flavour text when attempting to crowbar (or manual override) a welded firelock.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
