### PR TITLE
[NON-MODULAR] Disables Space Adaptation

### DIFF
--- a/code/datums/mutations/space_adaptation.dm
+++ b/code/datums/mutations/space_adaptation.dm
@@ -7,6 +7,7 @@
 	text_gain_indication = "<span class='notice'>Your body feels warm!</span>"
 	time_coeff = 5
 	instability = 30
+	locked = TRUE //SKYRAT EDIT ADDITION
 
 /datum/mutation/human/space_adaptation/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Speculative fix and formal proposal to remove the space adaptation mutation. Disables it in the same way as x-ray vision, laser eyes, etc.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Just like x-ray/thermal, there's been many many instances of non-antagonists, especially security, getting this mutation and then using it to their advantage. The ability to operate in space is something that is supposed to be carefully controlled and limited. Traitors and changelings pay full price for space-proofing, the entire security department should not get it for free. There's no sense in such a large portion of the station taking an ability that just removes the whole "space" aspect of being on a space station, and doing it nearly every round. In addition, space adaptation totally negates several effects it should not, such as pressure changes from not-space, and almost completely counteracts chemicals like Frost Oil and Hercuri. Like most of the other genetics goodies, it was never intended to be so widely given out, and it exists to benefit unassisted antagonists such as revs and blood brothers, who are reliant on their department's late game items, not an uplink. We do not have those game modes, and don't need the items and abilities intended for them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
config: Locked space adaptation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
