### PR TITLE
Sec locker room upgrade (Metastation)

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -3286,13 +3286,16 @@
 	},
 /area/security/prison)
 "ank" = (
-/obj/structure/lattice,
-/obj/machinery/camera/motion{
-	c_tag = "Armory External";
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron/dark,
+/area/security/office)
 "anl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -4288,27 +4291,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"arf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Armory";
-	req_access_txt = "3"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
 "arh" = (
 /obj/item/reagent_containers/glass/bottle/toxin{
 	pixel_x = 4;
@@ -4586,7 +4568,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -4599,21 +4584,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
-"ass" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -4667,17 +4637,14 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "asz" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 5
 	},
 /turf/open/floor/iron/dark,
@@ -6277,9 +6244,6 @@
 	req_access_txt = "3"
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -17555,6 +17519,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"bOH" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Secure Gear Storage";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/blue,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "bOL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -18408,6 +18388,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"bUK" = (
+/obj/machinery/suit_storage_unit/security_peacekeeper,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "bUL" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -27867,18 +27854,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"cQz" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Security - Gear Room";
-	dir = 8
-	},
-/obj/machinery/vending/wardrobe/peacekeeper_wardrobe,
-/obj/effect/turf_decal/bot_blue,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "cQJ" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
@@ -28550,21 +28525,22 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "cZk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Weapon Distribution";
-	req_access_txt = "3"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/item/paper,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/door/window/southleft{
-	name = "Requests Window"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "armory";
+	name = "armory shutters"
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "cZq" = (
@@ -29687,11 +29663,16 @@
 /turf/closed/wall,
 /area/service/library)
 "doZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/darkblue/filled/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -30536,6 +30517,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/item/gun/energy/laser/practice,
+/obj/item/gun/energy/laser/practice,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "dAC" = (
@@ -31019,6 +31006,9 @@
 "dHm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/darkblue/filled/corner,
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "dHo" = (
@@ -31723,6 +31713,18 @@
 /obj/structure/chair/stool,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
+"dYH" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "dYL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -32659,6 +32661,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
+"euS" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "evc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -32690,18 +32699,6 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"evw" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/door/airlock/security/glass{
-	name = "Gear Room";
-	req_one_access_txt = "1;4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "evB" = (
 /obj/machinery/door/window/brigdoor{
 	name = "Command Desk";
@@ -33139,21 +33136,26 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/structure/table,
+/obj/machinery/syndicatebomb/training,
+/obj/item/screwdriver{
+	pixel_x = -2;
+	pixel_y = 10
+	},
+/obj/item/wirecutters,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "eCv" = (
-/obj/structure/rack,
-/obj/item/vending_refill/security_peacekeeper,
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = -2;
-	pixel_y = -2
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "eCw" = (
@@ -33700,6 +33702,18 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/carpet,
 /area/command/corporate_showroom)
+"eMI" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Gear Room";
+	req_one_access_txt = "1;4"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/delivery/blue,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "eMJ" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -33844,6 +33858,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"eOU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "eOV" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/ai,
@@ -33979,12 +34002,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"eRF" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/structure/cable,
-/obj/effect/turf_decal/bot_blue,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "eRH" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -34945,17 +34962,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fjF" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/item/storage/toolbox/electrical,
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "fjG" = (
@@ -35623,6 +35635,15 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/commons/locker)
+"fzk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "fzn" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -36693,26 +36714,12 @@
 	},
 /area/medical/treatment_center)
 "fUv" = (
-/obj/machinery/flasher/portable,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = 30
-	},
-/obj/machinery/camera{
-	c_tag = "Security - Secure Gear Storage";
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "fUL" = (
@@ -38374,6 +38381,13 @@
 "gAz" = (
 /turf/closed/wall,
 /area/medical/surgery/room_c)
+"gAF" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/security_peacekeeper,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "gAH" = (
 /obj/structure/training_machine,
 /obj/item/target/syndicate,
@@ -38673,6 +38687,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/brig)
+"gFa" = (
+/obj/machinery/vending/wardrobe/peacekeeper_wardrobe,
+/obj/structure/cable,
+/obj/effect/turf_decal/bot_blue,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "gFy" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -39380,16 +39400,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
-"gTW" = (
-/obj/machinery/camera{
-	c_tag = "Security - Office - Port";
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "gUe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -39604,6 +39614,22 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"gYp" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "gYs" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -40382,11 +40408,11 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "hnP" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Firing Range";
-	req_one_access_txt = "1;4"
-	},
 /obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/airlock/security/glass{
+	name = "Equipment Room";
+	req_access_txt = "1"
+	},
 /turf/open/floor/iron/dark,
 /area/security/range)
 "hnW" = (
@@ -40956,6 +40982,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Security - Office - Port";
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "hAY" = (
@@ -42398,10 +42431,11 @@
 /area/command/teleporter)
 "igz" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "igY" = (
@@ -42838,6 +42872,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
+"ipb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "ipr" = (
 /turf/open/floor/glass/reinforced,
 /area/science/research)
@@ -43069,18 +43116,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"ivk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Secure Gear Storage";
-	req_access_txt = "3"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/delivery/blue,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "ivq" = (
 /turf/closed/wall,
 /area/science/cytology)
@@ -43417,6 +43452,25 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"iFl" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Armory";
+	req_access_txt = "3"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "iFn" = (
 /obj/machinery/camera{
 	c_tag = "Chapel - Port";
@@ -43784,17 +43838,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"iMT" = (
-/obj/machinery/vending/security_peacekeeper,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "iMY" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -44719,6 +44762,28 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
+"jeY" = (
+/obj/machinery/airalarm{
+	pixel_y = 28
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/electrical,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "jfc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/processor/slime,
@@ -45620,12 +45685,12 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "jvG" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/suit_storage_unit/security_peacekeeper,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -46059,6 +46124,9 @@
 	},
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -47301,12 +47369,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
-"khj" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "khk" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -48143,7 +48205,8 @@
 /obj/machinery/light_switch{
 	pixel_x = -25
 	},
-/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "kyp" = (
@@ -52016,6 +52079,43 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
+"mcL" = (
+/obj/structure/closet/crate/secure/weapon{
+	desc = "A secure clothing crate.";
+	name = "formal uniform crate";
+	req_access_txt = "3"
+	},
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/under/rank/security/warden/formal,
+/obj/item/clothing/suit/security/warden,
+/obj/item/clothing/under/rank/security/head_of_security/formal,
+/obj/item/clothing/suit/security/hos,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navywarden,
+/obj/item/clothing/head/beret/sec/navyhos,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "mcQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -53737,6 +53837,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
+"mIm" = (
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Armory External";
+	dir = 8
+	},
+/turf/open/space,
+/area/space/nearstation)
 "mIU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -54058,6 +54166,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"mPm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "mPM" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -54840,6 +54964,24 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
+"ndo" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bottle/morphine,
+/obj/item/storage/box/chemimp{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/storage/box/trackimp,
+/obj/item/storage/lockbox/loyalty,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "ndr" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/tile/purple{
@@ -54982,40 +55124,10 @@
 /turf/closed/wall,
 /area/commons/storage/primary)
 "nge" = (
-/obj/structure/closet/crate/secure/weapon{
-	desc = "A secure clothing crate.";
-	name = "formal uniform crate";
-	req_access_txt = "3"
-	},
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/under/rank/security/warden/formal,
-/obj/item/clothing/suit/security/warden,
-/obj/item/clothing/under/rank/security/head_of_security/formal,
-/obj/item/clothing/suit/security/hos,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navywarden,
-/obj/item/clothing/head/beret/sec/navyhos,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "ngf" = (
@@ -55825,30 +55937,8 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "nxb" = (
-/obj/structure/table,
-/obj/item/folder/red,
-/obj/item/restraints/handcuffs,
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/structure/cable,
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "nxk" = (
@@ -56618,6 +56708,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/storage_wing)
+"nMW" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "nMY" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -56820,20 +56915,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"nPM" = (
-/obj/machinery/airalarm{
-	pixel_y = 28
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot_blue,
-/obj/machinery/suit_storage_unit/security_peacekeeper,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "nPS" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -58916,18 +58997,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"oIZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 9
-	},
-/obj/machinery/photocopier{
-	pixel_y = 3
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "oJa" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -61177,7 +61246,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -62864,7 +62933,7 @@
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/bot_blue,
-/obj/machinery/suit_storage_unit/security_peacekeeper,
+/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "qeC" = (
@@ -63437,8 +63506,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qrP" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "qrV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -64697,6 +64771,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
+"qPA" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "qPR" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot{
@@ -65037,11 +65116,12 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "qWL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/structure/closet/bombcloset/security,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/head/bomb_hood/security,
+/obj/item/clothing/head/bomb_hood/security,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "qXH" = (
@@ -65260,6 +65340,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "rcO" = (
@@ -65519,6 +65602,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"rhO" = (
+/obj/structure/cable,
+/obj/machinery/button/door{
+	id = "armory";
+	name = "Armory Shutters";
+	pixel_y = -28;
+	req_access_txt = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "rhP" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -65921,6 +66014,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"rqE" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "rqO" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -66004,6 +66104,39 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"rsu" = (
+/obj/structure/table,
+/obj/item/folder/red,
+/obj/item/restraints/handcuffs,
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Security - Gear Room";
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "rsB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
@@ -66172,7 +66305,10 @@
 /area/medical/morgue)
 "ruv" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "ruD" = (
@@ -66252,8 +66388,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "rwn" = (
-/obj/machinery/newscaster/security_unit,
-/turf/closed/wall/r_wall,
+/obj/structure/table,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "rwO" = (
 /obj/effect/turf_decal/tile/blue{
@@ -68149,6 +68288,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
+"seQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Weapon Distribution";
+	req_access_txt = "3"
+	},
+/obj/item/paper,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/window/southleft{
+	name = "Requests Window"
+	},
+/turf/closed/wall/r_wall,
+/area/ai_monitored/security/armory)
 "seS" = (
 /obj/structure/lattice,
 /obj/item/broken_bottle,
@@ -68370,22 +68524,19 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "skU" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
 	},
-/obj/structure/rack,
-/obj/effect/turf_decal/tile/blue,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/item/storage/box/chemimp{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/storage/box/trackimp,
-/obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/structure/closet/l3closet/security,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/head/bio_hood/security,
+/obj/item/clothing/head/bio_hood/security,
+/obj/item/clothing/head/bio_hood/security,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "slf" = (
@@ -68612,6 +68763,12 @@
 "spr" = (
 /turf/open/floor/plating,
 /area/science/mixing)
+"spy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "spT" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -71310,11 +71467,6 @@
 /obj/machinery/destructive_scanner,
 /turf/open/floor/iron/white,
 /area/hallway/primary/central)
-"ttQ" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot_blue,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "ttZ" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/table,
@@ -71811,19 +71963,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
-"tFS" = (
-/obj/structure/table,
-/obj/item/wirecutters,
-/obj/item/screwdriver{
-	pixel_x = -2;
-	pixel_y = 10
-	},
-/obj/machinery/syndicatebomb/training,
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "tFU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71914,6 +72053,26 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"tIf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/camera{
+	c_tag = "Security - Secure Gear Storage";
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "tIo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -73567,6 +73726,22 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"une" = (
+/obj/structure/rack,
+/obj/item/vending_refill/security_peacekeeper,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/flashbangs{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "unk" = (
 /obj/machinery/door/window/northleft{
 	dir = 8;
@@ -74817,13 +74992,6 @@
 	dir = 1
 	},
 /area/engineering/atmos)
-"uPf" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "uPg" = (
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
@@ -76174,6 +76342,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"vlE" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "vmd" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -76679,6 +76855,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"vuB" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/vending/security_peacekeeper,
+/obj/effect/turf_decal/bot_blue,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "vuF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
@@ -79874,11 +80062,15 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "wLi" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -79988,13 +80180,15 @@
 /area/command/heads_quarters/hop)
 "wMV" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
-	dir = 5
+	dir = 1
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "wNe" = (
@@ -80048,13 +80242,6 @@
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/iron,
 /area/engineering/main)
-"wOj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "wOk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -80943,15 +81130,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/commons/locker)
-"xee" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "xel" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -81180,6 +81358,17 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"xhn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/airlock/security/glass{
+	name = "Equipment Room";
+	req_access_txt = "1"
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "xhJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -81527,6 +81716,20 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"xpi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "xpn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -110100,8 +110303,8 @@ ajr
 akK
 anl
 aou
-apJ
-arb
+apM
+aeq
 asq
 ava
 anB
@@ -110358,7 +110561,7 @@ aff
 aeq
 aga
 apJ
-arb
+iFl
 asr
 ahF
 auY
@@ -110606,7 +110809,7 @@ aaa
 aaf
 aaa
 aaf
-aav
+aaa
 aeq
 aeq
 aeq
@@ -110615,8 +110818,8 @@ aeq
 aeq
 agb
 apL
-aeq
-ass
+seQ
+asr
 ahI
 adY
 axi
@@ -110858,7 +111061,7 @@ ack
 aaf
 aaf
 aaf
-aaf
+mIm
 lMJ
 lMJ
 lMJ
@@ -110871,7 +111074,7 @@ akC
 alU
 ann
 agc
-apM
+rhO
 aeq
 ast
 avY
@@ -111115,12 +111318,12 @@ aaa
 aaa
 aaa
 aaf
-aaa
-aaa
-lMJ
-aaa
-lMJ
-aaa
+rmG
+rmG
+rmG
+fNA
+fNA
+rmG
 aeq
 aiA
 akD
@@ -111372,12 +111575,12 @@ aaa
 aaa
 aaa
 aaf
-aaa
-aaa
-lMJ
-aaa
-lMJ
-aaa
+rmG
+qPA
+vlE
+grJ
+mcL
+ndo
 aeq
 xVU
 ajv
@@ -111386,7 +111589,7 @@ alW
 iUC
 alW
 akE
-arf
+arb
 asv
 atR
 azb
@@ -111629,12 +111832,12 @@ aaa
 aaa
 aaa
 aaf
-aaa
-aaa
+rmG
+gal
 ank
-aaa
-lMJ
-aaa
+tIf
+gYp
+une
 aeq
 bLT
 bgB
@@ -111886,12 +112089,12 @@ aaa
 aaa
 aaa
 aaf
-aaf
-lMJ
-qrP
-fNA
-fNA
-qrP
+rmG
+rmG
+rmG
+rmG
+bOH
+rmG
 rmG
 aeq
 anl
@@ -112143,17 +112346,17 @@ aaa
 aaa
 aaa
 aaf
-aaa
 rmG
+euS
 qrP
-grJ
+eOU
 eCv
 skU
 rmG
 qep
 qsK
-ttQ
-ttQ
+nxb
+nxb
 rVj
 kyo
 nxb
@@ -112400,22 +112603,22 @@ aaa
 aaa
 aaa
 aaf
-aaa
 fNA
+rqE
 nge
 ruv
-jHW
+spy
 qWL
-ivk
-uLt
-pwh
-pwh
-pwh
-pwh
-qCO
-trZ
-evw
-asx
+rmG
+ipb
+xpi
+ipb
+ipb
+ipb
+mPm
+ipb
+kel
+dYH
 aiB
 apF
 awj
@@ -112657,21 +112860,21 @@ aaa
 aaa
 aaa
 aaf
-aaa
 rmG
-gal
+bUK
+gAF
 jvG
 wLi
 fUv
-rmG
-nPM
-qsK
-ttQ
-tVp
-iMT
-eRF
-cQz
-fNA
+xhn
+uLt
+pwh
+pwh
+pwh
+pwh
+qCO
+trZ
+eMI
 asz
 fjF
 kxh
@@ -112921,13 +113124,13 @@ aiJ
 hnP
 cTB
 aiJ
-rmG
+jeY
 rwn
-fNA
-tum
-wZI
-fNA
-wZI
+nMW
+tVp
+vuB
+gFa
+rsu
 hbe
 fNA
 wZI
@@ -113177,14 +113380,14 @@ gib
 qBy
 oCD
 eeq
-akW
-oIZ
-wOj
-xee
-uPf
-gTW
-khj
-tFS
+aiJ
+rmG
+rmG
+fNA
+tum
+wZI
+fNA
+wZI
 wZI
 tZX
 wZI
@@ -113438,7 +113641,7 @@ xFX
 wMV
 doZ
 igz
-trZ
+fzk
 hAX
 rcM
 pwX


### PR DESCRIPTION
Slight changes and expansion to the metastation security prep rooms to be more friendly to traffic

![image](https://user-images.githubusercontent.com/43841046/113666224-cf5f7380-9663-11eb-860f-42ac7db88b7a.png)
1. Moved EVA equipment from security prep to its own room, using the Gear Storage door used on Icebox station's EVA storage. Also adds bio and bomb suit lockers. Adds practice laser carbines
2. Expanded locker room width by one tile. All lockers are on one side, toolboxes and tables moved on the other side, with added crowbars and hand labeller
3. moved the shutters to the armoury so that they'd enter to the two tile wide space, for better traffic flow