### PR TITLE
Adds LOOC to the local chat filter

### DIFF
--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -82,7 +82,7 @@ export const MESSAGE_TYPES = [
     type: MESSAGE_TYPE_OOC,
     name: 'OOC',
     description: 'The bluewall of global OOC messages',
-    selector: '.ooc, .adminooc',
+    selector: '.ooc, .adminooc, .looc',
   },
   {
     type: MESSAGE_TYPE_ADMINPM,

--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -52,7 +52,7 @@ export const MESSAGE_TYPES = [
     type: MESSAGE_TYPE_LOCALCHAT,
     name: 'Local',
     description: 'In-character local messages (say, emote, etc)',
-    selector: '.say, .emote',
+    selector: '.say, .emote, .looc',
   },
   {
     type: MESSAGE_TYPE_RADIO,


### PR DESCRIPTION
## About The Pull Request

Adds LOOC to the local chat filter.

## Why It's Good For The Game

Because it is. Also, if you're on just a local tab, you shouldn't be able to have an excuse of "But I didn't see their LOOC!"

## Changelog
:cl:
tweak: adds LOOC to the local chat filter
/:cl: