### PR TITLE
[MODULAR] Clarifies exploration fuel crates name.

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -243,7 +243,7 @@
 */
 
 /datum/supply_pack/misc/fuel_pellets
-	name = "ExoDrone Fuel Crate"
+	name = "Exploration Drone Fuel Crate"
 	desc = "Atmos on fire, and you still really wanna explore the stars? We've got you covered, for the fuel atleast."
 	cost = CARGO_CRATE_VALUE * 15
 	contains = list(/obj/item/fuel_pellet,


### PR DESCRIPTION

## About The Pull Request
I'm bad at names.
## Why It's Good For The Game
no more "which crate has the fuel in it"
## Changelog
:cl:
qol: The exploration drones fuel crate is now properly titled.
/:cl: