### PR TITLE
Deltastation quick fix

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -1833,11 +1833,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/turnstile,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "aft" = (
@@ -16155,6 +16151,9 @@
 /obj/item/storage/fancy/egg_box,
 /obj/item/storage/fancy/egg_box,
 /obj/item/storage/fancy/egg_box,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "aPu" = (
@@ -18763,6 +18762,7 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/crowbar,
+/obj/item/plant_analyzer,
 /turf/open/floor/wood,
 /area/security/prison/safe)
 "aUD" = (
@@ -24805,9 +24805,15 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
-/obj/machinery/turnstile{
-	dir = 1;
-	req_one_access_txt = "2;63;81"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/security/brig)
@@ -51506,12 +51512,6 @@
 "cnp" = (
 /turf/open/floor/plating,
 /area/security/range)
-"cnq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/security/range)
 "cnr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -53186,13 +53186,6 @@
 	dir = 6
 	},
 /area/security/prison/safe)
-"crD" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/open/space,
-/area/space/nearstation)
 "crE" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -95488,6 +95481,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"emX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "ens" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -95700,6 +95703,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"evk" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "ewn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -95876,18 +95890,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/engineering/main)
-"eEF" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast door"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "eEX" = (
 /obj/machinery/light{
 	dir = 4
@@ -96954,12 +96956,15 @@
 	name = "Prison Blast door"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "gfu" = (
 /obj/structure/table,
-/obj/item/camera,
-/obj/item/storage/photo_album/prison,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "gfW" = (
@@ -97019,6 +97024,17 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
 /area/engineering/main)
+"ggA" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/range)
 "ghB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -97742,8 +97758,13 @@
 /area/hallway/primary/central/aft)
 "gYn" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/arrows/red,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "gZj" = (
@@ -98238,6 +98259,12 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
+"hCX" = (
+/obj/structure/table/wood/poker,
+/obj/item/storage/photo_album/prison,
+/obj/item/camera,
+/turf/open/floor/wood,
+/area/security/prison)
 "hDy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -98541,6 +98568,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"hWJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/range)
 "hWK" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/micro_laser{
@@ -98629,10 +98663,14 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/turnstile{
-	dir = 1;
-	req_one_access_txt = "2;63;81"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/security/prison)
 "hZA" = (
@@ -99340,16 +99378,21 @@
 /obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"iIL" = (
-/obj/machinery/light/small{
+"iIY" = (
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Gear Room";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/security/range)
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "iJh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -99851,7 +99894,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "jiF" = (
-/obj/effect/turf_decal/arrows/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "jjh" = (
@@ -100221,19 +100269,16 @@
 /turf/open/floor/iron/checker,
 /area/engineering/main)
 "jzM" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
+/obj/structure/cable,
+/obj/machinery/turnstile{
+	dir = 1;
+	req_one_access_txt = "2;63;81"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "jzO" = (
@@ -100720,13 +100765,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
+/obj/machinery/turnstile,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "kqX" = (
@@ -101025,7 +101064,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
-/obj/effect/landmark/start/junior_officer,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "kJc" = (
@@ -101037,6 +101075,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"kJl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/gun_vendor,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "kLu" = (
 /obj/structure/table,
 /obj/item/raw_anomaly_core/random{
@@ -101202,6 +101250,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"kXr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "kXx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -101591,19 +101645,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/lab)
-"lpF" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
-/area/space)
 "lpW" = (
 /obj/structure/window{
 	dir = 4
@@ -101794,20 +101835,6 @@
 	},
 /turf/open/floor/glass,
 /area/maintenance/space_hut/observatory)
-"lAA" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/janitorialcart{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
-/area/space)
 "lAQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -102093,31 +102120,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"lUe" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/washing_machine,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/machinery/camera{
-	c_tag = " Prison - Janitorial";
-	network = list("ss13","prison")
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
-/area/space)
 "lUo" = (
 /obj/machinery/camera{
 	c_tag = "Security - Brig Fore";
@@ -102311,22 +102313,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
-"mbl" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/landmark/start/junior_officer,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "mbB" = (
@@ -102527,18 +102513,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"mpy" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/washing_machine,
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
-/area/space)
 "mrd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -103313,6 +103287,15 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/primary/central/aft)
+"npZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "nqS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
@@ -103706,6 +103689,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
+"nLY" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/machinery/status_display/ai{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "nMo" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -103800,6 +103791,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engineering/main)
+"nSd" = (
+/obj/machinery/light,
+/obj/structure/table,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "nSh" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/closed/wall/r_wall,
@@ -104307,23 +104303,6 @@
 	},
 /turf/open/floor/iron,
 /area/medical/morgue)
-"oDY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
-/area/space)
 "oEw" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue{
@@ -104951,20 +104930,6 @@
 	icon_state = "wood-broken5"
 	},
 /area/security/prison)
-"pmJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
-/area/space)
 "pmQ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -105195,12 +105160,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/space/basic,
 /area/space/nearstation)
-"pDg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "pDi" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -105213,25 +105172,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"pED" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 12;
-	pixel_y = -6
-	},
-/obj/structure/sign/poster/contraband/lusty_xenomorph{
-	pixel_x = 32
-	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
-/area/space)
 "pEQ" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -106146,30 +106086,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"qxP" = (
-/obj/structure/rack,
-/obj/item/storage/box/lights/mixed,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/item/clothing/gloves/color/blue,
-/obj/item/caution,
-/obj/item/caution,
-/obj/item/caution,
-/obj/item/caution,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/mop,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/item/storage/bag/trash,
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
-/area/space)
 "qxX" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
@@ -106434,20 +106350,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/range)
-"qTq" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/item/reagent_containers/hypospray/medipen,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
-/area/space)
 "qTK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -106991,15 +106893,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"rxZ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "ryf" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -108010,7 +107903,12 @@
 /area/maintenance/port/aft)
 "sym" = (
 /obj/structure/cable,
-/obj/machinery/gun_vendor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "syn" = (
@@ -108185,21 +108083,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plating,
 /area/security/prison)
-"sLo" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Gear Room";
-	req_access_txt = "63"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "sLr" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
@@ -109255,20 +109138,14 @@
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "tVs" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/turnstile{
+	dir = 1;
+	req_one_access_txt = "2;63;81"
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -109322,10 +109199,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison/safe)
-"tXz" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/security/range)
 "tYH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/cable,
@@ -109860,7 +109733,7 @@
 /area/ai_monitored/security/armory)
 "uDH" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/gun_vendor,
+/obj/machinery/vending/security_ammo,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "uEc" = (
@@ -111039,6 +110912,16 @@
 	},
 /turf/closed/wall,
 /area/engineering/atmos/upper)
+"vMz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "vNp" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -113441,13 +113324,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"yjH" = (
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
-/obj/machinery/light,
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "ykb" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
@@ -160656,9 +160532,9 @@ aaa
 aaa
 aaa
 aaa
-lAA
-oDY
-lpF
+aaa
+aaa
+aaa
 aaa
 aaa
 aad
@@ -160913,9 +160789,9 @@ aaa
 aaa
 aaa
 aaa
-lUe
-pmJ
-qTq
+aaa
+aaa
+aaa
 aaa
 aaa
 aad
@@ -161170,9 +161046,9 @@ aaa
 aaa
 aaa
 aaa
-mpy
-pED
-qxP
+aaa
+aaa
+aaa
 aaa
 aaa
 aad
@@ -164525,10 +164401,10 @@ sxA
 oqg
 gYn
 jzM
-eEF
-rxZ
+lIN
+wQB
 tVs
-pDg
+lnH
 rHT
 uzY
 ngh
@@ -164783,9 +164659,9 @@ mgz
 jiF
 hZl
 gfr
-wQB
+npZ
 bhb
-lTC
+emX
 pOt
 pOt
 pOt
@@ -164803,10 +164679,10 @@ urE
 ihP
 eqb
 xzq
-mbl
+eqb
 kHZ
-mbl
-mbl
+eqb
+eqb
 eqb
 eIn
 gfW
@@ -165069,8 +164945,8 @@ jDw
 ovp
 tns
 pHy
-ovp
-tns
+vMz
+evk
 gfg
 ckl
 uDH
@@ -165326,9 +165202,9 @@ bXI
 tvi
 bFP
 bFL
-sLo
-biy
 dlI
+iIY
+bgZ
 bgZ
 bgZ
 cno
@@ -165583,7 +165459,7 @@ wFV
 sTY
 lIw
 bFP
-tNj
+kJl
 sym
 kRm
 ykb
@@ -165843,7 +165719,7 @@ xvG
 tNj
 pOt
 iqZ
-cdD
+nSd
 bgZ
 nIq
 coS
@@ -166100,7 +165976,7 @@ bFP
 xZs
 xNU
 vfM
-jtC
+nLY
 bgZ
 bhZ
 coT
@@ -166357,9 +166233,9 @@ bLs
 jeN
 pOt
 vfM
-euT
-bgZ
-cnp
+jtC
+biy
+coW
 coW
 cnr
 clA
@@ -166614,11 +166490,11 @@ bLs
 rDl
 qKW
 vfM
-jtC
-biy
-cnq
-coU
-kXx
+uVi
+bgZ
+cnp
+cnp
+cnp
 clA
 aad
 cuL
@@ -166826,7 +166702,7 @@ uSW
 jjh
 aIf
 tKa
-aMj
+hCX
 aMj
 aKV
 aAc
@@ -166871,12 +166747,12 @@ xiN
 vjz
 pOt
 vfM
-uVi
-bgZ
-cnr
-pPH
-coW
-qTe
+jtC
+kXr
+hWJ
+coU
+kXx
+clA
 aaa
 cuL
 cwd
@@ -167128,12 +167004,12 @@ cds
 lIC
 nYF
 vfM
-jtC
-biy
-iIL
+cdD
+bgZ
+cnr
+pPH
 coW
-iPg
-cns
+qTe
 aad
 cuM
 cwd
@@ -167385,11 +167261,11 @@ bLs
 lTC
 pOt
 vfM
-yjH
-bgZ
-cns
-tXz
-cns
+lTC
+kXr
+ggA
+coW
+iPg
 cns
 aaa
 cuM
@@ -167642,12 +167518,12 @@ bLs
 jtC
 gFW
 jtC
-jtC
+euT
 bgZ
-aad
-aaa
-aaa
-crD
+cns
+cns
+cns
+cns
 aaa
 cuM
 cwf


### PR DESCRIPTION
Quick, last second changes to deltastation map PR:
![image](https://user-images.githubusercontent.com/43841046/113521740-54596880-9550-11eb-8d8c-42440ac38c87.png)
1. Removed the floating laundry room in space (oversight?)
2. Made the turnstile gate in the front match the prison's gates (can be reverted if needed)
3. Added a paper bin to the perma and moved the photo album to the gambling table
4. Added one (1) plant analyzer
5. Added three (3) tomatoes

![image](https://user-images.githubusercontent.com/43841046/113521796-9c788b00-9550-11eb-879a-4d2225e5d10e.png)
Locker room changes to allow for a clearer path: replaced two of the ten lockers (only 6 officers and 2 civil disputes officers can spawn at max) with tables.
Added a hand labeler so that sec can actually properly claim lockers
Moved the weapons vendor up one tile so that people don't need to stand in front of the door to get a gun