### PR TITLE
[NON-MODULAR] Adds extra laces.

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -40,7 +40,7 @@
 	strip_delay = 5
 	equip_delay_other = 50
 	permeability_coefficient = 0.9
-	can_be_tied = FALSE
+	can_be_tied = TRUE //SKYRAT EDIT
 	species_exception = list(/datum/species/golem)
 
 /obj/item/clothing/shoes/sandal/marisa
@@ -145,7 +145,7 @@
 	resistance_flags = NONE
 	permeability_coefficient = 0.05 //Thick soles, and covers the ankle
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes
-	can_be_tied = FALSE
+	can_be_tied = TRUE //SKYRAT EDIT
 
 /obj/item/clothing/shoes/jackboots/fast
 	slowdown = -1
@@ -430,7 +430,7 @@
 	custom_price = PAYCHECK_EASY
 	var/list/occupants = list()
 	var/max_occupants = 4
-	can_be_tied = FALSE
+	can_be_tied = TRUE //SKYRAT EDIT
 
 /obj/item/clothing/shoes/cowboy/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This allows three types of shoes the possibility of become tied up.

## Why It's Good For The Game

Normally this wouldn't be an issue, but with our current load-out system you can just start with a pair of shoes that are just immune to that, and with talk of making it a wizard spell that seems like power-gaming. Jackboots already start with storage space they don't need to be even stronger. I left the shoes without laces that weren't in the load-out alone for the moment. Because at least you have to actually do something to get them.

## Changelog
:cl:
refactor: Changed important lace related variables.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
