### PR TITLE
[READY] You know what? Fuck you. *restricts your primaries*

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
@@ -193,10 +193,10 @@
 /obj/item/storage/box/gunset/pcr/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/pcr/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pcr/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pcr/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pcr/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pcr/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pcr/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pcr/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pcr/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pcr/(src)
 
 /obj/item/storage/box/gunset/norwind
 	name = "lg-2 norwind supply box"
@@ -207,10 +207,10 @@
 /obj/item/storage/box/gunset/norwind/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/norwind/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/norwind/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/norwind/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/norwind/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/norwind/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/norwind/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/norwind/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/norwind/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/norwind/(src)
 
 /obj/item/storage/box/gunset/ostwind
 	name = "ostwind supply box"
@@ -221,10 +221,10 @@
 /obj/item/storage/box/gunset/ostwind/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/ostwind/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/ostwind/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/ostwind/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/ostwind/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/ostwind/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/ostwind/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/ostwind/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/ostwind/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/ostwind/(src)
 
 /obj/item/storage/box/gunset/vintorez
 	name = "vintorez supply box"
@@ -235,10 +235,10 @@
 /obj/item/storage/box/gunset/vintorez/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/vintorez/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/vintorez/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/vintorez/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/vintorez/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/vintorez/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/vintorez/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/vintorez/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/vintorez/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/vintorez/(src)
 
 /obj/item/storage/box/gunset/pitbull
 	name = "pitbull supply box"
@@ -249,10 +249,10 @@
 /obj/item/storage/box/gunset/pitbull/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/pitbull/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pitbull/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pitbull/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pitbull/rubber(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pitbull/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pitbull/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pitbull/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pitbull/(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pitbull/(src)
 
 /////////////////
 //JOB SPECIFIC GUNSETS

--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
@@ -118,7 +118,7 @@
 	name = "primary armament holochip"
 	desc = "A holochip used in any armament vendor, this is for main arms. Do not bend."
 	icon_state = "token_primary"
-	minimum_sec_level = SEC_LEVEL_AMBER
+	minimum_sec_level = SEC_LEVEL_RED
 
 /obj/item/armament_token/primary/get_available_gunsets()
   return list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
# **Ok I haven't actually gotten a Verdict from Policy Commitee yet, but everyone seems to agree this is fine**
## About The Pull Request
Does what it says on the tin, primary supply boxes come with 4 mags of lethals, but are now restricted to red.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No one in security uses primaries with rubber rounds. Primaries are exclusively actually used against lethal threats.
*Yes* this may run the risk of encouraging lethal force, which is why they have been restricted to red alert once again.

All this PR effectively does is remove the unnecessary slowdown sec will experience when they have to unload their rubber rounds.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Armadyne has stopped distributing its military grade primary weapons with less-lethal rubber bullets. Accordingly, NanoTrasen has raised their restrictions to RED alert level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
