### PR TITLE
[MODULAR] Lets cargo purchase exodrone fuel for a 'steep' price.

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -242,6 +242,15 @@
 	crate_name = "dance machine crate"
 */
 
+/datum/supply_pack/misc/fuel_pellets
+	name = "ExoDrone Fuel Crate"
+	desc = "Atmos on fire, and you still really wanna explore the stars? We've got you covered, for the fuel atleast."
+	cost = CARGO_CRATE_VALUE * 15
+	contains = list(/obj/item/fuel_pellet,
+					/obj/item/fuel_pellet,
+					/obj/item/fuel_pellet)
+	crate_name = "drone fuel crate"
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Food Stuff //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## About The Pull Request
Lets cargo buy exodrone fuel, for a 'steep' (price is naturally very negotiable, I put in comparison to other 'job' crates) price, so the feature isn't dead in the water without atmos.


## Why It's Good For The Game
stops a new feature from being roadblocked by 0 atmos techs, or even worse, 0 engineers. 
(for comparison, the entirety of toxins has zero actual reliance on atmos) 
(It requires 'in-depth' atmos stuff, and at the very least would be blocked by power-gaming rules to make it in cargo.)
(Atmos techs can still mass produce, and produce the much more usable fuels, this is the low-tier stuff.)

## Changelog
:cl:
add: Cargo can now properly order fuel for their exo-drones, at a 'steep' price.
/:cl: