### PR TITLE
[SEMI-MODULAR] Fixes mutant bodyparts that share the hair color not updating from regenerative jelly exposure

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -52,9 +52,13 @@ There are several things that need to be remembered:
 /mob/living/carbon/human/update_hair()
 	dna.species.handle_hair(src)
 
+// SKYRAT EDIT REMOVAL - FIXING CUSTOMIZATION(?) (moved to modular)
+/*
 //used when putting/removing clothes that hide certain mutant body parts to just update those and not update the whole body.
 /mob/living/carbon/human/proc/update_mutant_bodyparts()
 	dna.species.handle_mutant_bodyparts(src)
+*/
+//SKYRAT EDIT REMOVAL END
 
 
 /mob/living/carbon/human/update_body()

--- a/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
@@ -52,6 +52,6 @@
 		H.reagents.remove_reagent(chem.type, REAGENTS_METABOLISM * delta_time)
 		return TRUE
 
-/datum/species/mush/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour)
+/datum/species/mush/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour, force_update = FALSE)
 	forced_colour = FALSE
 	..()

--- a/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
@@ -52,6 +52,6 @@
 		H.reagents.remove_reagent(chem.type, REAGENTS_METABOLISM * delta_time)
 		return TRUE
 
-/datum/species/mush/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour, force_update = FALSE)
+/datum/species/mush/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour, force_update = FALSE) //SKYRAT EDIT - ORIGINAL: /datum/species/mush/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour) (one parameter added)
 	forced_colour = FALSE
 	..()

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -116,9 +116,9 @@
 		return ..()
 
 
-/datum/species/synth/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour)
+/datum/species/synth/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour, force_update = FALSE)
 	if(fake_species)
-		fake_species.handle_mutant_bodyparts(H,forced_colour)
+		fake_species.handle_mutant_bodyparts(H,forced_colour, force_update)
 	else
 		return ..()
 

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -116,7 +116,7 @@
 		return ..()
 
 
-/datum/species/synth/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour, force_update = FALSE)
+/datum/species/synth/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour, force_update = FALSE) //SKYRAT EDIT - ORIGINAL: /datum/species/synth/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour) (one parameter added)
 	if(fake_species)
 		fake_species.handle_mutant_bodyparts(H,forced_colour, force_update)
 	else

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -946,6 +946,9 @@
 	exposed_human.hair_color = "C2F"
 	exposed_human.facial_hair_color = "C2F"
 	exposed_human.update_hair()
+	// SKYRAT EDIT ADDITION BEGIN
+	exposed_human.update_mutant_bodyparts(force_update=TRUE)
+	// SKYRAT EDIT END
 
 /datum/reagent/medicine/regen_jelly/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjustBruteLoss(-1.5 * REM * delta_time, 0)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_update_icons.dm
@@ -1,3 +1,7 @@
+//used when putting/removing clothes that hide certain mutant body parts to just update those and not update the whole body.
+/mob/living/carbon/human/proc/update_mutant_bodyparts(force_update=FALSE)
+	dna.species.handle_mutant_bodyparts(src, force_update = force_update)
+
 /mob/living/carbon/human/update_inv_w_uniform()
 	remove_overlay(UNIFORM_LAYER)
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -35,7 +35,7 @@ GLOBAL_LIST_EMPTY(customizable_races)
 	///Flavor text of the species displayed on character creation screeen
 	var/flavor_text = "No description."
 
-/datum/species/proc/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour)
+/datum/species/proc/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour, force_update = FALSE)
 	var/list/standing	= list()
 
 	var/obj/item/bodypart/head/HD = H.get_bodypart(BODY_ZONE_HEAD)
@@ -87,7 +87,7 @@ GLOBAL_LIST_EMPTY(customizable_races)
 		new_renderkey += "-[key]-[render_state]"
 		bodyparts_to_add[S] = render_state
 
-	if(new_renderkey == H.mutant_renderkey)
+	if(new_renderkey == H.mutant_renderkey && !force_update)
 		return
 	H.mutant_renderkey = new_renderkey
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes it so being exposed to regenerative jelly will now affect all bodyparts that are sharing their color with the hair of the character, instead of just the hair and facial hair.

Tested the changes on slimepeople and it still doesn't change their hair color, which means this is working how I intended it.

It also modularizes `update_mutant_bodyparts()` and adds an optional argument to dictate whether the update should be done regardless of the usual check for the bodypart difference to avoid useless overlay modifications, which means that more features changing mutant bodyparts in the future may benefit from this without having to do something more hacky.

I haven't tested the effects of this on anthro characters, but then again, most of the things already don't work on anthro characters.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is bad
![Pre-Regenerative-Jelly-Fix](https://user-images.githubusercontent.com/58045821/113525829-23dff180-9585-11eb-91df-56fe38131ce1.png)
This is good
![Post-Regenerative-Jelly-Fix](https://user-images.githubusercontent.com/58045821/113525833-2a6e6900-9585-11eb-9a28-f1f3dd79f034.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:GoldenAlpharex
fix: Regenerative jelly should now affect hair-related bodyparts.
code: Made handle_mutant_bodyparts() have an optional bypass argument to allow for ease of bodypart modifications in the future.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
