### PR TITLE
Makes self-surgery a skillchip (TBA)

### DIFF
--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -15,3 +15,7 @@
 
 // Trait sources
 #define GHOSTROLE_TRAIT "ghostrole" // SKYRAT EDIT ADDITION -- Ghost Cafe Traits
+
+// Skillchip traits
+///The trait needed to perform BASIC surgery
+#define TRAIT_BASIC_SURGEON "basic_surgeon"

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -48,7 +48,7 @@
 	suit_store = /obj/item/flashlight/pen/paramedic
 	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1, /obj/item/modular_computer/tablet/preset/advanced/command=1)
 
-	skillchips = list(/obj/item/skillchip/entrails_reader, /obj/item/skillchip/quickercarry)
+	skillchips = list(/obj/item/skillchip/entrails_reader, /obj/item/skillchip/quickercarry, /obj/item/skillchip/surgery) //SKYRAT EDIT CHANGE
 
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -38,7 +38,7 @@
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival/medical
 
-	skillchips = list(/obj/item/skillchip/entrails_reader, /obj/item/skillchip/quickcarry)
+	skillchips = list(/obj/item/skillchip/entrails_reader, /obj/item/skillchip/quickcarry, /obj/item/skillchip/surgery) //SKYRAT EDIT CHANGE
 
 	chameleon_extras = /obj/item/gun/syringe
 

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -41,6 +41,6 @@
 
 	pda_slot = ITEM_SLOT_LPOCKET
 
-	skillchips = list(/obj/item/skillchip/job/roboticist)
+	skillchips = list(/obj/item/skillchip/job/roboticist, /obj/item/skillchip/surgery) //SKYRAT EDIT CHANGE
 
 	id_trim = /datum/id_trim/job/roboticist

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -57,8 +57,10 @@
 		else
 			return TRUE
 
+	/* SKYRAT EDIT REMOVAL
 	if(!requires_tech && !replaced_by)
 		return TRUE
+	*/
 
 	if(requires_tech)
 		. = FALSE
@@ -71,6 +73,17 @@
 				return FALSE
 			if(type in SP.advanced_surgeries)
 				return TRUE
+
+	//SKRYAT EDIT ADDITION START
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		//This is the trait given to doctors and surgeons alike.
+		if(!(HAS_TRAIT(H, TRAIT_BASIC_SURGEON)) && !(HAS_TRAIT(H.mind, TRAIT_BASIC_SURGEON)) && !H.mind.has_antag_datum(/datum/antagonist, TRUE))
+			if(!is_species(H, /datum/species/robotic))
+				return FALSE
+			else if(location != BODY_ZONE_CHEST) //Synths can perform operatiosn on their
+				return FALSE
+	//SKRYAT EDIT END
 
 	var/turf/T = get_turf(patient)
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -83,6 +83,10 @@
 				return FALSE
 			else if(location != BODY_ZONE_CHEST || !(user == patient))
 				return FALSE
+
+	if(!requires_tech && !replaced_by)
+		return TRUE
+
 	//SKRYAT EDIT END
 
 	var/turf/T = get_turf(patient)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -81,7 +81,7 @@
 		if(!(HAS_TRAIT(H, TRAIT_BASIC_SURGEON)) && !(HAS_TRAIT(H.mind, TRAIT_BASIC_SURGEON)) && !H.mind.has_antag_datum(/datum/antagonist, TRUE))
 			if(!is_species(H, /datum/species/robotic))
 				return FALSE
-			else if(location != BODY_ZONE_CHEST) //Synths can perform operatiosn on their
+			else if(location != BODY_ZONE_CHEST || !(user == patient))
 				return FALSE
 	//SKRYAT EDIT END
 

--- a/modular_skyrat/modules/sec_haul/code/security_medic/security_medic.dm
+++ b/modular_skyrat/modules/sec_haul/code/security_medic/security_medic.dm
@@ -50,6 +50,8 @@
 
 	implants = list(/obj/item/implant/mindshield)
 
+	skillchips = list(/obj/item/skillchip/surgery)
+
 	id_trim = /datum/id_trim/job/security_medic
 
 /obj/effect/landmark/start/security_medic

--- a/modular_skyrat/modules/surgery_skillchip/code/surgery_skillchip.dm
+++ b/modular_skyrat/modules/surgery_skillchip/code/surgery_skillchip.dm
@@ -1,0 +1,10 @@
+/obj/item/skillchip/surgery
+	name = "SUR-GER-Y skillchip"
+	desc = "This biochip allows the user to perform advanced surgical operations by stabilizing their motor control neural signals."
+	skill_name = "Surgery"
+	skill_description = "Advanced surgery techniques all on a chip, brillaint. You can now perform flawless surgery, provided you use a table."
+	skill_icon = "sitemap"
+	activate_message = "<span class='notice'>You feel your hand movements stifen up as they become more precise.</span>"
+	deactivate_message = "<span class='notice'>Your hand movements become less precise.</span>"
+	auto_traits = list(TRAIT_BASIC_SURGEON)
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4105,6 +4105,7 @@
 #include "modular_skyrat\modules\specborg\code\game\objects\items\cyborg_items.dm"
 #include "modular_skyrat\modules\specborg\code\modules\living\sillicon\robot\robot_module.dm"
 #include "modular_skyrat\modules\ssd_indicator\code\mob.dm"
+#include "modular_skyrat\modules\surgery_skillchip\code\surgery_skillchip.dm"
 #include "modular_skyrat\modules\tableflip\code\flipped_table.dm"
 #include "modular_skyrat\modules\tagline\code\world.dm"
 #include "modular_skyrat\modules\turretid\code\turret_id_system.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

# This is TBA until I get host confirmation

This makes almost all self-surgeries require the TRAIT_BASIC_SURGEON to start, if you don't have this trait then it falls back onto backup checks.

Synthetics can perform self-surgeries on their own chests for self repair.

All antagonists are able to perform basic self-surgeries.

This was made on host request.

## Changelog
:cl:
balance: Self-surgeries is now a skillchip and is given to certain jobs such as the medical doctor, CMO and security medic.
balance: Antagonists can perform basic self-surgeries.
balance: Synthetics can only perform self-surgery on their chest.
/:cl:

