### PR TITLE
Rebalances CME's to give loot

### DIFF
--- a/modular_skyrat/modules/cme/code/_cme_defines.dm
+++ b/modular_skyrat/modules/cme/code/_cme_defines.dm
@@ -2,6 +2,16 @@
 //CME DEFINES FILE!
 ///////////////////////
 
+GLOBAL_LIST_INIT(cme_loot_list, list(
+	/obj/item/stack/sheet/bluespace_crystal = 30,
+	/obj/item/stack/sheet/mineral/diamond = 20,
+	/obj/item/stack/sheet/mineral/plasma = 50,
+	/obj/item/stack/sheet/mineral/gold = 80,
+	/obj/item/raw_anomaly_core/random = 10,
+	/obj/item/relic = 40))
+
+/obj/item/strange
+
 #define CME_RANDOM "random"
 #define CME_MINIMAL "minimal"
 #define CME_MODERATE "moderate"
@@ -15,43 +25,43 @@
 #define CME_MINIMAL_LIGHT_RANGE_UPPER 10 //The highest range for the emp pulse light range.
 #define CME_MINIMAL_HEAVY_RANGE_LOWER 5 //The lowest range for the emp pulse heavy range.
 #define CME_MINIMAL_HEAVY_RANGE_UPPER 7 //The highest range for the emp pulse heavy range.
-#define CME_MINIMAL_FREQUENCY_LOWER 25 / 0.5 //The lower time range for cme bubbles to appear.
-#define CME_MINIMAL_FREQUENCY_UPPER 30 / 0.5 //The higher time range for cme bubbles to appear.
+#define CME_MINIMAL_FREQUENCY_LOWER 25 * 0.5 //The lower time range for cme bubbles to appear.
+#define CME_MINIMAL_FREQUENCY_UPPER 30 * 0.5 //The higher time range for cme bubbles to appear.
 #define CME_MINIMAL_BUBBLE_BURST_TIME 40 SECONDS //The time taken for a cme bubble to pop.
-#define CME_MINIMAL_START_LOWER 120 / 0.5 //The lowest amount of time for the event to start from the announcement. - Prep time
-#define CME_MINIMAL_START_UPPER 180 / 0.5 //The highest amount of time for the event to start from the announcement. - Prep time
-#define CME_MINIMAL_END 240 / 0.5 //The amount of time starting from THE MINIMAL START TIME for the event to end. - How long it actually lasts.
+#define CME_MINIMAL_START_LOWER 120 * 0.5 //The lowest amount of time for the event to start from the announcement. - Prep time
+#define CME_MINIMAL_START_UPPER 180 * 0.5 //The highest amount of time for the event to start from the announcement. - Prep time
+#define CME_MINIMAL_END 240 * 0.5 //The amount of time starting from THE MINIMAL START TIME for the event to end. - How long it actually lasts.
 
 #define CME_MODERATE_LIGHT_RANGE_LOWER 10
 #define CME_MODERATE_LIGHT_RANGE_UPPER 15
 #define CME_MODERATE_HEAVY_RANGE_LOWER 7
 #define CME_MODERATE_HEAVY_RANGE_UPPER 10
-#define CME_MODERATE_FREQUENCY_LOWER 20 / 0.5
-#define CME_MODERATE_FREQUENCY_UPPER 25 / 0.5
+#define CME_MODERATE_FREQUENCY_LOWER 20 * 0.5
+#define CME_MODERATE_FREQUENCY_UPPER 25 * 0.5
 #define CME_MODERATE_BUBBLE_BURST_TIME 30 SECONDS
-#define CME_MODERATE_START_LOWER 120 / 0.5
-#define CME_MODERATE_START_UPPER 180 / 0.5
-#define CME_MODERATE_END 240 / 0.5
+#define CME_MODERATE_START_LOWER 120 * 0.5
+#define CME_MODERATE_START_UPPER 180 * 0.5
+#define CME_MODERATE_END 240 * 0.5
 
 
 #define CME_EXTREME_LIGHT_RANGE_LOWER 15
 #define CME_EXTREME_LIGHT_RANGE_UPPER 20
 #define CME_EXTREME_HEAVY_RANGE_LOWER 10
 #define CME_EXTREME_HEAVY_RANGE_UPPER 13
-#define CME_EXTREME_FREQUENCY_LOWER 15 / 0.5
-#define CME_EXTREME_FREQUENCY_UPPER 20 / 0.5
+#define CME_EXTREME_FREQUENCY_LOWER 15 * 0.5
+#define CME_EXTREME_FREQUENCY_UPPER 20 * 0.5
 #define CME_EXTREME_BUBBLE_BURST_TIME 20 SECONDS
