### PR TITLE
[MODULAR] Fixes/Changes Heretic Crafting

### DIFF
--- a/modular_skyrat/modules/antagonists/eldritch_cult/knowledge/ash_lore_skyrat.dm
+++ b/modular_skyrat/modules/antagonists/eldritch_cult/knowledge/ash_lore_skyrat.dm
@@ -1,0 +1,9 @@
+
+/datum/eldritch_knowledge/summon/ashy
+	name = "Ashen Ritual"
+	gain_text = "I combined my principle of hunger with my desire for destruction. And the Nightwatcher knew my name."
+	desc = "You can now summon an Ash Man by transmutating a pile of ash, a stomach, and a book."
+	cost = 1
+	required_atoms = list(/obj/effect/decal/cleanable/ash,/obj/item/organ/stomach,/obj/item/book)
+	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/ash_spirit
+	next_knowledge = list(/datum/eldritch_knowledge/summon/stalker,/datum/eldritch_knowledge/spell/flame_birth)

--- a/modular_skyrat/modules/antagonists/eldritch_cult/knowledge/ash_lore_skyrat.dm
+++ b/modular_skyrat/modules/antagonists/eldritch_cult/knowledge/ash_lore_skyrat.dm
@@ -7,4 +7,3 @@
 	required_atoms = list(/obj/effect/decal/cleanable/ash,/obj/item/organ/stomach,/obj/item/book)
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/ash_spirit
 	next_knowledge = list(/datum/eldritch_knowledge/summon/stalker,/datum/eldritch_knowledge/spell/flame_birth)
-    

--- a/modular_skyrat/modules/antagonists/eldritch_cult/knowledge/ash_lore_skyrat.dm
+++ b/modular_skyrat/modules/antagonists/eldritch_cult/knowledge/ash_lore_skyrat.dm
@@ -7,3 +7,4 @@
 	required_atoms = list(/obj/effect/decal/cleanable/ash,/obj/item/organ/stomach,/obj/item/book)
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/ash_spirit
 	next_knowledge = list(/datum/eldritch_knowledge/summon/stalker,/datum/eldritch_knowledge/spell/flame_birth)
+    

--- a/modular_skyrat/modules/antagonists/eldritch_cult/knowledge/flesh_lore_skyrat.dm
+++ b/modular_skyrat/modules/antagonists/eldritch_cult/knowledge/flesh_lore_skyrat.dm
@@ -1,0 +1,8 @@
+/datum/eldritch_knowledge/summon/rusty
+	name = "Rusted Ritual"
+	gain_text = "I combined my principle of hunger with my desire for corruption. And the Rusted Hills called my name."
+	desc = "You can now summon a Rust Walker by transmutating a vomit pool, a pair of lungs, and a book."
+	cost = 1
+	required_atoms = list(/obj/effect/decal/cleanable/vomit,/obj/item/book,/obj/item/organ/lungs)
+	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/rust_spirit
+	next_knowledge = list(/datum/eldritch_knowledge/spell/voidpull,/datum/eldritch_knowledge/spell/entropic_plume)

--- a/modular_skyrat/modules/antagonists/eldritch_cult/knowledge/flesh_lore_skyrat.dm
+++ b/modular_skyrat/modules/antagonists/eldritch_cult/knowledge/flesh_lore_skyrat.dm
@@ -6,3 +6,4 @@
 	required_atoms = list(/obj/effect/decal/cleanable/vomit,/obj/item/book,/obj/item/organ/lungs)
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/rust_spirit
 	next_knowledge = list(/datum/eldritch_knowledge/spell/voidpull,/datum/eldritch_knowledge/spell/entropic_plume)
+    

--- a/modular_skyrat/modules/antagonists/eldritch_cult/knowledge/flesh_lore_skyrat.dm
+++ b/modular_skyrat/modules/antagonists/eldritch_cult/knowledge/flesh_lore_skyrat.dm
@@ -6,4 +6,3 @@
 	required_atoms = list(/obj/effect/decal/cleanable/vomit,/obj/item/book,/obj/item/organ/lungs)
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/rust_spirit
 	next_knowledge = list(/datum/eldritch_knowledge/spell/voidpull,/datum/eldritch_knowledge/spell/entropic_plume)
-    

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3645,6 +3645,8 @@
 #include "modular_skyrat\modules\ambitions\code\mind.dm"
 #include "modular_skyrat\modules\antagonists\code\gamemodes.dm"
 #include "modular_skyrat\modules\antagonists\code\gang_things.dm"
+#include "modular_skyrat\modules\antagonists\eldritch_cult\knowledge\ash_lore_skyrat.dm"
+#include "modular_skyrat\modules\antagonists\eldritch_cult\knowledge\flesh_lore_skyrat.dm"
 #include "modular_skyrat\modules\ashwalkers\Ashwalker\Ashwalkers.dm"
 #include "modular_skyrat\modules\assaultops\code\_assaultops_defines.dm"
 #include "modular_skyrat\modules\assaultops\code\areas.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rust Walkers - Now created by transmutating a vomit pool, a pair of lungs, and a book. 
Ash Men - Now created by transmutating a pile of ash, a stomach, and a book.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

So, two heretic items used to require heads, meaning that you could RR by converting the full head into a mob. Additionally, one of the crafting recipes was broken, and required a borg rather than a head? (Which is what both the wiki and the in-game description said you needed) 

Either way, less Round Removal and actually functioning items is good, and this shouldn't stop the required lethality of a heretic, while opening other avenues to aquire these gristly crafting materials.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Heretics can finally summon Ash Men, as the Eldritch Powers that grant them their power accidentally messed up the recipe.
balance: Those crafty Heretics have gone eco-friendly, and are now creating Ash Men and Rust Walkers with stomachs and lungs respectively, rather than heads.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
