### PR TITLE
[MODULAR] Updates quirk blacklist, RDS and tongue tied people can no longer be on the security team.

### DIFF
--- a/code/__DEFINES/~skyrat_defines/jobs.dm
+++ b/code/__DEFINES/~skyrat_defines/jobs.dm
@@ -1,5 +1,5 @@
 #define JOB_UNAVAILABLE_QUIRK 6
 #define JOB_UNAVAILABLE_SPECIES 7
 
-#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Blood Deficiency" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE
+#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Blood Deficiency" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Tongue Tied" = TRUE, "Reality Dissociation Syndrome" = TRUE
 #define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

_Nanotrasen has upped their game and are investing more to better screen their security team! They now perform tests for "Reality Dissociation Syndrome" and speech! Those who fail the tests are no longer allowed onto the force._ 


Tongue tied and RDS are now on the quirk blacklist for security.

## Why It's Good For The Game

It doesn't make sense to hire those who would go completely crazy if off their meds for a bit, nor does it make sense to hire people who can't speak over comms should stuff get tight.

## Changelog
:cl:
fix: Tongue tied and RDS quirks are now blacklisted from security.
/:cl: