### PR TITLE
[Semi-modular] Robotic species rebalancing ,  changeling stings no longer affect robotic species

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -49,6 +49,10 @@
 		return
 	if(!get_path_to(user, target, max_distance = changeling.sting_range, simulated_only = FALSE))
 		return
+	var/mob/living/carbon/human/to_check = target
+	if(to_check.mob_biotypes & MOB_ROBOTIC)
+		to_chat(user, "<span class='warning'>Our sting would have no effect on robotic entities</span>")
+		return
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/changeling))
 		sting_feedback(user, target)
 		changeling.chem_charges -= chemical_cost

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -49,10 +49,10 @@
 		return
 	if(!get_path_to(user, target, max_distance = changeling.sting_range, simulated_only = FALSE))
 		return
-	var/mob/living/carbon/human/to_check = target
+	var/mob/living/carbon/human/to_check = target // SKYRAT EDIT START - STINGS DO NOT AFFECT ROBOTIC ENTITIES
 	if(to_check.mob_biotypes & MOB_ROBOTIC)
 		to_chat(user, "<span class='warning'>Our sting would have no effect on robotic entities</span>")
-		return
+		return // SKYRAT EDIT END
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/changeling))
 		sting_feedback(user, target)
 		changeling.chem_charges -= chemical_cost

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic.dm
@@ -7,10 +7,8 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	reagent_flags = PROCESS_SYNTHETIC
 	coldmod = 0.5
-	burnmod = 1.1
-	heatmod = 1.2
-	brutemod = 1.1
-	siemens_coeff = 1.2 //Not more because some shocks will outright crit you, which is very unfun
+	heatmod = 2
+	siemens_coeff = 1.4 //Not more because some shocks will outright crit you, which is very unfun
 	species_language_holder = /datum/language_holder/machine
 	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
 	mutantbrain = /obj/item/organ/brain/ipc_positron

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic.dm
@@ -7,7 +7,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	reagent_flags = PROCESS_SYNTHETIC
 	coldmod = 0.5
-	heatmod = 2
+	heatmod = 3
 	siemens_coeff = 1.4 //Not more because some shocks will outright crit you, which is very unfun
 	species_language_holder = /datum/language_holder/machine
 	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)


### PR DESCRIPTION
## About The Pull Request
Robotic species no longer take 10% extra burn and brute.
Robotic species damage from heat increased by 180% (1.2 > 3)
Robotic species damage from electrocution increase by 20% (1.2 > 1.4)
Changeling stings no longer affect robots
## Why It's Good For The Game
10% extra burn and brute was a debuff that barely did anything for IPC's , it barely added any damage when triggered. Focusing on the more robot specific aspects is much better and lets people be more creative.  Using fire on a IPC now will toast them much more faster than a human , and you can even electrocute them 40% deadlier than a normal human.
Also changeling are biological horrors , biological stings shouldn't affect robots, also fixes them being able to DNA Sting robots.
## Changelog
:cl:
balance:  Robotic species no longer take 10% extra burn and brute
balance:  Robotic species take 180% more damage from heat (1.2 > 3)
balance:  Robotic species take 20% more damage from electrocution (1.2 > 1.4)
balance:  Changelings can no longer blind/mute/arm sting robotic species
fix: Changelings being able to obtain robotic DNA
/:cl:
