### PR TITLE
Makes cyborgs ACTUALLY PROPERLY linked to the AI this time

### DIFF
--- a/modular_skyrat/master_files/code/modules/jobs/job_types/cyborg.dm
+++ b/modular_skyrat/master_files/code/modules/jobs/job_types/cyborg.dm
@@ -5,4 +5,6 @@
 		if(AI.z == 3)
 			if(!(R.connected_ai))
 				R.set_connected_ai(AI)
+	R.lawsync()
 	R.show_laws()
+	


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
i made a fuckywucky
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: NanoTrasen's silicon network has been updated AS INTENDED THIS TIME. Cyborgs now share the laws of their linked AIs when being shipped to a station mid-shift
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
