### PR TITLE
[MODULAR] Egun Crafting Fix

### DIFF
--- a/modular_skyrat/modules/crafting/recipes_skyrat.dm
+++ b/modular_skyrat/modules/crafting/recipes_skyrat.dm
@@ -1,0 +1,109 @@
+//So I don't know if this was an oversight or a balance issue, but none of these guns can be made without these changes.
+/datum/crafting_recipe/advancedegun
+	name = "Advanced Energy Gun"
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	result = /obj/item/gun/energy/e_gun/nuclear
+	reqs = list(/obj/item/gun/energy/laser/hitscan = 1,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/weaponcrafting/gunkit/nuclear = 1)
+	time = 200
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
+/datum/crafting_recipe/advancedegun/New()
+	..()
+	blacklist += subtypesof(/obj/item/gun/energy/laser/hitscan)
+
+/datum/crafting_recipe/tempgun
+	name = "Temperature Gun"
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	result = /obj/item/gun/energy/temperature
+	reqs = list(/obj/item/gun/energy/laser/hitscan = 1,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/weaponcrafting/gunkit/temperature = 1)
+	time = 200
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
+/datum/crafting_recipe/tempgun/New()
+	..()
+	blacklist += subtypesof(/obj/item/gun/energy/laser/hitscan)
+
+/datum/crafting_recipe/beam_rifle
+	name = "Particle Acceleration Rifle"
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	result = /obj/item/gun/energy/beam_rifle
+	reqs = list(/obj/item/gun/energy/laser/hitscan = 1,
+				/obj/item/assembly/signaler/anomaly/flux = 1,
+				/obj/item/assembly/signaler/anomaly/grav = 1,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/weaponcrafting/gunkit/beam_rifle = 1)
+	time = 200
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+    
+/datum/crafting_recipe/beam_rifle/New()
+	..()
+	blacklist += subtypesof(/obj/item/gun/energy/laser/hitscan)
+
+/datum/crafting_recipe/xraylaser
+	name = "X-ray Laser Gun"
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	result = /obj/item/gun/energy/xray
+	reqs = list(/obj/item/gun/energy/laser/hitscan = 1,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/weaponcrafting/gunkit/xray = 1)
+	time = 200
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
+/datum/crafting_recipe/xraylaser/New()
+	..()
+	blacklist += subtypesof(/obj/item/gun/energy/laser/hitscan)
+
+/datum/crafting_recipe/hellgun
+	name = "Hellfire Laser Gun"
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	result = /obj/item/gun/energy/laser/hellgun
+	reqs = list(/obj/item/gun/energy/laser/hitscan = 1,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/weaponcrafting/gunkit/hellgun = 1)
+	time = 200
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
+/datum/crafting_recipe/hellgun/New()
+	..()
+	blacklist += subtypesof(/obj/item/gun/energy/laser/hitscan)
+
+/datum/crafting_recipe/ioncarbine
+	name = "Ion Carbine"
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	result = /obj/item/gun/energy/ionrifle/carbine
+	reqs = list(/obj/item/gun/energy/laser/hitscan = 1,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/weaponcrafting/gunkit/ion = 1)
+	time = 200
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
+/datum/crafting_recipe/ioncarbine/New()
+	..()
+	blacklist += subtypesof(/obj/item/gun/energy/laser/hitscan)
+
+/datum/crafting_recipe/decloner
+	name = "Biological Demolecularisor"
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	result = /obj/item/gun/energy/decloner
+	reqs = list(/obj/item/gun/energy/laser/hitscan = 1,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/weaponcrafting/gunkit/decloner = 1,
+				/datum/reagent/baldium = 30,
+				/datum/reagent/toxin/mutagen = 40)
+	time = 200
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
+/datum/crafting_recipe/decloner/New()
+	..()
+	blacklist += subtypesof(/obj/item/gun/energy/laser/hitscan)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3701,6 +3701,7 @@
 #include "modular_skyrat\modules\cme\code\_cme_defines.dm"
 #include "modular_skyrat\modules\cme\code\cme.dm"
 #include "modular_skyrat\modules\combat_indicator\code\combat_indicator.dm"
+#include "modular_skyrat\modules\crafting\recipes_skyrat.dm"
 #include "modular_skyrat\modules\cryosleep\code\ai.dm"
 #include "modular_skyrat\modules\cryosleep\code\area.dm"
 #include "modular_skyrat\modules\cryosleep\code\config.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Yeah so, the E-guns that you're supposed to craft the super-specialized firearms with can't be acquired basically at all anymore, so I updated and modularized the crafting recipes to use what sec can get from energy tokens, the Armadyne Alistar SC-05 Laser Focus Rifle. 

<img width="280" alt="Gorble" src="https://user-images.githubusercontent.com/73589390/113463593-bd2bce00-93f4-11eb-91a7-dd73b656f282.PNG">

Shoutout to this homie who made the bug report https://github.com/Skyrat-SS13/Skyrat-tg/issues/4365
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We've got like 7 guns that can't be crafted due to an oversight. I don't like sec powercreep, but this is something they're supposed to have in the first place,.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Armadyne has received word of crafty Security Officers modifying the newer Laser Focus Rifles into specialized homebrew firearms, please be warned that this will void their warranty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
