### PR TITLE
[NONMODULAR] [READY] Fixes Xeno hat being invisible on muzzled people

### DIFF
--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -247,6 +247,7 @@
 	name = "xenos helmet"
 	icon_state = "xenos"
 	inhand_icon_state = "xenos_helm"
+	mutant_variants = NONE //SKYRAT EDIT ADDITION
 	desc = "A helmet made out of chitinous alien hide."
 	clothing_flags = SNUG_FIT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

![image](https://user-images.githubusercontent.com/26744576/113375453-03b9f380-9335-11eb-837c-17821c8a8b3e.png)

~~It's still a little buggy, I can't determine why it won't hide the hair, will try to determine the cause tomorrow or give up and slap that ready button.~~

I couldn't figure it out

## Why It's Good For The Game

I want to be a discount xeno

## Changelog
:cl:
fix: Xenohat no longer invisible on muzzled characters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
