### PR TITLE
Balances Colossus

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -8,10 +8,9 @@
  *
  *The colossus' true danger lies in its ranged capabilities. It fires immensely damaging death bolts that penetrate all armor in a variety of ways:
  *A. The colossus fires death bolts in alternating patterns: the cardinal directions and the diagonal directions.
- *B. The colossus fires death bolts in a shotgun-like pattern, instantly downing anything unfortunate enough to be hit by all of them.
- *C. The colossus fires a spiral of death bolts.
+ *B. The colossus fires a spiral of death bolts.
  *At 33% health, the colossus gains an additional attack:
- *D. The colossus fires two spirals of death bolts, spinning in opposite directions.
+ *C. The colossus fires two spirals of death bolts, spinning in opposite directions.
  *
  *When a colossus dies, it leaves behind a chunk of glowing crystal known as a black box. Anything placed inside will carry over into future rounds.
  *For instance, you could place a bag of holding into the black box, and then kill another colossus next round and retrieve the bag of holding from inside.
@@ -53,7 +52,6 @@
 	deathsound = 'sound/magic/demon_dies.ogg'
 	attack_action_types = list(/datum/action/innate/megafauna_attack/spiral_attack,
 							   /datum/action/innate/megafauna_attack/aoe_attack,
-							   /datum/action/innate/megafauna_attack/shotgun,
 							   /datum/action/innate/megafauna_attack/alternating_cardinals)
 	small_sprite_type = /datum/action/small_sprite/megafauna/colossus
 
@@ -75,19 +73,12 @@
 	chosen_message = "<span class='colossus'>You are now firing in all directions.</span>"
 	chosen_attack_num = 2
 
-/datum/action/innate/megafauna_attack/shotgun
-	name = "Shotgun Fire"
-	icon_icon = 'icons/obj/guns/ballistic.dmi'
-	button_icon_state = "shotgun"
-	chosen_message = "<span class='colossus'>You are now firing shotgun shots where you aim.</span>"
-	chosen_attack_num = 3
-
 /datum/action/innate/megafauna_attack/alternating_cardinals
 	name = "Alternating Shots"
 	icon_icon = 'icons/obj/guns/ballistic.dmi'
 	button_icon_state = "pistol"
 	chosen_message = "<span class='colossus'>You are now firing in alternating cardinal directions.</span>"
-	chosen_attack_num = 4
+	chosen_attack_num = 3
 
 /mob/living/simple_animal/hostile/megafauna/colossus/OpenFire()
 	anger_modifier = clamp(((maxHealth - health)/50),0,20)
@@ -100,8 +91,6 @@
 			if(2)
 				random_shots()
 			if(3)
-				blast()
-			if(4)
 				alternating_dir_shots()
 		return
 
@@ -195,18 +184,6 @@
 	for(var/T in RANGE_TURFS(12, U) - U)
 		if(prob(5))
 			shoot_projectile(T)
-
-/mob/living/simple_animal/hostile/megafauna/colossus/proc/blast(set_angle)
-	ranged_cooldown = world.time + 20
-	var/turf/target_turf = get_turf(target)
-	playsound(src, 'sound/magic/clockwork/invoke_general.ogg', 200, TRUE, 2)
-	newtonian_move(get_dir(target_turf, src))
-	var/angle_to_target = Get_Angle(src, target_turf)
-	if(isnum(set_angle))
-		angle_to_target = set_angle
-	var/static/list/colossus_shotgun_shot_angles = list(12.5, 7.5, 2.5, -2.5, -7.5, -12.5)
-	for(var/i in colossus_shotgun_shot_angles)
-		shoot_projectile(target_turf, angle_to_target + i)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/dir_shots(list/dirs)
 	if(!islist(dirs))


### PR DESCRIPTION
## About The Pull Request

Removes the colossus's shotgun attack, whilst keeping all the other attacks.

## Why It's Good For The Game

An instant crit is not fun. It makes crusher runs nearly impossible unless you get good RNG with the attacks, and makes KA runs much harder unless you have range mods and nothing else - even then, still easy to get killed. Megafauna should be hard, yes, but not instant-critical hard - plus, since brute translates into stam now, getting hit by even 2 or 3 bolts can severely slow you down, easy pickings for yet ANOTHER shotgun blast. You might say "get robust" and the likes, but no matter how robust you are, an instant crit will still fuck you over - old tasers and batons are a good example of this. No matter how challenging a megafauna should be, it should never be "one hit kill" level challenging. No megafauna, not even the Wendigo, is capable of this,

## Changelog
:cl:
del: Removed shotgun blast from colossus attack pool.
balance: Colossus is now challenging without having an instant critical attack.

/:cl: