### PR TITLE
Adds subtle and subtler to the local chat tab filter

### DIFF
--- a/modular_skyrat/modules/verbs/code/modules/mob/subtle.dm
+++ b/modular_skyrat/modules/verbs/code/modules/mob/subtle.dm
@@ -44,7 +44,7 @@
 
 	var/prefix_log_message = "(SUBTLE) [message]"
 	user.log_message(prefix_log_message, LOG_EMOTE)
-	message = "<b>[user]</b> " + "<i>[user.say_emphasis(message)]</i>"
+	message = "<span class='emote'><b>[user]</b> " + "<i>[user.say_emphasis(message)]</i></span>"
 
 	for(var/mob/M in GLOB.dead_mob_list)
 		if(!M.client || isnewplayer(M))
@@ -107,7 +107,7 @@
 		return FALSE
 
 	user.log_message(message, LOG_SUBTLER)
-	message = "<b>[user]</b> " + "<i>[user.say_emphasis(message)]</i>"
+	message = "<span class='emote'><b>[user]</b> " + "<i>[user.say_emphasis(message)]</i></span>"
 
 	if(emote_type == EMOTE_AUDIBLE)
 		user.audible_message_subtler(message=message,hearing_distance=1, ignored_mobs = GLOB.dead_mob_list)


### PR DESCRIPTION
## About The Pull Request

Adds subtle and subtler to the local chat filter. 
PS: the css class 'emote' doesn't do anything except be used in the chat filter for local, so it won't edit the formatting of the verbs.

## Why It's Good For The Game

Because it's annoying when I'm looking in local for an emote and it turns out it's actually a subtle emote in unsorted.

## Changelog
:cl:
tweak: Adds subtle and subtler to the local chat filter.
/:cl: