### PR TITLE
[MODULAR] Fixes distro and scrubber pipes being connected by a layer adaptor on deltastation (prob speedmerge?)

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -49536,9 +49536,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "cfE" = (
@@ -49546,8 +49543,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -104393,8 +104390,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -111120,6 +111117,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"wfr" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "wfN" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -137328,7 +137337,7 @@ cat
 cbX
 ckD
 cfE
-chx
+wfr
 cjh
 cjn
 xyr

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -40047,7 +40047,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/science/mixing)
 "bKe" = (
@@ -82579,9 +82581,6 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/science/mixing)
 "dCd" = (
@@ -82591,7 +82590,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
@@ -83632,9 +83631,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/science/mixing)
 "dEu" = (
@@ -101158,6 +101154,14 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/maintenance/solars/port/fore)
+"kdO" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "key" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -105442,6 +105446,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"pyy" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "pzj" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -107604,22 +107614,10 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "rYw" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/iron/white,
 /area/science/mixing)
 "rYU" = (
 /obj/structure/disposalpipe/segment,
@@ -144838,7 +144836,7 @@ dxR
 dzv
 dAy
 dCc
-rYw
+dzv
 dEs
 bKc
 bKF
@@ -145095,9 +145093,9 @@ tew
 dtl
 dtl
 dCd
-dDq
-dDq
-dDq
+rYw
+pyy
+kdO
 dDq
 dIx
 dJW


### PR DESCRIPTION
## About The Pull Request

With the thermomachine update, there have been some map changes. On deltastation in engineering there's a layer adaptor connecting the distro and scrubber pipes together and the same in toxins

## Why It's Good For The Game

Because a plasmaflood in one area will probably plasmaflood the whole station lmao

![uh oh](https://cdn.discordapp.com/attachments/610319166062460934/824864792338235402/unknown.png)
![stinky](https://cdn.discordapp.com/attachments/610319166062460934/824865635406053396/unknown.png)
![ree](https://i.imgur.com/ebYuRYs.png)
![REE](https://i.imgur.com/7PbCR4q.png)
## Changelog
:cl:
fix: Fixed two layer adaptors connecting distro and waste together on Deltastation
/:cl: