### PR TITLE
Probably fixes synthlizards killing themselves over their own tails

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic.dm
@@ -126,3 +126,20 @@
 	if(BMS)
 		markings = assemble_body_markings_from_set(BMS, passed_features, src)
 	return markings
+
+/datum/species/robotic/synthliz/on_species_gain(mob/living/carbon/owner, datum/species/old_species, pref_load)
+	var/real_tail_type = owner.dna.features["tail_lizard"]
+	var/real_spines = owner.dna.features["spines"]
+
+	. = ..()
+
+	if(pref_load)
+		owner.dna.features["tail_lizard"] = real_tail_type
+		owner.dna.features["spines"] = real_spines
+
+		var/obj/item/organ/tail/lizard/new_tail = new /obj/item/organ/tail/lizard()
+
+		new_tail.tail_type = owner.dna.features["tail_lizard"]
+		new_tail.spines = owner.dna.features["spines"]
+
+		new_tail.Insert(owner, TRUE, FALSE)


### PR DESCRIPTION
## About The Pull Request

This should fix the negative moodlet for synthlizards for having the wrong tail. I haven't tested it because it's 2am and I just want to get this PR posted so that someone in the comments can tell me how to do it better while I go to bed.

## Why It's Good For The Game

bug fix
fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/4287

## Changelog
:cl:
fix: Synthlizards no longer get a negative moodlet from their own tail.
/:cl: