### PR TITLE
[MODULAR] Fixes security sergeants and junior officers having no quirk restriction

### DIFF
--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -44,6 +44,12 @@
 /datum/job/warden
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 
+/datum/job/security_sergeant
+	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
+
+/datum/job/junior_officer
+	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
+
 /datum/job/blueshield
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

They shouldn't be able to have any of the restricted quirks.

## Changelog
:cl:
fix: Fixes sec sergeants and junior officers not being quirk locked
/:cl: