### PR TITLE
[MODULAR] Buffs ghosts

### DIFF
--- a/modular_skyrat/modules/verbs/code/modules/mob/subtle.dm
+++ b/modular_skyrat/modules/verbs/code/modules/mob/subtle.dm
@@ -110,9 +110,9 @@
 	message = "<b>[user]</b> " + "<i>[user.say_emphasis(message)]</i>"
 
 	if(emote_type == EMOTE_AUDIBLE)
-		user.audible_message_subtler(message=message,hearing_distance=1, ignored_mobs = GLOB.dead_mob_list)
+		user.audible_message_subtler(message=message,hearing_distance=1)
 	else
-		user.visible_message(message=message,self_message=message,vision_distance=1, ignored_mobs = GLOB.dead_mob_list)
+		user.visible_message(message=message,self_message=message,vision_distance=1)
 
 ///////////////// VERB CODE
 /mob/living/proc/subtle_keybind()


### PR DESCRIPTION
## About The Pull Request

Subtler no longer hides the contents from ghosts

## Why It's Good For The Game

Being able to obscure your actions from even a scrying orb is immensly unbalanced.

## Changelog
:cl:
add: Adds the ability for ghosts to see subtler visible emotes
add: Adds the ability for ghosts to see subtler audible emotes
del: Removes the piece of code that prevented that
qol: Made spectating on funny actions easier
balance: Buffs scrying orbs
fix: Fixed ghost vision not showing every emote
spellcheck: Fixed a typo in this PR
code: Changed subtle.dm
refactor: subtle.dm is now approximatlely 0.69 percent shorter
config: No
admin: Messed with admins
server: Alienated half of the playerbase
/:cl:
