### PR TITLE
Reverts #4474

### DIFF
--- a/code/datums/mutations/space_adaptation.dm
+++ b/code/datums/mutations/space_adaptation.dm
@@ -6,8 +6,8 @@
 	difficulty = 16
 	text_gain_indication = "<span class='notice'>Your body feels warm!</span>"
 	time_coeff = 5
-	instability = 30
-	locked = TRUE //SKYRAT EDIT ADDITION
+	instability = 60
+	locked = FALSE //SKYRAT EDIT ADDITION
 
 /datum/mutation/human/space_adaptation/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
 	..()


### PR DESCRIPTION

## About The Pull Request

Reverts the pull request #4474, re-adding Space Adaptation to the genetics pool.

## Why It's Good For The Game

_oh boy here we fucking go again._

Y'know what people always say? Improve, don't remove.

Yeah well clearly coders don't want to go by that. You just removed an incredibly beneficial mutation for "powergaming". Do you even UNDERSTAND what powergaming is anymore? The entirety of XENOBIOLOGY, TOXINS, ROBOTICS, NANITES; IMPLANTS, PROSTHETICS, That's "fine", but somehow SPACE ADAPTATION is "POWEGAMING"?

Yeah! No! Fuck that! You clearly don't know what's balanced and what isn't balanced. Space adapt protects you from pressure and cold; you are still fucked by most of atmospherics, and fucked over by heat. Space adpation is also fucking essential for most antagonist; blob, space dragon, loud traitors; hell, basically every antag can fuck over the atmosphere in a few clicks. Unless you want the entire fucking server getting shitstomped every time a blob or derg shows up, this was a horrible change.

Oh, yeah, by the way, I fucking nerfed it too. It now cause 70 instability. That enough?

## Changelog
:cl:
add: Space Adaptation is back.
balance: Space Adaptation causes more instability.

/:cl:
