### PR TITLE
Makes the baton's description sound less damaging.

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_baton.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_baton.dm
@@ -1,6 +1,6 @@
 /obj/item/melee/classic_baton/peacekeeper
 	name = "nightstick"
-	desc = "A metal-plastic bat, looks like it would REALLY hurt."
+	desc = "A firm rubber truncheon, looks like it would knock the wind out of you."
 	icon = 'modular_skyrat/modules/sec_haul/icons/peacekeeper/peacekeeper_items.dmi'
 	icon_state = "peacekeeper_baton"
 	inhand_icon_state = "peacekeeper_baton"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the flavour text of the sec nightstick to call it a "firm rubber truncheon" as opposed to a "metal plastic bat," and that it would "knock the wind out of you" as opposed to "REALLY hurt."
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Flavour text good, "truncheon" is just fun to say, and the batons are no longer damage dealing, so it makes sense to stop saying it "really hurts"
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Changed up the baton's flavour text.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