-#define CME_EXTREME_START_LOWER 60 / 0.5
-#define CME_EXTREME_START_UPPER 120 / 0.5
-#define CME_EXTREME_END 300 / 0.5
+#define CME_EXTREME_START_LOWER 60 * 0.5
+#define CME_EXTREME_START_UPPER 120 * 0.5
+#define CME_EXTREME_END 300 * 0.5
 
 #define CME_ARMAGEDDON_LIGHT_RANGE_LOWER 25
 #define CME_ARMAGEDDON_LIGHT_RANGE_UPPER 30
 #define CME_ARMAGEDDON_HEAVY_RANGE_LOWER 20
 #define CME_ARMAGEDDON_HEAVY_RANGE_UPPER 25
-#define CME_ARMAGEDDON_FREQUENCY_LOWER 5 / 0.5
-#define CME_ARMAGEDDON_FREQUENCY_UPPER 7 / 0.5
+#define CME_ARMAGEDDON_FREQUENCY_LOWER 5 * 0.5
+#define CME_ARMAGEDDON_FREQUENCY_UPPER 7 * 0.5
 #define CME_ARMAGEDDON_BUBBLE_BURST_TIME 10 SECONDS
-#define CME_ARMAGEDDON_START_LOWER 60 / 0.5
-#define CME_ARMAGEDDON_START_UPPER 70 / 0.5
-#define CME_ARMAGEDDON_END 600 / 0.5
+#define CME_ARMAGEDDON_START_LOWER 60 * 0.5
+#define CME_ARMAGEDDON_START_UPPER 70 * 0.5
+#define CME_ARMAGEDDON_END 600 * 0.5

--- a/modular_skyrat/modules/cme/code/cme.dm
+++ b/modular_skyrat/modules/cme/code/cme.dm
@@ -15,7 +15,7 @@ Armageddon is truly going to fuck the station, use it sparingly.
 /datum/round_event_control/cme
 	name = "Coronal Mass Ejection: Minimal"
 	typepath = /datum/round_event/cme
-	weight = 10
+	weight = 0
 	min_players = 30
 	max_occurrences = 3
 	earliest_start = 25 MINUTES

--- a/modular_skyrat/modules/cme/code/cme.dm
+++ b/modular_skyrat/modules/cme/code/cme.dm
@@ -275,6 +275,8 @@ Armageddon is truly going to fuck the station, use it sparingly.
 	color = COLOR_WHITE
 	light_color = COLOR_WHITE
 	neutralized = TRUE
+	var/atom/movable/loot = pickweight(GLOB.cme_loot_list)
+	new loot(loc)
 
 /obj/effect/cme/extreme/anomalyNeutralize()
 	playsound(src,'sound/weapons/resonator_blast.ogg',100,TRUE)
@@ -285,6 +287,8 @@ Armageddon is truly going to fuck the station, use it sparingly.
 	color = COLOR_WHITE
 	light_color = COLOR_WHITE
 	neutralized = TRUE
+	var/atom/movable/loot = pickweight(GLOB.cme_loot_list)
+	new loot(loc)
 
 /obj/effect/cme/armageddon/anomalyNeutralize()
 	playsound(src,'sound/weapons/resonator_blast.ogg',100,TRUE)
@@ -295,3 +299,5 @@ Armageddon is truly going to fuck the station, use it sparingly.
 	color = COLOR_WHITE
 	light_color = COLOR_WHITE
 	neutralized = TRUE
+	var/atom/movable/loot = pickweight(GLOB.cme_loot_list)
+	new loot(loc)


### PR DESCRIPTION
:cl:
fix: Fixes CME define maths causing them to last for double the time they were meant to.
balance: Reduced the amount of time CME's last.
balance: Reduced the chance for CME's to spawn.
balance: CME's now drop a random loot item when neutralized.
balance: CME's no longer spawn a fire when neutralized, unless they're extreme.
/:cl:

Loot list:
`GLOBAL_LIST_INIT(cme_loot_list, list(
	/obj/item/stack/sheet/bluespace_crystal = 30,
	/obj/item/stack/sheet/mineral/diamond = 20,
	/obj/item/stack/sheet/mineral/plasma = 50,
	/obj/item/stack/sheet/mineral/gold = 80,
	/obj/item/raw_anomaly_core/random = 10,
	/obj/item/relic = 40))`

The above numbers correspond to spawn chance using the weight system.

Normal CME's spawn 1 loot item, extreme CME's spawn 2 when neutralized.

Rip my GBP.