### PR TITLE
Should fix Satchels and Duffels of holding being accessible to any protolathe

### DIFF
--- a/modular_skyrat/modules/holdingfashion_port/code/research/designs/bluespace_design.dm
+++ b/modular_skyrat/modules/holdingfashion_port/code/research/designs/bluespace_design.dm
@@ -7,7 +7,8 @@
 	build_path = /obj/item/satchel_of_holding_inert
 	category = list("Bluespace Designs")
 	dangerous_construction = TRUE
-
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	
 /datum/design/duffel_holding
 	name = "Inert Duffel Bag of Holding"
 	desc = "A block of metal ready to be transformed into a duffel bag of holding with a bluespace anomaly core."
@@ -17,3 +18,4 @@
 	build_path = /obj/item/duffel_of_holding_inert
 	category = list("Bluespace Designs")
 	dangerous_construction = TRUE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/4612
'Should' in the title covers my ass in case I've overlooked something major
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
feex
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Design schematics for Satchels and Dufflebags of holding have now been erased from all non-science protolathes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
