### PR TITLE
Fixes the dark spot in Ice Box's pool.

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
@@ -2522,6 +2522,10 @@
 	},
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"jg" = (
+/obj/machinery/light/floor,
+/turf/open/water/overlay/hotspring,
+/area/commons/fitness)
 "jk" = (
 /obj/machinery/computer/prisoner,
 /obj/effect/turf_decal/tile/red{
@@ -5257,6 +5261,18 @@
 "Hd" = (
 /turf/closed/wall/r_wall,
 /area/mine/laborcamp/security)
+"Hg" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "Hk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -43673,18 +43689,18 @@ ak
 ak
 ak
 aA
-Kp
+wk
 Mj
 IV
 IV
 IV
 IV
-IV
+jg
 IV
 IV
 IV
 kE
-sS
+Hg
 aA
 aA
 aA


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a few more lights to the Ice Box pool to get rid of the dark spot in the middle.

![Screenshot_202](https://user-images.githubusercontent.com/31294280/113490785-742e5500-949a-11eb-9ce4-f08e54206bcc.png)

## Why It's Good For The Game

Dark pools aren't very fun.

## Changelog
:cl:
fix: Adds a few lights to the Ice Box pool to get rid of the dark spot in the middle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
