### PR TITLE
Brings TC back down to 30

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -78,7 +78,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge,list(/datum/eldritch_knowledge/spell/ba
 
 /// How many telecrystals a normal traitor starts with
 //#define TELECRYSTALS_DEFAULT 20 //ORIGINAL
-#define TELECRYSTALS_DEFAULT 45 //SKYRAT EDIT CHANGE - ORIGINAL: 20
+#define TELECRYSTALS_DEFAULT 30 //SKYRAT EDIT CHANGE - ORIGINAL: 20
 /// How many telecrystals mapper/admin only "precharged" uplink implant
 #define TELECRYSTALS_PRELOADED_IMPLANT 10
 /// The normal cost of an uplink implant; used for calcuating how many


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I disagree with it being any higher, especially with the state of our community and the amount of antags we're having. The point of higher amount of TC was so traitors can still afford a firearm while getting stuff for their gimmicks, or so they extra TC to fallback on in case they get stuff confiscated. 45 TC allows people to turn themselves into ultimate killing machines, and it's quite tempting to do so, so say no more

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Traitors now get 30 TC in the uplink
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
