### PR TITLE
[NON-MODULAR] Blob can't delay the end of the round for an hour.

### DIFF
--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	color = blobstrain.complementary_color
 	if(blob_core)
 		blob_core.update_appearance()
-	SSshuttle.registerHostileEnvironment(src)
+	// SSshuttle.registerHostileEnvironment(src) SKYRAT EDIT removal
 	. = ..()
 	START_PROCESSING(SSobj, src)
 
@@ -202,7 +202,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	GLOB.overminds -= src
 	QDEL_LIST_ASSOC_VAL(strain_choices)
 
-	SSshuttle.clearHostileEnvironment(src)
+	// SSshuttle.clearHostileEnvironment(src) SKYRAT EDIT removal
 	STOP_PROCESSING(SSobj, src)
 
 	return ..()


### PR DESCRIPTION
Commented out both the set and clear for blob's hostile environment shuttle lock.
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is because we have blob victory set to a ridiculous 700 tiles, when the battle is pretty clearly decided somewhere around the 200 mark. This results in long drawn out stalemates that mostly result in administrators nuking the station or just ending the round. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If players are not having fun, their shuttle vote should be respected and the round should end a reasonable amount of time later, not make everyone wait for an hour.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Blob no longer holds up the round ending.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
