### PR TITLE
[SEMI-MODULAR] Makes firelocks manually openable

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -78,7 +78,7 @@
 	. = ..()
 	INVOKE_ASYNC(src, .proc/latetoggle)
 
-/obj/machinery/door/firedoor/attack_hand(mob/user, list/modifiers)
+/* /obj/machinery/door/firedoor/attack_hand(mob/user, list/modifiers)
 	. = ..()
 	if(.)
 		return
@@ -88,7 +88,7 @@
 
 	user.visible_message("<span class='notice'>[user] bangs on \the [src].</span>", \
 		"<span class='notice'>You bang on \the [src].</span>")
-	playsound(loc, 'sound/effects/glassknock.ogg', 10, FALSE, frequency = 32000)
+	playsound(loc, 'sound/effects/glassknock.ogg', 10, FALSE, frequency = 32000) */ // SKYRAT EDIT CHANGE - MOVED TO modular_skyrat\master_files\game\machinery\doors\firedoor.dm
 
 /obj/machinery/door/firedoor/attackby(obj/item/C, mob/user, params)
 	add_fingerprint(user)

--- a/modular_skyrat/master_files/code/game/machinery/doors/firedoor.dm
+++ b/modular_skyrat/master_files/code/game/machinery/doors/firedoor.dm
@@ -1,0 +1,31 @@
+/obj/machinery/door/firedoor/attack_hand(mob/living/user, list/modifiers)
+	. = ..()
+	if(.)
+		return
+	if(operating || !density)
+		return
+	if(!user.combat_mode && try_manual_override(user))
+		return
+	user.changeNext_move(CLICK_CD_MELEE)
+
+	user.visible_message("<span class='notice'>[user] bangs on \the [src].</span>", \
+		"<span class='notice'>You bang on \the [src].</span>")
+	playsound(loc, 'sound/effects/glassknock.ogg', 10, FALSE, frequency = 32000)
+
+/obj/machinery/door/proc/try_manual_override(mob/user)
+	if(density)
+		to_chat(user, "<span class='notice'>You begin working the manual override mechanism...</span>")
+		if(do_after(user, 15 SECONDS, target = src))
+			try_to_crowbar(null, user)
+			return TRUE
+	return FALSE
+
+/obj/machinery/door/firedoor/try_to_crowbar(obj/item/I, mob/user)
+	if(welded || operating)
+		to_chat(user, "<span class='warning'>[src] refuses to budge!</span>")
+		return
+
+	if(density)
+		open()
+	else
+		close()

--- a/modular_skyrat/master_files/readme.md
+++ b/modular_skyrat/master_files/readme.md
@@ -23,6 +23,8 @@ MASTER CODE FILES
 - /master_files/code/game/objects/structures/trash_pile.dm
 - /master_files/code/modules/mob/living/carbon/carbon_say.dm
 - /master_files/code/modules/mob/living/emote_popup.dm
+- /master_files/code/game/machinery/doors/firedoor.dm
+
 MASTER GLOBAL VARS
 - modular_skyrat/master_files/code/_globalvars/configuration.dm > GLOBAL_VAR_INIT(looc_allowed, TRUE)
 

--- a/modular_skyrat/modules/aesthetics/firedoor/code/firedoor.dm
+++ b/modular_skyrat/modules/aesthetics/firedoor/code/firedoor.dm
@@ -1,13 +1,13 @@
 /obj/machinery/door/firedoor
 	name = "Emergency Shutter"
-	desc = "Emergency air-tight shutter, capable of sealing off breached areas. This one has a glass panel."
+	desc = "Emergency air-tight shutter, capable of sealing off breached areas. This one has a glass panel. It has a mechanism to open it with just your hands."
 	icon = 'modular_skyrat/modules/aesthetics/firedoor/icons/firedoor_glass.dmi'
 	var/door_open_sound = 'modular_skyrat/modules/aesthetics/firedoor/sound/firedoor_open.ogg'
 	var/door_close_sound = 'modular_skyrat/modules/aesthetics/firedoor/sound/firedoor_open.ogg'
 
 /obj/machinery/door/firedoor/heavy
 	name = "Heavy Emergency Shutter"
-	desc = "Emergency air-tight shutter, capable of sealing off breached areas."
+	desc = "Emergency air-tight shutter, capable of sealing off breached areas. It has a mechanism to open it with just your hands."
 	icon = 'modular_skyrat/modules/aesthetics/firedoor/icons/firedoor.dmi'
 
 /obj/structure/firelock_frame

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3505,6 +3505,7 @@
 #include "modular_skyrat\master_files\code\datums\traits\good.dm"
 #include "modular_skyrat\master_files\code\datums\traits\negative.dm"
 #include "modular_skyrat\master_files\code\datums\traits\neutral.dm"
+#include "modular_skyrat\master_files\code\game\machinery\doors\firedoor.dm"
 #include "modular_skyrat\master_files\code\game\objects\ghost_role_spawners.dm"
 #include "modular_skyrat\master_files\code\game\objects\items\hhmirror.dm"
 #include "modular_skyrat\master_files\code\game\objects\items\oxygen_candle.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title says it all.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Icebox.

But seriously, being trapped behind a firelock because of depressurization sucks, and as scummy as NT is lore-wise, they probably wouldn't skimp on a really cheap way to prevent deaths. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: After repeated incidents on their "Icebox" line of standardized research stations, NanoTrasen has added a manual override lever to their emergency shutter designs!
add: Added flavour text when attempting to crowbar (or manual override) a welded firelock.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->