### PR TITLE
[NON-MODULAR] Changes to Cargo's Drone activity

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1336,8 +1336,8 @@
 	icon_state = "science"
 	build_path = /obj/machinery/exoscanner
 	req_components = list(
-		/obj/item/stock_parts/micro_laser = 4,
-		/obj/item/stock_parts/scanning_module = 4)
+		/obj/item/stock_parts/micro_laser = 1, // SKYRAT EDIT - (Original 4)
+		/obj/item/stock_parts/scanning_module = 1) // SKYRAT EDIT - (Original 4) Due to requiring many of these and cargos option being autolathe for parts, the grind adds up quick
 
 /obj/item/circuitboard/machine/exodrone_launcher
 	name = "Exploration Drone Launcher (Machine Board)"

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -313,6 +313,7 @@
 	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/computer/exoscanner_console
 	category = list("Computer Boards")
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO //SKYRAT EDIT - Stops people not from cargo stealing their side activity
 
 /datum/design/board/exodrone_console
 	name = "Computer Design (Exploration Drone Control Console)"
@@ -321,3 +322,4 @@
 	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/computer/exodrone_console
 	category = list("Computer Boards")
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO //SKYRAT EDIT - Stops people not from cargo stealing their side activity


### PR DESCRIPTION
## About The Pull Request

This PR brings to change the parts required to build the arrays and who can print the boards due to this being cargo's new and.. really only other side activity other than ERP. Preventing people from messing with their 

## Why It's Good For The Game

Having the boards being able to be printed at other departments that control both the drones and the scanners isn't exactly fun when the entire side activity is meant for one person.

I've also dropped the parts required for the arrays down to one due to the fact cargo is heavily reliant on the autolathe for the parts which can become very _very_ tedious due to how slow it is to print from the autolathe. Plus four required making 8 parts in total is stupidly nuts

## Changelog
:cl:
qol: Dropped the parts required to build the Scanner Array to one, only needing two in total to build one
balance: Changed it so Cargo is the only one able to print the new drone stuff
/:cl: