### PR TITLE
[NONMODULAR] "Fixes" (removes) hypnoflash and Hypnogrenade.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1472,6 +1472,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/ai_module/syndicate
 	cost = 9
 
+//SKYRAT EDIT REMOVAL BEGIN - Remove Hypnostuff
+/*
 /datum/uplink_item/device_tools/hypnotic_flash
 	name = "Hypnotic Flash"
 	desc = "A modified flash able to hypnotize targets. If the target is not in a mentally vulnerable state, it will only confuse and pacify them temporarily."
@@ -1483,6 +1485,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A modified flashbang grenade able to hypnotize targets. The sound portion of the flashbang causes hallucinations, and will allow the flash to induce a hypnotic trance to viewers."
 	item = /obj/item/grenade/hypnotic
 	cost = 12
+*/
+//SKYRAT EDIT REMOVAL END - Remove Hypnostuff
 
 /datum/uplink_item/device_tools/medgun
 	name = "Medbeam Gun"


### PR DESCRIPTION
## About The Pull Request

Hypnoflash and hypno grenades seem to be broken, I can't get them to work in singleplayer and some players can't get them to work live. So rather than allow people to waste their TC on them and THINK they work, removing them is the better solution.

## Why It's Good For The Game

Hypnoflash and hypno grenade removed from traitor uplink. They appear to be inoperative at this time.

## Changelog
:cl:
fix: Disables purchasing of hypno flash and hypno grenade.
/:cl: