### PR TITLE
Sec locker room upgrade (Tramstation)

### DIFF
--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -9,9 +9,6 @@
 /area/maintenance/tram/left)
 "aab" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/commons/storage/art)
 "aac" = (
@@ -37,8 +34,6 @@
 "aah" = (
 /obj/structure/bed/dogbed/mcgriff,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /mob/living/simple_animal/pet/dog/pug/mcgriff,
 /turf/open/floor/iron/showroomfloor,
@@ -89,12 +84,6 @@
 	},
 /area/service/bar)
 "aan" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Permabrig Maintenance";
@@ -104,12 +93,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "aao" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -137,12 +120,6 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/port)
 "aar" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/closed/wall/r_wall,
@@ -175,13 +152,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/commons/locker)
-"aav" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "aaw" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -269,19 +239,6 @@
 "aaB" = (
 /turf/closed/wall,
 /area/maintenance/port/central)
-"aaC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "aaD" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -305,12 +262,6 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "aaG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /mob/living/simple_animal/bot/secbot/pingsky{
 	dir = 1
@@ -319,12 +270,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "aaH" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /mob/living/simple_animal/bot/cleanbot,
@@ -352,17 +297,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
-"aaL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "aaM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -375,17 +309,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
-"aaO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "aaP" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -431,8 +354,6 @@
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
 "aaT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -441,40 +362,7 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
-"aaV" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/hydroponics)
-"aaW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"aaX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "aaY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
@@ -485,9 +373,6 @@
 	},
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/south,
@@ -553,8 +438,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
@@ -565,17 +448,6 @@
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"abh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "abi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -604,21 +476,8 @@
 	id_tag = "private_f";
 	name = "Private Quarters F"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"abl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "abm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -656,7 +515,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "abq" = (
@@ -673,8 +531,6 @@
 /turf/open/floor/plating,
 /area/security/courtroom)
 "abs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Custodial Water Synth Access";
@@ -721,7 +577,6 @@
 /obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "abx" = (
@@ -767,20 +622,8 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"abC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "abD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -822,18 +665,7 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"abI" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
 "abJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
 	},
@@ -859,12 +691,6 @@
 "abM" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
 	},
 /obj/machinery/seed_extractor,
 /turf/open/floor/iron/dark,
@@ -893,12 +719,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -906,26 +726,11 @@
 /area/service/hydroponics)
 "abR" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/bar)
-"abS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "abT" = (
 /obj/machinery/door/airlock/security{
 	name = "Prison Workshop"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -938,14 +743,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"abV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "abW" = (
 /turf/closed/wall,
 /area/service/lawoffice)
@@ -985,20 +782,12 @@
 	req_access_txt = "25"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/bar)
 "acd" = (
 /obj/machinery/door/airlock{
 	name = "Crematorium";
 	req_access_txt = "27"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
@@ -1018,13 +807,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"ach" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "aci" = (
 /obj/machinery/door/airlock{
 	name = "Cleaning Closet"
@@ -1064,21 +846,9 @@
 	pixel_y = 28
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/service/bar)
 "acl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/landmark/event_spawn,
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
@@ -1100,7 +870,6 @@
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -1116,20 +885,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"acq" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/service/bar)
 "acr" = (
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -1154,17 +909,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"acu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "acv" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 8
@@ -1181,21 +925,6 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/service/hydroponics)
-"acx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"acy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "acz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/airalarm/directional/east,
@@ -1255,8 +984,6 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Laundry"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
@@ -1313,22 +1040,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"acQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
-"acR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "acS" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/line{
@@ -1369,8 +1080,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "acY" = (
@@ -1382,20 +1091,6 @@
 /obj/item/pipe_dispenser,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"acZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "ada" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1419,17 +1114,6 @@
 	},
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
-"adc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "add" = (
 /obj/structure/table/wood,
 /obj/item/food/grown/poppy{
@@ -1465,17 +1149,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"adg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "adh" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -1535,13 +1208,7 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "ado" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -1554,12 +1221,6 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "adq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -1620,19 +1281,11 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "ady" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "adz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
@@ -1648,19 +1301,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"adC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "adD" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon{
@@ -1734,12 +1378,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"adL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics/garden)
 "adM" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 1
@@ -1752,17 +1390,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"adN" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "adO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -1832,18 +1459,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"adY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/commons/locker)
 "adZ" = (
 /obj/structure/chair/pew/right{
 	dir = 4
@@ -1855,10 +1470,6 @@
 /area/service/chapel)
 "aea" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aeb" = (
@@ -1881,12 +1492,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aed" = (
@@ -1900,12 +1505,6 @@
 	dir = 8
 	},
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
@@ -1928,21 +1527,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"aeg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aeh" = (
@@ -1956,54 +1540,11 @@
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"aei" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "aej" = (
 /turf/closed/wall,
 /area/service/bar)
-"aek" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"ael" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "aem" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip,
@@ -2011,12 +1552,6 @@
 /area/hallway/primary/port)
 "aen" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
@@ -2057,12 +1592,6 @@
 /area/service/library)
 "aer" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
@@ -2098,8 +1627,6 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/central)
 "aev" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
@@ -2114,31 +1641,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/service/library)
-"aex" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
-"aey" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "aez" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -2187,17 +1689,6 @@
 	},
 /turf/open/floor/engine/cult,
 /area/service/library)
-"aeG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "aeH" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 6
@@ -2205,8 +1696,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aeI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -2216,12 +1705,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aeJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
 /obj/machinery/firealarm/directional/north,
@@ -2232,8 +1715,6 @@
 /area/service/theater)
 "aeL" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
@@ -2243,8 +1724,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aeM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
@@ -2283,9 +1762,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
@@ -2296,13 +1772,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/psychology)
-"aeU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/service/library)
 "aeV" = (
 /obj/structure/chair/pew/right{
 	dir = 4
@@ -2328,23 +1797,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "aeZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/service/library)
-"afa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/library)
@@ -2353,8 +1809,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 4
 	},
@@ -2366,17 +1820,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "afd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
@@ -2405,12 +1854,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"afh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "afi" = (
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
@@ -2441,8 +1884,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 4
 	},
@@ -2483,8 +1924,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 1
 	},
@@ -2566,8 +2005,6 @@
 /obj/machinery/door/airlock{
 	name = "Permabrig Showers"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/freezer,
@@ -2602,14 +2039,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
-"afG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "afH" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -2660,23 +2089,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"afL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "afM" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/library)
@@ -2733,12 +2149,6 @@
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -2753,7 +2163,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "afU" = (
@@ -2767,12 +2176,6 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage";
 	req_one_access_txt = "23;30"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -2831,28 +2234,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
-"agc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
-"agd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "age" = (
 /turf/closed/wall,
 /area/commons/storage/art)
@@ -2883,23 +2264,9 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "agi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"agj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "agk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -2945,13 +2312,6 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
-"agp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "agq" = (
 /turf/closed/mineral/random/stationside/asteroid,
 /area/maintenance/department/medical)
@@ -2964,26 +2324,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"ags" = (
-/obj/machinery/door/airlock/security{
-	name = "Prison Yard"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"agt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "agu" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -2991,16 +2331,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"agv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "agx" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -3015,8 +2348,6 @@
 "agy" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/library)
@@ -3039,8 +2370,6 @@
 /area/engineering/engine_smes)
 "agB" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -3052,13 +2381,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/chapel)
-"agD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "agE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -3076,12 +2398,6 @@
 /turf/open/floor/engine/cult,
 /area/service/library)
 "agG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3096,12 +2412,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "agI" = (
@@ -3116,8 +2426,6 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
@@ -3125,22 +2433,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"agK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "agL" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -3195,12 +2489,6 @@
 /area/maintenance/central)
 "agR" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
@@ -3211,12 +2499,6 @@
 /area/hallway/primary/port)
 "agS" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
 	name = "sorting disposal pipe (Lawyer's Office)";
@@ -3224,27 +2506,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"agT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/commons/dorms)
 "agU" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3258,15 +2525,9 @@
 	name = "Isolation A";
 	req_access_txt = "39"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/medical/virology)
@@ -3279,25 +2540,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"agY" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "agZ" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -3306,7 +2553,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/bar)
@@ -3318,8 +2564,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -3328,12 +2572,6 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -3359,12 +2597,6 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "ahi" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
@@ -3382,12 +2614,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "ahl" = (
@@ -3398,7 +2624,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/east,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -3410,8 +2635,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3419,9 +2642,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aho" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
@@ -3430,8 +2650,6 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -3488,12 +2706,6 @@
 	id_tag = "private_b";
 	name = "Private Quarters B"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "ahx" = (
@@ -3548,13 +2760,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"ahE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "ahF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/light_construct{
@@ -3718,20 +2923,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/art)
-"ahZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "aia" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -3749,7 +2943,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
@@ -3816,13 +3009,7 @@
 /area/science/mixing)
 "ail" = (
 /obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "aim" = (
@@ -3857,15 +3044,9 @@
 	name = "Isolation B";
 	req_access_txt = "39"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/medical/virology)
@@ -3901,17 +3082,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
-"aiu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "aiv" = (
 /obj/machinery/computer/station_alert,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -3963,8 +3133,6 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "aiC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/grimy,
@@ -4005,12 +3173,6 @@
 /area/hallway/secondary/command)
 "aiI" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "aiJ" = (
@@ -4041,7 +3203,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/cafeteria,
@@ -4052,22 +3213,6 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/commons/locker)
-"aiO" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
@@ -4120,12 +3265,6 @@
 "aiU" = (
 /turf/closed/wall,
 /area/service/chapel/office)
-"aiV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/service/library)
 "aiW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wallframe/airalarm,
@@ -4138,13 +3277,6 @@
 	},
 /turf/open/floor/grass,
 /area/service/hydroponics)
-"aiY" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "aiZ" = (
 /obj/structure/chair/stool,
 /turf/open/floor/carpet,
@@ -4165,9 +3297,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
@@ -4262,12 +3391,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -4291,25 +3414,6 @@
 /obj/machinery/door/poddoor/preopen,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
-"ajq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"ajr" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "ajs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -4347,18 +3451,6 @@
 /obj/item/screwdriver,
 /turf/open/floor/plating,
 /area/commons/vacant_room/commissary)
-"ajw" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "ajx" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -4407,12 +3499,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /turf/open/floor/plating,
 /area/commons/vacant_room/commissary)
 "ajD" = (
@@ -4464,12 +3550,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
@@ -4479,12 +3559,6 @@
 	name = "Commissary"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/commons/vacant_room/commissary)
 "ajJ" = (
@@ -4505,12 +3579,6 @@
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /turf/open/floor/iron,
 /area/security/courtroom)
 "ajL" = (
@@ -4520,22 +3588,10 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "ajM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "ajN" = (
@@ -4545,16 +3601,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"ajO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
 "ajP" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -4572,13 +3618,6 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/port)
-"ajQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "ajR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -4591,12 +3630,6 @@
 /area/commons/locker)
 "ajS" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/machinery/light,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
@@ -4626,23 +3659,11 @@
 /obj/structure/railing/corner,
 /turf/open/floor/glass,
 /area/commons/dorms)
-"ajV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "ajW" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "ajX" = (
@@ -4675,9 +3696,6 @@
 /area/hallway/primary/tram/left)
 "aka" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/event_spawn,
@@ -4691,19 +3709,12 @@
 /area/hallway/primary/port)
 "akc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "akd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/plating,
 /area/commons/vacant_room/commissary)
 "ake" = (
@@ -4712,12 +3723,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"akf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/service/theater)
 "akg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -4781,20 +3786,8 @@
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"akm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/commons/dorms)
 "akn" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -4856,9 +3849,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
 "akt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
@@ -4871,16 +3861,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "akv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
@@ -4945,8 +3929,6 @@
 "akD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/commons/vacant_room/commissary)
 "akE" = (
@@ -5007,12 +3989,6 @@
 	req_one_access_txt = "25;28"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Bar North";
 	dir = 6
@@ -5110,7 +4086,6 @@
 "akW" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "akX" = (
@@ -5148,8 +4123,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/commons/vacant_room/commissary)
 "alb" = (
@@ -5230,12 +4203,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"ali" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "alj" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -5294,7 +4261,6 @@
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "alp" = (
@@ -5365,12 +4331,6 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
@@ -5383,7 +4343,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "alx" = (
@@ -5415,9 +4374,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
@@ -5467,9 +4423,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "alG" = (
@@ -5482,12 +4435,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "alH" = (
@@ -5525,10 +4472,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "alM" = (
@@ -5544,17 +4489,11 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "alN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -5591,9 +4530,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "alR" = (
@@ -5613,9 +4549,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "alS" = (
@@ -5634,9 +4567,6 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
@@ -5674,9 +4604,6 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/effect/spawner/lootdrop/cigbutt,
 /turf/open/floor/iron,
@@ -5731,20 +4658,11 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "amd" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -5794,12 +4712,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
@@ -5810,12 +4722,6 @@
 /area/hallway/primary/port)
 "amk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
 /obj/structure/cable,
@@ -5882,18 +4788,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"amt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "amu" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
@@ -5905,9 +4801,6 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/north,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "amv" = (
@@ -5940,9 +4833,6 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
@@ -5979,9 +4869,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "amC" = (
@@ -6011,9 +4898,6 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
@@ -6057,30 +4941,13 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "amM" = (
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/service/hydroponics)
-"amN" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/tram/mid)
 "amP" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -6090,20 +4957,11 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "amQ" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/engine,
 /area/science/cytology)
-"amS" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "amU" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
@@ -6112,31 +4970,15 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "amW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"amX" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/hydroponics)
 "amY" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Tunnel Access";
@@ -6157,7 +4999,6 @@
 	req_one_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
@@ -6201,34 +5042,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
-"ang" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
-"anh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/chapel{
-	dir = 4
-	},
-/area/service/chapel)
-"ani" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/grimy,
-/area/service/chapel/office)
 "anj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -6239,9 +5052,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -6289,7 +5099,6 @@
 /area/commons/storage/primary)
 "anp" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
@@ -6329,7 +5138,6 @@
 	req_one_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
@@ -6357,12 +5165,6 @@
 /turf/open/floor/wood,
 /area/service/library)
 "anx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/service/hydroponics)
@@ -6428,26 +5230,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "anG" = (
 /turf/closed/wall,
-/area/hallway/primary/tram/left)
-"anH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "anI" = (
 /obj/structure/table,
@@ -6500,7 +5288,6 @@
 	dir = 4;
 	name = "External to Filter"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -6536,9 +5323,6 @@
 "anS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
@@ -6663,8 +5447,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "aoi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock{
 	name = "Coffin Storage";
 	req_access_txt = "27"
@@ -6686,9 +5468,6 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/light,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
@@ -6696,7 +5475,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
@@ -6714,9 +5492,6 @@
 /area/science/xenobiology)
 "aoo" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Atmospherics Incinerator";
 	dir = 6;
@@ -6739,8 +5514,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aor" = (
@@ -6756,12 +5529,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -6782,8 +5549,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aov" = (
@@ -6792,9 +5557,6 @@
 "aow" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/engine,
@@ -6865,8 +5627,6 @@
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
-/obj/machinery/atmospherics/pipe/multiz/layer2,
-/obj/machinery/atmospherics/pipe/multiz/layer4,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -6886,14 +5646,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"aoF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/chapel{
-	dir = 8
-	},
-/area/service/chapel)
 "aoG" = (
 /obj/structure/railing{
 	dir = 8
@@ -6901,8 +5653,6 @@
 /turf/open/floor/glass,
 /area/commons/dorms)
 "aoH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron/dark,
@@ -6932,8 +5682,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aoL" = (
@@ -6943,8 +5691,6 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aoM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/dark,
@@ -6977,12 +5723,6 @@
 /turf/open/floor/iron/dark,
 /area/security/processing)
 "aoS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -7098,12 +5838,6 @@
 	id_tag = "private_k";
 	name = "Private Quarters K"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "apf" = (
@@ -7186,28 +5920,10 @@
 	pixel_x = -2;
 	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"apm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "apn" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron,
@@ -7248,8 +5964,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -7287,12 +6001,6 @@
 /obj/machinery/door/airlock{
 	name = "Courtroom"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/security/courtroom)
 "apv" = (
@@ -7315,10 +6023,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "apy" = (
@@ -7342,12 +6046,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "apC" = (
@@ -7361,12 +6059,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "apD" = (
@@ -7379,12 +6071,6 @@
 /area/ai_monitored/command/storage/eva)
 "apE" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/carpet,
 /area/command/bridge)
@@ -7412,12 +6098,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/security/courtroom)
 "apH" = (
@@ -7507,12 +6187,6 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "apQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "apS" = (
@@ -7536,9 +6210,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/north,
@@ -7599,28 +6270,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"aqc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
-"aqd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "aqe" = (
 /obj/effect/turf_decal/tile{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -7677,23 +6331,7 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"aqj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "aqk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/wood,
@@ -7709,12 +6347,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aqn" = (
@@ -7727,12 +6359,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aqo" = (
@@ -7761,8 +6387,6 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "aqq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "aqr" = (
@@ -7947,7 +6571,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aqL" = (
@@ -8267,16 +6890,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/command/gateway)
 "aru" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron/dark,
@@ -8290,13 +6907,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"arw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "arx" = (
 /obj/machinery/mechpad,
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -8352,19 +6962,6 @@
 	dir = 4
 	},
 /area/service/theater)
-"arE" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Showers"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "arF" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -8373,7 +6970,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "arG" = (
@@ -8436,12 +7032,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	pixel_x = 24;
 	pixel_y = -22
@@ -8471,9 +7061,6 @@
 "arM" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
@@ -8555,12 +7142,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -8724,12 +7305,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "asn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
@@ -8741,12 +7316,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
@@ -8754,12 +7323,6 @@
 /obj/machinery/door/airlock{
 	id_tag = "private_l";
 	name = "Private Quarters L"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -8771,15 +7334,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint)
-"asr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "ass" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -8821,17 +7375,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
-"asw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "asx" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = -32
@@ -8865,16 +7408,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"asA" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "asB" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -8894,9 +7427,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -8905,10 +7435,6 @@
 /area/commons/dorms)
 "asD" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
@@ -8922,9 +7448,6 @@
 "asF" = (
 /obj/effect/turf_decal/siding/thinplating/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
@@ -8962,12 +7485,6 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
@@ -9093,9 +7610,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
@@ -9114,9 +7628,6 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
@@ -9130,21 +7641,12 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "atc" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
 	},
 /obj/structure/cable,
 /obj/item/stack/tile/wood,
@@ -9266,8 +7768,6 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "atq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/commons/vacant_room/office)
@@ -9288,10 +7788,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -9308,12 +7804,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "atv" = (
@@ -9327,12 +7817,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "atw" = (
@@ -9345,9 +7829,6 @@
 /obj/effect/landmark/start/mime,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
 	},
 /turf/open/floor/iron/white/side{
 	dir = 4
@@ -9468,8 +7949,6 @@
 /area/commons/dorms)
 "atH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "atI" = (
@@ -9514,9 +7993,6 @@
 /turf/open/floor/plating,
 /area/hallway/primary/tram/right)
 "atL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "atM" = (
@@ -9577,12 +8053,6 @@
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
@@ -9592,12 +8062,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -9613,12 +8077,6 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
@@ -9628,12 +8086,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/sign/departments/cargo{
@@ -9652,12 +8104,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
@@ -9668,23 +8114,11 @@
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "atY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
@@ -9738,8 +8172,6 @@
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "aud" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
@@ -9749,8 +8181,6 @@
 	req_access_txt = "28"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "auf" = (
@@ -9787,24 +8217,8 @@
 /area/service/chapel)
 "auj" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"auk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "aul" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/item/radio/intercom/directional/south,
@@ -9856,12 +8270,6 @@
 "auq" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/carpet,
 /area/command/bridge)
 "aur" = (
@@ -9883,9 +8291,6 @@
 "aut" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9914,12 +8319,6 @@
 	pixel_x = -6;
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -9939,12 +8338,6 @@
 /area/hallway/primary/tram/right)
 "auy" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -9956,8 +8349,6 @@
 	req_access_txt = "32"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
@@ -10022,12 +8413,6 @@
 	dir = 4
 	},
 /area/service/bar)
-"auH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/service/kitchen)
 "auI" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -10037,32 +8422,16 @@
 	req_access_txt = "62"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "auJ" = (
 /obj/structure/chair/stool,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"auK" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "auL" = (
 /obj/machinery/door/airlock{
 	id_tag = "private_m";
 	name = "Private Quarters M"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -10109,14 +8478,11 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "auR" = (
 /obj/structure/closet/secure_closet/medical1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
@@ -10126,8 +8492,6 @@
 	name = "Power Access Hatch";
 	req_one_access_txt = "19"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
@@ -10188,9 +8552,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "avb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -10221,8 +8582,6 @@
 /area/hallway/primary/tram/left)
 "ave" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "avf" = (
@@ -10252,36 +8611,6 @@
 /obj/item/stamp/hos,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
-"avh" = (
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"avi" = (
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "avj" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -10347,12 +8676,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/service/kitchen)
 "avp" = (
@@ -10380,12 +8703,6 @@
 /area/hallway/primary/tram/center)
 "avt" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "avu" = (
@@ -10411,16 +8728,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"avx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/service/kitchen)
 "avy" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
@@ -10478,24 +8785,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/gateway)
-"avF" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/service/library)
 "avH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -10520,12 +8815,6 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -10604,34 +8893,8 @@
 	req_access_txt = "20"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
-"avU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"avV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "avW" = (
 /obj/structure/sign/directions/evac{
 	dir = 4;
@@ -10673,30 +8936,16 @@
 /turf/open/floor/plating,
 /area/hallway/primary/tram/right)
 "awa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "awb" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "awc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/grimy,
@@ -10708,12 +8957,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -10795,12 +9038,6 @@
 /area/service/chapel)
 "awn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -10930,14 +9167,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
-"awB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "awC" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
@@ -10953,12 +9182,6 @@
 /area/security/courtroom)
 "awE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -10978,9 +9201,6 @@
 "awH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -11043,10 +9263,6 @@
 /area/service/library)
 "awP" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "awQ" = (
@@ -11075,8 +9291,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -11106,7 +9320,6 @@
 "awW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/gateway)
 "awX" = (
@@ -11164,26 +9377,8 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
-"axg" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/command/gateway)
-"axh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "axi" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -11200,7 +9395,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "axk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
@@ -11223,12 +9417,6 @@
 /area/service/library)
 "axn" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -11269,8 +9457,6 @@
 	name = "Chapel Office";
 	req_access_txt = "22"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -11305,16 +9491,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
-"axx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "axy" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -11331,12 +9507,6 @@
 "axA" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "axB" = (
@@ -11370,12 +9540,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/science/mixing)
-"axD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
 "axE" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Storage"
@@ -11383,12 +9547,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -11407,9 +9565,6 @@
 "axG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
@@ -11445,7 +9600,6 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "axL" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Atmospherics North";
 	dir = 6;
@@ -11488,10 +9642,6 @@
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 1
 	},
@@ -11525,14 +9675,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "axT" = (
@@ -11593,9 +9737,6 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
@@ -11647,31 +9788,16 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "ayi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "ayj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"ayk" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/service/bar)
 "ayl" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Port"
@@ -11765,12 +9891,6 @@
 /obj/machinery/door/airlock{
 	id_tag = "private_i";
 	name = "Private Quarters I"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -11911,9 +10031,6 @@
 /area/engineering/main)
 "ayM" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/engine,
@@ -11923,8 +10040,6 @@
 	name = "Atmospherics Testing Room";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -11933,20 +10048,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
-"ayO" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "ayP" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -12011,12 +10114,6 @@
 /obj/machinery/door/airlock{
 	id_tag = "private_g";
 	name = "Private Quarters G"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -12085,9 +10182,6 @@
 /area/construction/mining/aux_base)
 "azd" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
@@ -12097,9 +10191,6 @@
 	req_access_txt = "24"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -12115,14 +10206,10 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "azg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "azh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
@@ -12158,12 +10245,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
 	},
@@ -12173,12 +10254,6 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Disposal Access";
 	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -12226,12 +10301,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "azv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -12257,9 +10326,6 @@
 /turf/open/floor/vault,
 /area/hallway/primary/tram/left)
 "azy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
@@ -12343,12 +10409,6 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "azH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
@@ -12386,12 +10446,6 @@
 /obj/machinery/door/airlock/command{
 	name = "Teleport Access";
 	req_access_txt = "17"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -12458,23 +10512,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"azW" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/commons/locker)
 "azX" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
@@ -12514,12 +10554,6 @@
 /turf/open/floor/wood,
 /area/service/library)
 "aAe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -12527,8 +10561,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -12562,12 +10594,6 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "aAj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -12588,7 +10614,6 @@
 	name = "Tunnel Access";
 	req_one_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -12597,8 +10622,6 @@
 	name = "Auxillary Base Construction";
 	req_one_access_txt = "72"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
@@ -12700,8 +10723,6 @@
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
 "aAv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
@@ -12710,12 +10731,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"aAw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aAx" = (
@@ -12730,12 +10745,6 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aAy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -12764,23 +10773,11 @@
 "aAB" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aAC" = (
 /obj/effect/turf_decal/trimline/neutral/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -12792,22 +10789,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"aAE" = (
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "aAF" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aAG" = (
@@ -12832,13 +10819,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"aAH" = (
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "aAI" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -12846,9 +10826,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -12935,18 +10912,7 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
-"aAT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "aAU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -12967,16 +10933,6 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aAX" = (
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
-"aAY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
 "aAZ" = (
@@ -13019,16 +10975,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"aBe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/tram/right)
 "aBf" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -13036,18 +10982,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "aBg" = (
 /obj/machinery/light/small{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -13064,47 +11003,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aBj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"aBk" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"aBl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -13122,32 +11026,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"aBo" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"aBp" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "aBq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -13172,22 +11050,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aBt" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -13196,27 +11064,15 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"aBv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "aBw" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aBx" = (
@@ -13253,8 +11109,6 @@
 	name = "Garden"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "aBA" = (
@@ -13280,12 +11134,6 @@
 	req_access_txt = "38"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13352,8 +11200,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "aBL" = (
@@ -13415,12 +11261,6 @@
 /area/service/lawoffice)
 "aBT" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "aBU" = (
@@ -13438,19 +11278,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"aBW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics/garden)
 "aBX" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -13464,12 +11294,6 @@
 	req_access_txt = "28"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
@@ -13526,9 +11350,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint)
@@ -13548,9 +11369,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -13562,9 +11380,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 1
@@ -13574,14 +11389,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"aCj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "aCk" = (
 /obj/structure/table,
 /obj/structure/table,
@@ -13631,7 +11438,6 @@
 /turf/closed/wall,
 /area/service/kitchen)
 "aCq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -13778,9 +11584,6 @@
 /area/command/teleporter)
 "aCF" = (
 /obj/structure/filingcabinet,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
@@ -13826,7 +11629,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -13847,20 +11649,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/entry)
-"aCM" = (
-/obj/effect/turf_decal/siding/thinplating,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "aCN" = (
 /obj/machinery/vending/cart{
 	req_access_txt = "57"
@@ -13885,11 +11673,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
-"aCQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "aCR" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -13923,47 +11706,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
-"aCV" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "aCW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/left)
-"aCX" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/left)
-"aCY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/left)
-"aCZ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
@@ -13981,25 +11726,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"aDb" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "aDc" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -14007,8 +11733,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -14031,9 +11755,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_cw{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/sign/directions/vault{
 	dir = 4;
 	pixel_y = 22
@@ -14050,12 +11771,6 @@
 	name = "Custodial Closet";
 	req_access_txt = "26"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14069,9 +11784,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/trimline/neutral/corner,
@@ -14087,9 +11799,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -14112,9 +11821,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/sign/directions/upload{
 	dir = 4;
 	pixel_y = 22
@@ -14126,9 +11832,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 4
 	},
@@ -14138,9 +11841,6 @@
 "aDj" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -14238,9 +11938,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -14306,9 +12003,6 @@
 /area/hallway/primary/tram/center)
 "aDA" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Arrivals/Service Entry";
 	dir = 1
@@ -14349,23 +12043,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/center)
-"aDE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
@@ -14385,10 +12064,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
@@ -14432,21 +12107,6 @@
 	dir = 4;
 	pixel_y = 22
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/center)
-"aDK" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -14460,17 +12120,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
-"aDM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "aDN" = (
 /obj/structure/closet/crate,
 /obj/item/crowbar,
@@ -14479,9 +12128,6 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "aDO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -14493,27 +12139,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"aDQ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/center)
 "aDR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
@@ -14521,22 +12149,6 @@
 /obj/structure/bookcase,
 /turf/open/floor/iron/chapel,
 /area/service/chapel)
-"aDT" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
 "aDU" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -14547,28 +12159,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"aDV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"aDW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "aDX" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14790,14 +12380,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aEu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "aEv" = (
@@ -14821,12 +12407,6 @@
 /obj/machinery/door/airlock{
 	id_tag = "private_j";
 	name = "Private Quarters J"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -14858,7 +12438,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "aEA" = (
@@ -14883,12 +12462,6 @@
 /obj/effect/turf_decal/trimline/green/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
@@ -14932,12 +12505,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -14946,13 +12513,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
-"aEI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "aEJ" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
@@ -15153,12 +12713,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "aFd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
@@ -15212,7 +12766,6 @@
 "aFk" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -15220,9 +12773,6 @@
 "aFl" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "aFm" = (
@@ -15265,7 +12815,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -15309,7 +12858,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -15324,21 +12872,7 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"aFx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/chapel{
-	dir = 1
-	},
-/area/service/chapel)
 "aFy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15355,8 +12889,6 @@
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/light{
 	dir = 8
@@ -15366,9 +12898,6 @@
 "aFA" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Arrivals/Dorms Entry";
@@ -15388,17 +12917,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
-"aFC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "aFD" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -15495,9 +13013,6 @@
 /area/science/robotics/mechbay)
 "aFQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/neutral/corner,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
@@ -15506,17 +13021,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
 /obj/structure/sign/departments/science{
 	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/right)
-"aFT" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
@@ -15532,16 +13036,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/right)
-"aFW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -15550,12 +13045,6 @@
 /obj/effect/turf_decal/siding/thinplating/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
 	},
 /obj/machinery/duct,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -15570,12 +13059,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -15620,7 +13103,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -15637,12 +13119,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aGf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -15748,30 +13224,8 @@
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"aGr" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/central)
 "aGs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -15806,31 +13260,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "aGw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
-"aGx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "aGy" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -15904,20 +13341,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aGJ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -15947,12 +13376,6 @@
 /area/science/robotics/mechbay)
 "aGM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
@@ -16036,12 +13459,6 @@
 /turf/open/floor/wood,
 /area/service/library)
 "aGW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -16061,8 +13478,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "aHa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
@@ -16075,12 +13490,6 @@
 /area/science/research)
 "aHc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -16099,7 +13508,6 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "aHf" = (
@@ -16143,7 +13551,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -16161,12 +13568,6 @@
 /area/medical/medbay/central)
 "aHl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/status_display/evac{
 	pixel_y = -32
@@ -16186,21 +13587,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"aHo" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "aHp" = (
 /turf/closed/wall,
 /area/security/checkpoint/engineering)
@@ -16243,12 +13629,6 @@
 /area/hallway/primary/tram/right)
 "aHt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/machinery/chem_mass_spec,
 /turf/open/floor/iron/white,
@@ -16262,8 +13642,6 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
@@ -16289,22 +13667,10 @@
 	id_tag = "private_n";
 	name = "Private Quarters N"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "aHy" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/shower{
 	dir = 1
 	},
@@ -16331,12 +13697,7 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"aHB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/chapel,
-/area/service/chapel)
 "aHC" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
 "aHD" = (
@@ -16350,13 +13711,6 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aHE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "aHF" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/light/small{
@@ -16380,22 +13734,8 @@
 "aHI" = (
 /turf/closed/wall,
 /area/maintenance/tram/right)
-"aHJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "aHK" = (
 /obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -16501,9 +13841,6 @@
 	},
 /area/service/theater)
 "aHW" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
@@ -16531,12 +13868,6 @@
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "aIa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
@@ -16575,7 +13906,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aIf" = (
@@ -16589,15 +13919,6 @@
 "aIg" = (
 /turf/open/openspace,
 /area/commons/dorms)
-"aIh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
 "aIi" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -16657,18 +13978,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"aIn" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "aIo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -16681,8 +13990,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -16692,9 +13999,6 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
 "aIr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -16734,12 +14038,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aIx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -16748,12 +14046,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aIy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16762,8 +14054,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aIz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -16807,10 +14097,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "aIF" = (
@@ -16837,15 +14123,6 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
-"aIJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "aIK" = (
 /obj/structure/closet/l3closet,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -16865,12 +14142,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -16891,12 +14162,6 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -16952,17 +14217,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
-"aIW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aIX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -16970,28 +14224,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"aIY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"aIZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aJa" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
@@ -17090,8 +14322,6 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -17110,7 +14340,6 @@
 /area/commons/storage/primary)
 "aJr" = (
 /obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/item/storage/secure/briefcase{
 	pixel_x = 3;
 	pixel_y = 5
@@ -17129,58 +14358,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"aJv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"aJw" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "aJx" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -17193,21 +14377,7 @@
 "aJy" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/central/secondary)
-"aJz" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "aJA" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -17216,28 +14386,7 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"aJC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
-"aJD" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/hydroponics)
 "aJF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -17256,26 +14405,9 @@
 "aJH" = (
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"aJI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "aJJ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -17293,17 +14425,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"aJM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "aJO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -17318,28 +14439,6 @@
 /obj/structure/closet/crate/wooden/toy,
 /turf/open/floor/iron,
 /area/service/theater)
-"aJP" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"aJQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "aJS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -17368,24 +14467,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "aJX" = (
 /obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
 /obj/structure/cable,
@@ -17405,29 +14492,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"aKe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"aKf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "aKi" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -17445,13 +14513,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
-"aKo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "aKr" = (
 /obj/machinery/shower{
 	pixel_y = 24
@@ -17491,12 +14552,6 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
 "aKC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -17520,13 +14575,7 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet,
 /area/service/library)
-"aKF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
-/area/service/library)
 "aKI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry";
@@ -17545,17 +14594,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"aKJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "aKK" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/computer/security/telescreen{
@@ -17578,9 +14616,6 @@
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "aKN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
 /obj/machinery/light,
@@ -17599,8 +14634,6 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "aKP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -17615,17 +14648,6 @@
 /obj/machinery/gibber,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
-"aKS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "aKU" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -17697,19 +14719,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"aLu" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "aLx" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -17739,16 +14748,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint)
-"aLB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "aLF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -17763,45 +14762,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"aLH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"aLJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"aLK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "aLL" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -17817,28 +14777,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron/dark,
 /area/service/bar)
-"aLN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"aLO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "aLP" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/machinery/light/small{
@@ -17946,10 +14884,6 @@
 "aMr" = (
 /turf/open/floor/iron/grimy,
 /area/service/library)
-"aMw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
 "aMx" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
@@ -17969,9 +14903,6 @@
 /area/commons/dorms)
 "aMJ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -17999,24 +14930,12 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/lawyer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aMS" = (
 /obj/machinery/door/airlock{
 	id_tag = "private_h";
 	name = "Private Quarters H"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -18075,12 +14994,6 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "aNm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -18088,37 +15001,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
-"aNo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/tram/right)
-"aNq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "aNs" = (
 /obj/machinery/light/small{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -18127,12 +15012,6 @@
 /obj/machinery/door/airlock{
 	id_tag = "private_e";
 	name = "Private Quarters E"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -18150,16 +15029,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
-"aNv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/tram/left)
 "aNw" = (
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
@@ -18171,16 +15040,6 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
-"aNB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/tram/right)
 "aNC" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -18246,51 +15105,19 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "aNK" = (
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"aNL" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/tram/left)
 "aNM" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/turf/open/floor/iron,
-/area/maintenance/tram/left)
-"aNN" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/machinery/light/small,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
@@ -18298,12 +15125,6 @@
 /obj/machinery/door/airlock{
 	id_tag = "private_a";
 	name = "Private Quarters A"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -18379,19 +15200,6 @@
 "aOb" = (
 /turf/closed/wall,
 /area/commons/toilet/restrooms)
-"aOi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/service/library)
-"aOl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "aOt" = (
 /obj/structure/table/wood/fancy,
 /obj/machinery/door/window{
@@ -18410,12 +15218,6 @@
 "aOv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"aOw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -18444,12 +15246,6 @@
 /area/commons/storage/tools)
 "aOB" = (
 /obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aOC" = (
@@ -18461,12 +15257,6 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -18502,7 +15292,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
@@ -18519,16 +15308,6 @@
 	req_one_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
-"aON" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Tunnel Access";
-	req_one_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -18587,7 +15366,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aOZ" = (
@@ -18696,12 +15474,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"aPy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "aPz" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod One"
@@ -18717,41 +15489,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"aPC" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"aPE" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
-"aPF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/service/kitchen)
 "aPG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -18759,12 +15496,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "aPI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18772,12 +15503,6 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aPJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -18785,67 +15510,21 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aPK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"aPL" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aPM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aPN" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"aPP" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aPQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -18891,21 +15570,8 @@
 "aPX" = (
 /turf/open/floor/iron,
 /area/science/robotics/lab)
-"aPY" = (
-/obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
 "aPZ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
@@ -18948,12 +15614,6 @@
 /area/commons/lounge)
 "aQi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/machinery/light,
 /turf/open/floor/iron,
@@ -18967,10 +15627,6 @@
 "aQk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -18986,8 +15642,6 @@
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aQm" = (
@@ -18998,12 +15652,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -19022,22 +15670,10 @@
 /obj/structure/cable,
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/commons/lounge)
 "aQt" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
 /obj/structure/cable,
@@ -19048,24 +15684,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
-"aQv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -19083,8 +15701,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
@@ -19105,8 +15721,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/status_display/ai{
 	pixel_x = -32
@@ -19121,32 +15735,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"aQD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
-"aQE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/lounge)
-"aQF" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "aQG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -19158,24 +15746,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aQJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -19193,8 +15769,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
@@ -19216,8 +15790,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
@@ -19228,35 +15800,15 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
-"aQP" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "aQQ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -19266,12 +15818,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
@@ -19299,8 +15845,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
@@ -19324,9 +15868,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -19341,10 +15882,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
@@ -19383,8 +15920,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/status_display/evac{
 	pixel_x = 32
@@ -19411,8 +15946,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -19436,16 +15969,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
-/area/commons/lounge)
-"aRp" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aRq" = (
@@ -19507,13 +16030,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
-"aRy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "aRz" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -19525,12 +16041,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -19540,12 +16050,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aRC" = (
@@ -19560,10 +16064,6 @@
 /area/commons/lounge)
 "aRG" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Research Maintnenace";
@@ -19589,25 +16089,9 @@
 /obj/item/clothing/shoes/jackboots,
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
-"aRJ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "aRL" = (
 /turf/closed/wall,
 /area/maintenance/starboard/secondary)
-"aRM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "aRN" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
@@ -19618,8 +16102,6 @@
 /area/maintenance/starboard/secondary)
 "aRP" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -19657,12 +16139,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aRW" = (
@@ -19760,9 +16238,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/service/library)
 "aSj" = (
@@ -19802,12 +16277,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -19816,12 +16285,6 @@
 /area/commons/lounge)
 "aSo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19830,12 +16293,6 @@
 /area/commons/lounge)
 "aSp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
@@ -19849,12 +16306,6 @@
 /area/commons/dorms)
 "aSr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
@@ -19871,9 +16322,6 @@
 /area/service/bar)
 "aSt" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -19883,9 +16331,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -19893,19 +16338,6 @@
 /area/commons/lounge)
 "aSv" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/lounge)
-"aSx" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -19925,30 +16357,6 @@
 	req_one_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
-"aSA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
-"aSC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -19979,12 +16387,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
@@ -19992,37 +16394,9 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
 /area/service/library)
-"aSL" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
-"aSM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
 "aSP" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - South-East Escape Wing Entry";
@@ -20040,8 +16414,6 @@
 /obj/machinery/newscaster{
 	pixel_x = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -20052,8 +16424,6 @@
 	req_one_access_txt = "12"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
@@ -20061,17 +16431,8 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"aST" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
 "aSU" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/hatch{
 	name = "Test Chamber Maintenance";
 	req_access_txt = "47"
@@ -20119,15 +16480,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"aTm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "aTu" = (
 /obj/structure/chair/sofa{
 	dir = 8
@@ -20142,8 +16494,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aTC" = (
@@ -20512,7 +16862,6 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
 "aWu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
@@ -20574,7 +16923,6 @@
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aWS" = (
@@ -20584,21 +16932,12 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "aWU" = (
 /obj/machinery/door/airlock{
 	id_tag = "private_c";
 	name = "Private Quarters C"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -20615,9 +16954,6 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aXg" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "aXi" = (
@@ -20637,19 +16973,7 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
-"aXv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "aXx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
@@ -20658,18 +16982,7 @@
 "aXA" = (
 /turf/closed/wall/r_wall,
 /area/service/chapel)
-"aXC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "aXD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20677,12 +16990,6 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "aXE" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -20719,12 +17026,6 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "aXU" = (
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aXV" = (
@@ -20873,18 +17174,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"aZb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/effect/spawner/lootdrop/botanical_waste,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "aZe" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -20946,9 +17235,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aZC" = (
@@ -20972,22 +17258,6 @@
 	dir = 4
 	},
 /area/service/chapel)
-"aZK" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
 "aZL" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -21099,20 +17369,12 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "bbP" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer4{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -21176,7 +17438,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "bdB" = (
@@ -21204,18 +17465,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"beL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "beR" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
 "beS" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Power Access Hatch";
 	req_one_access_txt = "19"
@@ -21233,17 +17488,8 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/limb,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "bfR" = (
@@ -21253,12 +17499,6 @@
 	req_one_access_txt = "1;4"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "bgH" = (
@@ -21288,22 +17528,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "bgU" = (
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 11
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
-"bhe" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bhi" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -21335,15 +17565,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"bhy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/research)
 "bhH" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -21396,14 +17617,6 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
-"biA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "bjv" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -21412,12 +17625,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bjP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron/dark,
@@ -21449,17 +17656,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/lab)
-"bkb" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
-"bkn" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bkV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -21529,9 +17725,6 @@
 /area/cargo/miningdock)
 "bmJ" = (
 /obj/structure/chair/office/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "bnl" = (
@@ -21552,7 +17745,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "bnz" = (
@@ -21561,18 +17753,9 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
 "bnA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil/cut,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 9
-	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "bnF" = (
@@ -21731,18 +17914,10 @@
 	name = "Toxins Misc Storage";
 	req_access_txt = "71"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/science/mixing)
 "btd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
@@ -21758,12 +17933,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "btn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Research Maintnenace";
 	req_one_access_txt = "47"
@@ -21815,12 +17984,8 @@
 /area/engineering/engine_smes)
 "buT" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "bvw" = (
@@ -21854,6 +18019,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"bwq" = (
+/obj/machinery/griddle,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "bws" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/item/storage/toolbox/electrical,
@@ -21881,17 +18050,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
-"bxp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/tram/right)
 "bxw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -21907,12 +18065,6 @@
 "bxG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "bxH" = (
@@ -21999,12 +18151,6 @@
 /area/medical/virology)
 "bzh" = (
 /obj/structure/chair/office,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/landmark/start/depsec/engineering,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -22022,21 +18168,8 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
-"bzH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/main)
 "bzV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
@@ -22072,24 +18205,11 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bAI" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bAQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/science/robotics/lab)
 "bAS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris,
@@ -22098,11 +18218,6 @@
 "bBA" = (
 /turf/closed/wall,
 /area/maintenance/disposal)
-"bBB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
 "bCx" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -22121,10 +18236,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "bCZ" = (
@@ -22146,9 +18257,6 @@
 "bDC" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -22172,9 +18280,6 @@
 /area/maintenance/port/fore)
 "bEs" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -22248,7 +18353,6 @@
 /area/science/nanite)
 "bFR" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/janitor,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -22272,26 +18376,11 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bGf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "bGj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"bGK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "bGZ" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -22363,21 +18452,9 @@
 /area/command/heads_quarters/ce)
 "bJI" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"bJW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "bJX" = (
 /obj/structure/chair{
 	dir = 4
@@ -22426,12 +18503,6 @@
 	name = "Telecommunications";
 	req_access_txt = "61"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -22439,12 +18510,6 @@
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room";
 	req_access_txt = "8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -22455,19 +18520,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"bLI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bLV" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -22503,10 +18555,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -22525,10 +18573,6 @@
 "bMo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
@@ -22555,10 +18599,6 @@
 	name = "sorting disposal pipe (Head of Personnel's Office)";
 	sortType = 15
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "bMN" = (
@@ -22567,9 +18607,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "bNe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
 /obj/machinery/light_switch{
 	pixel_x = -26
 	},
@@ -22587,9 +18624,6 @@
 /area/hallway/secondary/exit)
 "bNv" = (
 /obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -22665,16 +18699,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"bPZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "bQN" = (
 /obj/machinery/door/window/southleft{
 	name = "Maximum Security Test Chamber";
@@ -22688,9 +18712,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bRF" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	name = "Waste Release"
 	},
@@ -22785,13 +18806,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"bUh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bUp" = (
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 1
@@ -22821,12 +18835,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"bUX" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter)
 "bVd" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "armory";
@@ -22845,7 +18853,6 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "bVO" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
@@ -22879,7 +18886,6 @@
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
 "bWq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
@@ -22888,15 +18894,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bWy" = (
@@ -22939,18 +18941,11 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "bXC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"bXF" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "bXI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -22973,18 +18968,9 @@
 /area/maintenance/disposal/incinerator)
 "bXY" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
-"bYl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "bYn" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -23034,9 +19020,6 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "bZx" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
 /obj/machinery/button/door/incinerator_vent_atmos_aux{
 	pixel_x = -8;
 	pixel_y = -24
@@ -23077,10 +19060,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
@@ -23137,20 +19116,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "cbN" = (
 /obj/structure/closet/secure_closet/warden,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
-"cbX" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/command/heads_quarters/captain/private)
 "ccj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -23162,12 +19133,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"cct" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
 "ccG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -23183,9 +19148,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -23221,8 +19183,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "cdF" = (
@@ -23269,9 +19229,6 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "ceY" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -23300,9 +19257,6 @@
 "cfG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/cable,
@@ -23353,9 +19307,6 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "cgI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -23377,19 +19328,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "cgV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/effect/landmark/event_spawn,
 /obj/machinery/destructive_scanner,
 /turf/open/floor/iron/white,
@@ -23428,19 +19370,7 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"chU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
 "cii" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "cit" = (
@@ -23476,32 +19406,12 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"ciJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
-"ciL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/research)
 "ciO" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "ciQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = -24
@@ -23512,25 +19422,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"cjg" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "cjp" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -23548,12 +19442,6 @@
 /area/science/genetics)
 "cjW" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -23563,8 +19451,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -23689,8 +19575,6 @@
 	req_access_txt = "1"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "cnD" = (
@@ -23702,9 +19586,6 @@
 /area/science/robotics/lab)
 "cnN" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "cok" = (
@@ -23715,12 +19596,6 @@
 /area/cargo/miningdock)
 "cot" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -23741,12 +19616,6 @@
 /area/maintenance/tram/right)
 "cox" = (
 /obj/structure/cable/multilayer/multiz,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/light/small,
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
@@ -23762,20 +19631,11 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "coO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"cpf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "cpj" = (
 /obj/structure/chair{
 	dir = 8
@@ -23785,12 +19645,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"cpn" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter)
 "cpp" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/loot_site_spawner,
@@ -23829,12 +19683,6 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "cqx" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -23843,7 +19691,6 @@
 	name = "Tunnel Access";
 	req_one_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -23909,8 +19756,6 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "csS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
@@ -23961,12 +19806,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"cuB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "cuD" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -23976,12 +19815,6 @@
 /area/hallway/primary/tram/left)
 "cuH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "11"
@@ -24012,19 +19845,10 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 10
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cvT" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -24036,8 +19860,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "cwG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
@@ -24047,12 +19869,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "cxj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 30
 	},
@@ -24112,8 +19928,6 @@
 	req_access_txt = "19;23"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -24140,12 +19954,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
@@ -24158,21 +19966,6 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"cAO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/break_room)
-"cAP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cAW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -24219,12 +20012,6 @@
 "cBF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Arrivals - North Hall";
@@ -24274,24 +20061,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "cDB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
-"cDF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "cDK" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -24310,8 +20083,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "cEk" = (
@@ -24335,30 +20106,11 @@
 /obj/item/pickaxe,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"cEx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
-"cEK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "cEN" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "cFF" = (
@@ -24408,22 +20160,9 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "cGF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/light,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"cGX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
 "cGY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -24432,45 +20171,12 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
-"cHa" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/door/airlock/command{
-	name = "Chief Engineer";
-	req_access_txt = "56"
-	},
-/turf/open/floor/iron,
-/area/command/heads_quarters/ce)
 "cHo" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "cHC" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -24480,16 +20186,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"cIa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/maintenance/disposal)
 "cIh" = (
 /turf/closed/wall,
 /area/security/prison/safe)
@@ -24553,9 +20249,6 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
@@ -24568,8 +20261,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
 "cJQ" = (
@@ -24632,15 +20323,7 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"cKK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "cLh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/button/door{
 	id = "miningdorm3";
 	name = "Door Bolt Control";
@@ -24650,24 +20333,9 @@
 	},
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
-"cLC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
 "cLR" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = -25;
 	pixel_y = -25
@@ -24684,7 +20352,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "cMo" = (
@@ -24760,33 +20427,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"cPH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "cQd" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/white,
 /area/science/explab)
-"cQr" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "cQv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -24840,12 +20484,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
@@ -24862,20 +20500,12 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "cRp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -24921,10 +20551,6 @@
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"cRZ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "cSq" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -24932,7 +20558,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -24980,20 +20605,8 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"cSV" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cTb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -25001,10 +20614,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"cTp" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/closed/wall,
-/area/maintenance/disposal/incinerator)
 "cTr" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/landmark/event_spawn,
@@ -25018,9 +20627,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cTA" = (
@@ -25030,13 +20636,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"cTF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "cTH" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
 	dir = 1
@@ -25066,32 +20665,12 @@
 /obj/structure/ladder,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"cTO" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "cTR" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/corner,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
@@ -25109,8 +20688,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cUc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -25212,9 +20789,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
@@ -25227,48 +20801,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"cXz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "cXC" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
-"cXF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/psychology)
-"cXH" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "cXM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
@@ -25298,12 +20837,6 @@
 /obj/structure/fluff/tram_rail,
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
-"cYc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/main)
 "cYj" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
@@ -25367,12 +20900,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -25418,12 +20945,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
-"daw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
 "daC" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -25473,12 +20994,6 @@
 /area/medical/treatment_center)
 "dby" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -25509,10 +21024,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "dcy" = (
@@ -25568,19 +21079,7 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
-"deg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "deo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -25626,13 +21125,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"dfF" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "dfT" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/disposaloutlet,
@@ -25646,16 +21138,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"dgr" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "dgP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -25665,7 +21147,6 @@
 "dgU" = (
 /obj/structure/table,
 /obj/item/assembly/flash/handheld,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "dhf" = (
@@ -25718,6 +21199,19 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"dig" = (
+/obj/structure/sign/poster/official/safety_report{
+	pixel_y = 32
+	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/bot,
+/obj/machinery/camera{
+	c_tag = "Security - Equipment Room";
+	dir = 6;
+	network = list("ss13","Security")
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "din" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
@@ -25811,12 +21305,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "dlF" = (
@@ -25840,12 +21328,6 @@
 /area/engineering/break_room)
 "dlZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25854,19 +21336,12 @@
 /area/command/bridge)
 "dmu" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/item/clothing/head/cone{
 	pixel_x = -8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"dmD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "dmZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25874,16 +21349,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
-"dnl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "dnG" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/machinery/light/small{
@@ -25903,12 +21368,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "dnM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
@@ -25939,12 +21398,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/research)
-"doo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/command/heads_quarters/ce)
 "dot" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 4"
@@ -25970,12 +21423,6 @@
 "doO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
@@ -26012,18 +21459,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dps" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/button/door{
@@ -26041,12 +21481,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/cytology)
-"dpB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "dpO" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -26055,20 +21489,9 @@
 /obj/item/radio/intercom{
 	pixel_y = -29
 	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"dql" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "dqs" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/flasher{
@@ -26151,23 +21574,12 @@
 "dso" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
-"dsp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/break_room)
 "dsq" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Bathroom"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/service/bar)
 "dsx" = (
@@ -26221,8 +21633,6 @@
 	id = "Holding Cell";
 	name = "Holding Cell"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
@@ -26234,12 +21644,6 @@
 	name = "Power Access Hatch";
 	req_one_access_txt = "11"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -26250,26 +21654,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"dum" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
 "duo" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
 	},
 /mob/living/simple_animal/bot/secbot{
 	arrest_type = 1;
@@ -26296,18 +21688,6 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engineering/main)
-"duP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
-"duQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "duU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -26336,9 +21716,6 @@
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "dwi" = (
@@ -26346,10 +21723,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "dxx" = (
@@ -26359,10 +21732,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria,
@@ -26377,9 +21746,6 @@
 /area/engineering/atmos)
 "dxI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "dxK" = (
@@ -26397,12 +21763,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -26419,20 +21779,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"dyE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/explab)
 "dzg" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -26443,8 +21789,6 @@
 /turf/closed/wall/r_wall,
 /area/cargo/miningdock)
 "dzB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -26465,19 +21809,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "dzG" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 6
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/science/server)
@@ -26502,23 +21837,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "dAD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26529,12 +21852,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dAS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Mining Maintenance Access";
@@ -26570,9 +21887,6 @@
 /obj/structure/sign/warning/radiation/rad_area{
 	dir = 1;
 	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -26622,24 +21936,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
-"dCV" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/left)
 "dDn" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -26658,11 +21957,6 @@
 	},
 /turf/open/openspace/airless/planetary,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"dDF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "dDP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
@@ -26704,10 +21998,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dED" = (
@@ -26767,17 +22057,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
 	name = "sorting disposal pipe (Detective's Office)";
 	sortType = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
@@ -26844,8 +22128,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
@@ -26868,8 +22150,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/duct,
@@ -26927,8 +22207,6 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
@@ -26950,12 +22228,6 @@
 /obj/item/food/deadmouse,
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
-"dIZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "dJh" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -26966,9 +22238,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -26977,12 +22246,6 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -27042,9 +22305,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27102,9 +22362,6 @@
 /area/security/prison)
 "dLY" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -27123,8 +22380,6 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
 "dMo" = (
@@ -27165,9 +22420,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dOc" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -27206,12 +22458,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"dOE" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "dOL" = (
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
@@ -27221,7 +22467,6 @@
 	name = "sorting disposal pipe (Toxins)";
 	sortType = 25
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
@@ -27233,12 +22478,6 @@
 /area/security/processing)
 "dPa" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/bot,
@@ -27258,7 +22497,6 @@
 	req_access_txt = "13"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "dPv" = (
@@ -27266,9 +22504,6 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dPD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -27279,33 +22514,14 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
-"dPP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "dPU" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Security - Equipment Room";
-	dir = 6;
-	network = list("ss13","Security")
-	},
-/obj/machinery/vending/security_peacekeeper,
+/obj/structure/table,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "dQI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -27317,28 +22533,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"dQX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/main)
 "dRg" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
 "dRl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
@@ -27394,8 +22594,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
@@ -27405,15 +22603,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"dSZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "dTm" = (
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
@@ -27432,12 +22621,6 @@
 	},
 /area/science/breakroom)
 "dTT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -27459,9 +22642,6 @@
 /area/engineering/main)
 "dUe" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
 	pixel_x = 8;
@@ -27515,12 +22695,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -27529,15 +22703,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/research)
-"dUY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "dVo" = (
 /obj/item/pickaxe/rusted,
 /turf/open/floor/plating/asteroid/airless,
@@ -27550,19 +22715,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
 /area/science/breakroom)
 "dVM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -27592,24 +22750,9 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"dXc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/explab)
 "dXf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -27623,12 +22766,6 @@
 	name = "Material Storage";
 	req_access_txt = "11"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "dXh" = (
@@ -27639,24 +22776,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"dXi" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
 "dXn" = (
 /obj/structure/chair{
 	dir = 1;
@@ -27736,7 +22855,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "dYA" = (
@@ -27748,12 +22866,6 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "dYF" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
 	pixel_x = -6;
@@ -27762,13 +22874,6 @@
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"dYM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "dYR" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
@@ -27783,12 +22888,6 @@
 /obj/machinery/door/airlock{
 	id_tag = "miningdorm2";
 	name = "Room 2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
@@ -27817,12 +22916,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -27832,22 +22925,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
-"dZX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "eaa" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "eaf" = (
@@ -27866,12 +22947,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/science/server)
 "eaU" = (
@@ -27888,7 +22963,6 @@
 "eaY" = (
 /obj/structure/grille,
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "ebe" = (
@@ -27897,12 +22971,6 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "ebk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/duct,
@@ -27947,8 +23015,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -27967,12 +23033,6 @@
 "edC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -28000,12 +23060,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -28018,12 +23072,6 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/secondary)
 "efx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
@@ -28033,8 +23081,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "efF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -28072,12 +23118,6 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/iron,
 /area/science/research)
@@ -28096,30 +23136,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"egC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"egF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
-"egN" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ehg" = (
 /obj/machinery/door/airlock/virology{
 	name = "Break Room";
@@ -28131,12 +23147,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
@@ -28150,20 +23160,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"ehy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "ehE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -28178,7 +23177,6 @@
 /obj/machinery/meter{
 	name = "Mixed Air Tank Out"
 	},
-/obj/machinery/atmospherics/pipe/simple,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "eiv" = (
@@ -28203,10 +23201,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/medical/coldroom)
-"eiX" = (
-/obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "eji" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -28217,8 +23211,6 @@
 "ejm" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "ejF" = (
@@ -28232,29 +23224,6 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
-"ejT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/brig)
-"ekA" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "ekC" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/segment{
@@ -28391,8 +23360,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorms West";
 	dir = 5
@@ -28443,12 +23410,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -28468,12 +23429,6 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "epk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
 "epT" = (
@@ -28527,12 +23482,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
@@ -28540,15 +23489,11 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "eru" = (
@@ -28602,12 +23547,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"esm" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/science/mixing)
 "esz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -28633,7 +23572,6 @@
 /area/ai_monitored/security/armory)
 "etc" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/space/basic,
 /area/space/nearstation)
 "eth" = (
@@ -28685,13 +23623,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"eui" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "eul" = (
 /obj/machinery/camera{
 	c_tag = "Security - Interrogation Observation";
@@ -28701,10 +23632,6 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "eup" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -28713,8 +23640,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "euP" = (
@@ -28732,12 +23657,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"evn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/foyer)
 "evv" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -28843,9 +23762,6 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "eyt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -28863,28 +23779,15 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "ezk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"ezn" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ezo" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain/private)
@@ -28907,7 +23810,6 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "eAa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -28922,7 +23824,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "eAx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
 	name = "Atmospherics Blast Door"
@@ -28930,15 +23831,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"eAy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/grimy,
-/area/service/chapel/office)
 "eAE" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -28975,9 +23867,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "eBk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "eBn" = (
@@ -28986,19 +23875,8 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"eBP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "eBS" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -29035,12 +23913,6 @@
 "eCl" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
-"eCr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "eCt" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -29082,9 +23954,6 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "eDs" = (
@@ -29148,13 +24017,6 @@
 /obj/structure/fluff/tram_rail/floor,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
-"eEO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "eFj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -29177,7 +24039,6 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "eFP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/navbeacon/wayfinding/tools,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
@@ -29198,12 +24059,6 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "eGo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -29222,24 +24077,10 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Radstorm Shelter"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
-"eGY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "eHk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -29256,9 +24097,6 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -29309,11 +24147,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/science/mixing)
-"eJm" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "eJo" = (
 /obj/structure/table/optable{
 	desc = "A cold, hard place for your final rest.";
@@ -29355,21 +24188,11 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "eLP" = (
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"eLQ" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "eLR" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/cable,
@@ -29437,7 +24260,6 @@
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding/techstorage,
 /turf/open/floor/iron/dark,
@@ -29455,9 +24277,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "eNO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -29481,19 +24300,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"eOp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/atmospherics_engine)
 "eOy" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -29517,20 +24323,11 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "eON" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29538,12 +24335,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"eOO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "eOT" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/carpet,
@@ -29553,12 +24344,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -29567,16 +24352,8 @@
 "ePt" = (
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
-"ePx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "ePB" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -29599,25 +24376,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"ePP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "eQe" = (
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/window/plasma/reinforced{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -29628,15 +24390,10 @@
 	req_access_txt = "30"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/science/server)
 "eQx" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -29658,10 +24415,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
@@ -29681,11 +24434,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
-"eSn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "eSt" = (
 /obj/machinery/computer/warrant{
 	dir = 8
@@ -29720,7 +24468,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "eSQ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -29739,12 +24486,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "eSZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -29769,13 +24510,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/commons/dorms)
 "eTD" = (
@@ -29786,15 +24521,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
-/area/engineering/main)
-"eTF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
 /area/engineering/main)
 "eTO" = (
 /obj/structure/disposalpipe/segment{
@@ -29824,15 +24550,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"eUx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "eUD" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -29946,12 +24663,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"eWy" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "eWI" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -29967,9 +24678,6 @@
 "eWR" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Hallway - North-West Escape Wing Entry";
 	dir = 1
@@ -30017,33 +24725,13 @@
 /area/security/prison)
 "eYk" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"eYz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/main)
 "eYE" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
@@ -30058,24 +24746,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"eZf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "eZn" = (
 /obj/effect/spawner/lootdrop/food_packaging,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "eZq" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "eZr" = (
@@ -30092,19 +24768,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
-"eZA" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "eZN" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/tile/neutral{
@@ -30153,10 +24816,6 @@
 	name = "sorting disposal pipe (Experimentor Lab)";
 	sortType = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
@@ -30213,18 +24872,8 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"fbj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/engine,
-/area/engineering/main)
 "fbm" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -30238,12 +24887,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fbn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/service/bar)
@@ -30257,25 +24900,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter)
-"fbF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/service/kitchen)
 "fbR" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
@@ -30284,12 +24908,6 @@
 /obj/machinery/door/airlock{
 	id_tag = "private_d";
 	name = "Private Quarters 4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -30302,18 +24920,6 @@
 /obj/item/pen,
 /turf/open/floor/iron/white,
 /area/science/explab)
-"fck" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/mine/explored)
-"fcv" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/main)
 "fcZ" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/tile/neutral{
@@ -30346,9 +24952,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
 	pixel_y = 25
@@ -30361,8 +24964,6 @@
 /area/science/xenobiology)
 "fdy" = (
 /obj/structure/ladder,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -30377,12 +24978,6 @@
 /turf/open/floor/plating,
 /area/medical/storage)
 "fej" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -30411,9 +25006,6 @@
 	},
 /obj/structure/sign/barsign{
 	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -30500,8 +25092,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fgX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
@@ -30548,9 +25138,6 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "fhE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -30567,15 +25154,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"fhQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "fhR" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
@@ -30628,22 +25206,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
-"fjy" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/freezer,
-/area/science/research)
 "fjD" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -30671,12 +25236,6 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -30686,19 +25245,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"flU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmospherics_engine)
 "fmd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -30750,10 +25296,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "fmq" = (
@@ -30770,12 +25312,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -30801,10 +25337,6 @@
 /obj/effect/turf_decal/trimline/purple/end,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"fnq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "fnX" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Medical Maintenance";
@@ -30813,38 +25345,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"foh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/atmospherics_engine)
-"fom" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "foD" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageSort2"
@@ -30920,8 +25420,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fqh" = (
@@ -30984,12 +25482,6 @@
 /obj/structure/closet/secure_closet/security_medic,
 /turf/open/floor/iron/white,
 /area/security/brig)
-"frJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/break_room)
 "frL" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -30998,7 +25490,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
@@ -31030,7 +25521,6 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/fore/secondary)
 "fsk" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
@@ -31052,7 +25542,6 @@
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
 "fsX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -31082,8 +25571,6 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "fvd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Hydroponics Maintenance Access";
 	req_access_txt = "35,12"
@@ -31103,12 +25590,6 @@
 	pixel_y = 32
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -31117,9 +25598,6 @@
 "fvz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -31136,12 +25614,6 @@
 /area/maintenance/disposal/incinerator)
 "fwm" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
@@ -31158,13 +25630,6 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"fwt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "fwu" = (
 /obj/item/stack/ore/glass,
 /obj/item/stack/ore/glass,
@@ -31176,12 +25641,6 @@
 /area/maintenance/central/secondary)
 "fwA" = (
 /obj/structure/rack,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/item/storage/box/armament_tokens_primary{
 	pixel_x = -8
 	},
@@ -31202,20 +25661,7 @@
 "fwP" = (
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/medical)
-"fwR" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "fxc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
 	},
@@ -31255,19 +25701,12 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/service/theater)
 "fye" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/meter,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -31287,7 +25726,6 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/mixing)
 "fyx" = (
@@ -31296,12 +25734,6 @@
 /area/maintenance/port/fore)
 "fyX" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -31326,8 +25758,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Arrivals - North Docking Hall";
@@ -31348,8 +25778,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/camera{
 	c_tag = "Science - Main AI Access Hall";
 	dir = 9;
@@ -31357,24 +25785,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"fAb" = (
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/command/nuke_storage)
 "fAv" = (
 /obj/effect/turf_decal/trimline/red/arrow_cw,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -31414,13 +25827,6 @@
 /obj/structure/closet/crate/goldcrate,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
-"fAV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/main)
 "fBd" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
@@ -31431,12 +25837,9 @@
 	req_access_txt = "19; 61"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "fBv" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
@@ -31476,14 +25879,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"fCt" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "fCx" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/stripes/corner{
@@ -31564,12 +25959,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
-"fFP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "fFQ" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -31577,15 +25966,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "fFZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
@@ -31619,12 +25999,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
@@ -31646,9 +26020,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "fGF" = (
@@ -31668,11 +26039,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"fGN" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/grass,
-/area/medical/virology)
 "fGX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -31681,12 +26047,6 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "fHU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/duct,
@@ -31700,15 +26060,9 @@
 /area/hallway/secondary/command)
 "fIj" = (
 /obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "fIp" = (
@@ -31719,20 +26073,10 @@
 "fIu" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/command/gateway)
-"fIK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/hallway/primary/tram/right)
 "fJy" = (
 /obj/machinery/air_sensor/atmos/nitrogen_tank,
 /turf/open/floor/engine/n2,
@@ -31769,12 +26113,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
@@ -31798,8 +26136,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "fLy" = (
@@ -31827,8 +26163,6 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fLR" = (
@@ -31849,13 +26183,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/service/bar)
-"fNd" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/interrogation)
 "fNh" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/disposalpipe/segment,
@@ -31876,18 +26203,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"fNH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/food_packaging,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "fNJ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -31900,9 +26215,6 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "fOh" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
@@ -32029,12 +26341,6 @@
 	},
 /turf/open/floor/plating,
 /area/service/hydroponics)
-"fQJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "fQS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/warning,
@@ -32062,7 +26368,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "fRg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
@@ -32072,7 +26377,6 @@
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -32092,7 +26396,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -32128,12 +26431,6 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
@@ -32197,9 +26494,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "fTq" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -32212,14 +26506,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"fTx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/office)
 "fTN" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -32231,25 +26517,11 @@
 	req_access_txt = "62"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
-"fTV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "fTY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -32258,26 +26530,9 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"fUf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "fUq" = (
 /turf/closed/wall/rust,
 /area/maintenance/central)
-"fUw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/office)
 "fVf" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
@@ -32307,7 +26562,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
 "fWU" = (
@@ -32334,9 +26588,6 @@
 /area/engineering/supermatter)
 "fXn" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "fXp" = (
@@ -32375,14 +26626,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "fZi" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -32400,9 +26647,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "fZr" = (
@@ -32452,13 +26697,7 @@
 /turf/open/floor/plating,
 /area/mine/explored)
 "gaD" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
@@ -32466,7 +26705,6 @@
 /area/hallway/primary/tram/right)
 "gbB" = (
 /obj/machinery/computer/camera_advanced/xenobio,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -32543,27 +26781,15 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "gdl" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "gdp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -32582,16 +26808,9 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/structure/chair/office,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
-"ger" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "geu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -32599,8 +26818,6 @@
 /area/engineering/break_room)
 "gew" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
@@ -32656,9 +26873,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "gfq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/explab)
@@ -32705,8 +26919,6 @@
 	},
 /obj/item/pen,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "ggQ" = (
@@ -32715,18 +26927,9 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "ghw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "ghY" = (
@@ -32747,12 +26950,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -32760,10 +26957,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "giq" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
@@ -32789,16 +26982,10 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "gki" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "gkF" = (
@@ -32818,14 +27005,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"gkT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "glg" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
@@ -32855,13 +27034,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
-"gly" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "gma" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -32882,27 +27054,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Hallway - South-West Escape Wing Entry";
 	dir = 6
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"gmv" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "gnn" = (
 /obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/science/research)
 "gnC" = (
@@ -32933,19 +27092,10 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "gpk" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gpo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/chapel,
@@ -32964,12 +27114,6 @@
 "gpL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
 	},
 /obj/structure/cable,
 /obj/structure/sign/warning/radshelter{
@@ -33027,11 +27171,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"gqr" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "gqu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -33084,12 +27223,6 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "gru" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
@@ -33101,12 +27234,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "grF" = (
@@ -33116,12 +27243,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
@@ -33129,20 +27250,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"grL" = (
-/obj/structure/sign/poster/official/safety_report{
-	pixel_y = 32
-	},
-/obj/machinery/gun_vendor,
-/turf/open/floor/iron/showroomfloor,
-/area/security/office)
 "gsb" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Storage";
 	req_access_txt = "71"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/science/mixing)
@@ -33163,12 +27275,6 @@
 	dir = 4;
 	name = "sorting disposal pipe (Chief Engineer's Office)";
 	sortType = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -33250,7 +27356,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "guh" = (
@@ -33262,16 +27367,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
-"gui" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Xenolab";
-	name = "test chamber blast door"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "guo" = (
 /obj/structure/table,
 /obj/item/paper/pamphlet/radstorm,
@@ -33282,14 +27377,6 @@
 "gut" = (
 /turf/closed/wall,
 /area/hallway/secondary/construction/engineering)
-"gux" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/rods,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "guy" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -33306,12 +27393,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/iron,
@@ -33320,9 +27401,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -25;
 	pixel_y = -8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
@@ -33337,12 +27415,6 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "gwn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -33367,12 +27439,6 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
 	},
 /obj/effect/landmark/event_spawn,
 /obj/machinery/light{
@@ -33426,7 +27492,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gyi" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Engine Room South-East";
@@ -33435,16 +27500,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"gyp" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "gyq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -33467,17 +27522,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
-"gyY" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "gzb" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -33489,26 +27533,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"gzh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "gzi" = (
 /obj/machinery/door/airlock/medical{
 	name = "Surgery";
 	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -33521,20 +27549,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"gzn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "gzu" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/camera{
 	c_tag = "Medical - Virology";
 	dir = 4;
@@ -33552,10 +27571,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"gzH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/break_room)
 "gAv" = (
 /obj/structure/rack,
 /obj/item/stack/cable_coil/five,
@@ -33563,24 +27578,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
-"gAz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/processing)
-"gAK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria{
-	dir = 5
-	},
-/area/science/breakroom)
 "gAR" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -33598,18 +27595,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "gAY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
@@ -33688,7 +27676,6 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "gCm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30
 	},
@@ -33733,9 +27720,6 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "gCL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -33751,12 +27735,6 @@
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
 	req_access_txt = "16"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -33782,12 +27760,6 @@
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -33816,9 +27788,6 @@
 "gEi" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -33840,8 +27809,6 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Laundromat"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria,
@@ -33850,17 +27817,9 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"gED" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "gEO" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
@@ -33888,12 +27847,6 @@
 /turf/open/floor/iron/dark,
 /area/security/processing)
 "gFw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
@@ -33913,11 +27866,6 @@
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"gFR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "gFV" = (
 /obj/structure/railing{
 	dir = 1
@@ -33956,12 +27904,6 @@
 "gGH" = (
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
@@ -34006,24 +27948,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"gHj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/medical/virology)
 "gHx" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -34037,24 +27964,15 @@
 /area/hallway/primary/tram/center)
 "gHS" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "gHT" = (
 /obj/machinery/ore_silo,
 /obj/effect/turf_decal/bot_white/right,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "gIc" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
@@ -34172,9 +28090,6 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
 "gKx" = (
@@ -34192,7 +28107,6 @@
 /area/science/mixing)
 "gKQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "gKY" = (
@@ -34204,7 +28118,6 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "gLi" = (
@@ -34215,8 +28128,6 @@
 /area/engineering/storage/tech)
 "gLq" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -34230,12 +28141,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "gLL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
@@ -34258,9 +28163,6 @@
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice)
 "gMk" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
@@ -34291,12 +28193,6 @@
 	},
 /area/commons/vacant_room/office)
 "gNI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -34328,10 +28224,6 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "gOj" = (
@@ -34356,9 +28248,6 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "gOu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "gOy" = (
@@ -34366,9 +28255,6 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "gOG" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
@@ -34406,7 +28292,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/camera{
 	c_tag = "Cargo - Mining South-East";
 	dir = 5;
@@ -34414,17 +28299,7 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"gQb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/medical/virology)
 "gQn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "gQo" = (
@@ -34449,13 +28324,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"gQQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "gRc" = (
 /obj/item/radio/intercom{
 	pixel_y = -26
@@ -34526,19 +28394,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "gSw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "gSA" = (
@@ -34629,8 +28488,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/processing)
@@ -34643,21 +28500,12 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "gUy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"gUE" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "gUJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -34675,12 +28523,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"gUY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
 "gVh" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Telecomms Relay Access";
@@ -34707,6 +28549,11 @@
 /obj/structure/fluff/tram_rail,
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
+"gVS" = (
+/obj/machinery/gun_vendor,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "gWm" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
@@ -34725,8 +28572,6 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "gXT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/hangover,
@@ -34754,7 +28599,6 @@
 /area/engineering/engine_smes)
 "gYH" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating/airless,
 /area/engineering/main)
 "gYZ" = (
@@ -34771,12 +28615,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"gZP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
 "hag" = (
 /turf/closed/wall,
 /area/medical/psychology)
@@ -34826,26 +28664,6 @@
 /obj/effect/turf_decal/siding/thinplating,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"hbu" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
-"hbW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "hbZ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -34915,30 +28733,12 @@
 /area/space/nearstation)
 "hdw" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/navbeacon/wayfinding/eva,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"hdC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"hdI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron/freezer,
-/area/science/research)
 "hdO" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "plating"
@@ -35031,8 +28831,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "hgo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Atmospherics Maintenance";
@@ -35046,20 +28844,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
-"hgt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "hgv" = (
 /obj/item/clothing/head/cone{
 	pixel_x = -8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -35083,8 +28871,6 @@
 	req_access_txt = "24"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -35131,10 +28917,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "hhJ" = (
@@ -35168,28 +28952,10 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "hjv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"hjw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/item/assembly/mousetrap/armed,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "hjB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/electricshock{
@@ -35198,12 +28964,6 @@
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
 "hjC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -35242,12 +29002,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "hkw" = (
@@ -35257,9 +29011,6 @@
 /area/mine/explored)
 "hkz" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 4
-	},
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -35309,10 +29060,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "hle" = (
@@ -35320,24 +29067,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"hlj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/research)
 "hlz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -35370,9 +29102,6 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "hlP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "hlR" = (
@@ -35401,12 +29130,6 @@
 	req_access_txt = "1"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -35502,6 +29225,14 @@
 	},
 /turf/open/floor/iron,
 /area/science/research)
+"hqb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 11
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "hqc" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -35524,11 +29255,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "hqL" = (
@@ -35538,7 +29265,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "hqN" = (
@@ -35549,8 +29275,6 @@
 /area/engineering/main)
 "hqU" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
@@ -35591,16 +29315,8 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"hrA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "hrI" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
@@ -35646,20 +29362,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"htq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"htC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "htT" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -35671,11 +29373,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
+"hub" = (
+/obj/machinery/processor,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "huj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/button/door{
 	id = "miningdorm1";
 	name = "Door Bolt Control";
@@ -35695,7 +29397,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "huu" = (
@@ -35703,12 +29404,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "huv" = (
@@ -35723,18 +29418,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"hux" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
-"huy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/science/mixing)
 "huF" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/landmark/start/hangover,
@@ -35776,12 +29459,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -35789,15 +29466,8 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "hxa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
-"hxu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "hxy" = (
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -35820,8 +29490,6 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "hzr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -35851,17 +29519,6 @@
 /obj/item/assembly/signaler,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"hzU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "hAf" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -35872,9 +29529,6 @@
 "hAA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -35933,22 +29587,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "hCF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -35982,9 +29624,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},
@@ -35992,12 +29631,6 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/science/server)
 "hDi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/processing)
@@ -36020,19 +29653,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"hDT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "hEf" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -36045,23 +29667,8 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
-"hEn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "hEu" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel Hall"
 	},
@@ -36076,12 +29683,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"hEA" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "hEC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 1;
@@ -36098,10 +29699,6 @@
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "hEO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/depsec/supply,
@@ -36115,12 +29712,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "hFq" = (
@@ -36130,8 +29721,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -36140,12 +29729,6 @@
 /area/cargo/office)
 "hFv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
@@ -36174,8 +29757,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
@@ -36278,13 +29859,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "hJG" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer4{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -36317,7 +29892,6 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -36353,25 +29927,12 @@
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
-"hKK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "hKP" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "hKU" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "hKW" = (
@@ -36416,7 +29977,6 @@
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "hMn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -36464,9 +30024,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "hOf" = (
@@ -36474,34 +30031,19 @@
 /obj/structure/closet/secure_closet/hop,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
-"hPE" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "hPM" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "hPR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/sand/plating,
 /obj/item/assembly/mousetrap/armed,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "hPV" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -36529,8 +30071,6 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "hQi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
@@ -36555,21 +30095,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar)
-"hQS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/corner,
-/turf/open/floor/iron/dark,
-/area/service/hydroponics)
 "hQY" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/turf_decal/bot{
@@ -36582,12 +30110,6 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "hRj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36608,7 +30130,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "hRw" = (
@@ -36654,12 +30175,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"hSF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "hTa" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -36667,10 +30182,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
-"hTg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "hTT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
@@ -36696,24 +30207,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"hUN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "hVw" = (
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 1
@@ -36747,12 +30246,6 @@
 /turf/open/floor/iron/airless,
 /area/mine/explored)
 "hWx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -36778,8 +30271,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -36787,7 +30278,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
 "hXD" = (
@@ -36797,13 +30287,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"hXR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "hYd" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
@@ -36829,9 +30312,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "hZa" = (
@@ -36845,12 +30325,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"hZq" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "hZH" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -36870,8 +30344,6 @@
 /obj/machinery/door/airlock/security{
 	name = "Permanent Cell 2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -36880,13 +30352,9 @@
 	name = "Captain's Quarters";
 	req_access_txt = "20"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "ias" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/chapel{
@@ -36897,10 +30365,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
@@ -36927,20 +30391,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/freezer,
 /area/service/bar)
-"icr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
-"icN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/security/processing)
 "idT" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Library Game Room"
@@ -36950,9 +30400,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -36968,21 +30415,12 @@
 /area/maintenance/starboard/secondary)
 "ieo" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 4;
+	pixel_y = 5
 	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/item/book/manual/chef_recipes,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/glass/rag,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "iep" = (
@@ -37013,8 +30451,6 @@
 	req_one_access_txt = "10;24"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
@@ -37111,7 +30547,6 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -37123,22 +30558,10 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "ihX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -37245,9 +30668,6 @@
 	name = "Distribution Loop";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -37278,12 +30698,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ili" = (
@@ -37297,9 +30711,6 @@
 	},
 /obj/machinery/status_display/ai{
 	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -37322,13 +30733,9 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/stool/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
@@ -37336,12 +30743,6 @@
 /area/service/bar)
 "imW" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -37444,16 +30845,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"ipP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "ipX" = (
 /obj/machinery/light,
 /turf/open/floor/iron/dark,
@@ -37470,12 +30861,7 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"iqe" = (
-/obj/machinery/atmospherics/pipe/manifold4w/green/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "iqm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -37511,7 +30897,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
 	},
@@ -37519,19 +30904,9 @@
 /area/engineering/main)
 "isH" = (
 /obj/machinery/holopad/secure,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"itk" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "itx" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
@@ -37561,8 +30936,6 @@
 	name = "MiniSat Chamber Hallway";
 	req_one_access_txt = "65"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -37570,12 +30943,6 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -37603,9 +30970,6 @@
 "iuh" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -37640,9 +31004,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -37663,12 +31024,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ivo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/item/clothing/head/cone{
 	pixel_y = -8
@@ -37678,8 +31033,6 @@
 /area/maintenance/port/aft)
 "ivp" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/main)
 "ivx" = (
@@ -37695,28 +31048,16 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
 "iwb" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/science/explab)
-"iwd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "iwe" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -37727,10 +31068,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/mine/explored)
-"iwk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
 "iwC" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -37742,9 +31079,6 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "iwI" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -37777,13 +31111,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"ixd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "ixu" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -37808,9 +31135,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "iyw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
@@ -37836,16 +31160,6 @@
 "iyX" = (
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"izj" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room";
-	req_one_access_txt = "10;24"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/engine,
-/area/engineering/main)
 "izq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -37886,16 +31200,6 @@
 /obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
-"iAF" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/escape)
 "iAL" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Office";
@@ -37964,14 +31268,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"iCv" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "iCx" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -38001,44 +31297,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"iCM" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "iCR" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
-"iCV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
-"iCX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
-"iDB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/cytology)
 "iDO" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/neutral{
@@ -38073,19 +31335,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
-"iFm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/iron,
-/area/engineering/atmospherics_engine)
-"iFq" = (
-/obj/structure/ladder,
-/obj/machinery/atmospherics/pipe/multiz/layer4,
-/obj/machinery/atmospherics/pipe/multiz/layer2,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "iFE" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -38097,8 +31346,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iFH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
@@ -38155,12 +31402,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -38171,17 +31412,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "iGJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/machinery/navbeacon/wayfinding/aiupload,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -38218,9 +31452,6 @@
 /area/hallway/secondary/exit)
 "iIQ" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -38325,11 +31556,6 @@
 /obj/structure/railing,
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
-"iLF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "iLJ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -38347,43 +31573,12 @@
 	req_access_txt = "57"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
-"iLL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
-"iMa" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
 "iMx" = (
 /obj/machinery/processor,
 /obj/effect/turf_decal/siding/thinplating/corner{
@@ -38417,11 +31612,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/mine/explored)
-"iMP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "iMU" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table/glass,
@@ -38451,7 +31641,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -38470,29 +31659,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"iOd" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/service/bar)
 "iOA" = (
 /obj/machinery/telecomms/server/presets/service,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "iOB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -38521,10 +31692,6 @@
 /obj/machinery/rnd/production/protolathe/department/security,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"iPg" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "iPj" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -38557,24 +31724,9 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"iPR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "iQb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -38601,16 +31753,10 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
 "iQi" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
 "iQl" = (
@@ -38637,7 +31783,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
@@ -38662,12 +31807,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
@@ -38689,9 +31828,6 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "iRZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
@@ -38703,10 +31839,6 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "iSt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
@@ -38827,10 +31959,6 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
-"iVY" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "iWm" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -38846,12 +31974,6 @@
 /turf/open/floor/iron/dark,
 /area/medical/psychology)
 "iWT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -38862,13 +31984,6 @@
 "iWU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -38897,10 +32012,6 @@
 /area/hallway/secondary/command)
 "iXH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -38932,9 +32043,6 @@
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "iZX" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
 /obj/machinery/meter/atmos/atmos_waste_loop,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -38969,13 +32077,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "jaS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/item/assembly/mousetrap/armed,
 /obj/effect/decal/cleanable/dirt,
@@ -38989,22 +32094,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"jbr" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "jbs" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"jbt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "jbA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/power/apc/auto_name/south,
@@ -39042,8 +32135,6 @@
 /area/maintenance/central/secondary)
 "jdw" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
@@ -39073,15 +32164,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/lab)
-"jeh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible,
-/obj/machinery/meter/atmos/atmos_waste_loop,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "jek" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -39089,29 +32173,12 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
-"jeL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/office)
 "jfy" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"jgd" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "jgi" = (
 /obj/item/pickaxe,
 /obj/structure/rack,
@@ -39126,8 +32193,6 @@
 /obj/machinery/door/airlock/glass{
 	name = "Break Room"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -39175,17 +32240,6 @@
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"jiv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "jiz" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/decal/cleanable/dirt,
@@ -39210,7 +32264,6 @@
 /area/maintenance/central)
 "jjf" = (
 /obj/machinery/computer/camera_advanced/xenobio,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -39257,12 +32310,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
@@ -39303,29 +32350,11 @@
 	dir = 5
 	},
 /area/command/heads_quarters/rd)
-"jkZ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "jld" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"jls" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/supermatter)
 "jmb" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -39349,16 +32378,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"jmu" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "jmC" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -39368,12 +32387,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -39381,7 +32394,6 @@
 /area/service/lawoffice)
 "jmK" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/science/research)
 "jng" = (
@@ -39396,12 +32408,6 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -39545,8 +32551,6 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
 "jrC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
@@ -39560,18 +32564,6 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/iron,
 /area/science/mixing)
-"jse" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/food_packaging,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "jst" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -39593,12 +32585,6 @@
 	name = "Research and Development Shutter"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "jtb" = (
@@ -39608,20 +32594,9 @@
 /turf/open/floor/plating,
 /area/hallway/primary/tram/right)
 "jtc" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"jto" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "jtI" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -39629,7 +32604,6 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "juc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -39647,7 +32621,6 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "juv" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -39684,12 +32657,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -39777,9 +32744,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "jwY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -39812,7 +32776,6 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "jxJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "jxN" = (
@@ -39911,9 +32874,6 @@
 /area/maintenance/port/aft)
 "jzA" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/science/explab)
 "jzL" = (
@@ -39925,12 +32885,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"jAf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
 "jAl" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1;
@@ -40050,14 +33004,6 @@
 /obj/machinery/light,
 /turf/open/floor/carpet/executive,
 /area/command/heads_quarters/captain/private)
-"jFb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "jFc" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -40073,12 +33019,6 @@
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -40110,7 +33050,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "jGz" = (
@@ -40135,21 +33074,8 @@
 /obj/effect/spawner/lootdrop/food_packaging,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"jHK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "jHL" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
@@ -40157,12 +33083,6 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "jHM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/research)
@@ -40309,6 +33229,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"jLk" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/camera{
+	c_tag = "Security - Prison Cafeteria";
+	dir = 1;
+	network = list("ss13","Security","prison")
+	},
+/obj/machinery/griddle,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "jLP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -40358,12 +33288,6 @@
 /obj/effect/turf_decal/siding/thinplating,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/corner,
@@ -40442,11 +33366,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
-"jPQ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "jQd" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
@@ -40456,20 +33375,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"jQk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "jQs" = (
 /obj/structure/chair/office/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
@@ -40487,8 +33396,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -40520,8 +33427,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/main)
 "jTk" = (
@@ -40529,10 +33434,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/mine/explored)
-"jTv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai)
 "jTP" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
@@ -40567,9 +33468,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -40597,20 +33495,10 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "jVy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"jVA" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "jVB" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -40629,18 +33517,11 @@
 	name = "Laser Room";
 	req_one_access_txt = "10;24"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/engineering/main)
 "jVH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Command - Bridge South";
@@ -40659,12 +33540,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "jVY" = (
@@ -40756,12 +33631,6 @@
 /area/hallway/secondary/construction/engineering)
 "jXA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -40784,7 +33653,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -40798,7 +33666,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -40819,19 +33686,7 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jZa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "jZf" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron,
@@ -40864,12 +33719,6 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/machinery/navbeacon/wayfinding/minisat_access_ai,
 /turf/open/floor/iron,
 /area/science/research)
@@ -40882,10 +33731,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"kal" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/security/checkpoint/engineering)
 "kam" = (
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/iron/dark/telecomms,
@@ -41014,10 +33859,6 @@
 /area/cargo/miningdock)
 "kcw" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
@@ -41029,8 +33870,6 @@
 /area/maintenance/tram/mid)
 "kcB" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
@@ -41096,7 +33935,6 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -41126,12 +33964,6 @@
 	id = "rndlab1";
 	name = "Research and Development Shutter"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "ker" = (
@@ -41145,12 +33977,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/sign/departments/restroom{
 	pixel_y = -32
 	},
@@ -41172,12 +33998,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
-"keL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kfa" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -41245,12 +34065,6 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "kgG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41279,12 +34093,6 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "khH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
@@ -41308,19 +34116,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "kiv" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
 /obj/effect/landmark/event_spawn,
@@ -41338,19 +34136,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
-"kjL" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "kjQ" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
@@ -41389,19 +34174,8 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
-"kkq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "kkx" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "11"
@@ -41427,20 +34201,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"klf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "klo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -41470,8 +34230,6 @@
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "kml" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
@@ -41498,17 +34256,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
 /obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "kmX" = (
@@ -41557,15 +34309,7 @@
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
-"knN" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "knO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -41597,12 +34341,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/commons/lounge)
 "koV" = (
@@ -41650,8 +34388,6 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "kqY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry";
@@ -41750,20 +34486,7 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"kuj" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kuw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -41819,15 +34542,7 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
-"kvR" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "kwc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
@@ -41838,7 +34553,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kwg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -41882,17 +34596,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"kwv" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/supermatter)
 "kwQ" = (
 /turf/closed/wall,
 /area/security/checkpoint/medical)
@@ -41924,12 +34627,6 @@
 	name = "Hydroponics";
 	req_access_txt = "35"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -41939,14 +34636,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"kyK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/science/mixing)
 "kze" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 1
@@ -42027,14 +34718,6 @@
 "kAu" = (
 /turf/open/floor/iron/stairs/medium,
 /area/science/research)
-"kAI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "kAK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42051,7 +34734,6 @@
 /area/security/office)
 "kAS" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/item/paper_bin/carbon{
 	pixel_x = -3;
 	pixel_y = 7
@@ -42090,9 +34772,6 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "kCj" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "O2 to Pure"
@@ -42156,12 +34835,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -42195,12 +34868,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
-"kEG" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kFd" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
@@ -42224,12 +34891,6 @@
 /area/cargo/office)
 "kFD" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -42286,8 +34947,6 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "kHz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
 /turf/open/floor/plating,
@@ -42301,13 +34960,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"kHD" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "kIt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -42317,7 +34969,6 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
 "kIA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "kIF" = (
@@ -42383,12 +35034,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "kJX" = (
@@ -42403,7 +35048,6 @@
 	pixel_x = -6;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -42454,23 +35098,14 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "kLi" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -42543,12 +35178,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"kMy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "kNk" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -42579,12 +35208,6 @@
 	req_access_txt = "4"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42596,16 +35219,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "kOv" = (
@@ -42637,8 +35251,6 @@
 "kPy" = (
 /obj/effect/landmark/start/head_of_security,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -42646,15 +35258,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"kPB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "kPK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
@@ -42708,10 +35311,6 @@
 /area/cargo/miningdock)
 "kRd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/table/glass,
 /turf/open/floor/iron/white,
@@ -42734,12 +35333,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "kSp" = (
@@ -42748,12 +35341,6 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "kSD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
@@ -42834,12 +35421,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/service/library)
-"kUF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "kUL" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -42850,13 +35431,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"kUO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "kUQ" = (
 /obj/structure/chair,
 /obj/structure/sign/poster/official/random{
@@ -42920,18 +35494,13 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "kVU" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/machinery/vending/security_peacekeeper,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "kWc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -42939,12 +35508,6 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "kWk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/item/assembly/mousetrap/armed,
 /obj/effect/decal/cleanable/dirt,
@@ -42956,14 +35519,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"kWq" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "kWz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -42980,8 +35535,6 @@
 /area/engineering/main)
 "kWH" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kWL" = (
@@ -43023,25 +35576,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"kXN" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "kYf" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -43073,27 +35612,12 @@
 	},
 /obj/effect/landmark/start/security_officer,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "kYC" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
-"kZc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "kZf" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -43111,7 +35635,6 @@
 	pixel_x = -6;
 	pixel_y = -3
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "kZs" = (
@@ -43125,14 +35648,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"kZD" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "kZF" = (
 /obj/machinery/computer/station_alert{
 	dir = 8
@@ -43151,16 +35666,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"kZY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "lap" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
@@ -43237,29 +35742,10 @@
 /obj/structure/cable,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"lce" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lcD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -43276,9 +35762,6 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -43322,25 +35805,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/right)
-"ldt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "ldA" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
@@ -43352,14 +35821,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
 /turf/open/floor/iron,
@@ -43378,37 +35841,11 @@
 /obj/structure/railing,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
-"ldQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
-"lec" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/main)
 "led" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
-"lee" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/science/robotics/mechbay)
 "lef" = (
 /obj/machinery/door/airlock{
 	id_tag = "restroom_6";
@@ -43499,9 +35936,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "lgR" = (
@@ -43509,9 +35943,6 @@
 /area/maintenance/central)
 "lgX" = (
 /obj/structure/chair/comfy/brown,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "lhu" = (
@@ -43565,18 +35996,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
-"ljs" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lju" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -43623,10 +36045,6 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "lkS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -43639,7 +36057,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
@@ -43661,7 +36078,6 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "lmk" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
@@ -43699,12 +36115,6 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "lmE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43767,8 +36177,6 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "loB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -43795,12 +36203,6 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
 "lpe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
@@ -43814,8 +36216,6 @@
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "lpU" = (
@@ -43829,13 +36229,6 @@
 "lpV" = (
 /turf/closed/wall,
 /area/engineering/main)
-"lqb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/maintenance/disposal)
 "lqN" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -43856,12 +36249,6 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -43887,12 +36274,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "lrM" = (
@@ -43901,12 +36282,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"lrU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "lsF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/light/small{
@@ -43918,13 +36293,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"lsZ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 6
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lth" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/mortar,
@@ -44002,9 +36370,6 @@
 /area/engineering/atmos)
 "luw" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Engine Room South-West";
 	dir = 1;
@@ -44017,8 +36382,6 @@
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
@@ -44032,9 +36395,6 @@
 "luP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -44120,12 +36480,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/server)
-"lwI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria{
-	dir = 5
-	},
-/area/science/breakroom)
 "lwN" = (
 /turf/closed/wall,
 /area/medical/pharmacy)
@@ -44137,12 +36491,6 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "lxo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron/white,
@@ -44151,18 +36499,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
-"lyr" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "lyN" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/tile/neutral{
@@ -44185,17 +36521,11 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
 "lzd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "lzr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
@@ -44216,9 +36546,6 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "lzT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
@@ -44240,16 +36567,6 @@
 /obj/item/shovel,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/medical)
-"lAf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "lAC" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -44290,13 +36607,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
-"lBk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
+"lBy" = (
+/obj/machinery/smartfridge,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "lBE" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -44357,9 +36671,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lEq" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/machinery/meter,
 /obj/machinery/button/door/incinerator_vent_toxmix{
 	pixel_x = -25;
@@ -44378,9 +36689,6 @@
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science/robotics/mechbay)
 "lEu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -44391,12 +36699,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -44410,22 +36712,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"lGe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
 "lGB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -44440,24 +36726,12 @@
 	req_access_txt = "69"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"lGS" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lGY" = (
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Upper External South";
@@ -44495,9 +36769,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -44528,12 +36799,6 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "lIF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
@@ -44601,9 +36866,6 @@
 /area/hallway/primary/tram/left)
 "lKd" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
@@ -44678,9 +36940,6 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "lMO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/landmark/start/blueshield,
 /obj/structure/chair/office{
 	dir = 8
@@ -44709,13 +36968,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
-"lNO" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lOd" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/ce)
@@ -44802,8 +37054,6 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -44811,9 +37061,6 @@
 "lRN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
@@ -44891,15 +37138,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/psychology)
-"lTg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/processing)
 "lTu" = (
 /obj/machinery/light_switch{
 	pixel_y = -23
@@ -44910,40 +37148,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"lTT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "lUf" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
-"lUm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "lUE" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/navbeacon/wayfinding/med,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"lUO" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
 "lUT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -44967,19 +37182,11 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "lVk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lVr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -44994,14 +37201,12 @@
 /area/science/mixing)
 "lVS" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "lVW" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45034,24 +37239,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/hallway/secondary/exit)
-"lXy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
-"lXH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "lXX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -45062,39 +37249,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"lYb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
-"lYg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"lYu" = (
-/obj/structure/grille,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "lYB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -45105,9 +37262,6 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "lYN" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
 /obj/machinery/meter/atmos/atmos_waste_loop,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
@@ -45117,15 +37271,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"lZC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lZG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -45144,9 +37289,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -45154,9 +37296,6 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "mal" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
@@ -45200,19 +37339,7 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"mbS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "mcB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
@@ -45223,8 +37350,6 @@
 /area/hallway/primary/tram/right)
 "mcH" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
@@ -45275,9 +37400,6 @@
 /turf/open/floor/iron/dark,
 /area/security/processing)
 "mep" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
 /obj/machinery/computer/atmos_control/incinerator{
 	dir = 1
 	},
@@ -45291,16 +37413,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"meV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "mfi" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/structure/cable,
@@ -45316,8 +37428,6 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -45333,24 +37443,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"mgz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "mgI" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
-"mgV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/research)
 "mha" = (
 /obj/structure/chair{
 	dir = 4
@@ -45377,19 +37473,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
-"mhU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "mik" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -45417,22 +37500,13 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "miu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"miQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "miZ" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -45467,10 +37541,6 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "mke" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/showroomfloor,
@@ -45483,13 +37553,6 @@
 /obj/structure/transit_tube_pod,
 /turf/open/floor/plating,
 /area/science/research)
-"mku" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/science/robotics/mechbay)
 "mkw" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -45508,8 +37571,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "mkJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
@@ -45524,12 +37585,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"mlc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/command/heads_quarters/hos)
 "mle" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -45599,8 +37654,6 @@
 /area/medical/treatment_center)
 "mmq" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -45638,12 +37691,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "mnP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/food/deadmouse,
@@ -45669,10 +37716,6 @@
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
 "mpI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
@@ -45706,12 +37749,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "mrd" = (
@@ -45773,16 +37810,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "msB" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45794,7 +37825,6 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "msG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
@@ -45823,12 +37853,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"mtq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "mtB" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -45860,12 +37884,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "mtL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
@@ -45924,12 +37942,6 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "mww" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -45966,12 +37978,6 @@
 /area/engineering/atmospherics_engine)
 "mxq" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/landmark/start/junior_officer,
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -46017,23 +38023,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "myf" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/bounty_board{
@@ -46089,23 +38083,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
-"myW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/explab)
-"mza" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "mzF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -46135,9 +38112,6 @@
 /area/science/xenobiology)
 "mAn" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/machinery/meter,
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/south,
@@ -46152,8 +38126,6 @@
 	name = "MiniSat Antechamber";
 	req_one_access_txt = "65"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/grimy,
@@ -46193,34 +38165,8 @@
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"mDF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
-"mEc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "mEf" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -46231,18 +38177,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
-"mEj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/processing)
 "mEk" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
 	name = "sorting disposal pipe (Cargo)";
 	sortType = 2
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
@@ -46270,12 +38210,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
-"mEK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "mEP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -46296,8 +38230,6 @@
 /area/service/theater)
 "mFe" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
@@ -46309,29 +38241,13 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"mFj" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "mFx" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
 	},
 /obj/structure/cable,
 /obj/item/radio/intercom{
@@ -46342,13 +38258,6 @@
 "mGe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -46366,32 +38275,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"mHc" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter)
-"mHf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/food_packaging,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
-"mHl" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/research)
 "mHo" = (
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 2
@@ -46412,12 +38295,6 @@
 /area/science/xenobiology)
 "mHq" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/item/airlock_painter,
 /turf/open/floor/iron,
@@ -46510,8 +38387,6 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "mKd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -46568,8 +38443,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
 "mMz" = (
@@ -46635,8 +38508,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "mNx" = (
@@ -46646,7 +38517,6 @@
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "mNz" = (
@@ -46667,9 +38537,6 @@
 /obj/structure/sign/barsign{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar)
@@ -46684,27 +38551,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"mNM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "mNY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/sign/departments/restroom{
 	pixel_y = 32
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "mOj" = (
@@ -46726,12 +38580,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"mOK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "mON" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -46751,9 +38599,6 @@
 /turf/closed/wall,
 /area/engineering/main)
 "mOV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -46812,12 +38657,6 @@
 "mQv" = (
 /obj/structure/disposalpipe/junction,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "mQy" = (
@@ -46846,24 +38685,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
-"mRa" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
-"mRm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "mRN" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -46927,49 +38748,14 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"mSY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
-"mTt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmospherics_engine)
 "mTV" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/sign/painting/library{
 	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46982,12 +38768,6 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "mUL" = (
@@ -46996,9 +38776,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "mUP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -47023,8 +38800,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "mVj" = (
@@ -47045,10 +38820,6 @@
 "mVl" = (
 /obj/effect/turf_decal/trimline/red/corner,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "mVs" = (
@@ -47084,9 +38855,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -47109,8 +38877,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -47155,12 +38921,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47169,7 +38929,6 @@
 /area/command/bridge)
 "mYh" = (
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -47226,8 +38985,6 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "mZg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
@@ -47236,12 +38993,6 @@
 "mZk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -47275,23 +39026,9 @@
 	id = "rndlab1";
 	name = "Research and Development Shutter"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/item/folder,
 /turf/open/floor/iron/white,
 /area/science/lab)
-"mZO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/food_packaging,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "mZS" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Quartermaster";
@@ -47311,8 +39048,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = 22;
@@ -47327,12 +39062,6 @@
 "naz" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -47358,34 +39087,8 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "naZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
-"nbf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/science/mixing)
-"nbr" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron,
-/area/maintenance/tram/mid)
 "nbx" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -47450,16 +39153,6 @@
 	},
 /turf/closed/wall,
 /area/cargo/sorting)
-"ncU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/command/heads_quarters/ce)
 "ndn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -47476,7 +39169,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "ndJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
@@ -47490,12 +39182,6 @@
 "nek" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
 	},
 /obj/machinery/light,
 /obj/structure/cable,
@@ -47530,35 +39216,17 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"nfe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "nfp" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "nfv" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "nfy" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -47592,10 +39260,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
@@ -47614,10 +39278,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -47646,16 +39306,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"nhn" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter)
 "nhq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "nhF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -47684,12 +39339,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -47749,7 +39398,6 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria,
@@ -47759,8 +39407,6 @@
 	name = "MiniSat Access";
 	req_access_txt = "65"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
@@ -47786,8 +39432,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -47797,11 +39441,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"nns" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "nnZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -47825,10 +39464,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
-"noT" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "npx" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -47877,8 +39512,6 @@
 /area/cargo/miningdock)
 "nqr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
@@ -47898,12 +39531,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "nqY" = (
@@ -47911,7 +39538,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -47964,12 +39590,6 @@
 /turf/open/openspace,
 /area/hallway/primary/tram/right)
 "nsv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
 	req_access_txt = "5;6"
@@ -48014,20 +39634,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
-"nto" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "cargowarehouse"
-	},
-/turf/open/floor/plating,
-/area/cargo/storage)
 "ntr" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -48057,13 +39663,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"ntQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/engine,
-/area/engineering/main)
 "ntR" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/heater{
 	dir = 8
@@ -48090,9 +39689,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "nuM" = (
@@ -48110,12 +39706,6 @@
 "nuZ" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/machinery/syndicatebomb/training,
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -48146,12 +39736,6 @@
 "nww" = (
 /turf/open/floor/plating,
 /area/security/processing)
-"nwx" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/main)
 "nxj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -48172,10 +39756,6 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
 "nyf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/iron/freezer,
 /area/service/bar)
 "nym" = (
@@ -48227,14 +39807,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
-"nzH" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "nzK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -48272,12 +39844,6 @@
 /area/cargo/miningdock)
 "nAC" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48290,12 +39856,6 @@
 "nBf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/cable,
@@ -48329,16 +39889,6 @@
 /obj/machinery/light,
 /turf/open/openspace,
 /area/hallway/primary/tram/right)
-"nBO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "nBV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment{
@@ -48357,9 +39907,6 @@
 /area/science/cytology)
 "nCl" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "nCx" = (
@@ -48369,7 +39916,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "nCX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -48381,9 +39927,6 @@
 	req_one_access_txt = null
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
 "nDB" = (
@@ -48397,12 +39940,8 @@
 /area/engineering/atmos)
 "nDF" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding/cargo,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "nDT" = (
@@ -48447,12 +39986,6 @@
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "nED" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil/cut,
@@ -48511,17 +40044,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "nFW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/newscaster{
@@ -48530,8 +40058,6 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "nGc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -48652,35 +40178,17 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"nJB" = (
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "nKe" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "nKp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "nKR" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
@@ -48708,16 +40216,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
-"nMN" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "nMQ" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/bot,
@@ -48760,28 +40258,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"nNB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"nNC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/science/mixing)
-"nNL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "nNX" = (
 /obj/structure/cable,
 /obj/structure/altar_of_gods,
@@ -48830,10 +40306,6 @@
 /area/science/research)
 "nOF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48888,9 +40360,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -48903,25 +40372,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"nQb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "nQg" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -48941,9 +40397,6 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Mix to Incinerator"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
@@ -48976,10 +40429,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"nRC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "nSg" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -49033,12 +40482,6 @@
 /area/science/server)
 "nTK" = (
 /obj/effect/turf_decal/trimline/white/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "nTN" = (
@@ -49081,7 +40524,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -49123,7 +40565,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -49209,25 +40650,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
-"nXK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "nXS" = (
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
@@ -49238,23 +40666,8 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
-"nYs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/food_packaging,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "nYv" = (
 /turf/closed/wall,
 /area/security/checkpoint/supply)
@@ -49277,9 +40690,6 @@
 /turf/closed/wall,
 /area/cargo/sorting)
 "nZT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
@@ -49316,25 +40726,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"oaP" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "oaQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "obw" = (
@@ -49345,21 +40742,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"obx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "ocb" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -49390,12 +40777,6 @@
 	req_access_txt = "70"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49413,16 +40794,10 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
 "ocV" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -49440,8 +40815,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "odE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -49458,22 +40831,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/navbeacon/wayfinding/vault,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "oeq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49530,12 +40891,6 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "ogo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -49599,22 +40954,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"ohI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai_upload)
 "ohZ" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -49653,10 +40996,18 @@
 	id_tag = "miningdorm1";
 	name = "Room 1"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
+"oiW" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	dir = 4;
+	name = "old sink";
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "oiX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -49700,11 +41051,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"okn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "okt" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
 	dir = 8
@@ -49731,20 +41077,9 @@
 /area/science/cytology)
 "okL" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"okN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/science/explab)
 "ola" = (
 /obj/machinery/button/door{
 	id = "xenobiobottomleft";
@@ -49787,13 +41122,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"olg" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "olj" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
@@ -49804,9 +41132,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "oly" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -49820,12 +41145,6 @@
 /area/hallway/primary/tram/right)
 "omk" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -49862,12 +41181,6 @@
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "omD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
@@ -49910,12 +41223,6 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "ooe" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -49949,9 +41256,6 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
@@ -49977,12 +41281,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron,
 /area/science/research)
-"ops" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "oqb" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/closet/crate,
@@ -50013,11 +41311,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "oqM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
@@ -50049,12 +41345,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"orQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/processing)
 "orU" = (
 /obj/structure/chair/stool,
 /obj/structure/disposalpipe/segment{
@@ -50078,17 +41368,11 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter)
-"otx" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "otY" = (
 /turf/open/floor/plating,
 /area/engineering/main)
 "out" = (
 /obj/machinery/modular_computer/console/preset/civilian,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -50135,12 +41419,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
-"ovu" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "ovv" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -50149,32 +41427,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"ovw" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "ovH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "ovK" = (
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"owd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "ows" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -50183,20 +41442,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"owv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "oww" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/structure/railing/corner,
@@ -50208,20 +41455,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
-"owy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "owK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/shower{
@@ -50261,7 +41494,6 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
 "oyE" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -50276,6 +41508,31 @@
 	dir = 5
 	},
 /area/science/breakroom)
+"oyZ" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
+	},
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/fruity,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	list_reagents = list(/datum/reagent/consumable/enzyme = 500);
+	name = "universe-sized universal enyzyme";
+	volume = 500
+	},
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "oza" = (
 /obj/item/stack/cable_coil,
 /obj/effect/turf_decal/sand/plating,
@@ -50357,12 +41614,6 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
-"oAx" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "oAH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -50430,12 +41681,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "oCQ" = (
@@ -50466,51 +41711,17 @@
 /turf/closed/wall,
 /area/hallway/primary/tram/right)
 "oDv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"oDw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
-"oDx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "oDy" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
-"oDz" = (
-/obj/effect/turf_decal/trimline/yellow/warning,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/maintenance/tram/right)
 "oDC" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "11"
@@ -50520,9 +41731,6 @@
 /area/maintenance/port/central)
 "oDW" = (
 /obj/structure/flora/bush,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/grass,
 /area/medical/virology)
 "oEz" = (
@@ -50595,9 +41803,6 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "oGX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -50646,8 +41851,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "oIq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
@@ -50704,8 +41907,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "oJJ" = (
@@ -50719,8 +41920,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "oJP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -50732,13 +41931,7 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
 "oJS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/plating,
 /area/service/hydroponics)
 "oJW" = (
@@ -50746,12 +41939,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "oKb" = (
@@ -50763,10 +41950,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
@@ -50793,6 +41976,11 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"oKl" = (
+/obj/machinery/vending/security_ammo,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "oKI" = (
 /obj/structure/closet/emcloset,
 /obj/item/flashlight,
@@ -50829,12 +42017,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -50857,27 +42039,9 @@
 /obj/machinery/door/airlock/security{
 	name = "Permanent Cell 7"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"oLA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"oLI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "oLN" = (
 /obj/structure/sign/poster/contraband/space_cube{
 	pixel_y = 32
@@ -50961,14 +42125,6 @@
 	},
 /turf/open/floor/iron,
 /area/tcommsat/computer)
-"oNF" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "oNH" = (
 /obj/structure/railing,
 /obj/effect/landmark/start/hangover,
@@ -50998,12 +42154,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
@@ -51070,12 +42220,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"oRc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "oRk" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/boxing/blue,
@@ -51115,8 +42259,6 @@
 /area/maintenance/disposal)
 "oSW" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -51172,12 +42314,6 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
@@ -51220,12 +42356,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "oVk" = (
@@ -51242,9 +42372,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -51258,8 +42385,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "oVS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -51269,15 +42394,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "oVZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "oWl" = (
@@ -51285,8 +42404,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -51299,12 +42416,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "oWE" = (
@@ -51312,14 +42423,6 @@
 /obj/item/electronics/apc,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/medical)
-"oXi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "oXj" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/light/small{
@@ -51340,15 +42443,6 @@
 "oXK" = (
 /obj/structure/chair{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/interrogation)
-"oYd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
@@ -51372,10 +42466,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/genetics)
-"oYS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "oYU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -51420,15 +42510,8 @@
 	name = "Secure Pen";
 	req_access_txt = "55"
 	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/engine,
 /area/science/cytology)
-"oZH" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "oZK" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -51441,8 +42524,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -51477,9 +42558,6 @@
 "pbb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -51542,12 +42620,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"pch" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "pco" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -51569,19 +42641,9 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "pcq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
-"pcI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "pcR" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -51615,9 +42677,6 @@
 "pex" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
 	},
 /obj/item/wrench,
 /turf/open/floor/iron/dark,
@@ -51654,12 +42713,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/assembly/mousetrap/armed,
@@ -51673,10 +42726,6 @@
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
-"pgt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "pgu" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -51706,8 +42755,6 @@
 	pixel_y = 7
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "phj" = (
@@ -51716,9 +42763,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
@@ -51726,9 +42770,6 @@
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/window/plasma/reinforced{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -51765,24 +42806,7 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"pib" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "pik" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
@@ -51790,7 +42814,6 @@
 /area/engineering/atmos)
 "piI" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "piZ" = (
@@ -51818,9 +42841,6 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "pjO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
 /obj/machinery/airalarm/all_access{
 	dir = 8;
 	pixel_x = 24
@@ -51847,15 +42867,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "pkw" = (
-/obj/machinery/atmospherics/pipe/multiz/layer4,
 /obj/effect/turf_decal/stripes/end,
-/obj/machinery/atmospherics/pipe/multiz/layer2,
 /turf/open/floor/plating,
 /area/service/hydroponics)
 "pkI" = (
@@ -51881,16 +42896,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"plu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "ply" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -51903,13 +42908,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"plK" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "plQ" = (
 /obj/effect/loot_site_spawner,
 /obj/effect/decal/cleanable/dirt,
@@ -51940,8 +42938,6 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
@@ -51996,20 +42992,11 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "pmO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/navbeacon/wayfinding/incinerator,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "pmT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -52043,29 +43030,6 @@
 	dir = 1
 	},
 /area/science/research)
-"pnq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"pns" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
 "pnN" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Lab";
@@ -52080,28 +43044,8 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"pnQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/door/window/northright{
-	dir = 2;
-	name = "Research Test Chamber";
-	req_access_txt = "7"
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "pnR" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -52140,9 +43084,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -52150,12 +43091,6 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "pov" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
 /obj/structure/disposalpipe/junction/flip{
@@ -52190,13 +43125,6 @@
 /obj/item/flashlight,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"pqV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "pqY" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/power/apc/auto_name/south,
@@ -52204,13 +43132,6 @@
 /obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
-"pre" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/main)
 "prw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52224,19 +43145,12 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
 "prX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "psb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -52281,13 +43195,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"psJ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "psM" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/loot_site_spawner,
@@ -52313,7 +43220,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "ptL" = (
@@ -52338,8 +43244,6 @@
 /obj/item/book/manual/wiki/engineering_guide{
 	pixel_x = -2
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "pug" = (
@@ -52347,12 +43251,6 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "puk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
@@ -52392,8 +43290,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron,
@@ -52402,12 +43298,6 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -52426,12 +43316,6 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "pwj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -52473,8 +43357,6 @@
 /area/engineering/main)
 "pwS" = (
 /obj/effect/landmark/start/cyborg,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/grimy,
@@ -52486,12 +43368,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -52519,8 +43395,6 @@
 /obj/machinery/door/airlock/security{
 	name = "Permanent Cell 5"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -52548,7 +43422,6 @@
 /obj/machinery/airlock_sensor/incinerator_toxmix{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Science - Toxins Burn Chamber";
 	dir = 6;
@@ -52611,20 +43484,11 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"pAi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "pAp" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -52669,8 +43533,6 @@
 /obj/machinery/door/airlock/silver{
 	name = "Bathroom"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
 "pBb" = (
@@ -52690,17 +43552,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/cytology)
-"pBw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "pBF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -52708,8 +43562,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "pBL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -52767,30 +43619,6 @@
 /obj/machinery/light,
 /turf/open/floor/iron/white,
 /area/science/research)
-"pCW" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/miningdock)
-"pDk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
-"pDq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "pDy" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -52870,14 +43698,7 @@
 	dir = 1
 	},
 /area/service/chapel)
-"pFg" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "pFk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera{
 	c_tag = "Security - Prison Entry";
@@ -52899,12 +43720,6 @@
 	dir = 8
 	},
 /area/service/chapel)
-"pFJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "pGa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -52922,12 +43737,6 @@
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"pGs" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "pGy" = (
 /obj/structure/railing{
 	dir = 8
@@ -52939,8 +43748,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -52963,8 +43770,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
 "pHb" = (
@@ -52980,10 +43785,6 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "pHm" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -53032,12 +43833,6 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/eva)
 "pJg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /mob/living/simple_animal/mouse/brown/tom,
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -53045,22 +43840,6 @@
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"pJH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
-"pJW" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/machinery/meter/atmos/atmos_waste_loop,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "pKf" = (
 /obj/structure/fluff/tram_rail/anchor{
 	dir = 1
@@ -53073,8 +43852,6 @@
 	id = "Cell 1";
 	name = "Cell 1"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "pKj" = (
@@ -53110,12 +43887,6 @@
 "pKy" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
@@ -53141,17 +43912,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "pKS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Medical Maintenance";
@@ -53174,9 +43937,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/machinery/power/apc/auto_name/north{
 	areastring = "/area/engineering/supermatter"
 	},
@@ -53191,9 +43951,6 @@
 "pMd" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -53259,16 +44016,10 @@
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "pOF" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
 "pOP" = (
@@ -53286,8 +44037,6 @@
 	id_tag = "miningdorm3";
 	name = "Room 3"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
 "pPr" = (
@@ -53300,30 +44049,18 @@
 /area/engineering/atmos)
 "pPH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "pPV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "pPW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -53349,20 +44086,8 @@
 	name = "Gateway Chamber";
 	req_access_txt = "62"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"pQD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "pQR" = (
 /obj/structure/chair/plastic{
 	dir = 1
@@ -53427,12 +44152,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "pSz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/cable,
 /obj/machinery/camera{
@@ -53443,16 +44162,10 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "pSL" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "pSS" = (
@@ -53505,12 +44218,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/service/bar)
 "pUs" = (
@@ -53552,37 +44259,19 @@
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "pVF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"pWq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "pWA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "pWG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
@@ -53613,12 +44302,6 @@
 /area/hallway/primary/tram/center)
 "pXr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/navbeacon/wayfinding/court,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
@@ -53653,21 +44336,8 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
-"pXR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/office)
 "pYo" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "pYu" = (
@@ -53691,18 +44361,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "pZn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"pZo" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "pZq" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -53737,12 +44398,6 @@
 	name = "Medical Freezer";
 	req_access_txt = "5"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/freezer,
@@ -53766,43 +44421,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"qaA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/command/heads_quarters/ce)
 "qbg" = (
 /obj/structure/fluff/tram_rail{
 	dir = 1
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/left)
-"qbA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "qbH" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/engineering/main)
-"qbS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/construction/engineering)
 "qch" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -53842,13 +44470,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "qcS" = (
@@ -53909,9 +44531,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qfo" = (
@@ -53920,19 +44539,11 @@
 /area/maintenance/department/medical)
 "qfE" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "qfJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -53951,7 +44562,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/service/theater)
@@ -53973,8 +44583,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
@@ -54010,15 +44618,6 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "qhD" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -54033,12 +44632,6 @@
 /turf/open/floor/glass/reinforced,
 /area/hallway/primary/tram/center)
 "qhT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -54085,10 +44678,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "qix" = (
@@ -54106,24 +44695,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"qiJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
 "qiW" = (
 /turf/open/floor/iron/dark,
 /area/security/processing)
@@ -54138,11 +44709,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"qjn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "qjO" = (
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
@@ -54151,7 +44717,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "qjX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
@@ -54202,9 +44767,6 @@
 /area/cargo/miningdock)
 "qkW" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
 /obj/machinery/button/door{
 	id = "engsm";
 	name = "Radiation Shutters Control";
@@ -54227,7 +44789,6 @@
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "qlx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/requests_console{
 	department = "Atmospherics";
 	departmentType = 4;
@@ -54258,12 +44819,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"qmJ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter)
 "qnr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54306,7 +44861,6 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "qor" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/dark,
@@ -54369,9 +44923,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/light{
 	dir = 1
@@ -54400,15 +44951,6 @@
 /obj/item/multitool,
 /turf/open/floor/iron,
 /area/cargo/office)
-"qqx" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "qqM" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -54426,7 +44968,6 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "qru" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -54446,12 +44987,6 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "qtb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -54486,15 +45021,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"qtq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/interrogation)
 "qtB" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -54511,18 +45037,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "quf" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
-"quA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "quT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54549,22 +45069,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"qvw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/main)
-"qvA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/security/checkpoint/engineering)
 "qvF" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/iron/dark/telecomms,
@@ -54576,12 +45080,6 @@
 /turf/closed/wall,
 /area/cargo/sorting)
 "qvV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -54590,12 +45088,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/landmark/start/station_engineer,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -54603,9 +45095,6 @@
 "qwk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
@@ -54622,7 +45111,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -54648,15 +45136,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"qxj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "qxp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -54680,12 +45159,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
 /obj/structure/cable,
@@ -54737,24 +45210,11 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
-"qyQ" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "qyW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"qyZ" = (
-/obj/structure/table,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/rice,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "qzb" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -54786,9 +45246,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "qzB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
@@ -54799,12 +45256,6 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "qzT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -54820,7 +45271,6 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "qAn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -54844,12 +45294,6 @@
 /area/science/xenobiology)
 "qAu" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
@@ -54857,8 +45301,6 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "qBb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
@@ -54872,10 +45314,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "qBk" = (
@@ -54926,16 +45364,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/command)
-"qBH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "qBS" = (
 /obj/docking_port/stationary/random{
 	dir = 8;
@@ -55042,9 +45470,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -55076,12 +45501,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "qFg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -55193,12 +45612,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door_buttons/access_button{
 	idDoor = "virology_airlock_interior";
 	idSelf = "virology_airlock_control";
@@ -55210,9 +45623,6 @@
 /area/medical/virology)
 "qHm" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -55253,8 +45663,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Hallway - South-East Service Wing";
@@ -55314,16 +45722,6 @@
 /obj/item/chair,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"qJG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/virology)
-"qJK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/iron/dark,
-/area/service/hydroponics)
 "qJQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55332,20 +45730,12 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
 "qKp" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"qKC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "qLb" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "plating"
@@ -55386,9 +45776,6 @@
 "qMx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -55472,10 +45859,6 @@
 /obj/structure/railing,
 /turf/open/openspace,
 /area/science/xenobiology)
-"qRN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/interrogation)
 "qRS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -55521,19 +45904,9 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "qTd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55575,12 +45948,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "qUf" = (
@@ -55613,22 +45980,10 @@
 	},
 /turf/closed/mineral/random/stationside/asteroid,
 /area/mine/explored)
-"qUN" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "qUZ" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
-"qVf" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "qVl" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
@@ -55712,10 +46067,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "qXU" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -55737,12 +46088,6 @@
 /area/maintenance/tram/right)
 "qYR" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "qYU" = (
@@ -55753,12 +46098,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"qZf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "qZl" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -55775,7 +46114,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
@@ -55783,9 +46121,6 @@
 "qZt" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55807,7 +46142,7 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "qZT" = (
-/obj/machinery/vending/security_ammo,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "rak" = (
@@ -55864,12 +46199,6 @@
 /area/maintenance/tram/left)
 "rbK" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/spawner/lootdrop/botanical_waste,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -55887,9 +46216,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/sign/departments/restroom{
 	pixel_y = 32
 	},
@@ -55897,20 +46223,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
-"rcj" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/medical/treatment_center)
 "rcv" = (
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Upper Ring Telecomms Relay";
@@ -55926,21 +46240,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"rdv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/science/research)
 "rdw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
@@ -55988,10 +46290,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rem" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -56006,7 +46304,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -56025,9 +46322,6 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "rfq" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -56055,8 +46349,6 @@
 /area/science/research)
 "rfP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/navbeacon/wayfinding/research,
 /turf/open/floor/iron/white,
 /area/science/lab)
@@ -56070,12 +46362,6 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "rgp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
@@ -56127,15 +46413,6 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"rhx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "rhN" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -56172,8 +46449,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
 	frequency = 1449;
@@ -56310,7 +46585,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "rkC" = (
@@ -56339,12 +46613,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
 "rkX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
@@ -56355,12 +46623,6 @@
 "rlv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
@@ -56469,16 +46731,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"rnP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "rnT" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
@@ -56488,23 +46740,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "rnU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/medical/virology)
 "rom" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -56514,12 +46757,6 @@
 /turf/open/floor/wood,
 /area/service/library)
 "rou" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/item/clothing/head/cone{
 	pixel_x = -8
 	},
@@ -56558,7 +46795,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -56570,12 +46806,6 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
 "rpy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/machinery/flasher{
 	id = "AI";
 	pixel_x = -25;
@@ -56599,35 +46829,6 @@
 /obj/effect/turf_decal/caution,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
-"rqr" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"rqy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
-"rqz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "rqB" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -56640,11 +46841,6 @@
 /obj/effect/spawner/lootdrop/garbage_spawner,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/central)
-"rqG" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "rqV" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -56676,12 +46872,6 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "rrD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/machinery/holopad/secure,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
@@ -56692,43 +46882,18 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"rsm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "rsN" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/iron/airless,
 /area/mine/explored)
-"rsP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/construction/engineering)
 "rtb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -56739,8 +46904,6 @@
 /obj/machinery/door/airlock/security{
 	name = "Permanent Cell 4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -56793,16 +46956,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"rvf" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "rvA" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -56815,10 +46970,6 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "rvT" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -56891,16 +47042,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
-"rwZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "rxe" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -56924,15 +47065,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"rxv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "rxL" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -56943,7 +47075,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -57055,9 +47186,6 @@
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "rzK" = (
@@ -57072,12 +47200,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -57099,12 +47221,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -57124,19 +47240,12 @@
 /area/maintenance/port/aft)
 "rDt" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "rDE" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57158,8 +47267,6 @@
 	id = "Cell 2";
 	name = "Cell 2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
@@ -57183,8 +47290,6 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Security - Brig Upper West";
@@ -57225,12 +47330,6 @@
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "rGJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/grimy,
@@ -57250,10 +47349,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -57267,12 +47362,6 @@
 /obj/structure/cable,
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - South Hall";
@@ -57321,12 +47410,6 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "rIY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -57426,13 +47509,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"rKY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "rLb" = (
 /obj/structure/closet/crate/bin,
 /obj/item/reagent_containers/pill/maintenance{
@@ -57480,10 +47556,6 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
 "rMk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -57492,12 +47564,6 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "rMC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57525,12 +47591,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"rMU" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "rMZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -57608,12 +47668,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"rQp" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
 "rQq" = (
 /obj/machinery/light,
 /turf/open/openspace,
@@ -57631,15 +47685,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "rQP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "rQZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
@@ -57656,12 +47705,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"rRu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "rRy" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Storage";
@@ -57670,16 +47713,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"rRR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "rSi" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer";
@@ -57693,8 +47726,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "rTw" = (
@@ -57724,17 +47755,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"rUe" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"rUN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/science/mixing)
 "rUX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -57749,12 +47769,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
-"rWh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "rWo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -57777,12 +47791,6 @@
 	name = "Drone Bay";
 	req_access_txt = "31"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "rWR" = (
@@ -57801,10 +47809,6 @@
 /obj/item/wirecutters,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"rXy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/research)
 "rXD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -57852,12 +47856,6 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
@@ -57885,12 +47883,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
-"rZv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "rZy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -57904,16 +47896,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
-"rZB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
-/area/security/processing)
 "rZI" = (
 /obj/machinery/shower{
 	dir = 1
@@ -57927,8 +47909,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
@@ -57940,7 +47920,6 @@
 /area/engineering/atmos)
 "saS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -57963,13 +47942,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "sby" = (
@@ -57986,10 +47960,6 @@
 /area/science/server)
 "sbA" = (
 /obj/effect/landmark/start/cyborg,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -58017,17 +47987,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/processing)
-"scw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "scz" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
@@ -58044,9 +48003,6 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "scU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
@@ -58093,9 +48049,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "sdU" = (
@@ -58128,28 +48081,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"seO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "seU" = (
 /obj/machinery/bluespace_beacon,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
@@ -58175,12 +48110,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -58198,12 +48127,6 @@
 /area/maintenance/port/fore)
 "sgf" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -58237,12 +48160,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "shk" = (
@@ -58254,18 +48171,8 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"shw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "shO" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
@@ -58274,19 +48181,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
-"sii" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/command/heads_quarters/ce)
 "siu" = (
 /turf/closed/wall,
 /area/tcommsat/computer)
@@ -58305,9 +48199,6 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -58348,30 +48239,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"skg" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
-"skn" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "sko" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 10
@@ -58382,12 +48249,6 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "skq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -58423,12 +48284,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = 22;
@@ -58436,15 +48291,6 @@
 	},
 /turf/open/floor/iron,
 /area/tcommsat/computer)
-"slo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "slp" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -58469,12 +48315,6 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/door_buttons/airlock_controller{
 	idExterior = "virology_airlock_exterior";
 	idInterior = "virology_airlock_interior";
@@ -58493,8 +48333,6 @@
 	req_access_txt = "40"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -58522,10 +48360,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"sme" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/science/mixing)
 "smu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58548,8 +48382,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -58626,12 +48458,6 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
 "soH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
@@ -58640,12 +48466,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/commons/lounge)
-"soS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "soX" = (
 /obj/structure/chair,
 /obj/structure/sign/warning/vacuum/external{
@@ -58683,25 +48503,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"sph" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/main)
 "spv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"spz" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "spB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
@@ -58716,12 +48523,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -58739,10 +48540,6 @@
 /turf/open/openspace,
 /area/science/xenobiology)
 "sqo" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
@@ -58759,8 +48556,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/main)
 "sqY" = (
@@ -58772,12 +48567,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "srb" = (
@@ -58820,16 +48609,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"ssb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
 "ssi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -58842,10 +48621,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -58868,12 +48643,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -58955,7 +48724,6 @@
 /obj/structure/fireaxecabinet{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -58999,8 +48767,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
@@ -59011,8 +48777,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
@@ -59021,7 +48785,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "svV" = (
@@ -59054,12 +48817,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "swZ" = (
@@ -59082,7 +48839,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -59109,9 +48865,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
 "syS" = (
@@ -59121,8 +48874,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -59152,12 +48903,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -59170,12 +48915,6 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -59247,8 +48986,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "sCl" = (
@@ -59273,18 +49010,9 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"sCE" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter)
 "sCF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -59326,7 +49054,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
 "sDu" = (
@@ -59373,30 +49100,9 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "sEo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
-"sEs" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "sEA" = (
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
@@ -59405,12 +49111,6 @@
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
 "sEO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59501,13 +49201,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/entry)
-"sHk" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/engineering/main)
 "sHn" = (
 /obj/machinery/camera{
 	c_tag = "Secure - External AI Upload";
@@ -59545,9 +49238,6 @@
 /area/science/research)
 "sJm" = (
 /obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -59555,9 +49245,6 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "sJT" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -59568,12 +49255,6 @@
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -59592,8 +49273,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "sKW" = (
@@ -59664,12 +49343,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "sMw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
@@ -59685,8 +49358,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -59695,6 +49366,14 @@
 /obj/machinery/door/poddoor/massdriver_toxins,
 /turf/open/floor/plating,
 /area/science/mixing)
+"sMR" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "sMW" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/girder,
@@ -59702,12 +49381,6 @@
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "sNc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
@@ -59735,12 +49408,6 @@
 "sNt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -59778,15 +49445,10 @@
 /area/maintenance/central)
 "sOn" = (
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/freezer,
 /area/science/research)
 "sOA" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
@@ -59859,7 +49521,6 @@
 /area/security/prison)
 "sQj" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
@@ -59872,7 +49533,6 @@
 	name = "Output to Waste"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -59928,8 +49588,6 @@
 	req_access_txt = "18"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -59953,7 +49611,6 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "sSf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/item/clothing/head/cone{
 	pixel_x = -8
 	},
@@ -59972,15 +49629,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"sSE" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/chapel,
-/area/service/chapel)
 "sTF" = (
 /turf/open/floor/glass,
 /area/cargo/storage)
@@ -60017,7 +49665,6 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
 "sUC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/dark,
@@ -60063,9 +49710,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -60079,13 +49723,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"sVQ" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "sVZ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -60127,9 +49764,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sWC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
 /obj/effect/landmark/event_spawn,
@@ -60200,15 +49834,26 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"sYv" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "sZb" = (
 /obj/machinery/door/airlock/security{
 	name = "Permanent Cell 6"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"sZx" = (
+/obj/structure/cable,
+/obj/machinery/dish_drive/bullet,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "sZy" = (
 /turf/open/floor/grass,
 /area/medical/virology)
@@ -60216,12 +49861,6 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
 	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -60247,9 +49886,6 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
 "tau" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -60297,16 +49933,6 @@
 	},
 /turf/closed/wall,
 /area/science/test_area)
-"tcm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
 "tct" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -60318,9 +49944,6 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "tcD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
@@ -60395,24 +50018,16 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "tej" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/iron/freezer,
 /area/science/research)
 "tep" = (
 /obj/machinery/door/airlock/security{
 	name = "Permanent Cell 1"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "ter" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
@@ -60421,17 +50036,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"teO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "teX" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -60456,8 +50060,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -60465,8 +50067,6 @@
 "tfO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "tgh" = (
@@ -60493,16 +50093,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"tgK" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/lab)
 "tgV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -60516,11 +50106,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"tgW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "tgX" = (
 /obj/machinery/camera{
 	c_tag = "Science - Maintenance Intersection";
@@ -60540,21 +50125,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "thl" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"thz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat_interior)
 "thB" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -60565,13 +50140,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"thR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/service/theater)
 "thT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -60624,16 +50192,6 @@
 "tiq" = (
 /turf/open/floor/iron,
 /area/cargo/storage)
-"tis" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "tiz" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -60691,9 +50249,6 @@
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
 "tjx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -60705,8 +50260,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -60723,27 +50276,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"tjU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/security/prison)
 "tka" = (
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
-"tkJ" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "tkL" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -60806,16 +50341,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"tml" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/science/research)
 "tmw" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
@@ -60832,13 +50357,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "tnm" = (
@@ -60859,12 +50378,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "tny" = (
@@ -60881,12 +50394,6 @@
 "tnH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -61037,7 +50544,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "tqj" = (
@@ -61052,8 +50558,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "tqs" = (
@@ -61127,8 +50631,6 @@
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "tqZ" = (
@@ -61136,8 +50638,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
 "tre" = (
@@ -61195,41 +50695,20 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "ttb" = (
 /obj/structure/flora/ausbushes/leafybush,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/grass,
 /area/medical/virology)
 "ttp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
-"ttH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ttN" = (
 /turf/open/openspace,
 /area/cargo/storage)
 "ttP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -61265,9 +50744,6 @@
 /turf/open/floor/iron/airless,
 /area/mine/explored)
 "tua" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -61296,12 +50772,6 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "tuJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -61328,31 +50798,10 @@
 /mob/living/simple_animal/pet/cat/jerry,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"tvr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"tvB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/service/theater)
 "tvJ" = (
 /obj/machinery/door/airlock/security{
 	name = "Permanent Cell 8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -61440,11 +50889,20 @@
 /area/hallway/secondary/exit)
 "txB" = (
 /obj/structure/table,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/camera{
-	c_tag = "Security - Prison Cafeteria";
-	dir = 1;
-	network = list("ss13","Security","prison")
+/obj/item/book/manual/chef_recipes,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -61480,12 +50938,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "tzr" = (
@@ -61509,23 +50961,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"tAe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/engineering/main)
 "tAh" = (
 /turf/closed/wall/r_wall,
 /area/engineering/storage/tech)
-"tAn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "tAo" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/item/clothing/glasses/welding,
@@ -61549,12 +50987,6 @@
 /area/hallway/primary/tram/right)
 "tAT" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
@@ -61573,12 +51005,6 @@
 "tBe" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "tBs" = (
@@ -61611,9 +51037,6 @@
 /turf/open/floor/iron/white,
 /area/security/brig)
 "tCf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/door/window/northright{
 	dir = 2;
 	name = "Research Test Chamber";
@@ -61683,10 +51106,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "tEe" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
@@ -61738,8 +51157,6 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/grimy,
@@ -61761,24 +51178,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "tFT" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/medical/treatment_center)
-"tFX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
-"tGb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "tGk" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
@@ -61811,22 +51214,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
-"tHJ" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "tHL" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "tHN" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -61837,10 +51230,6 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating/asteroid,
 /area/mine/explored)
-"tJd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai)
 "tJq" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -61900,9 +51289,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Hallway - Bar Entry East";
@@ -61937,7 +51323,6 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "tMb" = (
@@ -61970,8 +51355,6 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Radstorm Shelter"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/service)
@@ -61992,16 +51375,7 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"tNu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "tNB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "tNC" = (
@@ -62048,12 +51422,6 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/floor/grass,
 /area/science/genetics)
-"tQf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/science/research)
 "tQo" = (
 /obj/machinery/light{
 	dir = 8
@@ -62069,17 +51437,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"tQB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "tQH" = (
 /obj/machinery/monkey_recycler,
 /obj/structure/disposalpipe/segment{
@@ -62091,9 +51448,6 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "tQN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/machinery/meter/atmos/atmos_waste_loop,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -62101,9 +51455,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tRy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62112,7 +51463,6 @@
 /area/service/library)
 "tRD" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/navbeacon/wayfinding/det,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
@@ -62121,12 +51471,6 @@
 /area/medical/coldroom)
 "tRV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -62136,8 +51480,6 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "tRZ" = (
@@ -62153,13 +51495,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
-"tSh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "tSm" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/toggle/labcoat/chemist,
@@ -62180,12 +51515,6 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "tSY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -62197,12 +51526,6 @@
 /area/medical/surgery)
 "tSZ" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -62240,11 +51563,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tUc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -62259,12 +51580,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"tUF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "tUM" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -62333,7 +51648,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "tWH" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
@@ -62354,17 +51668,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"tXx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "tXz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -62508,35 +51811,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"uad" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"uaf" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"uaB" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/main)
 "uaC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/holopad,
@@ -62554,7 +51830,6 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "uaK" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
@@ -62572,12 +51847,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -62590,7 +51859,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ucf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
@@ -62606,6 +51874,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
+"udd" = (
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "udf" = (
 /obj/item/target,
 /obj/structure/window/reinforced,
@@ -62619,12 +51895,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
@@ -62680,8 +51950,6 @@
 	id = "Cell 3";
 	name = "Cell 3"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
@@ -62728,9 +51996,6 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "ufL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
@@ -62777,28 +52042,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"uge" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "ugh" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	dir = 1;
 	id = "Cell 4";
 	name = "Cell 4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "ugp" = (
@@ -62854,12 +52103,6 @@
 /turf/open/floor/iron/freezer,
 /area/service/bar)
 "ugF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /obj/item/assembly/mousetrap/armed,
@@ -62911,25 +52154,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
-"uiC" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/library)
-"uiE" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "uiI" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -63058,12 +52282,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "ukl" = (
@@ -63124,18 +52342,9 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"ulD" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "umL" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -63179,8 +52388,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -63242,12 +52449,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "uoT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63276,18 +52477,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
-"upt" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/service/lawoffice)
 "upI" = (
 /obj/structure/table,
 /obj/machinery/computer/bookmanagement,
@@ -63323,17 +52512,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"uqD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
 "uqE" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/brown/filled/line,
@@ -63357,12 +52535,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -63384,7 +52556,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/gateway)
 "urN" = (
@@ -63500,9 +52671,6 @@
 /obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/camera{
@@ -63523,7 +52691,6 @@
 	id = "garbage";
 	name = "disposal conveyor"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63535,20 +52702,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "uwx" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "uxd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
@@ -63577,9 +52736,6 @@
 "uxv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63610,10 +52766,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"uxU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/science/mixing)
 "uya" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/structure/railing/corner,
@@ -63641,7 +52793,6 @@
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
 "uzd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -63657,13 +52808,10 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "uzY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Atmospherics Maintenance";
 	req_one_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
 "uAe" = (
@@ -63702,8 +52850,6 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
@@ -63785,8 +52931,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
@@ -63802,12 +52946,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "uEV" = (
@@ -63815,7 +52953,6 @@
 	name = "Tunnel Access";
 	req_one_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -63839,12 +52976,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -63966,8 +53097,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "uIW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "11"
@@ -64071,14 +53200,8 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"uKN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/main)
 "uLq" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -64093,18 +53216,6 @@
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"uLI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
-"uLJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/engineering/main)
 "uLN" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -64173,17 +53284,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"uNb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "uNc" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -64222,8 +53322,6 @@
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -64245,8 +53343,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
@@ -64262,9 +53358,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "uOP" = (
@@ -64273,12 +53366,6 @@
 	pixel_y = -28
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -64300,7 +53387,6 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "uPi" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/structure/chair/stool,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -64329,24 +53415,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"uPu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "uPC" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/engineering,
 /obj/effect/turf_decal/trimline/white/filled/line,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"uPH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "uPJ" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -64431,12 +53505,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -64458,12 +53526,6 @@
 	req_one_access_txt = "10;24"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -64491,21 +53553,9 @@
 /obj/effect/turf_decal/trimline/white/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "uRX" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -64541,16 +53591,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "uSP" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "uTb" = (
@@ -64609,12 +53655,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"uUN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "uUX" = (
 /obj/item/stack/sheet/iron/ten,
 /obj/item/weldingtool,
@@ -64639,12 +53679,6 @@
 "uWm" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/cargo/storage)
@@ -64661,8 +53695,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "uXo" = (
@@ -64687,16 +53719,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
-"uXG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "uXX" = (
 /obj/structure/table,
 /obj/item/clothing/head/welding{
@@ -64786,7 +53810,6 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "vab" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
 	},
@@ -64832,12 +53855,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/genetics)
@@ -64857,12 +53874,6 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "vca" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -64885,7 +53896,6 @@
 	dir = 1;
 	id = "incineratorturbine"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -64902,17 +53912,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"vcC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "vcI" = (
 /obj/machinery/light{
 	dir = 4
@@ -64921,8 +53920,6 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Security - Brig Upper East";
@@ -64931,12 +53928,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"vdg" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vdk" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/holosign/barrier/atmos/sturdy,
@@ -64944,12 +53935,6 @@
 /turf/open/floor/vault,
 /area/hallway/primary/tram/left)
 "vds" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -65023,9 +54008,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -65033,12 +54015,6 @@
 /area/commons/dorms)
 "veR" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -65061,22 +54037,6 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/science/xenobiology)
-"vfx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"vfG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
 /area/science/xenobiology)
 "vfS" = (
 /obj/structure/table/reinforced,
@@ -65138,6 +54098,11 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"vhM" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/office)
 "vhP" = (
 /obj/structure/chair{
 	dir = 4
@@ -65179,13 +54144,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"vjj" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "vjl" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -65202,10 +54160,6 @@
 	pixel_x = 28
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "vjC" = (
@@ -65233,9 +54187,6 @@
 	name = "Library"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -65247,16 +54198,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"vkL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "vlt" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
@@ -65317,14 +54258,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "vlY" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -65395,8 +54331,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "voU" = (
@@ -65500,9 +54434,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
@@ -65512,9 +54443,6 @@
 "vsn" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "vss" = (
@@ -65525,16 +54453,10 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "vsG" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
 	name = "sorting disposal pipe (Head of Security's Office)";
@@ -65548,24 +54470,7 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"vtm" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "vtu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -65575,40 +54480,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "vtT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "vul" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"vuu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/freezer,
-/area/service/bar)
 "vux" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -65630,9 +54515,6 @@
 "vvx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -65666,18 +54548,9 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
-"vxX" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "vxZ" = (
 /obj/structure/chair/office/light{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
 	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
@@ -65692,8 +54565,6 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
@@ -65702,8 +54573,6 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "vyK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/landmark/start/shaft_miner,
@@ -65771,18 +54640,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorms East";
 	dir = 9
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"vAm" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vAt" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -65872,10 +54735,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/command)
 "vCk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/service)
@@ -65903,12 +54762,6 @@
 	sortType = 28
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "vCU" = (
@@ -65925,14 +54778,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "vDq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/yjunction,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vDH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
@@ -65958,18 +54807,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "vEh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -66087,7 +54928,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
@@ -66155,14 +54995,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"vHq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "vHs" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
@@ -66216,9 +55048,6 @@
 /area/science/xenobiology)
 "vIq" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_y = -25
 	},
@@ -66251,12 +55080,6 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -66298,12 +55121,6 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "vJL" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -66367,8 +55184,6 @@
 "vLs" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
@@ -66386,12 +55201,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"vLG" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vLU" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -66410,12 +55219,6 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66432,9 +55235,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "vNb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -66445,9 +55245,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "vNm" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
@@ -66496,7 +55293,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "vOV" = (
@@ -66607,8 +55403,6 @@
 /obj/machinery/door/airlock/security{
 	name = "Permanent Cell 3"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -66642,8 +55436,6 @@
 /turf/open/floor/iron,
 /area/science/research)
 "vSv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -66677,27 +55469,15 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "vSD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "vSS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"vTa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/service/library)
 "vTg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -66706,12 +55486,6 @@
 "vTj" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -66722,9 +55496,6 @@
 "vTG" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Mix"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -66749,18 +55520,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"vUq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "vUA" = (
 /obj/structure/fluff/tram_rail,
 /turf/open/openspace,
@@ -66787,16 +55546,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
-"vVs" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/iron,
-/area/engineering/main)
 "vVu" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three"
@@ -66841,7 +55590,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/science/research)
 "vWh" = (
@@ -66861,9 +55609,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vWC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
@@ -66884,18 +55629,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/research)
-"vXA" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "vXC" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/iron/dark/telecomms,
@@ -66940,12 +55673,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66977,18 +55704,7 @@
 /obj/structure/floodlight_frame,
 /turf/open/floor/iron/airless,
 /area/mine/explored)
-"wcd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "wcj" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
 /obj/machinery/meter,
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -67075,9 +55791,6 @@
 /turf/open/floor/plating,
 /area/cargo/office)
 "weN" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},
@@ -67095,9 +55808,6 @@
 /area/command/bridge)
 "wfb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Hallway - North-East Escape Wing Entry";
 	dir = 1
@@ -67128,21 +55838,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"wfU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "wgo" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -67164,22 +55862,7 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
-"whw" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "whV" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -67225,18 +55908,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "wjW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"wkk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "wkx" = (
 /obj/structure/chair{
 	dir = 1
@@ -67256,13 +55929,6 @@
 "wld" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/exit)
-"wlr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "wlZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67335,23 +56001,12 @@
 /obj/machinery/recharger,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"woa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "wob" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"woj" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "wos" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -67391,27 +56046,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "wpf" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "wpl" = (
@@ -67448,23 +56092,12 @@
 	name = "Library"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/service/library)
-"wpI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/main)
 "wpS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -67528,12 +56161,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wsA" = (
@@ -67543,9 +56170,6 @@
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
 "wsM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -67563,12 +56187,6 @@
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "wtt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/old,
@@ -67582,12 +56200,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
@@ -67620,9 +56232,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "wul" = (
@@ -67762,12 +56371,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "wyy" = (
@@ -67874,10 +56477,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"wAj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "wAx" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Checkpoint";
@@ -67890,8 +56489,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
@@ -67899,7 +56496,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wAL" = (
@@ -67910,16 +56506,11 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
 "wBg" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -67951,9 +56542,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
@@ -67972,12 +56560,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"wBP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "wCg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68047,12 +56629,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -68077,22 +56653,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"wFB" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "wFO" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
@@ -68109,9 +56670,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
 "wGG" = (
@@ -68199,13 +56757,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
-"wIq" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "wIw" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/item/clothing/under/rank/prisoner/skirt,
@@ -68227,20 +56778,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"wJh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "wJq" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -68332,16 +56869,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"wLB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "wLX" = (
 /obj/effect/decal/cleanable/chem_pile,
 /turf/open/floor/wood,
@@ -68373,8 +56900,6 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "wNg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
@@ -68417,12 +56942,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
@@ -68456,7 +56975,13 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "wOX" = (
-/obj/machinery/dish_drive/bullet,
+/obj/structure/table,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "wOZ" = (
@@ -68487,12 +57012,6 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "wPL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -68524,11 +57043,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "wQW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
@@ -68560,11 +57077,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"wRz" = (
-/obj/structure/tank_dispenser,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/iron,
-/area/science/mixing)
 "wRV" = (
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
@@ -68574,12 +57086,6 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "wSK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68627,10 +57133,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/qm)
@@ -68647,9 +57149,6 @@
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "wTC" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/machinery/meter,
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
 	pixel_x = -24
@@ -68662,12 +57161,6 @@
 "wTO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -68702,8 +57195,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -68721,13 +57212,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/cargo/office)
-"wUE" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "wUR" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -68742,7 +57226,6 @@
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/timer,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -68759,9 +57242,6 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "wVY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
@@ -68774,13 +57254,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"wWm" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "wWr" = (
 /obj/structure/table,
 /obj/item/camera,
@@ -68819,7 +57292,6 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -68852,12 +57324,6 @@
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68872,7 +57338,6 @@
 /turf/open/floor/plating/airless,
 /area/medical/virology)
 "wYb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
@@ -68928,15 +57393,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/research)
-"wZv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "wZN" = (
 /obj/structure/chair{
 	dir = 4
@@ -68947,8 +57403,6 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/service)
 "wZV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -68973,12 +57427,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xat" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -68989,9 +57437,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/sign/departments/restroom{
 	pixel_y = -32
 	},
@@ -69010,9 +57455,6 @@
 "xbf" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/light,
@@ -69043,8 +57485,6 @@
 /area/maintenance/port/central)
 "xbF" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/theater)
@@ -69066,45 +57506,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"xcu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "xcN" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"xcS" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "xdg" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xdn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
@@ -69149,8 +57565,6 @@
 	name = "Atmospherics Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -69158,26 +57572,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
-"xeq" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/medical/treatment_center)
 "xev" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine/n2o,
-/area/engineering/atmos)
-"xeA" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
 /area/engineering/atmos)
 "xeF" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -69250,12 +57649,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "xfZ" = (
@@ -69305,7 +57698,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
@@ -69317,7 +57709,6 @@
 /area/cargo/miningdock)
 "xhS" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -69353,13 +57744,11 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/stool/bar{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/bar)
 "xit" = (
@@ -69374,25 +57763,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
-"xiD" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"xiF" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "xiI" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -69407,6 +57777,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/freezer,
 /area/service/bar)
+"xiW" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "xja" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -69422,7 +57797,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -69455,7 +57829,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "xjG" = (
@@ -69484,8 +57857,6 @@
 "xjU" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/theater)
@@ -69507,12 +57878,6 @@
 /obj/effect/turf_decal/siding/thinplating,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -69544,9 +57909,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xlj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
@@ -69565,20 +57927,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"xlR" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
-"xmd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/command/gateway)
 "xmj" = (
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
@@ -69589,12 +57937,6 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
@@ -69648,12 +57990,6 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "xnL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -69668,12 +58004,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
-"xol" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai)
 "xor" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -69720,12 +58050,6 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "xqK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -69796,12 +58120,6 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -69821,17 +58139,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xsv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/service/library)
 "xsw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
@@ -69843,21 +58154,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "xsy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/cargo/office)
 "xsF" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -69868,16 +58170,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/mine/explored)
-"xsK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "xsV" = (
 /obj/machinery/computer/operating{
 	dir = 1;
@@ -69899,12 +58191,6 @@
 /area/cargo/storage)
 "xuQ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
@@ -69945,23 +58231,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"xvu" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
-"xws" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai_upload)
 "xwB" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
@@ -69969,8 +58238,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "xwF" = (
@@ -69978,12 +58245,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron,
 /area/science/mixing)
-"xwN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai)
 "xxk" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -70058,7 +58319,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/camera{
 	c_tag = "Hallway - South-West Service Wing";
 	dir = 9
@@ -70069,9 +58329,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
@@ -70081,9 +58338,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "xzP" = (
@@ -70101,23 +58355,11 @@
 	name = "Theatre Backstage";
 	req_access_txt = "46"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/theater)
-"xzQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "xAh" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 6
@@ -70182,27 +58424,9 @@
 /area/hallway/secondary/exit)
 "xBC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"xBR" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "xCs" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/rack,
@@ -70217,7 +58441,6 @@
 /turf/closed/mineral/random/stationside/asteroid,
 /area/maintenance/starboard/central)
 "xCT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/item/assembly/mousetrap/armed,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -70231,7 +58454,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -70256,12 +58478,6 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "xEa" = (
-/obj/machinery/atmospherics/pipe/multiz/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/multiz/layer4{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -70286,12 +58502,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"xEi" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/science/mixing)
 "xEo" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
@@ -70299,9 +58509,6 @@
 	dir = 4;
 	name = "sorting disposal pipe (Engineering General)";
 	sortTypes = list(4,5,6)
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -70322,12 +58529,6 @@
 "xES" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -70353,6 +58554,11 @@
 /obj/item/screwdriver,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"xFE" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "xFM" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -70373,15 +58579,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"xFQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "xFU" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Atmospherics Air Chamber";
@@ -70405,12 +58602,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
-"xGh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/science/research)
 "xGl" = (
 /obj/machinery/computer/security/mining{
 	dir = 8
@@ -70434,21 +58625,13 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "xGB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "xGC" = (
@@ -70469,10 +58652,6 @@
 /area/engineering/main)
 "xGQ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -70481,8 +58660,6 @@
 "xGU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -70493,12 +58670,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "xHs" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -70570,9 +58741,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -70581,7 +58749,6 @@
 /obj/machinery/meter{
 	name = "Mixed Air Tank In"
 	},
-/obj/machinery/atmospherics/pipe/simple,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "xIx" = (
@@ -70609,14 +58776,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
-"xJF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/construction/engineering)
 "xJX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -70712,9 +58871,6 @@
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
 "xLL" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "xLT" = (
@@ -70751,20 +58907,8 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/right)
-"xME" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xMY" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "11"
@@ -70772,12 +58916,6 @@
 /turf/open/floor/plating,
 /area/science/research)
 "xMZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /turf/open/floor/plating,
 /area/command/bridge)
 "xNa" = (
@@ -70822,12 +58960,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"xOf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/security/checkpoint/engineering)
 "xOw" = (
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
@@ -70847,13 +58979,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"xOB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xPb" = (
 /obj/structure/closet/crate,
 /obj/item/relic,
@@ -70878,8 +59003,6 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "xPq" = (
@@ -70908,22 +59031,11 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"xPC" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
 "xPD" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "xPR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -70932,17 +59044,10 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
-"xQi" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "xQn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -71010,12 +59115,6 @@
 /area/hallway/primary/tram/right)
 "xSO" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "11"
@@ -71028,8 +59127,6 @@
 	name = "Security Office";
 	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -71122,19 +59219,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "xUP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "xVk" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
@@ -71169,16 +59259,6 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "xVQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -71224,18 +59304,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"xXa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/rods,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "xXd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -71290,15 +59358,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
-"xXW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
 "xYj" = (
 /obj/structure/window/reinforced,
 /obj/structure/table,
@@ -71314,12 +59373,6 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "xYu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
@@ -71334,12 +59387,6 @@
 "xZg" = (
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"xZh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "xZt" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -71353,9 +59400,6 @@
 "xZC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
@@ -71389,16 +59433,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/office)
 "yaj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/table/wood,
 /obj/machinery/computer/secure_data/laptop{
 	dir = 4
@@ -71414,17 +59453,6 @@
 "yaU" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"ybc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "ybg" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Library Game Room"
@@ -71435,9 +59463,6 @@
 	},
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -71485,17 +59510,10 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ycm" = (
 /obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/item/folder/blue,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/neck/stethoscope,
@@ -71538,8 +59556,6 @@
 	req_access_txt = "53"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ai_monitored/command/nuke_storage)
 "yec" = (
@@ -71571,22 +59587,12 @@
 /area/mine/explored)
 "yeI" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"yft" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/service/kitchen)
 "yfG" = (
-/obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
+/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "yfK" = (
@@ -71617,9 +59623,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71641,21 +59644,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"ygJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/door/airlock/engineering{
-	name = "Power Access Hatch";
-	req_access_txt = "11"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "yho" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Quartermaster";
@@ -71665,17 +59653,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/qm)
-"yhr" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "yhw" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -71746,15 +59726,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
-"yje" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "yji" = (
 /obj/structure/disposalpipe/sorting/mail{
 	name = "sorting disposal pipe (Research Director's Office)";
@@ -71803,12 +59774,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
@@ -71840,14 +59805,9 @@
 	req_access_txt = "13"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/science/research)
 "ylS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/science/research)
@@ -87929,7 +75889,7 @@ aae
 aae
 aae
 ahI
-aIW
+aIz
 aIz
 fgX
 aJn
@@ -87943,8 +75903,8 @@ aiC
 vTj
 aeM
 aKi
-aKo
-aKo
+aKC
+aKC
 aKC
 aKl
 aae
@@ -88186,7 +76146,7 @@ aae
 aae
 aae
 ahI
-aIY
+aIz
 aCa
 aCa
 aCa
@@ -88202,7 +76162,7 @@ aEM
 aCa
 aCa
 aCa
-aKJ
+aKC
 aKl
 aae
 aae
@@ -88443,12 +76403,12 @@ aae
 aae
 aae
 ahI
-aIY
+aIz
 aCa
 arz
 arz
 aFN
-uiC
+vTj
 aCa
 aCa
 aCa
@@ -88459,7 +76419,7 @@ aFN
 aVX
 aVX
 aCa
-aKJ
+aKC
 aKl
 aae
 aae
@@ -88700,7 +76660,7 @@ ahI
 ahI
 ahI
 ahI
-aIY
+aIz
 aCa
 aFN
 rAb
@@ -88716,7 +76676,7 @@ aFN
 aFN
 aFN
 aCa
-aKJ
+aKC
 aKl
 aae
 aae
@@ -88957,12 +76917,12 @@ xFN
 cdu
 ahI
 cNm
-nYs
+fgX
 aCa
 asT
 asT
 aFN
-uiC
+vTj
 aCa
 and
 aeF
@@ -88973,7 +76933,7 @@ aFN
 aKE
 aKE
 aCa
-aKJ
+aKC
 aKl
 aae
 aae
@@ -89213,8 +77173,8 @@ azZ
 xFN
 dsx
 ahI
-aIW
-aIZ
+aIz
+aIz
 aCa
 aFN
 aFN
@@ -89230,7 +77190,7 @@ aFN
 aFN
 aFN
 aCa
-aKJ
+aKC
 aKl
 aae
 aae
@@ -89483,11 +77443,11 @@ cdV
 anw
 aCT
 qZt
-avF
+aCJ
 aeO
 aCa
 aCa
-aKJ
+aKC
 aKl
 aae
 aae
@@ -89726,13 +77686,13 @@ aIx
 aIz
 aIz
 aIz
-kZc
+hjv
 ugF
 ahI
 aae
 aCa
 aoE
-aeU
+aeM
 dQU
 ast
 aYz
@@ -89740,11 +77700,11 @@ tCR
 aYz
 arj
 dQU
-aOi
+aYz
 aSc
 aCa
 kni
-aKJ
+aKC
 aKl
 aae
 aae
@@ -89989,7 +77949,7 @@ ahI
 lmq
 aCa
 aqf
-aeU
+aeM
 dQU
 ahj
 xNF
@@ -89997,11 +77957,11 @@ kqy
 ufR
 aeQ
 dQU
-aOi
+aYz
 afR
 aCa
 rCB
-aKJ
+aKC
 aKl
 aKl
 aKl
@@ -90258,11 +78218,11 @@ aSi
 vpE
 aCa
 vRS
-mZO
-aKo
-aKo
-aKo
-aKo
+mtL
+aKC
+aKC
+aKC
+aKC
 aKC
 aKl
 aae
@@ -90511,7 +78471,7 @@ aZO
 rAb
 aFN
 kAc
-aiV
+aFN
 aOt
 aCa
 age
@@ -90520,7 +78480,7 @@ age
 age
 age
 age
-aKJ
+aKC
 aKl
 aae
 aKl
@@ -90751,7 +78711,7 @@ aJt
 aMK
 aNe
 aNe
-aNv
+aMK
 sFv
 aJt
 aIq
@@ -90760,7 +78720,7 @@ aEc
 aae
 aCa
 azz
-afa
+aeZ
 hMn
 rdw
 lcD
@@ -90768,7 +78728,7 @@ kUk
 gCL
 xsv
 nhF
-aKF
+aFN
 amC
 aCa
 anD
@@ -90777,7 +78737,7 @@ afu
 axF
 pDy
 age
-aKJ
+aKC
 aKl
 aae
 aKl
@@ -91022,7 +78982,7 @@ aCJ
 aew
 tRy
 aFN
-vTa
+kAc
 awO
 aCJ
 aeq
@@ -91034,7 +78994,7 @@ azS
 aqw
 omq
 age
-aKJ
+aKC
 aKl
 aae
 aKl
@@ -91279,7 +79239,7 @@ agL
 aCa
 tRy
 aFN
-vTa
+kAc
 aCa
 abK
 aGV
@@ -91291,7 +79251,7 @@ azS
 aab
 apJ
 age
-aKJ
+aKC
 aKl
 aKl
 aKl
@@ -91548,8 +79508,8 @@ ahY
 axG
 age
 age
-aKS
-aKo
+aKC
+aKC
 aKC
 aKl
 aKl
@@ -91807,12 +79767,12 @@ aOP
 aOP
 kXg
 aRW
-aKS
-aKo
-aKo
-aKo
-aKo
-aKo
+aKC
+aKC
+aKC
+aKC
+aKC
+aKC
 aKC
 aKl
 aKl
@@ -92044,23 +80004,23 @@ aOQ
 iBb
 aPZ
 aQx
-aQE
-aQE
-aQE
+aQV
+aQV
+aQV
 aQL
-aQP
+aQV
 aQV
 aRa
-aQE
+aQV
 aQV
 aQV
 aRf
 aRi
 qgE
-aRp
+aRV
 aRA
-aRp
-aRJ
+aRV
+aRV
 aRV
 aSn
 aRW
@@ -92070,7 +80030,7 @@ aRW
 aRW
 aRW
 aRW
-aKS
+aKC
 aKC
 aKl
 aae
@@ -92328,7 +80288,7 @@ ogJ
 ayp
 aRW
 aRW
-aLO
+aKC
 aKl
 aae
 aae
@@ -92585,7 +80545,7 @@ aAh
 aUD
 ayq
 aRW
-aLO
+aKC
 aKl
 aae
 aae
@@ -92772,10 +80732,10 @@ aae
 aae
 aaB
 qFg
-qZf
-qZf
-qZf
-mEc
+acg
+acg
+acg
+acg
 amK
 ahM
 cWu
@@ -92788,7 +80748,7 @@ fyx
 afq
 pwj
 aOF
-akf
+aeK
 aeK
 abX
 etq
@@ -92835,14 +80795,14 @@ aRE
 aSb
 aSo
 arc
-azW
+aUD
 hEf
 hEf
 hEf
 aUD
 jqB
 aRW
-aLO
+aKC
 aKl
 aae
 aae
@@ -93028,7 +80988,7 @@ aae
 aae
 aae
 aaB
-mSY
+acg
 yiT
 yiT
 yiT
@@ -93045,7 +81005,7 @@ aaB
 afq
 agG
 aeK
-akf
+aeK
 aeK
 abX
 ahV
@@ -93069,7 +81029,7 @@ gwU
 aNI
 bIb
 aOW
-aPL
+aPZ
 aQc
 aQy
 aII
@@ -93092,14 +81052,14 @@ aRE
 aSd
 aSp
 aBx
-azW
+aUD
 ozu
 ozu
 ozu
 aUD
 aks
 aRW
-aLO
+aKC
 aKl
 aae
 aae
@@ -93285,7 +81245,7 @@ aae
 aae
 aae
 aaB
-mSY
+acg
 yiT
 kFd
 xbw
@@ -93296,16 +81256,16 @@ gtG
 ama
 amK
 uKl
-aaL
+ady
 dmu
-abl
-aei
+ady
+aev
 cvT
-thR
-tvB
+xbF
+xbF
 xbF
 xjU
-iOd
+lRL
 imU
 xim
 lRL
@@ -93356,7 +81316,7 @@ aiM
 aiN
 ajR
 aRW
-aLO
+aKC
 aKl
 aae
 aae
@@ -93542,9 +81502,9 @@ aae
 aae
 aae
 aaB
-aaX
+ady
 oDC
-ldQ
+ady
 vsn
 aPh
 agV
@@ -93553,7 +81513,7 @@ cTr
 agV
 amK
 gma
-aaO
+ady
 aaB
 aaB
 afq
@@ -93568,7 +81528,7 @@ aEa
 awL
 pjm
 itJ
-ayk
+ahV
 aWC
 apZ
 aLL
@@ -93610,7 +81570,7 @@ aUD
 aau
 kTM
 aau
-aiO
+aiN
 nOJ
 aRW
 mtL
@@ -93799,7 +81759,7 @@ aae
 aae
 aae
 aaB
-fNH
+lpe
 yiT
 cSO
 ukc
@@ -93867,10 +81827,10 @@ aUD
 aUD
 aUD
 aUD
-adY
+aUD
 aYM
 aRW
-aLO
+aKC
 aKl
 aae
 aae
@@ -94056,7 +82016,7 @@ aae
 aae
 aae
 aaB
-aaO
+ady
 yiT
 yiT
 yiT
@@ -94067,7 +82027,7 @@ alS
 ahl
 amK
 mVy
-aaO
+ady
 aaB
 aae
 aae
@@ -94094,10 +82054,10 @@ aMK
 aMK
 aMK
 gwU
-aNL
+aNI
 bIb
 aOW
-aPP
+aQk
 aQh
 aQy
 aII
@@ -94124,10 +82084,10 @@ aUD
 aDH
 aDH
 aDH
-adY
+aUD
 aRI
 aRW
-aLO
+aKC
 aKl
 aae
 aae
@@ -94313,10 +82273,10 @@ aae
 aae
 aae
 aaB
-abh
-abl
-abl
-acu
+ady
+ady
+ady
+ady
 amK
 ahC
 aiX
@@ -94324,7 +82284,7 @@ agV
 amb
 amK
 inn
-aaO
+ady
 aaB
 aae
 aae
@@ -94333,7 +82293,7 @@ igu
 fbn
 abR
 acc
-acq
+pUl
 ahV
 pkI
 szq
@@ -94381,10 +82341,10 @@ aUD
 aDH
 aDH
 aDH
-adY
+aUD
 aii
 aRW
-aLO
+aKC
 aKl
 aae
 aae
@@ -94573,7 +82533,7 @@ aaB
 adr
 aaB
 aaB
-aaO
+ady
 amK
 amK
 amK
@@ -94581,7 +82541,7 @@ amK
 amK
 amK
 qNT
-aaO
+ady
 aaB
 aae
 aae
@@ -94608,7 +82568,7 @@ aMK
 aMK
 aMK
 gwU
-aNN
+aNF
 aOP
 aPa
 aPK
@@ -94641,7 +82601,7 @@ aAh
 aUL
 adR
 aRW
-aLO
+aKC
 aKl
 aae
 aae
@@ -94830,15 +82790,15 @@ bcv
 acg
 acg
 aaB
-aZb
-abl
-abl
-abl
-abl
-abl
-abl
-acQ
-acy
+rbK
+ady
+ady
+ady
+ady
+ady
+ady
+ady
+ady
 aaB
 aae
 aae
@@ -94889,7 +82849,7 @@ aQT
 aQT
 aQT
 aSk
-aSx
+aSt
 aRW
 aDF
 oZu
@@ -94898,7 +82858,7 @@ anE
 aEA
 aRW
 aRW
-aLO
+aKC
 aKl
 lvw
 mwz
@@ -95094,7 +83054,7 @@ aaB
 aaB
 aaB
 aaB
-acZ
+aev
 aaB
 aaB
 aae
@@ -95128,9 +83088,9 @@ aPe
 aPR
 aQk
 aQA
-aQF
-aQF
-aQF
+aQQ
+aQQ
+aQQ
 aQN
 aQQ
 aQT
@@ -95154,7 +83114,7 @@ aRW
 aRW
 aRW
 aRW
-aLJ
+aKC
 ivo
 ebN
 gnC
@@ -95351,7 +83311,7 @@ aae
 aae
 aae
 aaB
-adc
+ady
 aaB
 aae
 aae
@@ -95364,7 +83324,7 @@ aej
 fEk
 aZh
 xiS
-vuu
+nyf
 dsq
 dwi
 aLM
@@ -95406,12 +83366,12 @@ aiU
 aiU
 aiU
 aiU
-aLJ
-aKo
-aKo
-aKo
-aKo
-aLN
+aKC
+aKC
+aKC
+aKC
+aKC
+aKC
 aKl
 aKl
 hjW
@@ -95608,7 +83568,7 @@ aae
 aae
 aae
 aaB
-adc
+ady
 aaB
 aae
 aae
@@ -95663,7 +83623,7 @@ soZ
 aat
 ahQ
 aiU
-aLK
+aLz
 aKl
 aKl
 aKl
@@ -95865,7 +83825,7 @@ aae
 aae
 tZB
 aaB
-adc
+ady
 aaB
 aae
 aae
@@ -95920,7 +83880,7 @@ aat
 aat
 aol
 aiU
-aJQ
+aLy
 aJo
 kfa
 tdx
@@ -96122,7 +84082,7 @@ aBM
 aae
 aae
 aaB
-adc
+ady
 aaB
 aaB
 aaB
@@ -96177,7 +84137,7 @@ aat
 aat
 cJM
 aiU
-aJQ
+aLy
 bbb
 neO
 cUX
@@ -96379,7 +84339,7 @@ aBM
 aBM
 aBM
 aaB
-adc
+ady
 aaB
 fqR
 acg
@@ -96426,15 +84386,15 @@ aTE
 atZ
 aiU
 dXh
-aMw
-aIh
+aqq
+aqq
 aqq
 aoi
 aBf
 aHe
 arM
 aiU
-aJQ
+aLy
 aJo
 gsd
 xGu
@@ -96636,7 +84596,7 @@ aBM
 aBM
 aBM
 adt
-adc
+ady
 adr
 acg
 tFO
@@ -96691,7 +84651,7 @@ aiU
 aiU
 aiU
 aiU
-aJQ
+aLy
 aJo
 aJo
 aJo
@@ -96941,14 +84901,14 @@ pFx
 aiU
 aWV
 azQ
-ani
+azQ
 azQ
 aiU
-aJI
-aKf
-aKf
-aKf
-uNb
+aLy
+aLy
+aLy
+aLy
+aLy
 aJo
 aae
 aae
@@ -97201,7 +85161,7 @@ ahP
 ail
 amp
 aiU
-rqz
+aLy
 uCO
 sAK
 oKI
@@ -97458,7 +85418,7 @@ adV
 fIj
 aUe
 aiU
-rqz
+aLy
 sXN
 sXN
 sXN
@@ -97664,7 +85624,7 @@ aBM
 aae
 aae
 aaB
-adc
+ady
 aaB
 aae
 aBM
@@ -97700,22 +85660,22 @@ teX
 aaJ
 aoc
 anX
-anh
-aHB
+aoc
+anX
 hjC
 cwG
 cwG
 ias
-sSE
+gpo
 ias
 gpo
 axs
-eAy
+rGJ
 tFq
 rGJ
 aog
 aiU
-rqz
+aLy
 sXN
 rrm
 duJ
@@ -97957,13 +85917,13 @@ axc
 axc
 apw
 avI
-aFx
+afx
 avI
 arJ
 nNX
 arJ
 afx
-aoF
+avI
 afx
 avI
 aiU
@@ -97972,7 +85932,7 @@ azQ
 azQ
 xLZ
 aHf
-rqz
+aLy
 sXN
 jEz
 cdF
@@ -98178,7 +86138,7 @@ aae
 aae
 tZB
 aaB
-adc
+ady
 adt
 aBM
 aBM
@@ -98229,7 +86189,7 @@ azQ
 aRw
 deb
 aiU
-rqz
+aLy
 sXN
 nWz
 wNS
@@ -98435,7 +86395,7 @@ aae
 aae
 aae
 aaB
-adc
+ady
 adt
 aBM
 aBM
@@ -98486,7 +86446,7 @@ aiU
 aiU
 aiU
 aiU
-rqz
+aLy
 sXN
 qrK
 gSv
@@ -98692,7 +86652,7 @@ aae
 aae
 aae
 aaB
-adc
+ady
 aaB
 aae
 aae
@@ -98735,15 +86695,15 @@ aXA
 aXA
 aXA
 axc
-aJI
-aKf
-aKf
-aKf
-aKf
-aKf
-aKf
+aLy
+aLy
+aLy
+aLy
+aLy
+aLy
+aLy
 bXC
-uNb
+aLy
 sXN
 uQs
 oKf
@@ -98949,7 +86909,7 @@ aae
 aae
 aae
 aaB
-adc
+ady
 aaB
 aae
 aae
@@ -98991,8 +86951,8 @@ ckL
 aJK
 gki
 aJy
-aJI
-hjw
+aLy
+kWk
 dyu
 rmZ
 cfH
@@ -99003,7 +86963,7 @@ aLy
 neO
 sXN
 mrp
-fUf
+cdF
 olE
 fOI
 siu
@@ -99206,7 +87166,7 @@ aae
 aae
 aae
 aaB
-adc
+ady
 aaB
 aaB
 aaB
@@ -99245,10 +87205,10 @@ tAh
 tAh
 tAh
 aQS
-aJM
-aKe
+aLy
+neO
 aJy
-aJQ
+aLy
 aUb
 aUb
 aUb
@@ -99450,11 +87410,11 @@ nTn
 fSF
 fSF
 oJf
-rRu
+qCN
 cHC
-woa
+tuD
 cns
-iwd
+qCN
 gOy
 ujd
 nTn
@@ -99463,14 +87423,14 @@ aae
 aae
 aae
 aaB
-adg
+ady
 ady
 ady
 ady
 hQi
 ady
 aev
-afL
+agQ
 agQ
 agQ
 agQ
@@ -99502,10 +87462,10 @@ sXA
 grp
 tAh
 aJy
-ygJ
+cuH
 aJy
 aJy
-aJQ
+aLy
 aUb
 ame
 buL
@@ -99517,7 +87477,7 @@ aLy
 plQ
 sXN
 wJK
-fUf
+cdF
 kTy
 kTy
 wNR
@@ -99707,8 +87667,8 @@ nTn
 fSF
 fSF
 oJf
-rKY
-gkT
+rXZ
+tuD
 qCN
 eTY
 mLp
@@ -99727,7 +87687,7 @@ aaB
 aaB
 aaB
 aaB
-agc
+agQ
 aGF
 aGF
 aGF
@@ -99759,10 +87719,10 @@ doC
 cBt
 tAh
 neO
-aJP
-aKf
-aKf
-uNb
+aLy
+aLy
+aLy
+aLy
 aUb
 asV
 acC
@@ -99965,7 +87925,7 @@ fSF
 fSF
 ozW
 mLp
-jiv
+cHC
 afj
 nTn
 wHh
@@ -99984,7 +87944,7 @@ vLw
 dkx
 vLw
 aGF
-agc
+agQ
 aGF
 aae
 aae
@@ -100016,7 +87976,7 @@ nWi
 tAh
 tAh
 gHd
-aJQ
+aLy
 aUb
 aUb
 aUb
@@ -100241,7 +88201,7 @@ gQo
 sFt
 vLw
 sYh
-agc
+agQ
 aGF
 aae
 aae
@@ -100273,7 +88233,7 @@ hdc
 gqg
 ref
 gHd
-aJQ
+aLy
 aUb
 aDx
 vcn
@@ -100476,11 +88436,11 @@ aae
 aae
 lHo
 lnQ
-iMa
+ngL
 tep
-eBP
-pcI
-duQ
+qCN
+tuD
+rXZ
 pxX
 ngL
 rko
@@ -100498,7 +88458,7 @@ nsx
 aGF
 nsx
 aGF
-agc
+agQ
 aGF
 ngq
 aae
@@ -100530,7 +88490,7 @@ kSM
 xzC
 dPo
 gHd
-aJQ
+aLy
 aUb
 aDx
 eBT
@@ -100549,9 +88509,9 @@ jED
 cni
 wMp
 fuv
-sph
+jED
 uEJ
-uKN
+jED
 xYZ
 pAW
 pAW
@@ -100736,7 +88696,7 @@ kLl
 aWt
 cIh
 qCN
-tis
+tuD
 qCN
 cIh
 aWt
@@ -100755,7 +88715,7 @@ qkp
 aGF
 dCk
 aGF
-agc
+agQ
 aGF
 oXC
 aae
@@ -100787,7 +88747,7 @@ szi
 xzC
 mau
 gHd
-aJQ
+aLy
 aUb
 aaS
 gYs
@@ -100801,7 +88761,7 @@ aov
 qwk
 dHW
 aJS
-lGe
+tmH
 wtK
 cni
 wMp
@@ -100812,7 +88772,7 @@ jED
 eTD
 pAW
 aYx
-eUx
+hXd
 aFv
 isu
 hXd
@@ -100993,7 +88953,7 @@ cIh
 cIh
 cIh
 csu
-htC
+tuD
 rXZ
 cIh
 cIh
@@ -101012,7 +88972,7 @@ aGF
 aGF
 aGF
 aGF
-agc
+agQ
 aGF
 oXC
 oXC
@@ -101044,7 +89004,7 @@ nbR
 xzC
 gMr
 gHd
-aJQ
+aLy
 aUb
 eIm
 azl
@@ -101058,24 +89018,24 @@ aov
 aXg
 mkS
 aJS
-pib
+tmH
 jED
 cni
 wMp
 slp
 jED
-ePP
+uEJ
 jED
 ngN
 pAW
 qLC
-mEK
+eBk
 fTq
-wpI
-wpI
-wpI
-bzH
-wpI
+xIj
+xIj
+xIj
+xIj
+xIj
 oKO
 xIj
 reE
@@ -101247,11 +89207,11 @@ nTn
 nTn
 lHo
 lnQ
-iMa
+ngL
 iac
-duQ
-pcI
-duQ
+rXZ
+tuD
+rXZ
 sZb
 ngL
 paw
@@ -101260,16 +89220,16 @@ iNc
 eXn
 dGa
 qvj
-dIe
-kDG
+oyZ
+lBy
 nTn
 nTn
-aae
-aae
+nTn
+nTn
 aae
 aae
 aGF
-agc
+agQ
 aGF
 oXC
 ipz
@@ -101301,7 +89261,7 @@ acn
 aed
 gHd
 gHd
-aJQ
+aLy
 aUb
 azl
 azl
@@ -101326,9 +89286,9 @@ dTU
 ayG
 pAW
 mik
-mEK
-lec
-cXH
+eBk
+bXY
+eZq
 sCL
 fSu
 fbD
@@ -101339,7 +89299,7 @@ qkn
 qXU
 bXY
 jVE
-uLJ
+bTg
 hqN
 otY
 qbH
@@ -101507,7 +89467,7 @@ kdx
 aWt
 cIh
 wSO
-tis
+tuD
 qCN
 cIh
 aWt
@@ -101519,14 +89479,14 @@ pPW
 laM
 vPp
 vPp
-qyZ
+rge
+xiW
+hub
 nTn
 aae
 aae
-aae
-aae
 aGF
-jse
+rbk
 aGF
 aGF
 aGF
@@ -101557,8 +89517,8 @@ ahX
 kPg
 afS
 gHd
-aJI
-uNb
+aLy
+aLy
 aUb
 awy
 awy
@@ -101583,7 +89543,7 @@ wMp
 lpV
 pAW
 xGD
-mEK
+eBk
 exU
 hkz
 sCL
@@ -101592,7 +89552,7 @@ mYF
 nAf
 mYF
 wKG
-qxj
+mik
 blb
 cnN
 duL
@@ -101764,7 +89724,7 @@ cIh
 cIh
 cIh
 cel
-tis
+tuD
 sPW
 cIh
 cIh
@@ -101775,27 +89735,27 @@ itU
 pPW
 kuQ
 vPp
+vPp
+hqb
 jRn
-rge
+wTn
 nTn
 aae
 aae
-aae
-aae
 aGF
-xXa
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
+rks
+vLw
+vLw
+vLw
+vLw
+vLw
+vLw
 hgv
-iLF
-iLF
-iLF
-iLF
-iLF
+vLw
+vLw
+vLw
+vLw
+vLw
 uEV
 saS
 alw
@@ -101840,13 +89800,13 @@ nJr
 kWz
 pAW
 lhu
-mEK
-lec
+eBk
+bXY
 oms
 wKG
-bUX
-jls
-jls
+wKG
+phl
+phl
 phl
 wKG
 aow
@@ -102021,7 +89981,7 @@ iNm
 qCN
 rXZ
 qCN
-tQB
+cHC
 qCN
 rXZ
 qCN
@@ -102032,15 +89992,15 @@ qCN
 xzs
 jvO
 jRn
-vPp
+kDG
+wTn
+jRn
 wTn
 nTn
 aae
 aae
-aae
-aae
 aGF
-agc
+agQ
 aGF
 aGF
 aGF
@@ -102069,7 +90029,7 @@ aae
 aae
 gut
 avB
-qbS
+shO
 hqU
 shO
 vbR
@@ -102083,30 +90043,30 @@ gCq
 rqB
 lpV
 axH
-dnl
+uSP
 jED
-pFJ
+jED
 vEe
 jED
 upb
 jED
 jED
 jED
-vUq
+uEJ
 jED
 cni
 wMp
 mik
-mEK
+eBk
 ayM
-nhn
+wKG
 fXg
-qmJ
+wKG
 gCO
 gCO
 gCO
 aNy
-aXv
+dgP
 oMx
 ehE
 duL
@@ -102273,31 +90233,31 @@ gTp
 oiN
 mMz
 gDZ
-whw
+xvh
 tqX
 nGc
-eBP
-eBP
-pcI
-duQ
-eBP
+qCN
+qCN
+tuD
+rXZ
+qCN
 nGc
 ckc
-oNF
+jiI
 oWl
-duQ
+rXZ
 nfv
 yle
 jRn
-vPp
+dIe
 txB
+jRn
+jLk
 nTn
 aae
 aae
-aae
-aae
 aGF
-agc
+agQ
 aGF
 aae
 aae
@@ -102333,20 +90293,20 @@ mnj
 emU
 pAW
 gtx
-uKN
+jED
 sfD
 ivp
 ivp
 jTb
 ife
 mNs
-jgd
 tfO
-vVs
+tfO
+wgo
 mQv
-pre
+tfO
 sqS
-pre
+tfO
 wgo
 tfO
 gOg
@@ -102354,7 +90314,7 @@ uSP
 sBU
 jQx
 nFL
-eYz
+qXU
 dhD
 kae
 mYF
@@ -102363,8 +90323,8 @@ mYF
 nSy
 mYF
 ouR
-dfF
-xvu
+eZq
+eZq
 eZq
 duL
 jop
@@ -102535,7 +90495,7 @@ cIh
 cIh
 cIh
 afo
-tis
+tuD
 tsF
 cIh
 cIh
@@ -102543,18 +90503,18 @@ cIh
 cIh
 fBQ
 txx
-gly
+kcp
 eLS
 jRn
 vPp
-rge
+oiW
+jRn
+bwq
 nTn
-aae
-aae
 aGF
 aGF
 aGF
-agc
+agQ
 aGF
 aae
 aae
@@ -102585,7 +90545,7 @@ aHH
 aHH
 aHH
 awz
-xJF
+qYR
 hQH
 cXM
 pAW
@@ -102611,18 +90571,18 @@ jED
 dqP
 wMp
 mik
-rZv
+eBk
 qkW
-mHc
+wKG
 fXp
-sCE
+wKG
 dJI
 dJI
 dJI
 oAv
-hUN
+aYx
 qzo
-pJH
+sCF
 duL
 iic
 iic
@@ -102792,7 +90752,7 @@ rZn
 hkZ
 cIh
 rXZ
-tQB
+cHC
 qCN
 cIh
 hkZ
@@ -102800,18 +90760,18 @@ dtn
 cIh
 afK
 eru
-fCt
+pPW
 laM
 jRn
 vPp
 ieo
+wTn
+wTn
 nTn
-aae
-aae
 aGF
 rXw
 mzH
-agc
+agQ
 aGF
 aGF
 aae
@@ -102868,17 +90828,17 @@ xjN
 jkp
 pAW
 sCD
-rZv
+eBk
 mAn
 wKG
 oAv
-cpn
-kwv
-kwv
+wKG
+eQe
+eQe
 eQe
 wKG
 pLV
-fAV
+qXU
 cnN
 pAW
 gJH
@@ -103046,29 +91006,29 @@ nTn
 nTn
 lHo
 iQg
-qiJ
+ngL
 vRA
-duQ
-pcI
-duQ
+rXZ
+tuD
+rXZ
 oLp
-dXi
+ngL
 oUW
 cIh
 fet
 ycF
 scz
 bZm
-vPp
+sYv
 bgU
 nTn
 nTn
-aae
-aae
+nTn
+nTn
 aGF
 vLw
 aGF
-agc
+agQ
 vLw
 aGF
 aae
@@ -103125,8 +91085,8 @@ dey
 pAW
 pAW
 ayJ
-rZv
-uaB
+eBk
+bXY
 wrI
 wGM
 wKG
@@ -103134,7 +91094,7 @@ mYF
 nAf
 mYF
 wKG
-cXz
+mik
 nym
 eyE
 duL
@@ -103306,7 +91266,7 @@ cIh
 cIh
 cIh
 rXZ
-dPP
+tuD
 sNq
 cIh
 cIh
@@ -103325,7 +91285,7 @@ aGF
 aGF
 vLw
 aGF
-agc
+agQ
 vLw
 aac
 aac
@@ -103382,8 +91342,8 @@ lOd
 pAW
 pAW
 mik
-rZv
-uaB
+eBk
+bXY
 wrI
 wGM
 wmy
@@ -103391,11 +91351,11 @@ osV
 hCQ
 wTk
 fSu
-eTF
-dQX
+mik
+qXU
 sQx
-izj
-tAe
+jVE
+bTg
 wLa
 otY
 qbH
@@ -103548,8 +91508,8 @@ aae
 tmw
 uxk
 lAS
-iwk
-jAf
+lCr
+lCr
 qdM
 tmw
 mmz
@@ -103563,7 +91523,7 @@ fcZ
 hkZ
 cIh
 qCN
-tQB
+cHC
 sYd
 cIh
 hkZ
@@ -103582,7 +91542,7 @@ iuu
 aGF
 dAk
 aGF
-agc
+agQ
 ebt
 aac
 fjt
@@ -103594,7 +91554,7 @@ aBM
 aBM
 aiF
 aiW
-ajO
+ajM
 akO
 alf
 alR
@@ -103608,7 +91568,7 @@ afB
 afN
 agb
 afZ
-daw
+afD
 ahg
 cDB
 diZ
@@ -103639,17 +91599,17 @@ lOd
 rJM
 pAW
 bYA
-fbj
+eBk
 lim
 fYX
 fYX
 fYX
-fcv
-fcv
-fcv
-fcv
+qXU
+qXU
+qXU
+qXU
 hAA
-qvw
+qXU
 gyi
 duL
 iic
@@ -103806,7 +91766,7 @@ tmw
 muJ
 lCr
 gNZ
-chU
+lCr
 eze
 ydQ
 oek
@@ -103817,13 +91777,13 @@ tmw
 aae
 lHo
 iQg
-qiJ
+ngL
 rte
-duQ
-kUO
-duQ
+rXZ
+cHC
+rXZ
 tvJ
-dXi
+ngL
 paw
 lHo
 aae
@@ -103839,10 +91799,10 @@ mtF
 azq
 cfh
 aGF
-agd
-abS
+agQ
+agQ
 beS
-rwZ
+fjt
 ivx
 aac
 aBM
@@ -103865,7 +91825,7 @@ afB
 afO
 afD
 agh
-xXW
+afD
 fBn
 gdl
 wBg
@@ -103896,15 +91856,15 @@ lOd
 sRy
 pAW
 dgP
-kPB
+fvz
 obw
-ntQ
-ntQ
-ntQ
-ntQ
-ntQ
-ntQ
-ntQ
+fvz
+fvz
+fvz
+fvz
+fvz
+fvz
+fvz
 rxT
 fvz
 uYP
@@ -104069,7 +92029,7 @@ tmw
 ndn
 onn
 uRI
-fAb
+tmw
 tmw
 aae
 lHo
@@ -104077,7 +92037,7 @@ cIh
 cIh
 cIh
 abB
-tQB
+cHC
 rXZ
 cIh
 cIh
@@ -104096,10 +92056,10 @@ fDG
 aGF
 vLw
 aGF
-agc
+agQ
 vLw
 aac
-kkq
+aIN
 kLi
 aac
 aae
@@ -104122,7 +92082,7 @@ afB
 afZ
 agb
 afN
-cct
+afD
 ahg
 vxZ
 qPM
@@ -104144,7 +92104,7 @@ pHb
 uYT
 pMh
 kuF
-sii
+vvx
 nDB
 mfD
 pKF
@@ -104154,7 +92114,6 @@ kwu
 pAW
 pAW
 pAW
-nwx
 pAW
 pAW
 pAW
@@ -104164,7 +92123,8 @@ pAW
 pAW
 pAW
 pAW
-cYc
+pAW
+pAW
 pAW
 pAW
 pAW
@@ -104334,7 +92294,7 @@ rzK
 ewN
 ccM
 rXZ
-tQB
+cHC
 uBm
 ccM
 dGC
@@ -104353,7 +92313,7 @@ aGF
 aGF
 ggQ
 aGF
-agc
+agQ
 vLw
 aac
 aac
@@ -104391,7 +92351,7 @@ gXR
 gOs
 kSp
 cRp
-gzH
+cGs
 wMb
 yfV
 aHp
@@ -104421,7 +92381,7 @@ aae
 aae
 aae
 aae
-sHk
+gYH
 gYH
 vrP
 aae
@@ -104588,10 +92548,10 @@ aae
 nTn
 aaU
 hTT
-cEx
+rzK
 gEc
 rXZ
-tQB
+cHC
 qCN
 ccM
 abO
@@ -104610,7 +92570,7 @@ aae
 aGF
 vLw
 aGF
-agc
+agQ
 gQo
 aGF
 aae
@@ -104651,17 +92611,17 @@ ttP
 him
 alr
 bhR
-qvA
-xOf
-xOf
-xOf
-kal
-qaA
-ncU
-cHa
-ncU
-qaA
-doo
+uYT
+gUn
+gUn
+gUn
+uYT
+lOd
+wPP
+gac
+wPP
+lOd
+lOd
 xsr
 fbm
 uXX
@@ -104845,13 +92805,13 @@ nTn
 nTn
 emw
 xdr
-yje
+rzK
 acF
-duQ
+rXZ
 oSW
 vSS
 afC
-tjU
+tCB
 oZv
 eng
 nTn
@@ -104867,7 +92827,7 @@ aae
 aGF
 fDf
 mzH
-agc
+agQ
 aGF
 aGF
 aae
@@ -104900,9 +92860,9 @@ ant
 cbH
 cLS
 jYp
-cAO
-frJ
-dsp
+iXL
+iXL
+iXL
 geu
 sss
 geu
@@ -104920,11 +92880,11 @@ juv
 sud
 anN
 gIc
-uaf
+tnL
 lmk
 mYh
 fsk
-iCM
+bAI
 bAI
 ewH
 umL
@@ -105102,10 +93062,10 @@ rXD
 ccM
 dKT
 fjv
-hxu
+rzK
 gEc
-nBO
-hzU
+vSS
+oSW
 afv
 ccM
 bXa
@@ -105124,7 +93084,7 @@ aae
 aGF
 aGF
 aGF
-agc
+agQ
 aGF
 aae
 aae
@@ -105145,7 +93105,7 @@ aMP
 bNP
 aMP
 vQt
-nbr
+rwy
 aHH
 aHH
 aHH
@@ -105155,38 +93115,38 @@ aHH
 aHH
 aHH
 awA
-rsP
+mnj
 sOX
 bnO
 dCC
-owd
-aOl
+one
+kZV
 iWU
-bLI
-nNB
+jfy
+jfy
 eAx
-kUF
+one
 njO
 fqJ
 rhf
-keL
-xOB
-beL
-xVQ
-beL
-beL
-mbS
-beL
-beL
-beL
-beL
-tUF
 tnL
-hZq
+fqJ
+tnL
+xVQ
+tnL
+tnL
+tnL
+tnL
+tnL
+tnL
+tnL
+tnL
+tnL
+tnL
 pik
 wFO
-okn
-xQi
+tOl
+etc
 eaY
 cMz
 mzN
@@ -105381,7 +93341,7 @@ aae
 aae
 aae
 aGF
-agc
+agQ
 aGF
 aae
 aae
@@ -105402,7 +93362,7 @@ aMP
 aMP
 aMP
 vQt
-nbr
+rwy
 aHH
 aae
 aae
@@ -105419,28 +93379,28 @@ jXu
 one
 dxE
 sKW
-lZC
+mmq
 mmq
 xdZ
 hhn
 vEh
 xPR
-cAP
-lYg
+xPR
+xPR
 qBb
 xPR
 qhD
 ayj
-pgt
-pgt
-pgt
-qlx
-xME
 tnL
-vdg
-beL
+tnL
+tnL
+qlx
+tnL
+tnL
+tnL
+tnL
 xdg
-rMU
+tnL
 hXD
 tOl
 jwD
@@ -105611,7 +93571,7 @@ jmi
 faK
 wob
 xHE
-kZD
+xHE
 aaY
 ccM
 ccM
@@ -105619,7 +93579,7 @@ ccM
 ccM
 ccM
 aeJ
-tXx
+oSW
 tuD
 ccM
 ccM
@@ -105638,7 +93598,7 @@ aae
 aae
 aae
 fUq
-agc
+agQ
 aGF
 aGF
 aGF
@@ -105654,11 +93614,11 @@ aGF
 aHH
 aHH
 amE
-amN
-amN
-amN
-amN
-amN
+aMT
+aMT
+aMT
+aMT
+aMT
 amP
 aHH
 aHH
@@ -105673,20 +93633,20 @@ cFF
 cFF
 ntr
 vBo
-vxX
+one
 axi
 mGe
 gpk
 uaK
-skn
-hPE
+eAx
+one
 axL
-iVY
-iVY
-pAi
-wUE
-vLG
-wWm
+tnL
+tnL
+tnL
+xVQ
+tnL
+wsP
 dGP
 xjX
 xNN
@@ -105694,13 +93654,13 @@ xjX
 dGP
 agi
 tnL
-pch
-lGS
-iVY
+tnL
+tnL
+tnL
 pHm
 uKH
-gFR
-gED
+tOl
+etc
 eaY
 hEH
 mzN
@@ -105876,7 +93836,7 @@ nHL
 qCN
 uRd
 rXZ
-pQD
+oSW
 rXZ
 uPs
 qCN
@@ -105895,7 +93855,7 @@ aae
 aae
 aae
 fUq
-agc
+agQ
 agQ
 agQ
 agQ
@@ -105928,11 +93888,11 @@ fWv
 tOl
 cPj
 tOl
-oZH
-jbr
-pGs
+one
+one
+one
 uLN
-lce
+mGe
 ndT
 one
 one
@@ -105951,12 +93911,12 @@ dGP
 dGP
 hed
 tnL
-vdg
+tnL
 bRF
-ttH
+tnL
 vlY
 kwc
-ger
+one
 cTH
 iCR
 iCR
@@ -106128,20 +94088,20 @@ lrc
 jmb
 bjP
 abJ
-eBP
-tkJ
-duQ
-duQ
-eBP
+qCN
+rXZ
+rXZ
+rXZ
+qCN
 mFe
 aaT
-aaW
-aaW
-abV
-duQ
-ags
-eBP
-eBP
+tuD
+tuD
+tuD
+rXZ
+afX
+qCN
+qCN
 pJg
 nNA
 oRk
@@ -106152,7 +94112,7 @@ aae
 aae
 aae
 pOU
-agc
+agQ
 fUq
 aGF
 aGF
@@ -106194,12 +94154,12 @@ loB
 hgo
 cqx
 vwX
-oDx
-uXG
-oDx
+tOl
+tOl
+tOl
 ikD
-rsm
-xiD
+tOl
+xap
 snR
 dGP
 foH
@@ -106207,14 +94167,14 @@ daC
 foH
 dGP
 lEu
-beL
-bUh
-kEG
+tnL
+rPX
+tnL
 fqJ
 qHo
 fBv
-okn
-xQi
+tOl
+etc
 eaY
 sHz
 aSh
@@ -106382,15 +94342,15 @@ upI
 ePI
 qyr
 bag
-sVQ
-kAI
+bag
+hEv
 ccM
 ccM
 abT
 ccM
 ccM
 qCN
-pQD
+oSW
 qCN
 ccM
 ccM
@@ -106441,34 +94401,34 @@ fPU
 tnL
 tnL
 rPX
-eOO
+tnL
 tnL
 tnL
 usM
 xap
-lce
+mGe
 akU
 one
-aLB
+cqx
 one
 nNs
 jfy
 tQN
 bup
-tFX
+tOl
 uLB
-ezn
+wsP
 ayl
-pJW
-xeA
-xeA
-oRa
-egN
-oAx
-bjv
-rUe
+iZX
 tnL
-cSV
+tnL
+oRa
+tnL
+tnL
+bjv
+tau
+tnL
+tnL
 jyY
 tOl
 jwD
@@ -106643,7 +94603,7 @@ mLp
 hEv
 ccM
 hqm
-gzh
+rXZ
 jWe
 ccM
 aGF
@@ -106695,9 +94655,9 @@ aae
 one
 seV
 seV
-uPH
+tnL
 tTY
-pZo
+kWH
 dDY
 kWH
 mmq
@@ -106706,29 +94666,29 @@ sOA
 uQI
 bIu
 one
-bPZ
+cqx
 vwX
-jeh
+iZX
 tnL
 xEr
-oAx
-pDq
-qVf
-woj
+tnL
+tOl
+tau
+wsP
 tnL
 dGY
 fQc
 tnL
 dGY
 iky
-spz
+tnL
 tnL
 gVz
 tau
 whV
 iFE
-gFR
-gED
+tOl
+etc
 eaY
 qih
 aSh
@@ -106963,25 +94923,25 @@ khK
 mGV
 xXg
 one
-aLB
+cqx
 one
-eWy
+tnL
 ktD
-otx
+tnL
 hZT
-gQQ
-lsZ
-wIq
+tOl
+tau
+wsP
 oBQ
-qyQ
-qyQ
-qyQ
+tnL
+tnL
+tnL
 iZX
 uPi
-ljs
-iPg
+tnL
+tnL
 kCj
-uiE
+tnL
 rfq
 jvG
 one
@@ -107220,14 +95180,14 @@ one
 one
 one
 one
-aLB
+cqx
 one
 mOV
-oAx
-kuj
-dOE
-gQQ
-spz
+tnL
+rPX
+tnL
+tOl
+tnL
 wsP
 tnL
 oTZ
@@ -107235,14 +95195,14 @@ oTZ
 oTZ
 ntR
 pIu
-spz
 tnL
-gUE
-iVY
+tnL
+tnL
+tnL
 thl
 vab
-mgz
-jPQ
+tOl
+etc
 xIt
 moi
 che
@@ -107481,22 +95441,22 @@ kWk
 one
 tjx
 nTs
-hZq
+tnL
 bxw
-pDq
-eiX
-bkn
-bkn
-bkn
+tOl
+tnL
+wsP
+wsP
+wsP
 paY
-bkn
-bkn
-bkn
-rqG
 wsP
 wsP
-psJ
-lNO
+wsP
+wsP
+wsP
+wsP
+wsP
+wsP
 bUp
 tOl
 jwD
@@ -107694,7 +95654,7 @@ aae
 aae
 aae
 aGF
-agc
+agQ
 aGF
 tND
 goZ
@@ -107734,29 +95694,29 @@ aJo
 byo
 aJo
 fVf
-rqz
+aLy
 one
 aIr
 vTG
-iqe
+tnL
 cBq
-rqy
+tOl
 tEe
-vAm
+tnL
 nVQ
 bVO
 sqo
-vAm
+tnL
 nBs
 qKp
-bhe
-vAm
+gOG
+tnL
 gRw
 gOG
 iwI
 lju
-gFR
-gED
+tOl
+etc
 eip
 qBk
 che
@@ -107951,7 +95911,7 @@ aae
 aae
 aae
 fUq
-agc
+agQ
 aGF
 aGF
 aGF
@@ -107991,13 +95951,13 @@ vRc
 lMb
 aJo
 dkh
-wJh
-pFg
+aLy
+one
 nQR
 tWH
 cvS
 qfl
-gQQ
+tOl
 xsu
 sWu
 ter
@@ -108208,7 +96168,7 @@ aae
 aae
 aae
 aGF
-agc
+agQ
 aGF
 aae
 aae
@@ -108248,26 +96208,26 @@ tPz
 aJH
 phM
 vDX
-owy
+aLy
 one
 lYN
-ldt
-mgz
-jFb
-yhr
-bJW
-mgz
-fTV
-noT
-bJW
-mgz
-fTV
-noT
-bJW
-mgz
-fTV
-noT
-ovu
+tOl
+tOl
+tOl
+one
+tOl
+tOl
+tOl
+one
+tOl
+tOl
+tOl
+one
+tOl
+tOl
+tOl
+one
+one
 ayZ
 one
 jwD
@@ -108446,7 +96406,7 @@ aae
 aae
 aae
 aGF
-xcu
+uxd
 pMQ
 eAw
 xxm
@@ -108465,7 +96425,7 @@ aGF
 aGF
 aGF
 aGF
-agc
+agQ
 aGF
 aae
 aae
@@ -108505,24 +96465,24 @@ msT
 kDm
 aJo
 ijL
-owy
+aLy
 aJo
 jwD
-kvR
+etc
 jwD
-eui
+etc
 jwD
-kvR
+etc
 jwD
-eui
+etc
 jwD
-kvR
+etc
 jwD
-eui
+etc
 jwD
-kvR
+etc
 jwD
-eui
+etc
 jwD
 tOl
 xlb
@@ -108706,23 +96666,23 @@ aGF
 fHU
 uxd
 uxd
-aav
+agQ
 abs
-abS
+agQ
 jaS
-abS
-abS
-abS
-abS
-abS
-abS
-adN
-gux
-aav
-aav
-aav
-aex
-agj
+agQ
+agQ
+agQ
+agQ
+agQ
+agQ
+agQ
+rks
+agQ
+agQ
+agQ
+agQ
+agQ
 aGF
 aae
 aBM
@@ -108765,21 +96725,21 @@ iVs
 ghw
 aJo
 one
-lYu
+eaY
 ntZ
-lYu
+eaY
 iCR
-lYu
+eaY
 ntZ
-lYu
+eaY
 iCR
-lYu
+eaY
 ntZ
-lYu
+eaY
 iCR
-lYu
+eaY
 ntZ
-lYu
+eaY
 one
 dGP
 aza
@@ -108978,7 +96938,7 @@ aGF
 aGF
 aGF
 aGF
-aey
+ahp
 aGF
 aGF
 aae
@@ -109019,7 +96979,7 @@ aJo
 aJo
 aJo
 fkV
-owy
+aLy
 neO
 one
 wux
@@ -109276,7 +97236,7 @@ cAL
 xjM
 rxe
 neO
-owy
+aLy
 neO
 one
 dTm
@@ -109465,11 +97425,11 @@ aae
 rQC
 rwz
 nOP
-bBB
-xPC
-bBB
-xPC
-dql
+adk
+bry
+adk
+bry
+wgT
 aBM
 aae
 aae
@@ -109533,7 +97493,7 @@ aJo
 aJo
 aJo
 ofx
-owy
+aLy
 neO
 one
 kEz
@@ -109726,12 +97686,12 @@ ePt
 knV
 knV
 knV
-tHJ
-rvf
-bXF
-rvf
-rvf
-qUN
+wgT
+wgT
+aRN
+wgT
+wgT
+aRN
 aae
 aae
 aBM
@@ -109742,14 +97702,14 @@ aae
 aBM
 aBM
 aBM
-jto
-bXF
-rvf
+aRN
+aRN
+wgT
 wQG
 hDO
 tLQ
-oLI
-wZv
+aGf
+aGf
 aet
 agX
 aee
@@ -109789,7 +97749,7 @@ aae
 aae
 aae
 aJo
-uge
+aLy
 bnA
 aJo
 one
@@ -109988,7 +97948,7 @@ aBM
 aBM
 aBM
 aBM
-kHD
+aRN
 aBM
 aBM
 aBM
@@ -109999,14 +97959,14 @@ aae
 aae
 aae
 aBM
-kHD
+aRN
 aBM
 qgs
 adS
 adS
 adS
 jIg
-mHf
+kSD
 aet
 adS
 adS
@@ -110046,7 +98006,7 @@ aJo
 aJo
 aJo
 aJo
-owy
+aLy
 sAK
 aJo
 fwy
@@ -110068,10 +98028,10 @@ tVq
 diU
 dOL
 aze
-hTg
-hTg
+yak
+yak
 qFu
-eCr
+yak
 tom
 iRA
 iRA
@@ -110245,7 +98205,7 @@ aBM
 aBM
 aBM
 aBM
-kHD
+aRN
 aBM
 aBM
 aBM
@@ -110253,10 +98213,10 @@ aBM
 aBM
 aae
 aae
-jto
-bXF
-bXF
-ulD
+aRN
+aRN
+aRN
+aRN
 aBM
 aBM
 aBM
@@ -110297,12 +98257,12 @@ aJo
 aJo
 aJo
 aJW
-aJz
-aJz
-aJz
-aJz
-aJz
-aJz
+eaa
+eaa
+eaa
+eaa
+eaa
+eaa
 sbv
 vDX
 aJo
@@ -110328,8 +98288,8 @@ lKd
 bNe
 eDs
 bZx
-lrU
-eCr
+yak
+yak
 yak
 nVr
 yak
@@ -110502,15 +98462,15 @@ aae
 aBM
 aBM
 aBM
-fck
-rvf
-bXF
-bXF
-rvf
-bXF
-bXF
-bXF
-ulD
+aRN
+wgT
+aRN
+aRN
+wgT
+aRN
+aRN
+aRN
+aRN
 aBM
 aBM
 aBM
@@ -110520,10 +98480,10 @@ aBM
 aBM
 adS
 adS
-aeG
-agp
+aGf
+aGf
 ahp
-aiu
+aGf
 adS
 aae
 aBM
@@ -110551,8 +98511,8 @@ aae
 aae
 aJo
 aJu
-aJz
-aJz
+eaa
+eaa
 aJX
 wGY
 wGY
@@ -110560,7 +98520,7 @@ wGY
 wGY
 wGY
 wGY
-owy
+aLy
 rgO
 aJo
 fwy
@@ -110581,13 +98541,13 @@ syF
 eLR
 diU
 aoo
-jbt
-bGf
+kPz
+jxJ
 poj
 mep
-cTp
+dOL
 eHs
-itk
+yak
 mus
 yak
 yak
@@ -110807,7 +98767,7 @@ aHI
 aHI
 aae
 aJo
-aJv
+kNF
 wGY
 wGY
 wGY
@@ -110817,7 +98777,7 @@ iSp
 aiE
 rJa
 wGY
-owy
+aLy
 tyF
 aJo
 aJo
@@ -110834,7 +98794,7 @@ peZ
 udR
 jXF
 tZl
-foh
+syF
 ttp
 ayN
 wpf
@@ -111035,9 +98995,9 @@ aae
 aae
 aeu
 aeP
-agt
+aGf
 mkJ
-ajQ
+aGf
 adS
 aae
 aae
@@ -111064,7 +99024,7 @@ tYJ
 aHI
 aHI
 aJo
-aJv
+kNF
 wGY
 xLT
 xLT
@@ -111076,7 +99036,7 @@ dJk
 wGY
 vtJ
 eaa
-kjL
+eaa
 eaa
 eaa
 eaa
@@ -111090,18 +99050,18 @@ rzp
 wNL
 tiG
 caj
-flU
-eOp
+rzp
+syF
 nET
 diU
 bid
-lBk
+jxJ
 rem
 eSQ
 kKo
-itk
+yak
 iIQ
-itk
+yak
 bht
 yak
 yak
@@ -111339,25 +99299,25 @@ aJy
 aJo
 aJo
 kNF
-jmu
-dYM
-dYM
+bbb
+neO
+neO
 uzY
-iFm
+rzp
 led
 wAR
-iFm
-mTt
+rzp
+rzp
 tuo
 rkS
 diU
 mwf
-soS
+jxJ
 eup
 jxJ
 vcm
 qFu
-owv
+yak
 yak
 yak
 yak
@@ -111578,7 +99538,7 @@ aKA
 aHI
 aHI
 aJo
-aJv
+kNF
 wGY
 oLN
 jUB
@@ -111586,16 +99546,16 @@ tCf
 kGu
 xqx
 iwb
-myW
+dJk
 gGO
 wGY
 jcZ
-eGY
+aLy
 neO
 aJy
 aae
 aJo
-aLH
+kNF
 aJo
 neO
 kzW
@@ -111615,9 +99575,9 @@ azh
 fye
 piI
 ouV
-lUO
-lUO
-lUO
+fXn
+fXn
+fXn
 fXn
 aBM
 ajc
@@ -111835,24 +99795,24 @@ adS
 adS
 adS
 aJo
-aJv
+kNF
 wGY
 nIX
 xLT
-pnQ
+tCf
 mZg
-okN
-okN
-dXc
+xqx
+xqx
+dJk
 vFI
 wGY
 aJK
-aLu
+hPX
 pSL
 aJy
 aae
 aJo
-aLH
+kNF
 aJo
 aJo
 aJo
@@ -112092,11 +100052,11 @@ tzc
 bRH
 ffX
 aJo
-aJv
+kNF
 wGY
 qqd
 oEI
-nJB
+jzA
 uMm
 jwj
 xqx
@@ -112109,7 +100069,7 @@ aJy
 aJy
 aae
 aJo
-aLH
+kNF
 aJo
 aae
 aae
@@ -112349,7 +100309,7 @@ tzc
 aet
 aet
 aJo
-aJv
+kNF
 wGY
 ipH
 uny
@@ -112357,7 +100317,7 @@ oFv
 fbX
 cQd
 xqx
-dyE
+dJk
 wGY
 aae
 aae
@@ -112366,7 +100326,7 @@ aZC
 aBM
 aae
 aJo
-aLH
+kNF
 aJo
 aae
 aae
@@ -112572,16 +100532,16 @@ sHb
 raL
 cLh
 pPn
-gyY
-eJm
+xwB
+qoJ
 tqk
 oiT
 huj
 jXg
 sHb
 kSD
-agp
-aiu
+aGf
+aGf
 adS
 aae
 aae
@@ -112623,7 +100583,7 @@ aBM
 iox
 aBM
 aJo
-aLH
+kNF
 aJo
 aae
 aae
@@ -112639,8 +100599,8 @@ iVc
 cVq
 qAt
 lQG
-rQp
-bkb
+xLL
+xLL
 xLL
 lQG
 aae
@@ -112830,7 +100790,7 @@ sHb
 sHb
 sHb
 nyp
-slo
+qoJ
 ajS
 sHb
 sHb
@@ -112838,7 +100798,7 @@ sHb
 sHb
 sHb
 sHb
-ang
+aGf
 adS
 adS
 aae
@@ -112880,7 +100840,7 @@ der
 aBM
 aae
 aJo
-aLH
+kNF
 aJo
 aae
 aae
@@ -113088,7 +101048,7 @@ agz
 sHb
 qkR
 qoJ
-xiF
+oHn
 iWV
 qpv
 vkb
@@ -113096,7 +101056,7 @@ vkb
 cok
 sHb
 dRl
-aiu
+aGf
 adS
 adS
 adS
@@ -113106,7 +101066,7 @@ enG
 adS
 adS
 aHI
-oDz
+ghY
 pmY
 aMY
 aMY
@@ -113117,17 +101077,17 @@ aHI
 adS
 adS
 aQt
-aQD
-aQD
-aQD
+aQJ
+aQJ
+aQJ
 aQJ
 srR
 aPx
 aQX
 dDn
 dOU
-bhy
-bhy
+jHL
+jHL
 fak
 jHL
 jHL
@@ -113137,7 +101097,7 @@ der
 aae
 aae
 aJo
-aLH
+kNF
 aJo
 aae
 aae
@@ -113152,7 +101112,7 @@ wYp
 aPG
 lPd
 lPd
-dum
+lQG
 maq
 nQg
 pKo
@@ -113353,15 +101313,15 @@ sxR
 qHm
 sHb
 sHb
-apm
-aAT
-aAT
-aAT
-aAT
+aGf
+aet
+aet
+aet
+aet
 xCT
 sSf
-aAT
-aAT
+aet
+aet
 aAl
 gEi
 pmY
@@ -113394,7 +101354,7 @@ der
 aae
 aae
 aJo
-aLH
+kNF
 aJo
 aae
 aae
@@ -113597,7 +101557,7 @@ aae
 sHb
 qiA
 svb
-nMN
+uUu
 aht
 sHb
 qkR
@@ -113666,7 +101626,7 @@ lQG
 lQG
 lQG
 lQG
-gZP
+lQG
 agm
 daS
 oVk
@@ -113854,7 +101814,7 @@ aae
 sHb
 mSH
 uUu
-eZA
+uUu
 pAe
 jgS
 lqW
@@ -113890,7 +101850,7 @@ adS
 aQu
 ifA
 avu
-lwI
+apV
 wQW
 dVI
 uvE
@@ -113916,19 +101876,19 @@ aRO
 lQG
 mOo
 klo
-lXy
+veB
 pfC
 tqw
 chx
 veB
 agk
 veB
-fhQ
+veB
 aXx
 dpU
 kZf
-gui
-cRZ
+dZR
+lPd
 puK
 lPd
 rtz
@@ -114122,7 +102082,7 @@ uJC
 fDM
 bJm
 eSZ
-uLI
+jVy
 jVy
 voj
 oJu
@@ -114168,19 +102128,19 @@ aSz
 uAG
 lVr
 aSR
-aST
-aST
+aSl
+aSl
 aSU
 kcB
-fFP
-cPH
+eGo
+eGo
 cRo
 fdy
-tNu
+eGo
 gLq
-tNu
-tNu
-icr
+eGo
+eGo
+eGo
 eGo
 cDK
 lFn
@@ -114373,12 +102333,12 @@ uUu
 gzb
 amg
 qoJ
-xiF
+oHn
 sHb
 uJC
 fDM
 xVP
-mza
+qoJ
 reH
 jQP
 qTd
@@ -114405,7 +102365,7 @@ aQu
 ifA
 aUf
 uKw
-gAK
+apV
 raq
 eMe
 fhu
@@ -114430,7 +102390,7 @@ aRO
 lQG
 aon
 dnT
-xFQ
+nPQ
 jcN
 gFf
 bOD
@@ -114625,17 +102585,17 @@ aae
 sHb
 gBy
 hhx
-dgr
+uUu
 uUu
 sHb
 ami
 nhq
-xlR
+oHn
 sHb
 sHb
 sHb
 agM
-gqr
+reH
 sAN
 sHb
 qhT
@@ -114675,11 +102635,11 @@ bJd
 bJd
 ixu
 hWx
-xGh
+der
 aRL
 aRL
 aRL
-aSL
+aSR
 aRL
 aRL
 aRL
@@ -114891,19 +102851,19 @@ fjD
 vGF
 oqG
 gPR
-olg
-nzH
+hYd
+wRf
 sHb
 sHb
 avL
-aCj
+aQJ
 mcH
-aCj
-aCj
-aCj
-aCj
-aCj
-aIn
+aQJ
+aQJ
+aQJ
+aQJ
+aQJ
+aQJ
 aJk
 fpk
 pmY
@@ -114932,11 +102892,11 @@ vkJ
 vkJ
 lMH
 hWx
-xGh
+der
 pED
 ffU
 jFG
-aSC
+aSl
 aRL
 aae
 aae
@@ -115144,7 +103104,7 @@ jWg
 sHb
 acB
 qoJ
-xiF
+oHn
 iWV
 mOQ
 jQP
@@ -115179,21 +103139,21 @@ aae
 der
 kbY
 tej
-fjy
+qSj
 eDr
 frM
-mgV
-mgV
+xfs
+xfs
 eQZ
 wNg
 wNg
 wNg
 lIF
-xGh
+der
 aRT
 aSl
-aSA
-aSM
+aSl
+aSl
 aRL
 aae
 aae
@@ -115401,7 +103361,7 @@ sHb
 sHb
 qkR
 qoJ
-mRa
+wRf
 sHb
 sHb
 nao
@@ -115426,10 +103386,10 @@ aMY
 aMY
 uom
 iuS
-aON
+aOM
 rDt
-aPy
-aQv
+aPx
+aQI
 adS
 der
 der
@@ -115446,10 +103406,10 @@ lar
 der
 der
 der
-tQf
-huy
-nNC
-ssb
+der
+mSi
+mSi
+aRO
 aRL
 aRL
 aae
@@ -115658,7 +103618,7 @@ kQP
 qpv
 hYd
 qoJ
-pCW
+xNa
 cok
 bmr
 ozh
@@ -115666,15 +103626,15 @@ sLz
 ada
 wdg
 xnD
-cIa
+hcW
 aho
 bBA
 gGN
 fiQ
 aet
 adS
-aFC
-aHJ
+aGf
+aGf
 aHI
 dIX
 pmY
@@ -115690,9 +103650,9 @@ aGf
 adS
 der
 yhS
-fjy
+qSj
 gnn
-hdI
+tej
 qSj
 oab
 der
@@ -115705,8 +103665,8 @@ mSi
 wbE
 wbE
 wbE
-nbf
-ssb
+mSi
+aRO
 aRL
 aae
 aae
@@ -115915,7 +103875,7 @@ kQP
 qkR
 qoJ
 xnL
-jZa
+qoJ
 oHn
 jUP
 uCS
@@ -115923,7 +103883,7 @@ cUf
 lll
 sRB
 uvF
-lqb
+hcW
 juI
 bBA
 tEb
@@ -115962,8 +103922,8 @@ mSi
 beR
 beR
 beR
-nbf
-ssb
+mSi
+aRO
 aRL
 aae
 aae
@@ -116016,14 +103976,14 @@ xeZ
 eYL
 eYL
 mJH
-hSF
-pDk
-pDk
+eYL
+eYL
+eYL
 ucf
-pDk
-pDk
-pDk
-knN
+eYL
+eYL
+eYL
+eYL
 cRL
 eYL
 eYL
@@ -116186,8 +104146,8 @@ bBA
 iBI
 cmy
 adS
-aFC
-aHJ
+aGf
+aGf
 aHI
 lCc
 iij
@@ -116219,8 +104179,8 @@ mSi
 nKT
 prF
 nKT
-nbf
-tcm
+mSi
+dYV
 aRL
 lmq
 aae
@@ -116272,16 +104232,16 @@ oOa
 xeZ
 vSA
 fmk
-hSF
-wBP
+eYL
+eYL
 lVh
 nsl
 nsl
 mOW
 nsl
 fmk
-lYb
-miQ
+eYL
+eYL
 pGq
 mJH
 gre
@@ -116463,21 +104423,21 @@ dYi
 aet
 mSi
 aik
-uxU
-uxU
-aRy
+hWi
+hWi
+hWi
 btc
-kyK
-xEi
-hEn
+hWi
+xZt
+doO
 lgh
 kbJ
 mSi
 eUU
 nKT
 tqT
-nbf
-tcm
+mSi
+dYV
 dYV
 oXC
 vKG
@@ -116529,7 +104489,7 @@ dYA
 xeZ
 xeZ
 tsK
-xZh
+eYL
 lVh
 kOG
 gre
@@ -116538,7 +104498,7 @@ gre
 gre
 gre
 wDu
-xZh
+eYL
 pGq
 ipX
 gre
@@ -116730,10 +104690,10 @@ kWc
 jys
 dSz
 mSi
-esm
+mSi
 xJw
-esm
-nbf
+mSi
+mSi
 hPR
 nur
 iAV
@@ -116747,7 +104707,7 @@ dnX
 hpE
 der
 uft
-rdv
+hpE
 lar
 aBM
 aBM
@@ -116786,7 +104746,7 @@ yaU
 gfh
 xeZ
 tsK
-xZh
+eYL
 oxi
 gre
 gre
@@ -116964,8 +104924,8 @@ aJf
 aMG
 fKQ
 aNi
-bxp
-aNB
+aNi
+aMY
 aMY
 aMG
 aJf
@@ -116985,13 +104945,13 @@ awY
 jjN
 uvK
 brq
-wRz
-sme
+okC
+mSi
 pyt
 bFu
 fyw
-rUN
-tcm
+mSi
+dYV
 mkC
 oXC
 iAV
@@ -117043,7 +105003,7 @@ cYt
 gTT
 xeZ
 xAh
-xZh
+eYL
 dXO
 gre
 sVe
@@ -117221,7 +105181,7 @@ aHI
 aMG
 tTu
 aNj
-aNo
+aNi
 aMY
 jiz
 aMG
@@ -117244,11 +105204,11 @@ oCG
 okL
 swZ
 mSi
-esm
-mhs
-esm
 mSi
-tcm
+mhs
+mSi
+mSi
+dYV
 aRL
 oXC
 aae
@@ -117265,12 +105225,12 @@ dnM
 ylO
 jmK
 vWg
-bXF
-bXF
-bXF
-bXF
-bXF
-bXF
+aRN
+aRN
+aRN
+aRN
+aRN
+aRN
 etc
 etc
 etc
@@ -117292,28 +105252,28 @@ etc
 etc
 etc
 dPs
-evn
+miu
 miu
 hRv
 sbA
 pwS
 pZn
 mAY
-uPu
+oly
 aaG
 cID
 gre
 qDt
-wkk
-xsK
+jtc
+jtc
 jrC
 jtc
 luG
 pPH
-dDF
-dDF
+eYL
+eYL
 itB
-cEK
+mJH
 xmU
 tbX
 koV
@@ -117471,10 +105431,10 @@ aae
 aae
 aae
 adS
-ajV
-agp
-agp
-aiu
+aGf
+aGf
+aGf
+aGf
 aMG
 aMG
 aMG
@@ -117482,10 +105442,10 @@ sNc
 aMG
 aMG
 aMG
-aFC
-agp
-agp
-aHJ
+aGf
+aGf
+aGf
+aGf
 adS
 aae
 mSi
@@ -117505,7 +105465,7 @@ wTC
 jXs
 lEq
 mSi
-ssb
+aRO
 aRL
 aRL
 aRL
@@ -117731,15 +105691,15 @@ adS
 adS
 adS
 adS
-ajV
-agp
-agp
-agp
-aNq
-agp
-agp
-agp
-aHJ
+aGf
+aGf
+aGf
+aGf
+aGf
+aGf
+aGf
+aGf
+aGf
 tzc
 osD
 exW
@@ -117762,16 +105722,16 @@ fiD
 ioj
 kzY
 aSm
-pns
-gUY
-gUY
+aRO
+aRO
+aRO
 kHz
-gUY
-gUY
-gUY
+aRO
+aRO
+aRO
 wZV
-gUY
-cGX
+aRO
+aRO
 aRO
 der
 mkm
@@ -117827,7 +105787,7 @@ jwY
 lVh
 tsT
 gre
-vfx
+tcD
 tcD
 iiK
 gre
@@ -118004,15 +105964,15 @@ adS
 aae
 mSi
 tiz
-uxU
-uxU
-uxU
-nXK
+hWi
+hWi
+hWi
+hWi
 gsb
-shw
-shw
-shw
-xcS
+ioj
+ioj
+ioj
+ioj
 iyw
 cbi
 qTI
@@ -118085,7 +106045,7 @@ pGq
 ipX
 gre
 gre
-thz
+gre
 gre
 gre
 ajc
@@ -118269,7 +106229,7 @@ mSi
 okC
 ewK
 ako
-bGK
+hWi
 alD
 hQD
 mSi
@@ -118328,16 +106288,16 @@ kXJ
 xeZ
 pjU
 uIP
-oaP
-tSh
+oly
+oly
 dXO
 hlR
 hlR
 jxY
 hlR
 uIP
-mNM
-pqV
+oly
+oly
 pGq
 mJH
 gre
@@ -118586,14 +106546,14 @@ xeZ
 eYL
 eYL
 eTX
-ixd
-nns
-nns
-nns
-oXi
-nns
-nns
-pqV
+oly
+oly
+oly
+oly
+pPH
+oly
+oly
+oly
 xBm
 eYL
 eYL
@@ -118783,7 +106743,7 @@ mSi
 fYH
 fYH
 axo
-dZX
+hWi
 kKS
 ftL
 fYH
@@ -119040,7 +107000,7 @@ mSi
 fYH
 fjs
 hWi
-iPR
+hWi
 tEW
 uQe
 fYH
@@ -149348,7 +137308,7 @@ awZ
 aHn
 dnJ
 lHt
-vjj
+okd
 aVR
 aVR
 aVR
@@ -149361,7 +137321,7 @@ aVR
 aVR
 aVR
 hNz
-plK
+okd
 awZ
 aYr
 aYr
@@ -149605,7 +137565,7 @@ awZ
 waG
 vsH
 aBa
-vjj
+okd
 aVR
 aVR
 aVR
@@ -149618,7 +137578,7 @@ aVR
 aVR
 aVR
 vsH
-vjj
+okd
 awZ
 aYr
 aYr
@@ -149861,8 +137821,8 @@ aYr
 awZ
 aMf
 fBY
-fnq
-fwR
+aBa
+okd
 aVR
 aVR
 aVR
@@ -150119,7 +138079,7 @@ awZ
 aPv
 lSz
 fWU
-gyp
+okd
 aVR
 aVR
 aVR
@@ -150132,7 +138092,7 @@ aVR
 aVR
 aVR
 vsH
-vjj
+okd
 awZ
 aYr
 aYr
@@ -150376,7 +138336,7 @@ awZ
 awZ
 awZ
 vsH
-gyp
+okd
 aVR
 aVR
 aVR
@@ -150389,7 +138349,7 @@ aVR
 aVR
 aVR
 vsH
-qKC
+okd
 awZ
 awZ
 awZ
@@ -150633,7 +138593,7 @@ akH
 aES
 aHA
 vsH
-gyp
+okd
 aVR
 aVR
 aVR
@@ -150646,7 +138606,7 @@ aVR
 aVR
 aVR
 vsH
-qKC
+okd
 vQn
 aVR
 vQn
@@ -150903,7 +138863,7 @@ aVR
 aVR
 aVR
 vsH
-aXC
+aZs
 awZ
 awZ
 awZ
@@ -151147,20 +139107,20 @@ aYr
 awZ
 arv
 lHt
-vXA
+vdY
 tpQ
 dQI
-hbW
-hbW
-hbW
-hbW
-hbW
+azs
+azs
+azs
+azs
+azs
 fRK
-hbW
+azs
 dQI
-hbW
-qqx
-cTF
+azs
+lHt
+okd
 aGH
 aYr
 aYr
@@ -151388,7 +139348,7 @@ atc
 atq
 aud
 auz
-avh
+aqe
 aBa
 okd
 aMZ
@@ -151416,7 +139376,7 @@ aBa
 aBa
 aMZ
 aBa
-axh
+aBa
 xnI
 aGH
 aYr
@@ -151645,8 +139605,8 @@ xZC
 oxe
 gyL
 sWD
-avi
-avU
+aqe
+axT
 vdY
 azs
 azs
@@ -151661,7 +139621,7 @@ wdJ
 azs
 lHt
 aBa
-aOw
+aBa
 aBa
 kJG
 aBa
@@ -151673,7 +139633,7 @@ aBa
 aBa
 aPg
 cyH
-axh
+aBa
 aBa
 aGH
 aYr
@@ -151903,7 +139863,7 @@ wKs
 gyL
 sWD
 cJQ
-avV
+awS
 awS
 awS
 awS
@@ -151913,24 +139873,24 @@ awS
 fzB
 aAf
 iFH
-aAw
-avU
+axT
+axT
 aBa
 ldi
 pSS
-aOw
 aBa
-aIJ
-tgW
-dpB
-bYl
+aBa
+aBa
+aBa
+aCS
+azr
 cUc
 hzr
-bYl
+azr
 odE
-bYl
+azr
 cUc
-oLA
+azr
 mQn
 aGH
 aBM
@@ -152175,9 +140135,9 @@ aAy
 azr
 azr
 cTb
-qBH
-bYl
-iCv
+azr
+azr
+ajz
 aCS
 aDP
 aGH
@@ -152434,7 +140394,7 @@ axp
 axp
 axp
 adj
-aPC
+apc
 asu
 axp
 abG
@@ -152942,7 +140902,7 @@ aAV
 aBU
 oev
 adX
-aAE
+aAC
 ukK
 awt
 aox
@@ -153210,7 +141170,7 @@ aBa
 aGG
 aHi
 aly
-adL
+aNw
 aye
 psZ
 abG
@@ -153455,8 +141415,8 @@ prX
 azV
 aAm
 aAv
-aAw
-aAH
+axT
+aAC
 awt
 avy
 iPk
@@ -153720,7 +141680,7 @@ avy
 aiZ
 awt
 aBj
-aBv
+axT
 aBw
 aBz
 aBK
@@ -153976,12 +141936,12 @@ awt
 aox
 awt
 aRH
-aBk
+aBj
 aBa
 aSD
 abG
 abo
-aBW
+aBT
 ahy
 atM
 abG
@@ -154233,7 +142193,7 @@ aDp
 tpy
 aFB
 tjo
-aBp
+aBj
 aEF
 aSD
 abG
@@ -154998,7 +142958,7 @@ amA
 anA
 aoW
 auB
-pnq
+qth
 aEO
 ayD
 ayD
@@ -155255,13 +143215,13 @@ amH
 axp
 app
 auD
-awB
+axT
 axT
 axT
 azj
 axT
 axT
-aBl
+axT
 aCH
 aSD
 axp
@@ -155282,8 +143242,8 @@ akE
 akE
 aOb
 hwy
-aGx
-aCQ
+jpX
+jpX
 arl
 aOb
 aae
@@ -155511,14 +143471,14 @@ wUi
 amL
 anF
 apr
-rqr
 awE
-auK
-auK
+awE
+aCK
+aCK
 azo
-auK
-auK
-aBo
+aCK
+aCK
+aCK
 aCK
 aEt
 aGc
@@ -155765,7 +143725,7 @@ mGy
 mGy
 akz
 alV
-amS
+amH
 aGH
 apt
 auM
@@ -155784,19 +143744,19 @@ hCH
 abF
 akE
 akx
-akm
+apz
 akE
 akx
-akm
+apz
 akE
 akx
-akm
+apz
 akE
 akx
-akm
+apz
 aOb
 aRC
-hKK
+jpX
 aOb
 awg
 aOb
@@ -156000,13 +143960,13 @@ aae
 aae
 azJ
 azM
-aRM
-amt
+amD
+amD
 eFP
 akW
 qjX
-aqc
-abC
+aqa
+amD
 aJq
 azJ
 aOz
@@ -156030,7 +143990,7 @@ awF
 axU
 ayE
 azv
-meV
+apv
 apv
 awF
 anG
@@ -156053,7 +144013,7 @@ aGa
 apQ
 aOb
 vUN
-hKK
+jpX
 aYu
 vhE
 aOb
@@ -156262,7 +144222,7 @@ amD
 amD
 aQp
 amD
-aqj
+aqa
 amD
 aCg
 azJ
@@ -156287,7 +144247,7 @@ awF
 hjB
 lLY
 lLY
-aAY
+apv
 apv
 awF
 lJR
@@ -156310,7 +144270,7 @@ akE
 fbV
 aOb
 aVF
-hKK
+jpX
 aOb
 aOb
 aOb
@@ -156536,7 +144496,7 @@ aak
 ajX
 akB
 amf
-amS
+amH
 anG
 apv
 auP
@@ -156555,7 +144515,7 @@ oTo
 aMH
 aFX
 agu
-aJw
+aos
 agu
 ent
 aos
@@ -156793,7 +144753,7 @@ aak
 aak
 akz
 alV
-amS
+amH
 anG
 acE
 anG
@@ -156824,7 +144784,7 @@ aoa
 aDu
 aOb
 arX
-hKK
+jpX
 deL
 ofV
 aOb
@@ -157050,7 +145010,7 @@ acL
 acL
 ahA
 alV
-amS
+amH
 anG
 apM
 asf
@@ -157064,7 +145024,7 @@ aEX
 aCU
 aEx
 anG
-abI
+aGj
 fqX
 aSq
 aHK
@@ -157081,7 +145041,7 @@ aoT
 aAI
 aOb
 bCx
-hKK
+jpX
 aOb
 aOb
 aOb
@@ -157286,17 +145246,17 @@ aae
 aak
 aal
 abb
-ach
-acR
-acR
-acR
-aeg
+aeD
+aeN
+aeN
+aeN
+aeE
 aem
 aeE
 aeX
 afk
-afG
-agK
+aeE
+aeE
 aeE
 aeE
 aeE
@@ -157308,8 +145268,8 @@ jog
 aeN
 amh
 ank
-anH
-dCV
+anZ
+mZo
 auY
 eCj
 axW
@@ -157324,7 +145284,7 @@ abp
 aDg
 aSq
 aSq
-aPY
+aOB
 anM
 aIg
 aIg
@@ -157338,7 +145298,7 @@ aoT
 kev
 aOb
 aKk
-pWq
+jpX
 aOb
 aua
 aOb
@@ -157547,7 +145507,7 @@ acr
 acr
 adF
 adQ
-aek
+aeI
 aen
 aeI
 afb
@@ -157555,13 +145515,13 @@ afm
 aBt
 adz
 adB
-agY
+acJ
 ahk
 xzq
-ahE
-ahE
-aiY
-ali
+acJ
+acJ
+ahJ
+acr
 acr
 acr
 amH
@@ -157575,13 +145535,13 @@ ajY
 jhH
 axX
 aBy
-aCX
+aDk
 aEB
 aoN
 aGj
 vGk
 aSq
-aPY
+aOB
 aFt
 aoG
 aoG
@@ -157594,8 +145554,8 @@ aoG
 sMm
 aGy
 xPS
-kMy
-teO
+jpX
+oKb
 ipr
 aXN
 aOb
@@ -157832,18 +145792,18 @@ azB
 qbg
 axX
 aBy
-aCY
+auX
 aED
 abt
 auF
 aDi
 aWu
 asC
-ayO
-aZK
+aTB
+ams
 aTB
 aTB
-aDT
+ams
 aTB
 aTB
 ams
@@ -158089,7 +146049,7 @@ azB
 qbg
 axX
 aBy
-aCZ
+aCW
 aFj
 aJV
 aJV
@@ -158572,10 +146532,10 @@ aPh
 aPh
 all
 aVW
-qJK
-amX
+aOU
 acS
-aaV
+acS
+acS
 kze
 apd
 amK
@@ -158603,7 +146563,7 @@ azB
 wUT
 axX
 pSs
-aCX
+aDk
 aEH
 aBD
 azU
@@ -158829,7 +146789,7 @@ anx
 kkx
 aou
 aoK
-hQS
+apH
 axP
 aoq
 aQl
@@ -158837,11 +146797,11 @@ pbS
 aQg
 acw
 aUO
-axD
+auC
 apq
 aGY
 ltD
-avx
+avt
 aEU
 axa
 ayY
@@ -158860,7 +146820,7 @@ azB
 qbg
 axX
 pAE
-aCZ
+aCW
 aEH
 aBD
 aRS
@@ -159097,7 +147057,7 @@ doA
 acl
 atH
 aue
-auH
+avt
 ssi
 aRR
 axQ
@@ -159351,7 +147311,7 @@ pbS
 aQg
 amK
 acW
-aJC
+auC
 auC
 aGY
 wzb
@@ -159374,7 +147334,7 @@ azB
 qbg
 axX
 hfO
-aCX
+aDk
 aEH
 aBD
 alb
@@ -159603,7 +147563,7 @@ axI
 aOU
 acS
 acS
-aJD
+acS
 rNZ
 aBb
 amK
@@ -159612,7 +147572,7 @@ atV
 aKQ
 aGY
 aiT
-fbF
+aqp
 wDL
 awv
 abq
@@ -159631,7 +147591,7 @@ azB
 wUT
 axX
 jWp
-aCZ
+aCW
 aEH
 aBD
 aBL
@@ -159869,8 +147829,8 @@ aGY
 aGY
 aGY
 afA
-yft
-aPF
+eyt
+afT
 aPk
 xzj
 xyW
@@ -159899,10 +147859,10 @@ aSa
 bzV
 akE
 axB
-agT
+avv
 akE
 ayH
-agT
+avv
 akE
 jpq
 aHc
@@ -160145,7 +148105,7 @@ azB
 qbg
 axX
 aBH
-aCX
+aDk
 aEK
 aJV
 aJV
@@ -160402,15 +148362,15 @@ azB
 qbg
 axX
 aBH
-aCY
+auX
 dpc
 mbx
 bPy
 aCi
 aCq
 asF
-aCV
-aDb
+aDc
+aEG
 aDc
 aDc
 aEG
@@ -160631,7 +148591,7 @@ acr
 hGl
 adO
 tAT
-ael
+aeL
 aer
 aeL
 afc
@@ -160676,9 +148636,9 @@ aWe
 aWe
 glp
 aoa
-aHo
+aGy
 aHv
-aHE
+asn
 asn
 vqe
 syo
@@ -160884,16 +148844,16 @@ aae
 aak
 aay
 abA
-acx
-acx
-acx
+acr
+acr
+acr
 aea
 acr
 aeD
 aeN
 aff
 aft
-agD
+aeN
 agS
 aeN
 aeN
@@ -160901,7 +148861,7 @@ ahs
 aeN
 aeN
 aeN
-ajq
+aeE
 akc
 alL
 amj
@@ -160918,7 +148878,7 @@ axY
 qGt
 aDk
 nuC
-egC
+abp
 vlS
 bdp
 bdp
@@ -160936,7 +148896,7 @@ aoT
 xav
 aOb
 azA
-asr
+asn
 aOb
 aVP
 aOb
@@ -161193,7 +149153,7 @@ aoT
 aZB
 aOb
 arX
-asw
+asn
 aOb
 aOb
 aOb
@@ -161436,7 +149396,7 @@ awF
 aAX
 aAX
 awF
-aCM
+eTA
 aFt
 vdO
 aoG
@@ -161450,7 +149410,7 @@ aYv
 aRB
 aOb
 bCx
-asw
+asn
 loK
 emS
 aOb
@@ -161688,9 +149648,9 @@ qbg
 axX
 anG
 aCP
-wlr
+aHa
 awF
-iFq
+auN
 aHa
 uIW
 aFY
@@ -161945,7 +149905,7 @@ wUT
 axX
 anG
 auN
-wlr
+aHa
 awF
 aGC
 aHg
@@ -162221,7 +150181,7 @@ aUv
 apQ
 aOb
 aki
-asw
+asn
 lef
 crg
 aOb
@@ -162436,7 +150396,7 @@ aNx
 aNx
 aFF
 cbs
-upt
+jmJ
 afl
 aDw
 abW
@@ -162478,7 +150438,7 @@ akx
 agJ
 aOb
 asd
-asw
+asn
 aOb
 aXq
 aOb
@@ -162735,7 +150695,7 @@ amI
 aIu
 aOb
 aOb
-arE
+alv
 aOb
 aOb
 aOb
@@ -162973,7 +150933,7 @@ qbg
 axX
 axX
 eFB
-kWq
+wgT
 aae
 aae
 aae
@@ -162992,8 +150952,8 @@ akE
 akE
 aOb
 guh
-axx
-agv
+jpX
+jpX
 aKz
 aOb
 aBM
@@ -163230,7 +151190,7 @@ wUT
 axX
 axX
 eFB
-kWq
+wgT
 aBM
 aae
 aae
@@ -163254,12 +151214,12 @@ jpX
 fZt
 aOb
 aBM
-eLQ
+wgT
 vOI
-hEA
+bOF
 dYo
-pBw
-oYS
+oDf
+aVD
 uec
 pTU
 aae
@@ -163487,7 +151447,7 @@ qbg
 axX
 axX
 eFB
-kWq
+wgT
 aBM
 aae
 lvw
@@ -163511,7 +151471,7 @@ aZo
 mRY
 aOb
 aBM
-kWq
+wgT
 pug
 pug
 pug
@@ -163744,20 +151704,20 @@ qbg
 axX
 sCS
 anG
-tHJ
-rvf
-rvf
-rvf
-rvf
-rvf
-rvf
+wgT
+wgT
+wgT
+wgT
+wgT
+wgT
+wgT
 svU
-bXF
-bXF
-bXF
-bXF
-bXF
-qUN
+aRN
+aRN
+aRN
+aRN
+aRN
+aRN
 lvw
 lvw
 aae
@@ -163768,7 +151728,7 @@ aOb
 aOb
 aOb
 aBM
-kWq
+wgT
 aBM
 aBM
 pTU
@@ -164014,8 +151974,8 @@ aae
 aae
 aae
 aae
-fck
-qUN
+aRN
+aRN
 lvw
 aae
 aae
@@ -164024,7 +151984,7 @@ aae
 bzw
 aBM
 aBM
-eLQ
+wgT
 gdj
 aBM
 aae
@@ -164273,15 +152233,15 @@ hce
 aae
 lvw
 sdS
-rvf
-rvf
-rvf
-rvf
-rvf
-bXF
-bXF
-bXF
-kXN
+wgT
+wgT
+wgT
+wgT
+wgT
+aRN
+aRN
+aRN
+wgT
 aae
 aae
 aae
@@ -164781,8 +152741,8 @@ aae
 aae
 hce
 kpe
-aDM
-tvr
+kpe
+wWF
 hce
 aae
 tRH
@@ -164988,7 +152948,7 @@ rJF
 mNk
 qCN
 qCN
-dIZ
+qCN
 wMq
 nTn
 aae
@@ -165245,7 +153205,7 @@ wKp
 mZf
 qCN
 qCN
-dIZ
+qCN
 wMv
 nTn
 aae
@@ -165295,7 +153255,7 @@ lbM
 lbM
 sdU
 fzc
-aDV
+gNI
 lbM
 wWF
 ldj
@@ -165502,7 +153462,7 @@ eOy
 iFO
 qCN
 qCN
-dIZ
+qCN
 wMq
 nTn
 aae
@@ -165552,8 +153512,8 @@ fiT
 mzF
 wWF
 nrF
-aDW
-aEI
+gNI
+gNI
 aFd
 aFh
 tRH
@@ -165759,7 +153719,7 @@ nTn
 nTn
 xfN
 qCN
-dIZ
+qCN
 ahq
 nTn
 aae
@@ -165822,7 +153782,7 @@ bsl
 ofE
 kgy
 ndJ
-eZf
+kGh
 rIE
 sjU
 snA
@@ -166016,7 +153976,7 @@ azR
 dOV
 hzL
 gOy
-dIZ
+qCN
 wMq
 ktC
 xkv
@@ -166267,13 +154227,13 @@ aBM
 aBM
 dOV
 xao
-mEj
-icN
+qiW
+qiW
 qiW
 sck
 bek
 qCN
-dIZ
+qCN
 wMq
 ktC
 pUs
@@ -166292,11 +154252,11 @@ ieT
 rLA
 toF
 sAS
-xmd
+wAL
 pQp
 urD
 uzd
-axg
+awW
 uiW
 hkC
 iEY
@@ -166525,12 +154485,12 @@ sck
 sck
 oqn
 qiW
-orQ
+qiW
 qiW
 mQy
-uad
-wAj
-cuB
+qCN
+qCN
+qCN
 wMv
 ktC
 vCU
@@ -166782,10 +154742,10 @@ nww
 tNh
 oqn
 qiW
-rZB
+gQF
 mel
 sck
-jQk
+qCN
 qCN
 gBp
 utu
@@ -167039,7 +154999,7 @@ sck
 sck
 dOd
 qiW
-lTg
+qiW
 uXo
 dOV
 aoS
@@ -167305,7 +155265,7 @@ ktC
 apj
 qSm
 pKg
-iMP
+gNM
 eYk
 vWt
 rgK
@@ -167315,14 +155275,14 @@ bjY
 oez
 cTA
 lSJ
-vcC
+oDv
 oDv
 oDv
 gXT
 oDv
 oDv
 puM
-ovw
+ubf
 ubf
 gvg
 gio
@@ -167588,7 +155548,7 @@ uSM
 uSM
 mFg
 lkU
-aaC
+aba
 uXA
 avC
 usd
@@ -167611,16 +155571,16 @@ aPt
 btd
 mww
 aXE
-mRm
-mRm
-mRm
-mRm
+piZ
+piZ
+piZ
+piZ
 pov
-mRm
-mRm
-mRm
-mRm
-mRm
+piZ
+piZ
+piZ
+piZ
+piZ
 giq
 dTT
 mKP
@@ -167810,7 +155770,7 @@ nww
 qZI
 oqn
 iHP
-gAz
+hDi
 woW
 dOV
 xsF
@@ -168070,14 +156030,14 @@ uGd
 ahi
 aoH
 gUi
-ejT
-hrA
+iCq
+iCq
 rED
-hrA
+iCq
 aoM
 uLq
-xzQ
-aPE
+iCq
+rIY
 apA
 xkv
 pNu
@@ -168335,7 +156295,7 @@ vWt
 riw
 oUk
 xat
-iMP
+gNM
 rDR
 mVl
 apP
@@ -168605,7 +156565,7 @@ lSK
 yeI
 bnt
 bnt
-auk
+avH
 auQ
 avH
 nek
@@ -168660,7 +156620,7 @@ alB
 eIq
 lgb
 mVs
-oDw
+mVs
 mVs
 mVs
 mVs
@@ -168827,10 +156787,10 @@ aBM
 aBM
 aBM
 aBM
-aBM
-aBM
 bcm
 nEl
+vhM
+vhM
 nEl
 nEl
 hNf
@@ -168848,7 +156808,7 @@ goY
 cbN
 alq
 iCq
-hgt
+gNM
 anJ
 xkv
 pNu
@@ -168888,18 +156848,18 @@ aFf
 goy
 wzC
 uOY
-aqd
+eLP
 eAa
 nUZ
 dpp
 psb
-aqd
+eLP
 kRd
 uht
 nso
 oAH
 gKY
-rcj
+xnR
 oyE
 tFT
 ceY
@@ -168917,7 +156877,7 @@ eIq
 eIq
 lgb
 mVs
-oDw
+mVs
 mVs
 mVs
 mVs
@@ -169084,10 +157044,10 @@ aBM
 aBM
 aBM
 aBM
-aae
-aBM
 bcm
 jdK
+cii
+cii
 gBH
 yfG
 hNf
@@ -169101,7 +157061,7 @@ esz
 alq
 dMF
 lVS
-tAn
+goY
 ouE
 alq
 iCq
@@ -169154,7 +157114,7 @@ eLP
 rlv
 hJM
 hqL
-htq
+gKY
 xnR
 asa
 gTf
@@ -169174,7 +157134,7 @@ duU
 aIX
 twB
 mVs
-oDw
+mVs
 mVs
 mVs
 mVs
@@ -169341,10 +157301,10 @@ aBM
 aBM
 aBM
 aBM
-aae
-aae
 bcm
 oZm
+cii
+udd
 cii
 yfG
 hNf
@@ -169363,7 +157323,7 @@ nWm
 rmi
 cdZ
 tSZ
-iMP
+gNM
 dtY
 fAv
 aqb
@@ -169428,10 +157388,10 @@ mKd
 ooe
 aKI
 aKP
-oRc
-oRc
-oRc
-vkL
+odg
+odg
+odg
+odg
 uaC
 odg
 odg
@@ -169598,15 +157558,15 @@ aBM
 aBM
 aBM
 aae
-aae
-aae
 bcm
 jdK
+cii
+xFE
 cii
 yfG
 hNf
 aoC
-egF
+qan
 tzk
 eog
 ssX
@@ -169656,16 +157616,16 @@ biz
 mRN
 aDD
 aFk
-aGr
+aGo
 jaK
-quA
-hXR
+vWy
+vWy
 wds
 bqL
 bhn
 xGC
 eLP
-vtm
+rlv
 uKg
 iIX
 sLq
@@ -169674,7 +157634,7 @@ akS
 pXL
 tvR
 aHW
-tGb
+gKY
 xDr
 kdB
 cSq
@@ -169688,7 +157648,7 @@ bwi
 vXx
 mVs
 mVs
-duP
+mVs
 mVs
 mVs
 mVs
@@ -169855,9 +157815,9 @@ aBM
 aBM
 aBM
 aae
-aae
-aae
 bcm
+sMR
+cii
 dPU
 cii
 yfG
@@ -169876,7 +157836,7 @@ rtb
 uoC
 alq
 iCq
-hgt
+gNM
 anQ
 xkv
 pNu
@@ -169911,27 +157871,27 @@ knD
 eDw
 vjI
 hsN
-aDE
+aDr
 aFf
 goy
 dWp
 mOS
-mFj
+eLP
 vDq
 nqY
-sEs
+dpp
 fsX
-quA
+vWy
 dVM
 uht
 aHQ
 sLq
 sLq
-xeq
+asM
 quf
 lUf
 fZi
-hdC
+gKY
 iby
 uht
 uDV
@@ -169945,7 +157905,7 @@ nAX
 lgb
 mVs
 mVs
-duP
+mVs
 mVs
 mVs
 mVs
@@ -170112,12 +158072,12 @@ aBM
 aBM
 aBM
 aae
-aae
-aae
 bcm
-grL
+dig
 cii
-yfG
+cii
+cii
+sZx
 hNf
 hNf
 hdj
@@ -170147,7 +158107,7 @@ qAn
 iwe
 qwS
 qwS
-klf
+hGv
 dIH
 hGv
 rAv
@@ -170202,7 +158162,7 @@ nAX
 aLe
 mVs
 mVs
-duP
+mVs
 mVs
 mVs
 mVs
@@ -170369,12 +158329,12 @@ aBM
 aae
 aBM
 aae
-aae
-aae
 bcm
+cii
+cii
 qZT
 scU
-fUw
+rQP
 wOX
 hNf
 hNf
@@ -170386,12 +158346,12 @@ hNf
 gNM
 gNM
 gNM
-mhU
+xGQ
 gNM
 ioF
 iCq
 vJL
-iMP
+gNM
 ufe
 dbP
 aqh
@@ -170425,7 +158385,7 @@ qLb
 cdx
 lIu
 aCl
-aDK
+aDs
 aFf
 nbz
 nbz
@@ -170459,7 +158419,7 @@ nAX
 nUi
 wHR
 vXx
-lTT
+xdn
 mVs
 mVs
 mVs
@@ -170626,27 +158586,27 @@ aBM
 aae
 aae
 aae
-aae
-aae
 bcm
+oKl
+gVS
 kVU
 gCm
-fTx
+rQP
 rQP
 vyh
 ulr
-biA
+rFo
 tuJ
 kAQ
 akV
 bcm
-rxv
-nfe
+gNM
+eYk
 vcI
 nKR
-eEO
+oUk
 xGU
-qbA
+oUk
 oJP
 anR
 xkv
@@ -170883,17 +158843,17 @@ aBM
 aae
 aae
 aae
-aae
-cso
-cso
-cso
-cso
-cso
-cso
-cso
+bcm
+bcm
+bcm
+bcm
+bcm
+bcm
+bcm
+bcm
 phH
 xZz
-hbu
+gyG
 gyG
 azX
 bcm
@@ -170923,7 +158883,7 @@ kIT
 vem
 wXQ
 iXt
-skg
+vem
 hhU
 ffq
 ffq
@@ -170939,7 +158899,7 @@ azT
 bgI
 ayd
 aCl
-aDQ
+aDr
 aFn
 avK
 aGT
@@ -170950,7 +158910,7 @@ nbz
 rej
 eLP
 mOS
-scw
+hRj
 toV
 asU
 wpq
@@ -170963,7 +158923,7 @@ kYg
 dFl
 dlF
 uOY
-jHK
+hRj
 vYV
 kwQ
 lnB
@@ -171152,16 +159112,16 @@ ajx
 snY
 nuZ
 ejm
-lAf
+ajx
 euG
-wLB
+ajx
 kKK
 xkv
 lSt
 jBw
 amn
 anc
-ybc
+xGQ
 iCq
 amn
 iCq
@@ -171182,7 +159142,7 @@ rMC
 ffq
 cTR
 bMJ
-cQr
+hhI
 hhI
 dFR
 puy
@@ -171209,7 +159169,7 @@ vds
 efF
 xHs
 dzB
-adC
+piZ
 lxo
 ggn
 ggn
@@ -171409,7 +159369,7 @@ ajx
 vzr
 nSg
 lnC
-wfU
+ajx
 hvy
 rFo
 iJx
@@ -171417,9 +159377,9 @@ xkv
 apo
 vjv
 ugh
-dUY
+gNM
 aAj
-ipP
+vWt
 rgK
 vWt
 vWt
@@ -171467,7 +159427,7 @@ eVQ
 eVQ
 oKV
 lub
-fom
+ptL
 lub
 jMF
 vIB
@@ -171916,24 +159876,24 @@ cso
 irc
 vWh
 bsd
-mlc
+vWh
 aad
 cso
 ajB
 vzr
 byf
 lnC
-wfU
+ajx
 hvy
 xZz
 apa
 czK
 nZk
-qRN
+qjO
 sUC
 rgp
 czK
-qtq
+qjO
 urB
 jWX
 rJw
@@ -172180,7 +160140,7 @@ ajx
 nBV
 dgU
 wUS
-cDF
+ajx
 kAQ
 xZz
 kAQ
@@ -172188,7 +160148,7 @@ czK
 hrv
 mha
 mha
-oYd
+qjO
 jbd
 oXK
 ory
@@ -172212,7 +160172,7 @@ vyJ
 ezo
 aCF
 tRD
-cLC
+dZV
 aER
 aLX
 lkK
@@ -172238,7 +160198,7 @@ irj
 eVQ
 uMO
 arO
-cXF
+aFy
 aeA
 aeT
 hag
@@ -172445,9 +160405,9 @@ czK
 rak
 reD
 voU
-oYd
+qjO
 jbd
-fNd
+voU
 gFy
 jWX
 tUT
@@ -172457,7 +160417,7 @@ ezo
 taq
 naZ
 pBa
-cbX
+gQn
 rrD
 ezo
 cxj
@@ -172702,7 +160662,7 @@ czK
 ahr
 plI
 plI
-oYd
+qjO
 jbd
 oXK
 qjO
@@ -172743,7 +160703,7 @@ aFr
 avn
 wWF
 eVQ
-arw
+akt
 mIG
 irj
 dCv
@@ -172765,9 +160725,9 @@ aIE
 vss
 gzu
 ahd
-ahZ
-ahZ
-qJG
+alm
+alm
+alm
 bXe
 joC
 aae
@@ -173024,9 +160984,9 @@ ftr
 alm
 ahT
 alm
-obx
+alm
 auR
-gQb
+joC
 wXV
 aBM
 aBM
@@ -173208,7 +161168,7 @@ ksf
 mGs
 xKB
 bcm
-iCX
+eQx
 lTF
 jDM
 iuC
@@ -173465,7 +161425,7 @@ bcm
 vVu
 bcm
 bcm
-uqD
+eQx
 eQx
 eQx
 eQx
@@ -173787,14 +161747,14 @@ lbM
 wWF
 joC
 mtB
-gHj
+hxa
 hxa
 iWm
 joC
 kVO
 oDW
-fGN
-fGN
+kVO
+kVO
 ttb
 kVO
 joC
@@ -176863,7 +164823,7 @@ cGY
 iUt
 hVw
 pZq
-bAQ
+rQZ
 ufN
 dLe
 sKX
@@ -177112,9 +165072,9 @@ aux
 axR
 uHz
 mOF
-lee
-lee
-mku
+wjW
+wjW
+wjW
 uEd
 mWj
 dHc
@@ -177889,19 +165849,19 @@ rEt
 kQy
 rmf
 lJk
-wFB
-mHl
+jHL
+jHL
 dzE
-mHl
-mHl
-mHl
-mHl
-mHl
+jHL
+jHL
+jHL
+jHL
+jHL
 sqY
-mHl
-mHl
-mHl
-mHl
+jHL
+jHL
+jHL
+jHL
 bCy
 mLA
 qUb
@@ -178146,7 +166106,7 @@ hRI
 owK
 lar
 jLP
-ciL
+nsH
 hIG
 hIG
 hIG
@@ -178366,9 +166326,9 @@ sop
 wDe
 aqF
 xHg
-uUN
-nRC
-iLL
+tiq
+tiq
+tFC
 bJI
 bSv
 apI
@@ -178403,7 +166363,7 @@ vPF
 qLz
 rfB
 vYn
-cTO
+kbv
 mxF
 mxF
 ngW
@@ -178432,8 +166392,8 @@ dGu
 dGu
 dGu
 lQG
-rQp
-bkb
+xLL
+xLL
 xLL
 lQG
 aae
@@ -178877,7 +166837,7 @@ nlo
 myC
 xSW
 tcP
-xBR
+omD
 fqg
 mVf
 fLP
@@ -178907,7 +166867,7 @@ ujT
 ayt
 aod
 aEe
-aFT
+aHu
 pmr
 big
 dqE
@@ -179134,7 +167094,7 @@ pcp
 xQn
 lva
 qOb
-plu
+iJD
 wws
 gbQ
 sTF
@@ -179164,17 +167124,17 @@ gSR
 ayt
 rqh
 aur
-aFT
+aHu
 pmr
 msN
 xej
-rWh
+hIG
 aPA
 aGE
 kvg
 wzX
 imJ
-tgK
+xeG
 xeG
 asW
 wwC
@@ -179391,7 +167351,7 @@ nbx
 cZJ
 rkN
 oQH
-wcd
+oQH
 nWb
 sTF
 sTF
@@ -179401,7 +167361,7 @@ ttN
 ttN
 pXz
 bli
-ePx
+fHE
 eqy
 ufr
 heF
@@ -179425,7 +167385,7 @@ aFV
 swz
 lMH
 ngB
-rhx
+mxF
 bLs
 jrL
 oky
@@ -179648,7 +167608,7 @@ wDe
 ujH
 tiq
 tiq
-mtq
+tiq
 haY
 qCl
 wIC
@@ -179658,15 +167618,15 @@ ttN
 ttN
 pXz
 adv
-pXR
+aqy
 oZV
 nDF
 yaf
 sML
 hFq
-rnP
-jeL
-jeL
+aqy
+aqy
+aqy
 nKe
 atY
 awq
@@ -179678,12 +167638,12 @@ ujT
 ayt
 oDr
 aEh
-aFW
+aEb
 ykx
 hIG
 jrL
 cgV
-ehy
+msN
 tqZ
 mZw
 jdN
@@ -179718,7 +167678,7 @@ fwL
 hIw
 fnh
 fGi
-nNL
+qMx
 fzC
 nzS
 dGu
@@ -179905,7 +167865,7 @@ nbx
 bLW
 uNc
 iJD
-gzn
+iJD
 haY
 sTF
 sTF
@@ -179915,9 +167875,9 @@ ttN
 ttN
 pXz
 adE
-kZY
+aqy
 qzJ
-afh
+fHE
 afW
 pXz
 ene
@@ -179939,7 +167899,7 @@ aFQ
 aLZ
 bLs
 aPA
-lXH
+vkJ
 lMH
 jrL
 oky
@@ -179975,7 +167935,7 @@ msG
 jQs
 msG
 vSD
-mDF
+qMx
 gGH
 spY
 dGu
@@ -180192,11 +168152,11 @@ gSR
 ayt
 lJz
 aEd
-aFT
+aHu
 pmr
 msN
 kPK
-iCV
+hIG
 ngB
 buy
 kvg
@@ -180449,7 +168409,7 @@ ujT
 ayt
 aod
 aEk
-aFT
+aHu
 pmr
 tJX
 lSf
@@ -180482,7 +168442,7 @@ dGu
 dGu
 qRS
 atf
-vfG
+dPD
 qRI
 dGu
 dGu
@@ -180681,7 +168641,7 @@ wDe
 gRP
 gRP
 gRP
-nto
+gRP
 wDe
 jJo
 jJo
@@ -180739,7 +168699,7 @@ dGu
 dGu
 mAl
 ato
-hDT
+tua
 bFg
 dGu
 dGu
@@ -180996,7 +168956,7 @@ dGu
 dGu
 qRS
 atp
-vfG
+dPD
 qRI
 dGu
 dGu
@@ -181192,7 +169152,7 @@ wDe
 wDe
 wDe
 lgG
-dSZ
+wAC
 wAC
 gLf
 bxG
@@ -181220,9 +169180,9 @@ ena
 ayt
 aCA
 aEd
-fIK
+mON
 aGw
-ops
+uwx
 xBv
 rqf
 lar
@@ -181244,8 +169204,8 @@ dhf
 hIG
 hIG
 kPK
-rXy
-hlj
+hIG
+oJW
 jrL
 lQG
 dGu
@@ -181253,7 +169213,7 @@ dGu
 dGu
 qRS
 atp
-vfG
+dPD
 qRI
 dGu
 dGu
@@ -181449,10 +169409,10 @@ aae
 wDe
 pEJ
 lFg
-vHq
-dmD
-dmD
-qjn
+uxe
+uxe
+uxe
+uxe
 vWv
 ncJ
 ijS
@@ -181490,18 +169450,18 @@ jVB
 oVf
 ivJ
 cJP
-tml
-tml
+xfs
+xfs
 tBe
 xfs
 xfs
 xfs
 yji
 myd
-tml
-tml
-tml
-tml
+xfs
+xfs
+xfs
+xfs
 pGY
 jrL
 lQG
@@ -181518,7 +169478,7 @@ dVz
 ubz
 avm
 fXt
-iDB
+hBV
 okK
 ubz
 aae
@@ -181705,7 +169665,7 @@ aBM
 aae
 wDe
 aqx
-rRR
+uxe
 fkL
 wxO
 vMl
@@ -181962,7 +169922,7 @@ aae
 aae
 wDe
 mHT
-rRR
+uxe
 uxe
 uxe
 uxe
@@ -181979,7 +169939,7 @@ jJo
 xnE
 fxf
 sei
-jkZ
+tCx
 aod
 adu
 aod
@@ -181993,7 +169953,7 @@ axR
 aod
 adu
 aod
-gmv
+fxf
 uwx
 kuT
 cYH
@@ -182069,9 +170029,9 @@ uoZ
 bRI
 kHC
 qxF
-deg
+rUY
 rpy
-mOK
+rUY
 uHK
 rUY
 uoZ
@@ -182236,7 +170196,7 @@ jJo
 tJC
 fxf
 uIa
-jkZ
+tCx
 aod
 aux
 jtb
@@ -182250,7 +170210,7 @@ axR
 aDX
 aux
 aod
-gmv
+fxf
 uwx
 tCx
 rjs
@@ -182273,7 +170233,7 @@ tct
 ylJ
 tQd
 oYI
-ekA
+iQb
 aPA
 vkJ
 cfU
@@ -182325,12 +170285,12 @@ wxd
 uoZ
 xIh
 dFA
-tJd
+dtL
 hKU
 xEa
 hOe
-jTv
-xwN
+dtL
+dtL
 uoZ
 bEQ
 uSH
@@ -182493,7 +170453,7 @@ ajF
 jwo
 fxf
 uIa
-jkZ
+tCx
 aod
 aux
 avY
@@ -182501,13 +170461,13 @@ axR
 aux
 rWR
 rWR
-aBe
+aux
 aux
 axR
 avY
 aux
 aod
-gmv
+fxf
 uwx
 tCx
 tkL
@@ -182530,7 +170490,7 @@ tzu
 als
 tKT
 oYI
-ekA
+iQb
 hIG
 coz
 vnZ
@@ -182587,7 +170547,7 @@ uoZ
 uoZ
 uoZ
 xSo
-xol
+dtL
 uoZ
 ker
 kga
@@ -182730,9 +170690,9 @@ aBM
 wDe
 wXM
 sqB
-seO
-fwt
-fwt
+tcP
+omD
+omD
 omD
 xKh
 wDe
@@ -182750,7 +170710,7 @@ qvK
 lWJ
 qVK
 lZo
-jkZ
+tCx
 aod
 aod
 aod
@@ -182764,7 +170724,7 @@ axR
 aod
 aod
 aod
-gmv
+fxf
 uwx
 tCx
 qze
@@ -183101,7 +171061,7 @@ uoZ
 uoZ
 uoZ
 lmw
-xol
+dtL
 uoZ
 aVJ
 geF
@@ -183267,8 +171227,8 @@ bMo
 hle
 abf
 syS
-ajr
-ajw
+xNV
+xNV
 kkf
 vNK
 xGA
@@ -183519,23 +171479,23 @@ ntd
 nCX
 pcq
 eGU
-lyr
+fxf
 eVY
 tCx
 cmf
 twF
 bTr
-lUm
-fQJ
-fQJ
+uJw
+uJw
+uJw
 tHN
 xGB
-eSn
-aTm
+uwx
+uwx
 wHf
 tCx
 cmf
-gmv
+fxf
 bdb
 tCx
 qze
@@ -183788,12 +171748,12 @@ tbQ
 rkX
 bNs
 uiL
-cjg
-jVA
+uiL
+uiL
 sKi
 rvd
 caQ
-asA
+arW
 tjm
 qze
 aae
@@ -184331,7 +172291,7 @@ nhJ
 kzi
 byg
 dZO
-xws
+acO
 oMJ
 byg
 kzi
@@ -184587,7 +172547,7 @@ nhJ
 nhJ
 ebe
 byg
-ohI
+tNB
 isH
 tNB
 byg
@@ -184815,8 +172775,8 @@ qvV
 xBC
 thX
 are
-ciJ
-cKK
+eHH
+eHH
 fxr
 jbm
 aFu
@@ -185068,7 +173028,7 @@ gIh
 wBO
 eHH
 eHH
-nQb
+dNy
 ujA
 aXR
 arf
@@ -185320,12 +173280,12 @@ aYr
 uEX
 mUX
 cQG
-iAF
+pUM
 oNe
 nXw
 eHH
 eHH
-nQb
+dNy
 cYR
 loN
 arg
@@ -185582,7 +173542,7 @@ wAx
 cdB
 xPl
 cEi
-cpf
+dNy
 taS
 loN
 arh
@@ -185839,7 +173799,7 @@ uEX
 gBY
 gBY
 aEN
-nQb
+dNy
 cYR
 loN
 ffk
@@ -186096,7 +174056,7 @@ xxk
 aEj
 nnZ
 nXw
-nQb
+dNy
 taS
 loN
 ffk
@@ -186353,7 +174313,7 @@ nLj
 qBh
 cgK
 uOC
-hux
+dNy
 ujA
 qlJ
 tqs


### PR DESCRIPTION
Makes the locker room on Tramstation bigger!

![image](https://user-images.githubusercontent.com/43841046/113694187-4ad11d00-9684-11eb-96ce-f64c0b181915.png)
Expands the room's depth by 2 tiles and ups the number of peacekeeper lockers from 8 (what kind of station only has lockers for 3 officers?). Moves vendors to the back of the room, adds table in the center with a hand labeler and crowbars.

![image](https://user-images.githubusercontent.com/43841046/113694203-4f95d100-9684-11eb-8e0d-b5b5bcbe5936.png)
Also expands permabrig kitchen because why not, makes cooking a lot more viable beyond just having a microwave. Adds enough equipment to cook most things, including 2 griddles, a food processor, a grinder, dispensers, and a smart fridge.