### PR TITLE
[NON-MODULAR] ""removes"" """"""LRP"""""" words from the code

### DIFF
--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -160,7 +160,7 @@
 
 /obj/item/banner/cargo
 	name = "cargoslavia banner"
-	desc = "The banner of the newly formed Cargoslavia, with the mystical power of conjuring any object into existence."
+	desc = "The banner of the newly formed station-state of Cargoslavia, with the mystical power of conjuring any object into existence."
 	icon_state = "banner_cargo"
 	inhand_icon_state = "banner_cargo"
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
@@ -175,7 +175,7 @@
 	inspiration_available = FALSE
 
 /datum/crafting_recipe/cargo_banner
-	name = "Carslavia Banner"
+	name = "Cargoslavia Banner"
 	result = /obj/item/banner/cargo/mundane
 	time = 40
 	reqs = list(/obj/item/stack/rods = 2,

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -159,13 +159,13 @@
 	category = CAT_MISC
 
 /obj/item/banner/cargo
-	name = "cargonia banner"
-	desc = "The banner of the eternal Cargonia, with the mystical power of conjuring any object into existence."
+	name = "cargoslavia banner"
+	desc = "The banner of the newly formed Cargoslavia, with the mystical power of conjuring any object into existence."
 	icon_state = "banner_cargo"
 	inhand_icon_state = "banner_cargo"
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
-	warcry = "Hail Cargonia!"
+	warcry = "Glory to Cargoslavia!!"
 
 /obj/item/banner/cargo/Initialize()
 	. = ..()
@@ -175,7 +175,7 @@
 	inspiration_available = FALSE
 
 /datum/crafting_recipe/cargo_banner
-	name = "Cargonia Banner"
+	name = "Carslavia Banner"
 	result = /obj/item/banner/cargo/mundane
 	time = 40
 	reqs = list(/obj/item/stack/rods = 2,

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -159,7 +159,7 @@
 	category = CAT_MISC
 
 /obj/item/banner/cargo
-	name = "cargoslavia banner"
+	name = "cargoslavia banner"                 ////SKYRAT EDIT START
 	desc = "The banner of the newly formed station-state of Cargoslavia, with the mystical power of conjuring any object into existence."
 	icon_state = "banner_cargo"
 	inhand_icon_state = "banner_cargo"
@@ -175,7 +175,7 @@
 	inspiration_available = FALSE
 
 /datum/crafting_recipe/cargo_banner
-	name = "Cargoslavia Banner"
+	name = "Cargoslavia Banner"                 ////SKYRAT EDIT END
 	result = /obj/item/banner/cargo/mundane
 	time = 40
 	reqs = list(/obj/item/stack/rods = 2,


### PR DESCRIPTION
## About The Pull Request

This PR switches out the names of Cargonia for Cargoslavia.

## Why It's Good For The Game

i can't fucking say cargonia IC so let's go with the option everyone says it's okay

## Changelog
:cl:
tweak: After Central Command, with the support of Nanotrasen, banned Cargonia as a movement, the Free Trade Union's workers have been starting to use the newly-formed state of Cargoslavia as a term.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
