### PR TITLE
Fixes Secmedic quirks, removes RDS from sec restrictions

### DIFF
--- a/code/__DEFINES/~skyrat_defines/jobs.dm
+++ b/code/__DEFINES/~skyrat_defines/jobs.dm
@@ -1,5 +1,5 @@
 #define JOB_UNAVAILABLE_QUIRK 6
 #define JOB_UNAVAILABLE_SPECIES 7
 
-#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Blood Deficiency" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Reality Dissociation Syndrome" = TRUE
+#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Blood Deficiency" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE
 #define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE

--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -46,6 +46,9 @@
 
 /datum/job/security_sergeant
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
+	
+/datum/job/security_medic
+	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 
 /datum/job/junior_officer
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title

RDS is managable for an officer.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix and removal of unneccesary restrictions
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: NanoTrasen Corporate Security is now hiring those with Reality Disassociation Syndrome. You can thank the RDS Equality committee for that one.
fix: Security Medics are now held to the same recruitment standard as the rest of security.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
