### PR TITLE
Deltastation map port (Security)

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -1446,19 +1446,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"adw" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/plant_analyzer,
-/obj/machinery/camera{
-	c_tag = "Permabrig - Garden";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/security/prison)
 "adx" = (
 /obj/structure/table/reinforced,
 /obj/item/analyzer{
@@ -1636,7 +1623,7 @@
 /area/hallway/secondary/entry)
 "aeA" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "aeB" = (
 /obj/machinery/status_display/evac,
@@ -1794,17 +1781,13 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "afs" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/machinery/door/firedoor,
+/obj/machinery/turnstile,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aft" = (
 /obj/structure/closet/emcloset,
@@ -1847,7 +1830,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "afz" = (
 /obj/effect/spawner/randomcolavend,
@@ -2620,13 +2603,22 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aiM" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box{
+	pixel_x = -8;
+	pixel_y = -4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "aiQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -5035,18 +5027,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal)
-"apH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/blobstart,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
-/area/security/prison)
 "apN" = (
 /obj/machinery/light,
 /obj/structure/closet/radiation,
@@ -8195,13 +8175,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"axs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "axw" = (
 /obj/machinery/light{
 	dir = 4
@@ -9857,6 +9830,12 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
+"aBu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/security/prison)
 "aBw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10226,7 +10205,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aCk" = (
 /obj/structure/table/reinforced,
@@ -12071,16 +12050,21 @@
 /turf/open/space/basic,
 /area/space)
 "aGI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
 /area/security/prison)
 "aGL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/effect/spawner/randomarcade,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
 	},
-/turf/open/floor/plating,
 /area/security/prison)
 "aGO" = (
 /obj/machinery/light/small{
@@ -12734,20 +12718,23 @@
 /area/security/prison)
 "aIf" = (
 /obj/structure/table,
-/obj/machinery/computer/bookmanagement,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "aIg" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/iron,
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "aIh" = (
-/obj/structure/bookcase/random,
-/obj/structure/sign/poster/ripped{
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
 /area/security/prison)
 "aIk" = (
 /obj/machinery/power/turbine{
@@ -13259,6 +13246,11 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/cargo/sorting)
+"aJl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "aJq" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
@@ -13328,9 +13320,9 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "aJA" = (
-/obj/structure/cable,
+/obj/structure/chair/stool,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "aJD" = (
 /turf/closed/wall,
 /area/space/nearstation)
@@ -13959,25 +13951,21 @@
 /turf/closed/wall,
 /area/security/prison)
 "aKW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/chair/stool/bar,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/security/prison)
 "aKY" = (
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood,
+/area/security/prison)
 "aKZ" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
@@ -14414,76 +14402,48 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "aMf" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt3";
-	name = "Cell 3"
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut3"
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "aMh" = (
-/obj/structure/closet/crate/trashcart,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
-"aMi" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/chair/stool/bar,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/wood,
 /area/security/prison)
-"aMj" = (
-/obj/structure/curtain,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
 "aMm" = (
-/obj/structure/chair/stool,
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -30;
-	prison_radio = 1
-	},
+/obj/item/kirbyplants/random,
+/obj/machinery/light,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "aMn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "aMo" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Permabrig - Kitchen";
+	dir = 1;
+	network = list("ss13","prison")
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "aMp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/table,
+/turf/open/floor/iron/kitchen,
 /area/security/prison)
 "aMr" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -15752,37 +15712,67 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aPo" = (
-/obj/machinery/shower{
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/turf/open/floor/iron,
+/area/security/prison)
+"aPq" = (
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/item/soap/homemade,
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
-"aPq" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/flasher{
+	id = "visitorflash";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/security/prison)
 "aPt" = (
-/obj/machinery/vending/sustenance,
-/obj/machinery/camera{
-	c_tag = "Permabrig - Kitchen";
-	dir = 1;
-	network = list("ss13","prison")
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/italian,
+/obj/item/storage/box/ingredients/fruity,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/american,
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 600);
+	name = "Premium All-Purpose Flour (16KG)";
+	volume = 600
+	},
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	list_reagents = list(/datum/reagent/consumable/enzyme = 500);
+	name = "universe-sized universal enyzyme";
+	volume = 500
+	},
+/obj/item/reagent_containers/food/condiment/rice{
+	list_reagents = list(/datum/reagent/consumable/rice = 150);
+	name = "Basmati Rice Sack (4KG)";
+	volume = 150
+	},
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "aPu" = (
-/obj/structure/table,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/turf/open/floor/plating,
+/obj/effect/landmark/start/prisoner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "aPx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16600,46 +16590,16 @@
 /turf/open/floor/plating,
 /area/cargo/qm)
 "aQZ" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/item/reagent_containers/hypospray/medipen,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/iron,
+/area/security/prison)
 "aRb" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt2";
-	name = "Cell 2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security/prison/safe)
-"aRc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
 /area/security/prison)
 "aRm" = (
 /obj/structure/lattice/catwalk,
@@ -17382,28 +17342,14 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "aSD" = (
-/turf/open/floor/iron/white,
-/area/security/prison)
-"aSG" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/security/prison)
 "aSJ" = (
-/obj/machinery/button/door{
-	id = "visitation";
-	name = "Visitation Shutters";
-	pixel_x = 6;
-	pixel_y = 25;
-	req_access_txt = "2"
-	},
-/obj/machinery/button/flasher{
-	id = "visitorflash";
-	pixel_x = -6;
-	pixel_y = 24
-	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/processor,
 /turf/open/floor/iron,
 /area/security/prison)
 "aSO" = (
@@ -18316,23 +18262,34 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "aUv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/turnstile{
+	dir = 1;
+	req_one_access_txt = "2;63;81"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/prison)
+"aUx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/button/door{
+	id = "isolationshutter";
+	name = "Isolation Shutter";
+	pixel_y = 23;
+	req_access_txt = "63" 
 	},
-/area/security/prison/safe)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "aUz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Visitation";
+	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/door/poddoor/preopen{
+	id = "brigprison";
+	name = "Prison Blast door"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "aUA" = (
@@ -19341,24 +19298,28 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "aWc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "isolationshutter"
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "aWf" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt1";
-	name = "Cell 1"
+/obj/effect/turf_decal/arrows/red{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"aWj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell2";
+	name = "curtain"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut1"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/security/prison/safe)
 "aWm" = (
 /obj/machinery/light{
@@ -19367,13 +19328,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aWq" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aWr" = (
 /turf/open/floor/plating,
@@ -20194,40 +20152,11 @@
 /area/cargo/qm)
 "aXK" = (
 /obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast door"
-	},
-/obj/machinery/button/flasher{
-	id = "Cell 1";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/machinery/button/door{
-	id = "permashut1";
-	name = "Cell Lockdown Button";
-	pixel_x = 25;
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
-"aXR" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast door"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
 	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Visitation";
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
 /area/security/prison)
 "aXV" = (
 /obj/machinery/light/small{
@@ -20892,11 +20821,11 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "aZJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aZL" = (
 /turf/open/floor/plating{
@@ -21490,17 +21419,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"bbp" = (
-/obj/machinery/light/small,
-/obj/structure/sign/warning/securearea{
-	pixel_y = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "bbA" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
@@ -22710,16 +22628,18 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "bet" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/bombcloset/security,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -23425,31 +23345,27 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "bfR" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/structure/closet/secure_closet/genpop,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "bfS" = (
-/obj/structure/closet/l3closet/security,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -24150,14 +24066,22 @@
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "bhb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: BLAST DOORS"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "bhd" = (
 /turf/closed/wall/r_wall,
@@ -25802,12 +25726,9 @@
 /area/cargo/miningoffice)
 "bkm" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/effect/landmark/start/security_medic,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "bky" = (
@@ -26542,10 +26463,27 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "blU" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table/wood,
+/obj/item/folder/red{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/folder/blue{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/lighter,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "blV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26594,10 +26532,12 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "bmg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/medbay/alt,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/security/brig)
 "bmr" = (
 /obj/item/kirbyplants/random,
@@ -27909,11 +27849,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -27939,11 +27877,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
@@ -29758,29 +29694,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
-"btk" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "btw" = (
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot,
@@ -31352,8 +31265,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "bxu" = (
@@ -32011,6 +31926,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/photocopier,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "byN" = (
@@ -32721,11 +32637,17 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "bzW" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/sink{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
+	},
+/area/security/prison/safe)
 "bzX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -39680,12 +39602,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
-"bNa" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "bNb" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/cigarette/cigar/cohiba{
@@ -42188,6 +42104,16 @@
 /obj/structure/filingcabinet/security,
 /turf/open/floor/iron/grimy,
 /area/tcommsat/computer)
+"bSG" = (
+/obj/structure/table,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/iron,
+/area/security/prison)
 "bSH" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/grimy,
@@ -45590,6 +45516,27 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
+"bZW" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "bZY" = (
 /obj/machinery/light{
 	dir = 4
@@ -46615,24 +46562,16 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "ccE" = (
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5;
-	pixel_y = -1
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/item/storage/firstaid/regular,
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/item/reagent_containers/glass/bottle/multiver,
+/obj/item/reagent_containers/syringe,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "ccH" = (
@@ -46972,28 +46911,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"cdy" = (
-/obj/structure/closet/secure_closet/brig{
-	name = "Prisoner Locker"
-	},
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "cdz" = (
 /obj/machinery/camera/motion{
 	c_tag = "AI - Upload";
@@ -47326,19 +47243,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hop)
-"ceq" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/caution,
-/obj/structure/sign/poster/official/no_erp{
-	pixel_x = -30
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
 "cer" = (
 /obj/machinery/camera{
 	c_tag = "Bridge - Head of Personnel's Office";
@@ -49441,11 +49345,10 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "ckl" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
+/obj/machinery/vending/security_ammo,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/security/range)
 "ckm" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -50692,25 +50595,16 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/maintenance/starboard)
 "cno" = (
-/obj/machinery/door/window/brigdoor/westright{
-	name = "Shooting Range";
-	req_access_txt = "63"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
 /turf/open/floor/plating,
 /area/security/range)
 "cnp" = (
@@ -50720,13 +50614,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/security/range)
-"cns" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/open/space,
-/area/space/nearstation)
 "cnt" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -51357,8 +51244,13 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "coQ" = (
-/obj/structure/window/reinforced{
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/security/range)
@@ -51789,28 +51681,32 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "cqg" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	dir = 1;
-	freq = 1400;
-	location = "Security"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/security/range)
-"cqh" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Security Maintenance";
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/northleft{
+	name = "Security Delivery";
 	req_access_txt = "63"
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/maintenance/starboard)
+/obj/machinery/power/apc/auto_name/west,
+/turf/open/floor/iron/dark,
+/area/security/range)
+"cqh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/range)
 "cqj" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -52319,11 +52215,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cry" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	dir = 1;
+	freq = 1400;
+	location = "Security"
+	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
+/turf/open/floor/iron/dark,
+/area/security/range)
 "crE" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -53139,14 +53040,16 @@
 /area/maintenance/starboard)
 "ctc" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ctd" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -53155,7 +53058,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -53178,13 +53081,11 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "cth" = (
+/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/nuclearbomb/beer,
+/obj/item/storage/box/flashes,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -53750,14 +53651,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cuK" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/closet/bombcloset/security,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32
 	},
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/flashes,
-/obj/effect/turf_decal/stripes/end,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/maintenance/starboard)
 "cuL" = (
 /turf/closed/wall,
@@ -55900,6 +55802,13 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
+"cyT" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
 "cyU" = (
 /obj/structure/disposalpipe/junction,
 /obj/effect/turf_decal/tile/neutral{
@@ -60647,7 +60556,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "cIE" = (
 /obj/effect/turf_decal/stripes/line{
@@ -72493,6 +72402,21 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/science/research/abandoned)
+"dhT" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "brigprison";
+	name = "Prison Blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell2";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "dhU" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
@@ -74290,19 +74214,9 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
 "dlI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Gear Room";
-	req_access_txt = "63"
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/brig)
 "dlL" = (
 /obj/effect/turf_decal/tile/purple,
@@ -74814,18 +74728,14 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "dnm" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prisoner Workroom"
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/airlock/grunge{
+	name = "Cell 4"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "dnn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -75595,19 +75505,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/research)
-"doJ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Visitation";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "doM" = (
 /obj/structure/table/reinforced,
 /obj/item/aicard,
@@ -76972,20 +76869,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dsr" = (
-/obj/machinery/door/airlock/medical/glass{
+/obj/structure/cable,
+/obj/machinery/door/window/westleft{
+	dir = 4;
 	name = "Infirmary"
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "dsA" = (
@@ -78764,6 +78654,10 @@
 	},
 /turf/open/floor/iron,
 /area/medical/surgery)
+"dxk" = (
+/obj/structure/easel,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "dxn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue,
@@ -79562,7 +79456,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "dzA" = (
 /obj/structure/closet/secure_closet/research_director,
@@ -79981,18 +79875,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"dAD" = (
-/obj/structure/sign/poster/official/here_for_your_safety{
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "dAE" = (
 /obj/machinery/light{
 	dir = 8
@@ -88207,13 +88089,10 @@
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "dRO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
 /area/security/prison)
 "dRP" = (
 /obj/structure/table/reinforced,
@@ -92812,6 +92691,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"eda" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "edb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -94523,6 +94406,19 @@
 "eiX" = (
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
+"eiZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/bed,
+/obj/effect/landmark/start/prisoner,
+/obj/item/bedsheet/dorms,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 5
+	},
+/area/security/prison/safe)
 "ejt" = (
 /obj/machinery/flasher{
 	id = "brig1";
@@ -94536,7 +94432,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "eju" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
@@ -94601,16 +94497,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/chemistry)
-"emX" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "ens" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
@@ -94655,11 +94541,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"epN" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/west,
-/turf/open/floor/iron,
-/area/security/prison)
 "epU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -94681,47 +94562,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/brig)
-"eqG" = (
-/obj/structure/closet/secure_closet/brig{
-	name = "Prisoner Locker"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/brig)
 "eqU" = (
 /turf/open/space,
 /area/space)
-"err" = (
-/obj/structure/closet/secure_closet/brig{
-	name = "Prisoner Locker"
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "eth" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -94772,25 +94617,36 @@
 /area/hallway/secondary/entry)
 "evk" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/security/brig)
-"ewn" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
-/area/security/prison)
-"ewO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/security/range)
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"ewc" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/storage/bag/tray,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/rollingpin,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
+"ewn" = (
+/obj/structure/cable,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"ewD" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "exE" = (
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
@@ -94897,17 +94753,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"eAR" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/vending/security_ammo,
-/turf/open/floor/iron,
-/area/security/brig)
 "eBZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -94935,6 +94780,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"eCE" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/chair/comfy,
+/turf/open/floor/wood,
+/area/security/prison)
 "eCM" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
@@ -94957,6 +94807,19 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"eDO" = (
+/obj/structure/cable,
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = -10
+	},
+/obj/structure/mirror{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "eDR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -94976,12 +94839,10 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "eEX" = (
-/obj/structure/chair/stool,
-/obj/machinery/flasher{
-	id = "visitorflash";
-	pixel_y = 28
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "eFf" = (
@@ -94989,12 +94850,14 @@
 /turf/open/space,
 /area/service/abandoned_gambling_den)
 "eFt" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/item/radio/intercom{
+	pixel_y = -26
 	},
-/obj/item/radio/intercom/directional/south,
-/obj/structure/closet/secure_closet/security_medic,
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood/o_minus,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/security/brig)
 "eFA" = (
@@ -95027,6 +94890,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/warden)
+"eHr" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/wood,
+/area/security/prison/safe)
 "eHJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -95049,7 +94916,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "eIr" = (
 /obj/structure/sign/poster/official/help_others{
@@ -95136,6 +95003,14 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"eMA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/nuclearbomb/beer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "eMD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -95174,6 +95049,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
+"eNh" = (
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/genpop,
+/obj/effect/turf_decal/box,
+/obj/machinery/light,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "eNo" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -95182,7 +95064,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "eNA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -95201,18 +95083,36 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "eOk" = (
 /turf/open/floor/plating,
 /area/cargo/storage)
 "ePM" = (
-/obj/machinery/camera{
-	c_tag = "Security - Prison Port"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Sanitarium";
+	req_access_txt = "63"
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/security/prison)
+"eQm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "eQU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -95221,10 +95121,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"eRq" = (
-/mob/living/simple_animal/mouse/gray,
-/turf/open/floor/iron,
-/area/security/prison)
 "eSP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
 	dir = 4
@@ -95292,9 +95188,8 @@
 /area/engineering/main)
 "eXa" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "eXF" = (
 /obj/effect/turf_decal/tile/red{
@@ -95316,6 +95211,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/commons/dorms)
+"eYZ" = (
+/obj/effect/turf_decal/arrows/red,
+/turf/open/floor/iron,
+/area/security/prison)
 "faI" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/camera{
@@ -95354,6 +95253,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
+"fbZ" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/iron,
+/area/security/prison)
+"fcD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
+/area/security/prison/safe)
 "fdc" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -95364,6 +95278,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"fdw" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "fdR" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "brigfront";
@@ -95376,8 +95295,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
+"feB" = (
+/obj/structure/chair/office,
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "ffn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/engine,
@@ -95396,25 +95321,37 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/engineering/main)
-"fgv" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+"fgQ" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bowl,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/box/drinkingglasses,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "fhz" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -95431,10 +95368,10 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "fiN" = (
-/obj/structure/window,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/beach_ball/holoball,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "fjK" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "transitlock";
@@ -95449,16 +95386,36 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/engineering/storage_shared)
-"fjW" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+"fka" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/security/range)
 "flv" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"fmK" = (
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -2
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
+	},
+/area/security/prison/safe)
 "fno" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -95525,6 +95482,14 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"fqv" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
 "fru" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
@@ -95539,18 +95504,26 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/space_hut/observatory)
-"fta" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
-/area/security/prison)
 "ftl" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"ftQ" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "brigprison";
+	name = "Prison Blast door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell1";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "ftX" = (
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/iron/dark,
@@ -95661,7 +95634,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "fAI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -95676,12 +95649,15 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "fBg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/holohoop{
+	pixel_y = -10
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=0.01;n2=0.01;TEMP=2.7";
+	luminosity = 2;
+	temperature = 2.7
+	},
+/area/security/prison/safe)
 "fBy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -95693,29 +95669,29 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "fCE" = (
-/obj/machinery/washing_machine,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/structure/chair/comfy{
+	color = "#596479"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/curtain{
+	id = "prisoncell4";
+	pixel_y = 21
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/iron/dark/purple/side{
+	dir = 5
+	},
+/area/security/prison/safe)
 "fDA" = (
-/obj/machinery/washing_machine,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
+/obj/structure/bed,
+/obj/effect/landmark/start/prisoner,
+/obj/item/bedsheet/dorms,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "fEm" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -95751,7 +95727,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "fFv" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -95760,6 +95736,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"fGU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/security/prison)
 "fHJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -95778,25 +95762,12 @@
 	},
 /area/hallway/secondary/entry)
 "fIc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/flasher{
-	id = "Cell 4";
-	pixel_y = -25
+/obj/machinery/door/airlock{
+	id_tag = "Toilet3";
+	name = "Toilet Unit"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
-"fJc" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "fKp" = (
 /obj/structure/chair/stool,
@@ -95812,6 +95783,17 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
+"fKH" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/laser/practice,
+/obj/item/gun/energy/laser/practice{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/turf/open/floor/iron/dark,
+/area/security/range)
 "fKP" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light{
@@ -95823,11 +95805,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"fNd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "fNm" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -95870,7 +95847,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "fOu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
@@ -95881,19 +95858,22 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"fOD" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/range)
 "fOE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"fOT" = (
-/obj/docking_port/stationary/random{
-	dir = 4;
-	id = "pod_4_lavaland";
-	name = "lavaland"
-	},
-/turf/open/space,
-/area/space)
 "fPR" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
@@ -95989,28 +95969,14 @@
 /turf/open/floor/iron,
 /area/security/warden)
 "fVa" = (
-/obj/structure/toilet/greyscale,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
-"fXw" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig - Central";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -30;
-	prison_radio = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "fXx" = (
 /obj/structure/table/reinforced,
@@ -96024,6 +95990,39 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/service/library)
+"fYh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -30;
+	prison_radio = 1
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/wood,
+/area/security/prison)
+"fYi" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "fYL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -96046,6 +96045,10 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/engineering/main)
+"gaC" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/security/prison)
 "gaK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -96083,52 +96086,34 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
-"gcZ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/south,
-/turf/open/floor/iron,
-/area/security/prison)
-"gdG" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "gfg" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/brig)
+"gfi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/range)
 "gfr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "brigprison";
 	name = "Prison Blast door"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gfW" = (
 /obj/effect/landmark/event_spawn,
@@ -96149,7 +96134,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "gfY" = (
 /obj/structure/closet/emcloset,
@@ -96171,10 +96156,16 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "ggt" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "ggv" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -96198,6 +96189,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"ghQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
+/area/security/prison/safe)
 "gjj" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
@@ -96205,16 +96204,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"gjM" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "gjS" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
@@ -96284,6 +96273,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"gpR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/security/prison)
 "gqD" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -96322,38 +96318,27 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "gsB" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/iron,
-/area/security/prison)
-"gth" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 4
+	},
 /turf/open/floor/iron,
-/area/security/brig)
-"gtl" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/security/prison)
+/area/security/prison/safe)
 "gtY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
+"guM" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 8
+	},
+/area/security/prison/safe)
 "guR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -96371,28 +96356,17 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "gwA" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/dark/blue/side{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"gyu" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/machinery/camera{
-	c_tag = "Permabrig - Cell 2";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
 /area/security/prison/safe)
 "gyA" = (
 /obj/effect/turf_decal/tile/red{
@@ -96413,6 +96387,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"gzd" = (
+/obj/machinery/light,
+/turf/open/floor/carpet,
+/area/security/prison)
 "gzi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -96426,7 +96404,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "gAB" = (
 /obj/machinery/light{
@@ -96438,17 +96416,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
-"gBq" = (
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "gCK" = (
 /turf/closed/wall,
 /area/maintenance/department/science)
@@ -96477,17 +96444,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"gEN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "gFw" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
@@ -96505,23 +96461,33 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
+"gFT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera{
+	c_tag = "Permabrig - Hall";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "gFW" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32;
+	pixel_y = -32
+	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32;
 	pixel_y = 32
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "gFZ" = (
 /obj/machinery/nanite_program_hub,
@@ -96572,7 +96538,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "gGP" = (
 /obj/structure/cable,
@@ -96617,7 +96583,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "gHF" = (
 /obj/structure/chair{
@@ -96630,7 +96596,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "gIE" = (
 /obj/effect/turf_decal/stripes/line{
@@ -96682,25 +96648,12 @@
 	},
 /turf/open/floor/circuit/green,
 /area/science/research/abandoned)
-"gLf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+"gKy" = (
+/obj/machinery/camera{
+	c_tag = "Security - Visitation";
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "gLB" = (
@@ -96747,13 +96700,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/maintenance/department/science)
-"gNA" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
 "gNS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral{
@@ -96853,8 +96799,23 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
+"gQU" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/inflatable,
+/turf/open/floor/iron,
+/area/security/prison/safe)
+"gRt" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/grunge{
+	name = "Cell 2"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "gRL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -96862,17 +96823,11 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "gRM" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/machinery/light,
-/turf/open/floor/iron,
+/obj/machinery/deepfryer,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen,
 /area/security/prison)
 "gRN" = (
 /obj/machinery/smartfridge/organ,
@@ -96901,58 +96856,53 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "gTK" = (
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/target,
-/obj/item/target/syndicate,
-/obj/item/target/alien,
-/obj/item/target/clown,
-/obj/structure/closet/crate/secure{
-	desc = "A secure crate containing various materials for building a customised test-site.";
-	name = "Test Site Materials Crate";
-	req_access_txt = "63"
-	},
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
 	},
 /obj/machinery/light_switch{
 	pixel_x = -36
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 32
+/obj/machinery/dish_drive/bullet{
+	succrange = 6
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "gUL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/library)
 "gVl" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark/purple/side{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
+/area/security/prison/safe)
+"gVB" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gWD" = (
 /obj/structure/disposalpipe/segment{
@@ -96985,30 +96935,8 @@
 /area/hallway/primary/central/aft)
 "gYn" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"gZX" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig - Workroom";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -30;
-	prison_radio = 1
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/arrows/red,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "had" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -97017,6 +96945,13 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/server)
+"haq" = (
+/obj/structure/cable,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/purple/side,
+/area/security/prison/safe)
 "hbk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -97044,6 +96979,13 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
+"hew" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "heQ" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
@@ -97101,6 +97043,14 @@
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
+"hhK" = (
+/obj/machinery/computer/libraryconsole{
+	pixel_y = 8
+	},
+/obj/structure/table,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/wood,
+/area/security/prison)
 "hhR" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -97115,7 +97065,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "hij" = (
 /obj/effect/decal/cleanable/dirt,
@@ -97162,7 +97112,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "hkg" = (
 /obj/structure/lattice,
@@ -97178,6 +97128,20 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"hkM" = (
+/obj/machinery/light/small,
+/obj/structure/sign/warning/securearea{
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "hkZ" = (
 /obj/machinery/computer/security{
 	dir = 4
@@ -97204,25 +97168,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"hmI" = (
-/obj/structure/rack,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "hos" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
@@ -97250,7 +97195,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "hpy" = (
 /obj/structure/lattice,
@@ -97366,33 +97311,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"hwc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
-/area/security/prison)
-"hxr" = (
-/obj/machinery/button/door{
-	id = "brigprison";
-	name = "Prison Lockdown";
-	pixel_x = 26;
-	pixel_y = 26;
-	req_access_txt = "63"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "hxy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -97432,16 +97350,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "hAI" = (
-/obj/structure/window,
-/obj/structure/sink{
-	pixel_y = 30
+/obj/item/mop,
+/obj/structure/janitorialcart{
+	dir = 4
 	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "hAT" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
@@ -97470,6 +97384,21 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"hCH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "hCV" = (
 /obj/machinery/computer/security/labor,
 /obj/effect/turf_decal/tile/red{
@@ -97483,27 +97412,32 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "hCX" = (
-/obj/machinery/door/airlock{
-	name = "Permabrig Showers"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
-"hEu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
+/obj/structure/table/wood/poker,
+/obj/item/storage/photo_album/prison,
+/obj/item/camera,
+/turf/open/floor/wood,
 /area/security/prison)
+"hDo" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"hEu" = (
+/obj/structure/toilet/greyscale{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
+/area/security/prison/safe)
 "hFQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -97574,6 +97508,22 @@
 /obj/structure/reflector/double,
 /turf/open/floor/plating,
 /area/engineering/main)
+"hIH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "hKj" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/status_display/ai{
@@ -97591,7 +97541,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "hLm" = (
 /obj/structure/cable,
@@ -97605,17 +97555,30 @@
 /mob/living/simple_animal/hostile/cockroach,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"hNs" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/red{
+"hMw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/area/security/prison/safe)
+"hNs" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "hNv" = (
 /obj/structure/chair{
@@ -97662,7 +97625,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "hPf" = (
 /obj/machinery/door/airlock/security/glass{
@@ -97701,13 +97664,6 @@
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"hQh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
 "hQp" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -97715,6 +97671,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"hQA" = (
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -2
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
+	},
+/area/security/prison/safe)
 "hQT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -97744,7 +97715,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "hTK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -97777,7 +97748,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "hVS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -97817,17 +97788,10 @@
 /area/commons/fitness/recreation)
 "hXF" = (
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/airalarm{
+	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "hXG" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -97947,15 +97911,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"ibL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "ibN" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -97966,11 +97921,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"ibY" = (
-/obj/structure/chair/stool,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "icy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -97995,24 +97945,22 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "icR" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/storage/secure/briefcase,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "ide" = (
 /obj/effect/decal/cleanable/dirt,
@@ -98030,19 +97978,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"ier" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast door"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "ieO" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -98055,17 +97990,22 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"igd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red{
+"ifD" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "igE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -98122,31 +98062,66 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ihX" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/brown/tom,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/window,
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -2
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Garden";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
+	},
+/area/security/prison/safe)
 "iiU" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
-"ijr" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/security/prison)
 "ikH" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/medical/surgery)
 "ilu" = (
-/obj/structure/window,
-/obj/machinery/biogenerator,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/seeds/onion,
+/obj/item/seeds/garlic,
+/obj/item/seeds/potato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/carrot,
+/obj/item/seeds/grass,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/seeds/tower,
+/obj/item/seeds/chili,
+/obj/item/seeds/corn,
+/obj/item/seeds/cotton,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/tomato/blood,
+/obj/item/seeds/tea,
+/obj/item/seeds/cotton/durathread,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/seeds/cabbage,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "imL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -98184,6 +98159,10 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
+"inU" = (
+/obj/item/storage/box/masks,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "ioU" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -98195,7 +98174,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "ipp" = (
 /obj/effect/turf_decal/stripes/line{
@@ -98210,19 +98189,12 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "iqd" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/syndicatebomb/training,
 /obj/structure/table,
 /obj/item/wirecutters,
 /obj/item/screwdriver,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "iqi" = (
 /obj/machinery/status_display/ai{
@@ -98244,26 +98216,33 @@
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "iqZ" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32;
+	pixel_y = -64
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
-"isb" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
+"iry" = (
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 4;
+	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/item/storage/box/drinkingglasses,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/kitchen,
 /area/security/prison)
 "isC" = (
 /obj/structure/cable,
@@ -98316,29 +98295,32 @@
 	},
 /turf/open/floor/iron,
 /area/medical/surgery)
+"itB" = (
+/obj/machinery/door/airlock/freezer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
+"itI" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "iua" = (
-/obj/machinery/door/window/northleft,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "ivg" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/taperecorder,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "iwj" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -98353,6 +98335,16 @@
 /obj/machinery/light,
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
+"ixd" = (
+/obj/structure/cable,
+/obj/structure/chair/sofa/corp,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
+"ixE" = (
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "ixI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -98408,20 +98400,17 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"iAp" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/glasses/blindfold,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"izw" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/nanotrasen{
+	pixel_y = -32
 	},
-/turf/open/floor/iron/white,
-/area/security/prison)
-"iAx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"iAp" = (
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/wood,
 /area/security/prison)
 "iAG" = (
 /obj/machinery/door/airlock/external{
@@ -98433,13 +98422,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
-"iAK" = (
-/obj/machinery/camera{
-	c_tag = "Security - Visitation";
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "iAW" = (
 /obj/machinery/light{
 	dir = 4
@@ -98472,7 +98454,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/security_unit/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "iCo" = (
 /obj/machinery/door/firedoor,
@@ -98494,14 +98476,25 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "iCN" = (
-/obj/structure/table,
-/obj/structure/window{
-	dir = 8
+/obj/structure/closet/secure_closet/freezer/meat{
+	req_access = null
 	},
-/obj/structure/reagent_dispensers/servingdish,
-/obj/structure/reagent_dispensers/servingdish,
-/obj/item/clothing/head/chefhat,
-/turf/open/floor/iron/cafeteria,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "iCR" = (
 /obj/effect/turf_decal/delivery,
@@ -98556,17 +98549,14 @@
 "iFA" = (
 /turf/open/floor/iron/white,
 /area/maintenance/department/science)
-"iFW" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+"iGI" = (
+/obj/structure/bed,
+/obj/effect/landmark/start/prisoner,
+/obj/item/bedsheet/black,
+/turf/open/floor/iron/dark/purple/side{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "iIr" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -98639,16 +98629,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"iMR" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/storage/crayons,
-/turf/open/floor/iron,
+"iMJ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
 /area/security/prison)
+"iMR" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "iNI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -98658,6 +98654,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"iNP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "iOd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -98690,7 +98692,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "iOJ" = (
 /obj/structure/cable,
@@ -98713,17 +98715,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/newscaster/security_unit/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
-"iPa" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "iPg" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -98733,6 +98726,21 @@
 	},
 /turf/open/floor/plating,
 /area/security/range)
+"iPw" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "brigprison";
+	name = "Prison Blast door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell3";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "iPH" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -98753,6 +98761,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
+"iPV" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/grunge{
+	name = "Cell 3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "iQh" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -98804,14 +98821,8 @@
 /area/maintenance/starboard/aft)
 "iQQ" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "iRl" = (
 /obj/machinery/iv_drip,
@@ -98844,7 +98855,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "iSO" = (
 /obj/structure/disposalpipe/segment,
@@ -98883,17 +98900,19 @@
 /area/science/mixing)
 "iUx" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/security{
+	name = "Shooting Range";
+	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
+	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "iUF" = (
 /obj/effect/turf_decal/tile/purple{
@@ -98901,6 +98920,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/aft)
+"iUR" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "iVb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -98917,9 +98943,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/range)
 "iVw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -98942,13 +98972,25 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
+"iWx" = (
+/obj/machinery/door/airlock{
+	name = "Permabrig Showers"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "iWN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
 /turf/open/space,
 /area/space/nearstation)
+"iXw" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/wood,
+/area/security/prison)
 "iXz" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -98974,7 +99016,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "iYC" = (
 /obj/machinery/computer/crew,
@@ -98993,7 +99035,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "iZd" = (
 /obj/effect/turf_decal/stripes/line{
@@ -99010,42 +99052,13 @@
 /area/maintenance/starboard/fore)
 "jar" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button/ignition{
-	id = "justicespark";
-	pixel_x = 7;
-	pixel_y = 26;
-	req_access_txt = "63"
-	},
-/obj/machinery/button/flasher{
-	id = "justiceflash";
-	pixel_x = 7;
-	pixel_y = 38;
-	req_access_txt = "63"
-	},
-/obj/machinery/button/door{
-	id = "justiceblast";
-	name = "Justice Shutters Control";
+/obj/machinery/light_switch{
 	pixel_x = -7;
-	pixel_y = 26;
-	req_access_txt = "63"
+	pixel_y = -26
 	},
-/obj/machinery/button/door{
-	id = "justicechamber";
-	name = "Justice Chamber Control";
-	pixel_x = -7;
-	pixel_y = 38;
-	req_access_txt = "3"
-	},
-/obj/item/folder/red{
-	pixel_x = 3
-	},
-/obj/item/restraints/handcuffs,
-/obj/item/taperecorder,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/item/flashlight/lamp,
+/obj/item/radio/intercom{
+	pixel_x = -26
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
@@ -99106,17 +99119,9 @@
 	c_tag = "Security - Gear Room"
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/iron,
+/obj/machinery/vending/security_peacekeeper,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jgw" = (
 /obj/structure/disposalpipe/segment,
@@ -99144,26 +99149,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"jgW" = (
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/office)
-"jhf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "jhv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
@@ -99175,22 +99160,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"jit" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "jiF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jjN" = (
 /obj/structure/table/reinforced,
@@ -99222,7 +99195,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jlh" = (
 /obj/effect/turf_decal/tile/purple{
@@ -99288,20 +99261,14 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "joB" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "joU" = (
 /obj/structure/disposalpipe/segment{
@@ -99355,47 +99322,25 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "jrh" = (
-/obj/structure/window,
-/obj/machinery/seed_extractor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/security/prison)
-"jrr" = (
-/obj/structure/chair/office{
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 4
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/office)
-"jsm" = (
-/obj/structure/sign/poster/ripped{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"jrq" = (
+/obj/item/soap,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison)
+"jrr" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "jsE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -99446,23 +99391,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
-"jtC" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "jtW" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
@@ -99486,17 +99416,38 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "jud" = (
-/obj/machinery/flasher{
-	id = "justiceflash";
-	pixel_x = 26;
-	req_access_txt = "63"
+/obj/machinery/door/poddoor/preopen{
+	id = "justicechamber";
+	name = "Justice Chamber Blast door"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/door/window/brigdoor/northright{
+	dir = 2;
+	name = "Justice Chamber";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Justice Chamber";
+	req_access_txt = "3"
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "juf" = (
@@ -99533,29 +99484,34 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
+"jvj" = (
+/obj/machinery/button/door{
+	id = "brigprison";
+	name = "Prison Lockdown";
+	pixel_x = 26;
+	pixel_y = 26;
+	req_access_txt = "63"
+	},
+/obj/machinery/camera{
+	c_tag = "Security - EVA Storage";
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "jwg" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "jwH" = (
-/mob/living/simple_animal/mouse/brown/tom,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "jwS" = (
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "Prisoner Telescreen";
-	network = list("prison");
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/airless,
+/area/security/prison/safe)
 "jxz" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -99566,8 +99522,15 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
+"jyg" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "jyU" = (
 /obj/machinery/light{
 	dir = 1
@@ -99588,20 +99551,17 @@
 /turf/open/floor/iron/checker,
 /area/engineering/main)
 "jzM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/turnstile{
+	dir = 1;
+	req_one_access_txt = "2;63;81"
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jzO" = (
 /obj/effect/turf_decal/stripes/line{
@@ -99629,6 +99589,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"jBA" = (
+/obj/structure/window,
+/obj/machinery/plate_press,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "jCA" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -99639,7 +99604,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jDa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
@@ -99665,7 +99630,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jEz" = (
 /obj/machinery/camera{
@@ -99688,7 +99653,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "jGy" = (
 /obj/machinery/door/firedoor,
@@ -99715,14 +99680,16 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "jIP" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/camera{
-	c_tag = "Permabrig - Isolation";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/airless,
+/area/security/prison)
+"jKc" = (
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "jKp" = (
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
@@ -99739,13 +99706,13 @@
 	name = "Holding Cell"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jMX" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -99776,7 +99743,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jNU" = (
 /obj/structure/cable,
@@ -99797,6 +99764,18 @@
 	heat_capacity = 1e+006
 	},
 /area/maintenance/starboard/aft)
+"jPv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/button/curtain{
+	id = "prisoncell3";
+	pixel_x = -24
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 9
+	},
+/area/security/prison/safe)
 "jQl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -99824,6 +99803,10 @@
 	heat_capacity = 1e+006
 	},
 /area/commons/fitness/recreation)
+"jRQ" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
+/area/security/prison)
 "jSe" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/spawner/structure/window/reinforced,
@@ -99835,14 +99818,14 @@
 /area/science/mixing)
 "jTB" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/door/airlock/security{
+	name = "Isolation Cell";
+	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue,
+/area/security/prison/safe)
 "jUo" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Access"
@@ -99875,21 +99858,22 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/engineering/main)
-"jXO" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 4";
-	req_access_txt = "2"
+"jVP" = (
+/obj/machinery/door/window/brigdoor/westright{
+	name = "Shooting Range";
+	req_access_txt = "63"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/turf/open/floor/plating,
+/area/security/range)
+"jWj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell3";
+	name = "curtain"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/security/prison/safe)
 "jYa" = (
 /turf/closed/wall/r_wall,
@@ -99939,6 +99923,18 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/maintenance/solars/port/fore)
+"kbG" = (
+/obj/docking_port/stationary/random{
+	dir = 4;
+	id = "pod_4_lavaland";
+	name = "lavaland"
+	},
+/turf/open/space/basic,
+/area/space)
+"kbO" = (
+/obj/structure/table,
+/turf/open/floor/wood,
+/area/security/prison)
 "kei" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -99994,6 +99990,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"kfW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/purple/side,
+/area/security/prison/safe)
 "kgp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -100002,11 +100004,41 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "kiO" = (
+/obj/machinery/light,
+/turf/open/floor/iron/white,
+/area/security/prison)
+"kjf" = (
+/obj/machinery/plate_press,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
+"kjj" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/door/poddoor/preopen{
+	id = "brigprison";
+	name = "Prison Blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell4";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
+"kkz" = (
+/obj/structure/cable,
+/obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 8
+	},
 /area/security/prison)
 "kma" = (
 /obj/structure/cable,
@@ -100030,16 +100062,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "kpy" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Sanitarium";
-	req_access_txt = "63"
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/bottle/morphine,
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/glass/bottle/morphine,
+/obj/machinery/camera{
+	c_tag = "Security - Prison Port"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
+/turf/open/floor/iron/white,
 /area/security/prison)
 "kpL" = (
 /obj/structure/disposalpipe/segment,
@@ -100078,20 +100108,13 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hos)
 "kqL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/machinery/door/firedoor,
+/obj/machinery/turnstile,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "kra" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -100195,10 +100218,36 @@
 	},
 /turf/open/floor/iron,
 /area/medical/surgery)
+"kvR" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/inflatable/torn,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/security/prison/safe)
 "kvX" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space/basic,
 /area/space/nearstation)
+"kwb" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = -10
+	},
+/obj/structure/mirror{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side,
+/area/security/prison/safe)
 "kwv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -100212,12 +100261,26 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/hallway/secondary/construction)
-"kxv" = (
-/obj/structure/chair/stool,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+"kwM" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
 /area/security/prison)
+"kxv" = (
+/obj/structure/closet/crate,
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/instrument/harmonica,
+/obj/item/storage/pill_bottle/dice,
+/obj/item/toy/cards/deck/tarot,
+/obj/machinery/light,
+/obj/item/stack/medical/gauze/twelve,
+/obj/item/stack/medical/splint/twelve,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "kyo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -100235,7 +100298,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "kzm" = (
 /obj/structure/cable,
@@ -100253,17 +100316,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"kzD" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "kAL" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/secure_data/laptop,
@@ -100341,30 +100393,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science)
+"kGL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "kHZ" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "kJl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/machinery/gun_vendor,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "kLu" = (
 /obj/structure/table,
@@ -100414,23 +100458,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
-"kOb" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light_switch{
-	pixel_x = -7;
-	pixel_y = -26
+"kPg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 11
 	},
-/obj/item/flashlight/lamp,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
 "kPU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -100441,41 +100477,34 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"kQT" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "brigprison";
+	name = "Prison Blast door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "kRm" = (
-/obj/structure/table/reinforced,
-/obj/item/radio{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/radio{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/radio,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "kRD" = (
-/obj/machinery/button/flasher{
-	id = "Cell 6";
-	name = "Prisoner Flash";
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "kSS" = (
@@ -100486,16 +100515,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "kTw" = (
-/obj/structure/chair/office,
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "kUH" = (
 /obj/structure/lattice/catwalk,
@@ -100518,7 +100542,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "kVY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -100594,7 +100618,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "kZf" = (
 /obj/structure/chair/comfy/brown{
@@ -100638,6 +100662,16 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"kZN" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/storage/crayons,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "lac" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -100645,6 +100679,12 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"lan" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "lap" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/meter,
@@ -100663,13 +100703,19 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lce" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -2
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/door/window/southright,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
+	},
+/area/security/prison/safe)
 "lcz" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/structure/cable,
@@ -100740,14 +100786,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ldR" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "lec" = (
 /obj/effect/turf_decal/stripes/line{
@@ -100824,14 +100867,8 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "lgw" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/toy/figure/syndie,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "lgV" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -100872,8 +100909,14 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
+"lho" = (
+/obj/structure/cable,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/coffee,
+/turf/open/floor/iron/dark/blue/corner,
+/area/security/prison)
 "lia" = (
 /obj/machinery/telecomms/message_server/preset,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -100884,7 +100927,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "ljM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -100905,6 +100948,9 @@
 	},
 /turf/open/space,
 /area/engineering/atmos)
+"lkn" = (
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "lkF" = (
 /obj/machinery/power/emitter{
 	dir = 8
@@ -100930,19 +100976,9 @@
 /area/engineering/main)
 "lls" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "llC" = (
 /obj/machinery/computer/shuttle/labor,
@@ -100956,7 +100992,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "lmx" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -100987,7 +101023,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "lnX" = (
 /obj/effect/landmark/event_spawn,
@@ -101008,16 +101044,24 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/lab)
+"lpM" = (
+/obj/machinery/button/flasher{
+	id = "IsolationFlash";
+	pixel_x = 21;
+	pixel_y = 21
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "lpW" = (
-/obj/structure/closet/crate,
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/instrument/harmonica,
-/obj/item/storage/pill_bottle/dice,
-/obj/item/toy/cards/deck/tarot,
-/obj/machinery/light,
-/turf/open/floor/iron,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
 /area/security/prison)
 "lqa" = (
 /obj/effect/turf_decal/tile/blue{
@@ -101169,7 +101213,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "lzM" = (
 /obj/machinery/door/airlock/security{
@@ -101209,6 +101253,19 @@
 	},
 /turf/open/floor/glass,
 /area/maintenance/space_hut/observatory)
+"lAB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/button/curtain{
+	id = "prisoncell2";
+	pixel_x = -24
+	},
+/obj/structure/chair/comfy{
+	color = "#596479"
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 9
+	},
+/area/security/prison/safe)
 "lAQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -101231,8 +101288,16 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
+"lCx" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/plunger,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "lEl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -101256,51 +101321,24 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "lEv" = (
-/obj/structure/table/glass,
-/obj/item/folder/blue,
-/obj/item/healthanalyzer,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
 /area/security/prison)
 "lEO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/newscaster/security_unit/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "lEZ" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/flashlight/seclite,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "lFl" = (
 /obj/structure/cable,
@@ -101314,16 +101352,14 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "lGy" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
+/obj/machinery/door/window/southright,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/security/prison)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/inflatable/torn/door,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "lHi" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -101338,17 +101374,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
-"lIb" = (
-/obj/machinery/light,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"lHP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Security - Escape Pod"
 	},
-/obj/machinery/vending/security_peacekeeper,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"lIb" = (
+/obj/machinery/holopad/secure,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "lIw" = (
 /obj/structure/table/reinforced,
@@ -101365,34 +101403,16 @@
 	pixel_x = -26;
 	pixel_y = -26
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
-"lIC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "lIN" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "brigprison";
 	name = "Prison Blast door"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/pods{
-	pixel_x = -32
-	},
-/obj/structure/cable,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "lKR" = (
 /obj/structure/lattice/catwalk,
@@ -101402,35 +101422,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
-"lKV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/security/range)
-"lMM" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/security/prison)
-"lNL" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
-/obj/structure/closet/bombcloset/security,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "lOS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
@@ -101501,17 +101492,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "lQl" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
 /area/security/prison)
 "lRi" = (
 /obj/machinery/status_display/evac{
@@ -101542,6 +101527,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"lRT" = (
+/obj/machinery/sparker{
+	dir = 1;
+	id = "justicespark";
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "lTa" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/red{
@@ -101576,7 +101572,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "lTN" = (
 /obj/structure/cable,
@@ -101598,19 +101594,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/security_unit/directional/east,
-/turf/open/floor/iron,
-/area/security/brig)
-"lUK" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "lUT" = (
 /obj/structure/table/reinforced,
@@ -101625,7 +101609,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "lUX" = (
 /obj/structure/girder,
@@ -101647,7 +101631,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "lWi" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -101771,6 +101755,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/checkpoint)
+"lZy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/security/prison)
 "lZI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -101783,7 +101774,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "mak" = (
 /obj/structure/disposalpipe/segment{
@@ -101822,7 +101813,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mbB" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -101859,34 +101850,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"mbQ" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "mbS" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -101902,32 +101865,11 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "mdG" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/bedsheetbin,
+/obj/structure/table,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "meZ" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "justicechamber";
-	name = "Justice Chamber Blast door"
-	},
-/obj/machinery/door/window/brigdoor/northright{
-	dir = 2;
-	name = "Justice Chamber";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/window/brigdoor/northright{
-	name = "Justice Chamber";
-	req_access_txt = "3"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -101939,21 +101881,20 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"mgz" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+"mfL" = (
+/obj/structure/rack,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "mgV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -101965,11 +101906,20 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"mio" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
+"mhu" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
 /area/security/prison)
+"mio" = (
+/obj/structure/window,
+/obj/machinery/seed_extractor,
+/turf/open/floor/wood,
+/area/security/prison/safe)
 "miy" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -101995,6 +101945,11 @@
 	},
 /turf/open/floor/iron,
 /area/medical/surgery/room_b)
+"mkl" = (
+/obj/machinery/light,
+/obj/structure/table,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "mkm" = (
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
 	pixel_y = 26
@@ -102014,6 +101969,11 @@
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
+"mkq" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "mlF" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -102027,7 +101987,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mmV" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -102046,18 +102006,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "mnH" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "moH" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/newscaster/security_unit/directional/north,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mrd" = (
 /obj/effect/turf_decal/stripes/line{
@@ -102072,14 +102033,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"msh" = (
-/obj/machinery/door/window/southright,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "mst" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
@@ -102094,7 +102047,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "msR" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -102145,7 +102098,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "muD" = (
 /obj/structure/closet/secure_closet/medical2,
@@ -102164,38 +102117,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
-"mvD" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/nearstation)
 "mvP" = (
 /obj/structure/reflector/single,
 /turf/open/floor/plating,
 /area/engineering/main)
-"mwm" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
-"mws" = (
-/obj/item/kirbyplants/random,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -30
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "mxJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -102215,18 +102140,6 @@
 /obj/machinery/door/poddoor/atmos_test_room_mainvent_1,
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
-"myL" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/clothing/suit/armor/vest,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "myZ" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light/small{
@@ -102234,17 +102147,16 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mzo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "mAm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -102267,17 +102179,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"mCf" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "brigprison";
+	name = "Prison Blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "mCL" = (
 /turf/closed/wall,
 /area/engineering/storage_shared)
-"mEZ" = (
-/obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "mHt" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/medical_doctor,
@@ -102320,18 +102233,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "mIv" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt3";
-	name = "Cell 5"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut5"
-	},
-/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "mIX" = (
@@ -102390,9 +102292,9 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "mNS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "mOe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -102465,16 +102367,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/space_hut/observatory)
-"mSf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/security/office)
 "mSk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -102485,18 +102377,6 @@
 	},
 /turf/open/floor/iron,
 /area/medical/surgery/room_b)
-"mTM" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod 3"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "mTZ" = (
 /obj/item/flashlight{
 	pixel_x = 1;
@@ -102563,7 +102443,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mVE" = (
 /obj/effect/turf_decal/tile/purple{
@@ -102636,18 +102516,58 @@
 "mYr" = (
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"nai" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+"mZm" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/prison)
+"nai" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"naj" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/ignition{
+	id = "justicespark";
+	pixel_x = 7;
+	pixel_y = 26;
+	req_access_txt = "63"
+	},
+/obj/machinery/button/flasher{
+	id = "justiceflash";
+	pixel_x = 7;
+	pixel_y = 38;
+	req_access_txt = "63"
+	},
+/obj/machinery/button/door{
+	id = "justiceblast";
+	name = "Justice Shutters Control";
+	pixel_x = -7;
+	pixel_y = 26;
+	req_access_txt = "63"
+	},
+/obj/machinery/button/door{
+	id = "justicechamber";
+	name = "Justice Chamber Control";
+	pixel_x = -7;
+	pixel_y = 38;
+	req_access_txt = "3"
+	},
+/obj/item/folder/red{
+	pixel_x = 3
+	},
+/obj/item/restraints/handcuffs,
+/obj/item/taperecorder,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
+"naN" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "naZ" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot{
@@ -102676,46 +102596,25 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "nbd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/obj/structure/cable,
-/obj/machinery/flasher{
-	id = "Cell 5";
-	pixel_y = -25
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell1";
+	name = "curtain"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/security/prison/safe)
+"nbx" = (
+/obj/structure/closet/secure_closet/injection,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "nbA" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"nbL" = (
-/obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
-/obj/item/electropack,
-/obj/item/assembly/signaler,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/clothing/head/helmet/sec,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "nbU" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -102781,8 +102680,33 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
+"ndl" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/secateurs,
+/obj/item/secateurs,
+/obj/item/wrench,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/crowbar,
+/obj/item/plant_analyzer,
+/turf/open/floor/wood,
+/area/security/prison/safe)
 "neh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -102805,7 +102729,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "nhw" = (
 /obj/structure/cable,
@@ -102822,6 +102746,35 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"nhK" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/structure/sign/nanotrasen{
+	pixel_x = 32
+	},
+/obj/item/tank/internals/oxygen/red{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/oxygen/red{
+	pixel_x = -3
+	},
+/obj/item/wrench,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "njr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
@@ -102829,17 +102782,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"nkc" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "nkV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -102862,11 +102804,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"nlR" = (
-/obj/structure/table,
-/obj/item/trash/raisins,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "nlX" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
@@ -102875,11 +102812,6 @@
 /obj/item/crowbar,
 /turf/open/floor/plating,
 /area/engineering/supermatter)
-"nmd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "nmg" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -102900,14 +102832,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"nph" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+"npn" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "npz" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "npG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -102957,20 +102890,27 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "nqS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/security/prison)
 "nsp" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = " Permabrig - Library";
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "nsO" = (
 /obj/machinery/door_timer{
 	id = "medcell";
@@ -103119,17 +103059,8 @@
 	pixel_x = -32;
 	pixel_y = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
-"nAj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "nAG" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -103147,8 +103078,15 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
+"nCp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/range)
 "nDz" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -103182,18 +103120,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "nFI" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/ambrosia_vulgaris{
-	pixel_x = -30
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/security/prison)
+/area/security/prison/safe)
 "nGy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -103328,19 +103259,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "nKS" = (
-/obj/structure/toilet/greyscale,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
 /area/security/prison/safe)
 "nLd" = (
 /obj/structure/cable,
@@ -103410,18 +103336,11 @@
 /area/maintenance/starboard/fore)
 "nOM" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "nQQ" = (
 /obj/structure/disposalpipe/junction{
@@ -103447,21 +103366,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"nSC" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "nSN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -103472,20 +103376,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"nTk" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "nTK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/toilet{
@@ -103505,20 +103395,12 @@
 /turf/open/floor/iron,
 /area/commons/toilet/auxiliary)
 "nUf" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 2";
-	req_access_txt = "2"
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
 /area/security/prison/safe)
 "nUh" = (
 /obj/effect/turf_decal/stripes/line{
@@ -103531,27 +103413,7 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "nVs" = (
-/obj/structure/cable,
-/obj/machinery/button/flasher{
-	id = "Cell 3";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/machinery/button/door{
-	id = "permashut3";
-	name = "Cell Lockdown Button";
-	pixel_x = 25;
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/light,
 /turf/open/floor/iron,
 /area/security/prison)
 "nVE" = (
@@ -103569,8 +103431,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
+"nXH" = (
+/obj/structure/bed,
+/obj/item/toy/plush/beeplushie{
+	desc = "Maybe hugging this will make you feel better about yourself.";
+	name = "Therabee"
+	},
+/obj/item/bedsheet/blue,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
+/area/security/prison/safe)
 "nXJ" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/tile/red{
@@ -103585,39 +103458,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "nYc" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Permabrig - Isolation";
+	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"nYF" = (
-/obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/chair/comfy{
+	color = "#596479";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/flasher{
+	id = "IsolationFlash";
+	pixel_y = 28
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/security/brig)
+/area/security/prison/safe)
 "nYN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -103634,20 +103493,12 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "nZp" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/machinery/camera{
-	c_tag = "Permabrig - Cell 4";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "oaQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -103655,20 +103506,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"obd" = (
-/obj/structure/table,
-/obj/item/book/manual/chef_recipes,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/storage/fancy/egg_box,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "obk" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch{
@@ -103682,46 +103519,52 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
-"obA" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Storage Closet";
-	req_access_txt = "63"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+"obS" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "obU" = (
 /obj/structure/sign/departments/examroom,
 /turf/closed/wall,
 /area/medical/treatment_center)
-"odH" = (
-/obj/machinery/photocopier,
-/obj/effect/turf_decal/tile/red{
+"ocm" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
+"odB" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/security/office)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "oeq" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
 /area/service/library/abandoned)
+"oft" = (
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "ogv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -103735,17 +103578,11 @@
 	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "ohL" = (
 /obj/effect/turf_decal/tile/purple,
@@ -103777,25 +103614,34 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/medical/chemistry)
+"oiv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/prisoner,
+/obj/structure/chair/comfy{
+	color = "#596479"
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 5
+	},
+/area/security/prison/safe)
+"oiP" = (
+/obj/structure/girder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/range)
 "okB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "olN" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
-	},
-/obj/item/trash/sosjerky,
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/wood,
+/area/security/prison)
 "olO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
 	dir = 4
@@ -103812,24 +103658,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/storage)
-"omg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/landmark/start/security_sergeant,
-/turf/open/floor/iron,
-/area/security/office)
+"ood" = (
+/obj/machinery/vending/sustenance,
+/turf/open/floor/plating,
+/area/security/prison)
 "ooK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -103851,32 +103683,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
-"opR" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/camera{
-	c_tag = "Permabrig - Cell 3";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
-"oqg" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "oql" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -103912,6 +103720,13 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
+"ouZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "ovb" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -103935,7 +103750,7 @@
 	name = "Brig Blast door"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "oxa" = (
 /obj/structure/disposalpipe/segment{
@@ -103961,7 +103776,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "oxL" = (
 /obj/effect/turf_decal/tile/purple{
@@ -103977,6 +103792,20 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"oxN" = (
+/obj/structure/chair/sofa/corp/left,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "oyj" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -104048,13 +103877,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"oBa" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 7
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "oCf" = (
 /obj/machinery/door/poddoor{
 	id = "justiceblast";
@@ -104112,11 +103934,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"oEY" = (
-/obj/structure/table,
-/obj/item/kitchen/fork/plastic,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "oFc" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Supermatter";
@@ -104197,6 +104014,16 @@
 "oLd" = (
 /turf/open/space/basic,
 /area/service/abandoned_gambling_den)
+"oLW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell4";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "oMw" = (
 /obj/docking_port/stationary/public_mining_dock{
 	dir = 4
@@ -104256,18 +104083,11 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "oPl" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/sign/warning/pods{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "oPu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -104289,21 +104109,18 @@
 	},
 /turf/open/floor/iron,
 /area/medical/morgue)
-"oPJ" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
+"oQe" = (
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/sink{
+	pixel_y = 17
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/security/brig)
+/area/security/prison/safe)
 "oQn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -104338,8 +104155,7 @@
 /obj/structure/plaque/static_plaque/golden{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "oSo" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -104372,15 +104188,10 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "oTt" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -30
-	},
 /obj/machinery/camera{
-	c_tag = "Permabrig - Fitness";
-	dir = 1;
-	network = list("ss13","prison")
+	c_tag = "Security - Prison"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "oUc" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -104398,7 +104209,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "oUW" = (
 /obj/structure/disposalpipe/segment{
@@ -104419,14 +104230,19 @@
 /obj/machinery/camera{
 	c_tag = "Security - Office Fore"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
+"oXe" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#00ff00";
+	name = "green"
+	},
+/obj/effect/landmark/start/prisoner/latejoin,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "oXi" = (
 /obj/machinery/computer/security{
 	dir = 4
@@ -104441,7 +104257,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "oXq" = (
 /obj/effect/landmark/event_spawn,
@@ -104465,6 +104281,18 @@
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"oYW" = (
+/obj/structure/window,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/security/prison/safe)
 "oZd" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -104489,7 +104317,6 @@
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
 "pad" = (
-/obj/effect/landmark/start/security_officer,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -104501,7 +104328,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "pbb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -104537,6 +104367,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"pcD" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/rag,
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
 "pdq" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/tile/red{
@@ -104586,7 +104421,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "pfk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -104602,11 +104437,6 @@
 "pfC" = (
 /obj/machinery/light/small,
 /obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/bed/roller,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "pfG" = (
@@ -104732,19 +104562,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/warden)
-"pkw" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "plN" = (
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 11
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/table,
+/turf/open/floor/iron/kitchen,
 /area/security/prison)
 "pmj" = (
 /obj/machinery/light{
@@ -104757,26 +104580,36 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
+"pmq" = (
+/obj/structure/table/reinforced,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -32
+	},
+/obj/item/electropack,
+/obj/item/assembly/signaler,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/clothing/head/helmet/sec,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "pmQ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
 "pmV" = (
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/prison)
-"poi" = (
-/obj/machinery/door/window/southleft,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 6
+	},
+/area/security/prison/safe)
 "pop" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -104794,6 +104627,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/main)
+"pqD" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "prj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -104803,39 +104642,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
-"psa" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"ptD" = (
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/office)
-"ptD" = (
-/obj/structure/cable,
-/obj/machinery/button/flasher{
-	id = "Cell 4";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/machinery/button/door{
-	id = "permashut4";
-	name = "Cell Lockdown Button";
-	pixel_x = 25;
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "pva" = (
 /obj/structure/disposalpipe/segment,
@@ -104888,6 +104704,21 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"pxS" = (
+/obj/machinery/meter,
+/obj/machinery/door/window/westright,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "pzj" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -104913,7 +104744,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "pzy" = (
 /obj/structure/disposalpipe/segment{
@@ -104959,11 +104790,7 @@
 /area/commons/vacant_room/commissary)
 "pAS" = (
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "pBM" = (
 /turf/closed/wall,
@@ -104997,16 +104824,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/space/basic,
 /area/space/nearstation)
-"pDd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "pDi" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
@@ -105017,16 +104834,7 @@
 "pEw" = (
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "pEQ" = (
 /obj/effect/turf_decal/tile/blue,
@@ -105056,7 +104864,7 @@
 	pixel_x = 26;
 	pixel_y = -7
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "pHV" = (
 /obj/structure/table/glass,
@@ -105102,7 +104910,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "pJp" = (
 /obj/effect/turf_decal/stripes/line{
@@ -105112,19 +104920,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"pJw" = (
-/obj/structure/sign/poster/official/work_for_a_future{
-	pixel_y = -32
+"pJC" = (
+/obj/machinery/button/door{
+	id = "brigprison";
+	name = "Prison Lockdown";
+	pixel_x = 26;
+	pixel_y = 26;
+	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "pJU" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -105175,40 +104980,41 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"pNZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"pNN" = (
+/obj/machinery/flasher{
+	id = "justiceflash";
+	pixel_x = 26;
+	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
+"pNZ" = (
+/obj/structure/table/wood,
+/obj/item/inspector,
+/obj/item/inspector{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/office)
-"pOt" = (
-/obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32;
-	pixel_y = -64
-	},
+/turf/open/floor/iron/dark,
+/area/security/office)
+"pPj" = (
+/obj/structure/cable,
+/obj/structure/table,
 /turf/open/floor/iron,
-/area/security/brig)
+/area/security/prison)
 "pPH" = (
 /obj/item/target/syndicate,
 /obj/effect/decal/cleanable/dirt,
@@ -105217,24 +105023,6 @@
 /obj/structure/training_machine,
 /turf/open/floor/iron,
 /area/security/range)
-"pPP" = (
-/obj/effect/spawner/randomarcade{
-	dir = 8
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig - Hall";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "pQm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -105282,7 +105070,7 @@
 	pixel_x = 24;
 	pixel_y = -26
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "pSk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -105322,20 +105110,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"pUT" = (
-/obj/effect/landmark/start/prisoner,
-/obj/machinery/flasher{
-	id = "Cell 3";
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "pWp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
 	dir = 1
@@ -105364,6 +105138,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
+"pXI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/easel,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/security/prison/safe)
 "pXW" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "medcell";
@@ -105379,16 +105166,20 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "pYw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table/wood,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "pYz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -105398,31 +105189,29 @@
 /turf/open/floor/glass,
 /area/maintenance/space_hut/observatory)
 "pYL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/northleft{
-	name = "Security Delivery";
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/target,
+/obj/item/target/syndicate,
+/obj/item/target/alien,
+/obj/item/target/clown,
+/obj/structure/closet/crate/secure{
+	desc = "A secure crate containing various materials for building a customised test-site.";
+	name = "Test Site Materials Crate";
 	req_access_txt = "63"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/security/range)
-"pZz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+"pZL" = (
+/obj/machinery/shower{
+	pixel_y = 16
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/structure/curtain,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "qab" = (
 /obj/structure/girder,
@@ -105472,20 +105261,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"qcf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "qcx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -105502,16 +105277,9 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "qdc" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "qdq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -105537,21 +105305,21 @@
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "qdS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/toilet/greyscale{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/vomit,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/obj/structure/mirror{
+	pixel_x = -26
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "qej" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/brown{
@@ -105664,17 +105432,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "qjp" = (
 /obj/structure/barricade/wooden,
@@ -105773,14 +105534,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"qmm" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"qnh" = (
+/obj/structure/window{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/security/office)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plating,
+/area/security/prison)
 "qnj" = (
 /obj/structure/table/reinforced,
 /obj/item/weldingtool,
@@ -105828,6 +105588,18 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"qok" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod 3"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "qpq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -105864,7 +105636,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "qqQ" = (
 /obj/effect/landmark/event_spawn,
@@ -105891,32 +105663,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"qsj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
-"qsy" = (
-/obj/structure/chair,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "qsN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -105940,6 +105686,15 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
 /turf/open/space,
 /area/engineering/atmos)
+"qtB" = (
+/obj/structure/cable,
+/obj/structure/chair/comfy{
+	dir = 1
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/security/prison)
 "qtI" = (
 /obj/structure/table/reinforced,
 /obj/item/lightreplacer,
@@ -106013,22 +105768,6 @@
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"qyo" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "qyG" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -106101,37 +105840,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"qAN" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/prisoner,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"qAZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "qBA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -106153,25 +105861,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"qBC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"qCu" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "qCX" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/exoscanner{
@@ -106184,17 +105873,10 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qDs" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "qEb" = (
 /obj/structure/reflector/box,
@@ -106219,7 +105901,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "qJK" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -106256,9 +105938,20 @@
 /area/engineering/atmos/upper)
 "qKW" = (
 /obj/structure/cable,
-/obj/machinery/holopad/secure,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "qMx" = (
 /obj/effect/turf_decal/stripes/line,
@@ -106274,22 +105967,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"qNq" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 1";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "qNG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -106312,21 +105989,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
-"qQJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "qSG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -106341,38 +106003,33 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port)
-"qSL" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/shovel/spade,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/security/prison)
 "qTe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/range)
 "qTK" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table/wood,
+/obj/item/storage/secure/briefcase,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "qUc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -106391,11 +106048,15 @@
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "qUm" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26;
+	pixel_y = 32
+	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "qUo" = (
 /obj/structure/table/reinforced,
@@ -106410,7 +106071,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "qUt" = (
 /obj/structure/table/reinforced,
@@ -106429,8 +106090,26 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
+"qUC" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/toy/cards/deck/kotahi{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/toy/cards/deck/wizoff{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/storage/pill_bottle/dice,
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/security/prison)
 "qUN" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
@@ -106440,27 +106119,11 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "qVm" = (
-/obj/effect/decal/remains/human,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/window,
+/turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
-"qVt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Shooting Range";
-	req_access_txt = "63"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
+/area/security/prison)
 "qWg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
@@ -106531,6 +106194,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"rby" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/wood,
+/area/security/prison)
 "rbH" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -106550,18 +106220,21 @@
 /obj/item/lighter,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
+"rbP" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/office)
 "rch" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "rcM" = (
 /obj/structure/cable,
@@ -106576,7 +106249,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rdI" = (
 /obj/structure/disposalpipe/segment,
@@ -106593,18 +106266,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"rdP" = (
-/obj/item/kirbyplants/random,
-/obj/structure/sign/warning/pods{
-	dir = 8;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "reZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -106625,25 +106286,12 @@
 /area/maintenance/port)
 "rfh" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/machinery/suit_storage_unit/security_peacekeeper,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "rgs" = (
-/obj/structure/closet/secure_closet/injection,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -32
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
@@ -106683,11 +106331,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"rjE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "rjH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -106725,11 +106368,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"rlh" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/security/prison)
 "rlN" = (
 /obj/structure/chair{
 	dir = 4
@@ -106774,6 +106412,18 @@
 /obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plating,
 /area/engineering/main)
+"rmM" = (
+/obj/structure/closet/l3closet/security,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/head/bio_hood/security,
+/obj/item/clothing/head/bio_hood/security,
+/obj/effect/turf_decal/bot,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "rmX" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -106794,7 +106444,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "rpm" = (
 /obj/structure/chair/office{
@@ -106808,7 +106458,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "rpC" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -106830,6 +106480,14 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
+"rtV" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/machinery/status_display/ai{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "ruk" = (
 /obj/structure/displaycase/trophy,
 /obj/effect/landmark/start/hangover,
@@ -106846,6 +106504,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"rvp" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "rvL" = (
 /obj/structure/cable,
 /obj/machinery/shower{
@@ -106872,21 +106535,20 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "rvR" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/obj/structure/bed,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/blindfold,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "rwd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/iron/kitchen,
 /area/security/prison)
 "rwJ" = (
 /obj/machinery/computer/security{
@@ -106941,7 +106603,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ryf" = (
 /obj/item/kirbyplants/random,
@@ -106966,7 +106628,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "ryC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
@@ -107056,36 +106718,29 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"rAm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "rCv" = (
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
 "rDl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/item/radio/intercom{
+	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/north,
 /obj/machinery/dish_drive/bullet{
 	succrange = 3
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rDI" = (
-/obj/machinery/flasher{
-	id = "Cell 6";
-	pixel_y = -25
-	},
-/obj/machinery/light/small/broken,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/turf/open/floor/iron/dark/airless,
+/area/security/prison)
 "rEm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -107096,6 +106751,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
+"rEz" = (
+/obj/structure/bed,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/blindfold,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "rEG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -107109,6 +106771,15 @@
 	},
 /turf/open/floor/iron,
 /area/medical/surgery)
+"rFs" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "rFt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -107122,38 +106793,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port)
-"rFP" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
-/obj/item/tank/internals/oxygen/red{
-	pixel_x = 3
-	},
-/obj/item/tank/internals/oxygen/red{
-	pixel_x = -3
-	},
-/obj/item/wrench,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "rHm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit/old,
@@ -107180,7 +106819,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"rIr" = (
+/obj/structure/closet/secure_closet/security_medic,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/security/brig)
 "rIE" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -107196,50 +106842,52 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"rJa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+"rIQ" = (
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/machinery/button/flasher{
+	id = "visitorflash";
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/machinery/button/door{
+	id = "visitation";
+	name = "Visitation Shutters";
+	pixel_x = 6;
+	pixel_y = 25;
+	req_access_txt = "2"
+	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/security/prison)
 "rJj" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/closet/athletic_mixed,
+/obj/item/clothing/gloves/boxing,
+/obj/item/clothing/gloves/boxing/blue,
+/obj/item/clothing/gloves/boxing/green,
+/obj/item/clothing/gloves/boxing/yellow,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/security/prison)
-"rJC" = (
-/obj/structure/cable,
-/obj/machinery/button/flasher{
-	id = "Cell 2";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/machinery/button/door{
-	id = "permashut2";
-	name = "Cell Lockdown Button";
-	pixel_x = 25;
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/tile/red{
+/area/security/prison/safe)
+"rJE" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/iron/dark/purple/side{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/area/security/prison/safe)
+"rJG" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "rJL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "rKo" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -107250,19 +106898,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"rKv" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "rKA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/glass,
@@ -107283,6 +106918,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"rLe" = (
+/obj/machinery/door/window/southright{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
 "rLD" = (
 /obj/machinery/camera{
 	c_tag = "Medbay - Surgery B";
@@ -107389,7 +107033,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "rPv" = (
 /obj/machinery/light{
@@ -107420,6 +107064,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/checkpoint)
+"rSF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "rSK" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -107462,7 +107112,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rUz" = (
 /obj/structure/chair{
@@ -107581,16 +107231,14 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "rYt" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/security/execution/education)
+/area/security/prison)
 "rYu" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -107639,7 +107287,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rZZ" = (
 /obj/machinery/shower{
@@ -107737,17 +107389,11 @@
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "sdP" = (
+/obj/structure/bed,
 /obj/effect/landmark/start/prisoner,
-/turf/open/floor/plating,
-/area/security/prison)
-"sea" = (
-/obj/effect/spawner/randomarcade{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/item/bedsheet/black,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "seb" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
@@ -107760,14 +107406,37 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"seF" = (
+/obj/structure/cable,
+/obj/structure/window,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
+/area/security/prison)
 "sfb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/clothing/gloves/color/blue,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/storage/bag/trash,
+/turf/open/floor/iron/kitchen{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "sfo" = (
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/engine/vacuum,
@@ -107806,28 +107475,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"sgm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/security/prison)
 "sgz" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/item/reagent_containers/syringe,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
-"sgI" = (
-/obj/structure/easel,
-/turf/open/floor/iron,
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/wood,
 /area/security/prison)
 "shb" = (
 /obj/docking_port/stationary{
@@ -107841,66 +107491,31 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
-"sif" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
+"sjU" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/landmark/start/head_of_security,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"sjU" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/food/donut/jelly/choco,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "slu" = (
 /obj/structure/cable,
 /mob/living/simple_animal/hostile/carp/lia,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hos)
-"slw" = (
-/obj/machinery/camera{
-	c_tag = "Security - Prison"
+"slG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/maintenance/starboard)
 "slR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -107913,21 +107528,6 @@
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"smi" = (
-/obj/machinery/light,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/security/prison)
 "snQ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -107992,13 +107592,23 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "spr" = (
 /obj/machinery/exoscanner,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"ssh" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "stQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -108036,14 +107646,14 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "svG" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/arrows/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Security - Medbay";
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "swd" = (
 /obj/structure/lattice,
@@ -108054,14 +107664,22 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"sxA" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast door"
+"swR" = (
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/turf/open/space/basic,
+/area/space)
+"sxA" = (
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
+"sxF" = (
+/obj/structure/curtain/cloth/fancy{
+	icon_state = "bounty-open"
+	},
+/turf/open/floor/carpet,
 /area/security/prison)
 "sxM" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -108081,50 +107699,32 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sym" = (
-/obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "syn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"syv" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/mob/living/simple_animal/mouse/white,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "syA" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Permabrig - Cell 1";
-	dir = 8;
-	network = list("ss13","prison")
+/obj/structure/cable,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "szm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -108164,12 +107764,11 @@
 /area/medical/psychology)
 "sBL" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "sCe" = (
 /obj/effect/turf_decal/stripes/line{
@@ -108294,6 +107893,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"sNa" = (
+/obj/structure/table,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 4
+	},
+/area/security/prison/safe)
 "sNB" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
@@ -108316,17 +107921,16 @@
 /area/service/kitchen)
 "sOm" = (
 /obj/structure/table/glass,
-/obj/item/storage/firstaid/regular,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/reagent_containers/glass/bottle/multiver,
-/obj/item/reagent_containers/syringe,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/item/clothing/gloves/color/latex,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -3;
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 5;
+	pixel_y = -1
 	},
+/obj/item/healthanalyzer,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "sPM" = (
@@ -108340,16 +107944,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/toilet/auxiliary)
-"sQU" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "sQY" = (
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -108373,9 +107967,28 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"sSm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/security/prison/safe)
 "sSF" = (
 /turf/open/floor/iron,
 /area/engineering/main)
+"sSG" = (
+/obj/structure/closet/bombcloset/security,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/head/bomb_hood/security,
+/obj/item/clothing/head/bomb_hood/security,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "sTt" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/delivery,
@@ -108413,7 +108026,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "sTZ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -108433,9 +108046,12 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "sUa" = (
+/obj/structure/cable,
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
+	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/departments/medbay/alt,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
 "sUc" = (
@@ -108455,23 +108071,6 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
-"sUl" = (
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "Prisoner Telescreen";
-	network = list("prison");
-	pixel_x = 27
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "sUu" = (
 /obj/item/retractor,
 /obj/item/hemostat,
@@ -108495,19 +108094,17 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "sUU" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "sVd" = (
 /obj/machinery/holopad,
@@ -108535,14 +108132,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
-"sVY" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clipboard,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "sWF" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/tile/neutral{
@@ -108567,15 +108158,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"sXx" = (
-/obj/structure/chair/stool,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "sXG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
 	dir = 4
@@ -108593,6 +108175,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos/upper)
+"sZa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "tah" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
@@ -108612,6 +108199,34 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint)
+"taU" = (
+/obj/structure/table/reinforced,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/glass/bottle/chloralhydrate{
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/glass/bottle/facid{
+	pixel_x = 7
+	},
+/obj/item/storage/backpack/duffelbag/sec/surgery{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "tbn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/loot_site_spawner,
@@ -108701,12 +108316,13 @@
 /area/maintenance/space_hut/observatory)
 "thl" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/range)
 "tht" = (
 /obj/structure/cable,
@@ -108718,36 +108334,17 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "tij" = (
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/obj/item/clothing/suit/armor/vest,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Security - Escape Pod"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/security/prison)
-"tiQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/starboard)
 "tjT" = (
 /obj/structure/sink{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "tki" = (
@@ -108803,7 +108400,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "tol" = (
 /obj/structure/table/reinforced,
@@ -108816,6 +108413,18 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint)
+"tpa" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Security Maintenance";
+	req_access_txt = "63"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "tpg" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -108858,16 +108467,39 @@
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "tqQ" = (
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "Prisoner Telescreen";
-	network = list("prison");
-	pixel_x = 27
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/chair/comfy{
+	color = "#596479"
+	},
+/obj/machinery/button/curtain{
+	id = "prisoncell1";
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 9
+	},
+/area/security/prison/safe)
+"tqY" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "trD" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -108901,27 +108533,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "trU" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/item/reagent_containers/syringe,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/structure/chair/office{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/security/prison)
-"tsM" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
 /area/security/prison)
 "ttq" = (
 /obj/structure/table/wood,
@@ -108956,16 +108575,13 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "tuJ" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "tvi" = (
 /obj/machinery/door/firedoor,
@@ -109089,13 +108705,24 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tAm" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/range)
 "tBs" = (
 /obj/machinery/camera{
@@ -109205,7 +108832,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "tHC" = (
 /obj/structure/disposalpipe/segment,
@@ -109234,6 +108861,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
+"tHM" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "tJj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -109252,16 +108888,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"tKa" = (
-/obj/structure/chair/stool,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "tKo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -109317,21 +108943,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
-"tNj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "tQS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown{
@@ -109343,25 +108954,18 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"tRX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "tSD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/warden)
+"tSX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/security/prison)
 "tUB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -109374,41 +108978,17 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron,
 /area/security/checkpoint)
-"tUG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "tVs" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/door/firedoor,
+/obj/machinery/turnstile{
+	dir = 1;
+	req_one_access_txt = "2;63;81"
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "tWl" = (
 /obj/structure/chair{
@@ -109424,16 +109004,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
-"tWA" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "tWK" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -109447,18 +109017,21 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "tXx" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/structure/sign/poster/official/obey{
-	pixel_x = 30
-	},
+/obj/structure/cable,
 /obj/machinery/camera{
-	c_tag = "Permabrig - Cell 5";
-	dir = 8;
+	c_tag = "Permabrig - Central";
+	dir = 4;
 	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plating,
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -30;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison/safe)
 "tYH" = (
 /obj/structure/cable,
@@ -109479,44 +109052,12 @@
 /turf/closed/wall/r_wall,
 /area/engineering/gravity_generator)
 "ubH" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/item/seeds/onion,
-/obj/item/seeds/garlic,
-/obj/item/seeds/potato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/structure/window,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/seeds/tower,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = 25;
-	pixel_y = -2;
-	prison_radio = 1
+/obj/structure/punching_bag,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security/prison)
-"ubI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "ucT" = (
 /obj/machinery/light{
 	dir = 4
@@ -109525,20 +109066,11 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "uef" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/turf/open/floor/iron/dark/purple/side{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
 /area/security/prison/safe)
 "ueM" = (
 /obj/structure/window/reinforced{
@@ -109606,19 +109138,6 @@
 /obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
-"uiM" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "uiZ" = (
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_x = -32
@@ -109628,6 +109147,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"ujd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "ujG" = (
 /obj/structure/window/plasma/reinforced/spawner/west{
 	dir = 4
@@ -109721,7 +109245,7 @@
 "umO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "ung" = (
 /obj/effect/landmark/start/hangover,
@@ -109729,36 +109253,53 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
-"unK" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/south,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "uox" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = " Permabrig - Cafeteria";
+	dir = 5;
+	network = list("ss13","prison")
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
 /area/security/prison)
 "uoy" = (
-/obj/machinery/plate_press,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
+"uoA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "uoB" = (
 /obj/structure/disposalpipe/segment{
@@ -109769,12 +109310,12 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "upd" = (
 /obj/structure/chair{
@@ -109810,7 +109351,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uqA" = (
 /obj/structure/disposalpipe/segment,
@@ -109865,23 +109406,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uta" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "utm" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
@@ -109893,7 +109423,7 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "uuT" = (
 /obj/item/kirbyplants/random,
@@ -109935,6 +109465,17 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port)
+"uxa" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "brigprison";
+	name = "Prison Blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/sign/warning/pods{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "uxC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -109966,7 +109507,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "uzY" = (
 /obj/effect/turf_decal/tile/red{
@@ -109974,7 +109515,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uAe" = (
 /obj/item/kirbyplants/random,
@@ -109988,22 +109529,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
-"uBf" = (
-/obj/machinery/sparker{
-	dir = 1;
-	id = "justicespark";
-	pixel_x = -22
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
-/area/security/execution/education)
+/area/security/brig)
 "uBo" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -110018,7 +109545,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "uCc" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -110031,6 +109558,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"uCI" = (
+/obj/structure/rack,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "uCU" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -110067,13 +109600,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "uDH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/obj/machinery/vending/security_ammo,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "uEc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
@@ -110084,16 +109613,14 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "uEf" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/light,
+/turf/open/floor/wood,
 /area/security/prison)
 "uFG" = (
 /obj/structure/table/glass,
@@ -110124,7 +109651,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "uGH" = (
 /obj/machinery/button/door{
@@ -110162,7 +109689,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uGL" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -110175,6 +109702,16 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"uHl" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison)
 "uHw" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -110190,18 +109727,8 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "uIb" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
+/obj/machinery/suit_storage_unit/security_peacekeeper,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "uIt" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -110209,13 +109736,20 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "uIu" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/gun_vendor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uIV" = (
 /obj/structure/disposalpipe/segment,
@@ -110245,7 +109779,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uJI" = (
 /obj/structure/disposalpipe/segment{
@@ -110262,7 +109796,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uKa" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -110272,29 +109806,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "uKf" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/weightmachine/weightlifter,
 /turf/open/floor/iron,
-/area/security/prison)
-"uKn" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/area/security/prison/safe)
 "uKr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -110307,13 +109821,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/education)
-"uKS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "uLs" = (
 /obj/effect/turf_decal/box/white{
 	color = "#9FED58"
@@ -110333,7 +109840,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "uMN" = (
 /obj/structure/table,
@@ -110351,6 +109862,14 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"uNB" = (
+/obj/structure/sign/poster/official/here_for_your_safety{
+	pixel_x = 30
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "uNP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -110372,16 +109891,27 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron,
 /area/engineering/main)
-"uPf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"uOp" = (
+/obj/structure/table,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = -26;
+	pixel_y = -26
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/item/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "uPl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -110461,20 +109991,28 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"uRm" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+"uRZ" = (
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -2
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/area/security/prison/safe)
+"uSA" = (
+/obj/structure/window,
+/obj/machinery/vending/coffee,
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/landmark/start/security_sergeant,
-/turf/open/floor/iron,
-/area/security/office)
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
+/area/security/prison)
 "uSW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -110491,6 +110029,20 @@
 	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
+"uTv" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "uTQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -110510,7 +110062,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "uUN" = (
 /obj/effect/turf_decal/tile/red{
@@ -110639,28 +110191,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "vcs" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/glasses/blindfold,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
 /area/security/prison)
-"vdp" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "vdB" = (
 /obj/machinery/door/window/brigdoor{
 	id = "cargocell";
@@ -110703,13 +110240,22 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
-"ver" = (
-/obj/structure/table,
-/obj/item/trash/popcorn,
-/obj/machinery/light{
+"vez" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "veN" = (
 /obj/structure/disposalpipe/segment{
@@ -110737,21 +110283,20 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "vfM" = (
-/obj/structure/sign/poster/official/do_not_question{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vip" = (
 /obj/structure/disposalpipe/segment{
@@ -110764,42 +110309,40 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "viz" = (
-/obj/machinery/button/door{
-	id = "brigprison";
-	name = "Prison Lockdown";
-	pixel_x = 26;
-	pixel_y = 26;
-	req_access_txt = "63"
-	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "viN" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "vjn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/structure/window,
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -2
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
+	},
+/area/security/prison/safe)
 "vjw" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -110810,20 +110353,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
-"vjz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "vjB" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/kirbyplants{
@@ -110886,28 +110417,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science)
-"vlU" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -32
+"vmv" = (
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -2
 	},
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/water_source{
+	dir = 8;
+	name = "sink";
+	pixel_x = 12;
+	pixel_y = -6
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/prison/safe)
 "vmK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -110915,6 +110442,24 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"vmN" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "brigprison";
+	name = "Prison Blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"vna" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Visitation"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "vnf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -110948,10 +110493,6 @@
 /area/engineering/main)
 "vpi" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/landmark/start/security_medic,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "vpk" = (
@@ -111013,15 +110554,15 @@
 "vqs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
+"vqA" = (
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 6
+	},
+/area/security/prison/safe)
 "vqI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -111037,7 +110578,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vre" = (
 /obj/structure/sign/warning/securearea{
@@ -111080,27 +110621,18 @@
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
 "vtY" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box{
-	pixel_x = -8;
-	pixel_y = -4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/item/inspector,
-/obj/item/inspector{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "vvD" = (
 /obj/item/kirbyplants/random,
@@ -111124,8 +110656,15 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
+"vvE" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/effect/spawner/randomarcade,
+/turf/open/floor/wood,
+/area/security/prison)
 "vwn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
@@ -111181,18 +110720,15 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"vyd" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/security/office)
 "vyv" = (
-/obj/machinery/plate_press,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/griddle,
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/kitchen,
 /area/security/prison)
 "vyL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -111207,17 +110743,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"vzh" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden{
-	dir = 5
-	},
-/obj/machinery/newscaster/security_unit/directional/south,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "vzl" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -111272,29 +110797,25 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "vCN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "vDU" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "vEx" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/prisoner{
+	pixel_y = 8
+	},
+/obj/item/storage/box/prisoner,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "vET" = (
 /obj/structure/table/reinforced,
@@ -111355,14 +110876,24 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "vJo" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/structure/table/rolling,
+/obj/item/storage/crayons{
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/storage/crayons{
+	pixel_x = -6;
+	pixel_y = 1
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison/safe)
 "vJu" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Nanite Lab Maintenance";
@@ -111374,6 +110905,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
+"vKu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "brigprison";
+	name = "Prison Blast door"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "vMe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -111385,14 +110925,7 @@
 /area/engineering/atmos/upper)
 "vMz" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vNp" = (
 /obj/effect/turf_decal/tile/blue{
@@ -111407,7 +110940,7 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vNO" = (
 /obj/effect/turf_decal/tile/red{
@@ -111442,40 +110975,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"vOt" = (
-/obj/structure/table/reinforced,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/glass/bottle/chloralhydrate{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/glass/bottle/facid{
-	pixel_x = 7
-	},
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "vOW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -111510,7 +111009,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vSC" = (
 /obj/machinery/door/window/brigdoor/security/cell/westright{
@@ -111530,53 +111029,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
-"vSS" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt3";
-	name = "Cell 4"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut4"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "vST" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vTA" = (
 /turf/closed/wall,
 /area/medical/treatment_center)
-"vTW" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = 25;
-	pixel_y = -2;
-	prison_radio = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "vUp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -111596,7 +111063,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vVc" = (
 /obj/structure/lattice/catwalk,
@@ -111616,11 +111083,7 @@
 	c_tag = "Security - Office Aft";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "vWJ" = (
 /obj/item/kirbyplants{
@@ -111631,13 +111094,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "vXr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/structure/window,
 /turf/open/floor/iron,
 /area/security/prison)
 "vXz" = (
@@ -111675,30 +111132,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"vYx" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/folder/blue{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/lighter,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/office)
 "vYF" = (
 /obj/structure/chair,
 /obj/machinery/light/small{
@@ -111713,7 +111146,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vZP" = (
 /obj/item/kirbyplants/random,
@@ -111782,12 +111215,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"wbx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/security/range)
 "wcV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -111854,7 +111281,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "wfN" = (
 /obj/structure/disposalpipe/segment,
@@ -111890,16 +111317,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/port)
-"whJ" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "whP" = (
 /obj/machinery/power/solar_control{
 	dir = 4;
@@ -111916,19 +111333,12 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_x = 26;
 	pixel_y = 26
 	},
-/turf/open/floor/iron,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "wiW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -111999,21 +111409,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"wkZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "wmi" = (
 /obj/machinery/button/door{
 	id = "armouryaccess";
@@ -112054,18 +111449,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"wnL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "wnN" = (
 /obj/structure/table/reinforced,
 /obj/structure/reagent_dispensers/peppertank{
@@ -112130,10 +111513,10 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "wtx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen,
 /area/security/prison)
 "wtL" = (
 /obj/structure/closet/radiation,
@@ -112177,6 +111560,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter)
+"wyd" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/security/prison)
+"wyx" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "wyO" = (
 /obj/structure/chair{
 	dir = 4
@@ -112199,6 +111591,15 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
 /area/science/misc_lab/range)
+"wBg" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/grunge{
+	name = "Cell 1"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "wBq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -112227,42 +111628,12 @@
 /turf/open/floor/iron/white,
 /area/maintenance/department/science)
 "wDi" = (
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null
-	},
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/onion,
-/obj/item/food/grown/onion,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/poster/ripped{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/iron/kitchen,
 /area/security/prison)
 "wDB" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 5";
-	req_access_txt = "2"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison/safe)
 "wEb" = (
 /obj/structure/cable,
@@ -112304,7 +111675,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "wEq" = (
 /obj/item/retractor,
@@ -112336,6 +111707,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"wFg" = (
+/obj/machinery/smartfridge,
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
 "wFV" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -112344,7 +111719,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "wHQ" = (
 /obj/structure/bookcase/random,
@@ -112382,6 +111757,12 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"wIO" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/iron,
+/area/security/prison)
 "wIU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -112394,18 +111775,17 @@
 /area/space/nearstation)
 "wJA" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/landmark/start/security_sergeant,
+/obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "wJW" = (
 /obj/structure/bed/dogbed/mcgriff,
@@ -112418,37 +111798,26 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /mob/living/simple_animal/pet/dog/pug/mcgriff,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "wKn" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison/safe)
+"wLE" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/prison)
-"wLE" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/energy/laser/practice{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/obj/item/gun/energy/laser/practice,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "wMw" = (
 /obj/structure/table/reinforced,
@@ -112460,7 +111829,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/security_unit/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "wMR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden{
@@ -112484,18 +111853,18 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/landmark/start/security_sergeant,
+/obj/structure/chair/office{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "wNc" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -112515,16 +111884,13 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "wNW" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "wPc" = (
@@ -112554,26 +111920,17 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/port)
 "wQu" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/area/security/prison)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "wQB" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wRg" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
@@ -112617,7 +111974,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "wXk" = (
 /obj/machinery/computer/secure_data{
@@ -112656,7 +112013,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "wXQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -112680,6 +112037,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"wYd" = (
+/turf/closed/wall/r_wall,
+/area/security/range)
 "wYf" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -112687,7 +112047,7 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "wZq" = (
 /obj/effect/landmark/start/medical_doctor,
@@ -112718,6 +112078,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/surgery)
+"xcU" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "xdt" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -112755,40 +112122,16 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
-"xeR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "xhF" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
-"xhK" = (
-/obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "xiN" = (
 /obj/machinery/door/poddoor{
 	id = "armouryaccess";
@@ -112800,25 +112143,10 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
-"xjv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/security/range)
 "xjZ" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "xkD" = (
@@ -112831,7 +112159,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "xlt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -112891,42 +112219,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/rd)
-"xmM" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"xmS" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "xmU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -112966,6 +112258,9 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"xoK" = (
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "xoR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -112977,6 +112272,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"xqc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side,
+/area/security/prison/safe)
 "xrb" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/landmark/start/hangover,
@@ -112999,18 +112300,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"xrY" = (
-/obj/effect/turf_decal/tile/red{
+"xsJ" = (
+/obj/structure/chair/sofa/corp{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/security/office)
-"xsf" = (
-/obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 8
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "xte" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -113026,7 +112323,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "xtB" = (
 /turf/closed/wall/r_wall,
@@ -113034,44 +112331,18 @@
 "xuc" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xuz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/office)
-"xve" = (
-/obj/machinery/meter,
-/obj/machinery/door/window/westright,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
-	dir = 5
-	},
 /turf/open/floor/iron/dark,
-/area/security/execution/education)
+/area/security/office)
 "xvf" = (
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
@@ -113136,13 +112407,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"xvZ" = (
-/obj/structure/table,
-/obj/item/storage/photo_album/prison,
-/obj/item/camera,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "xwx" = (
 /turf/open/floor/iron,
 /area/science/research/abandoned)
@@ -113151,23 +112415,15 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "xxu" = (
-/obj/structure/bed,
-/obj/machinery/iv_drip,
-/obj/item/bedsheet/medical,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_y = 26;
 	use_power = 0
 	},
-/obj/machinery/camera{
-	c_tag = "Security - Medbay"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood/o_minus,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "xxD" = (
@@ -113216,7 +112472,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xzu" = (
 /obj/machinery/piratepad/civilian,
@@ -113280,22 +112536,6 @@
 "xAl" = (
 /turf/open/floor/eighties,
 /area/maintenance/starboard/fore)
-"xAz" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 3";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "xAW" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/computer/shuttle/mining/common,
@@ -113411,19 +112651,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xHr" = (
 /obj/effect/turf_decal/stripes/line,
@@ -113517,20 +112745,20 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "xLb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/flashlight/seclite,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xLG" = (
 /obj/machinery/door/firedoor,
@@ -113593,10 +112821,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
-"xNU" = (
-/obj/effect/landmark/start/security_officer,
+"xNS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -113608,10 +112835,18 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"xNZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xOc" = (
 /obj/machinery/door/window/brigdoor{
@@ -113661,7 +112896,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xPh" = (
 /obj/structure/disposalpipe/segment{
@@ -113671,12 +112906,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xPp" = (
-/obj/structure/punching_bag,
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/item/clothing/gloves/color/blue,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "xPy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/purple{
@@ -113684,19 +112919,6 @@
 	},
 /turf/open/floor/glass,
 /area/maintenance/space_hut/observatory)
-"xPA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "xPE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -113716,6 +112938,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"xRc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "xRj" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/neutral{
@@ -113732,21 +112960,35 @@
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "xRW" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/taperecorder,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/office)
-"xSR" = (
-/obj/machinery/holopad/secure,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/security/office)
+"xSR" = (
+/obj/structure/table/wood,
+/obj/item/food/donut/jelly/choco,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xTH" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -113767,6 +113009,14 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"xUg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/security/prison)
 "xUV" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop{
@@ -113776,15 +113026,6 @@
 	},
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/security/brig)
@@ -113867,13 +113108,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xXL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -113908,24 +113147,20 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "xZs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xZM" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
+"yaI" = (
+/obj/machinery/turnstile{
+	req_one_access_txt = "2;63;80"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/prison)
 "yaW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -113955,7 +113190,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ybr" = (
 /obj/structure/lattice/catwalk,
@@ -114002,13 +113237,30 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"yfl" = (
-/obj/structure/table,
+"ydN" = (
 /obj/structure/cable,
-/obj/item/toy/cards/deck,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Gear Room";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"yfl" = (
 /turf/open/floor/iron,
+/area/security/prison/safe)
+"yfr" = (
+/obj/structure/table/glass,
+/obj/item/folder/blue,
+/obj/item/healthanalyzer,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "yfv" = (
 /obj/structure/disposalpipe/segment{
@@ -114020,26 +113272,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "yfD" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"yfZ" = (
-/obj/machinery/door/airlock/security{
-	name = "Isolation Cell";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/prison)
+/area/security/prison/safe)
 "ygR" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
@@ -114136,27 +113375,20 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "ylM" = (
-/obj/machinery/button/flasher{
-	id = "Cell 5";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/machinery/button/door{
-	id = "permashut5";
-	name = "Cell Lockdown Button";
-	pixel_x = 25;
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
+/area/security/prison/safe)
 "ylP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -162574,10 +161806,10 @@ abj
 abj
 aaa
 aaa
-aaa
+qYo
 aad
 aaa
-aad
+qYo
 aad
 aad
 aad
@@ -162831,10 +162063,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
+qYo
 aac
-aad
-aad
+qYo
+qYo
 aaa
 aaa
 aad
@@ -163088,10 +162320,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
+qYo
 aac
 aaa
-aad
+qYo
 aaa
 aaa
 aad
@@ -163332,31 +162564,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
 aad
 aad
 aad
 aad
 aad
 aac
-aaa
+aac
+aac
 aac
 aad
 aad
 aad
 aad
+qYo
+aac
+nOg
 aad
 aad
 aad
 aad
+aad
+aad
+aad
+qYo
+qYo
 aad
 aad
 aad
@@ -163589,30 +162821,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aad
 aaa
 aaa
 aad
-aaa
-aad
-aaa
 aaa
 aac
 aaa
 aaa
-aaa
 aad
+aFm
+oql
+oql
+oql
+aFm
+vKu
+oql
+oql
+aFm
+aFm
+aFm
+aFm
+aFm
+aFm
 aaa
-aad
-aaa
-aaa
-aad
-aaa
-aaa
-aaa
-aad
 aaa
 aaa
 aaa
@@ -163846,30 +163078,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aad
 aaa
 aaa
 aad
 aad
 aac
-aac
 aad
 aad
+aad
+oql
+uHl
+xsJ
+kkz
+uSA
+eCE
+wyd
+qtB
+hhK
+aFm
+jKc
+rAm
+rEz
+aFm
 aaa
-aaa
-aaa
-aFm
-aFm
-aFm
-aFm
-aFm
-aFm
-aFn
-aFn
-aFm
-aFm
 aaa
 bgZ
 biy
@@ -164103,30 +163335,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 abj
 aaa
 aaa
 abj
 aaa
-aad
+aac
 aaa
 aaa
 aad
-xtB
-xtB
-xtB
-xtB
+oql
+ixd
+lho
+fGU
+seF
+iMJ
 trU
 vcs
 uEf
-gBq
-aFn
+aFm
+yfr
 mnH
 kiO
-xmM
 aFm
+aaa
 aaa
 bgZ
 xUV
@@ -164360,31 +163592,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 abj
 aaa
 aaa
 abj
-aad
-aad
+aac
+aac
 aad
 qYo
 qYo
-xtB
+oql
+oxN
+mhu
 jIP
 rDI
-xtB
+aBu
 lEv
 aSD
 dRO
-nmd
-kpy
-fjW
-rvR
-qQJ
 aFm
-aad
+kpy
+mnH
+rvR
+aFm
+aaa
+aaa
 bgZ
 tjT
 vpi
@@ -164617,31 +163849,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 abj
 aaa
 aaa
 aad
+uHd
 aaa
 aaa
-qYo
 aaa
-aaa
-xtB
+aFm
+aFm
+aKV
+aKV
 nsp
 qVm
-xtB
+gaC
 sgz
 iAp
 lQl
-jit
+aFm
 sUa
 ePM
-smi
+mZm
 aFm
-aFm
-aaa
+mZm
+mZm
 bgZ
 xxu
 bkm
@@ -164870,37 +164102,37 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+qYo
+qYo
+qYo
+qYo
 abj
-aad
+qYo
+qYo
+qYo
+uHd
+aaa
+aaa
+aaa
 aFm
-aFm
-aUA
-aUA
-aUA
-aUA
-aFm
-aFm
-aFm
-yfZ
-aFm
-aFm
-aFm
-aFm
-aFm
-aFm
+rFs
+jrq
+aKV
+iNP
+piT
+vXz
+vXz
+vXz
+vXz
+xtB
+itI
 moH
 nai
 aFm
-aFm
-aFm
+pPj
+bSG
 bgZ
-biy
+rIr
 dsr
 bmg
 bnG
@@ -164930,12 +164162,12 @@ bNj
 biy
 jMl
 biy
-bgZ
+wYd
 clA
 cnk
 clA
 clA
-clw
+oiP
 ctc
 bHq
 bHq
@@ -165127,39 +164359,39 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-mvD
 qYo
+uHd
+uHd
 qYo
-qYo
-aaa
-aUA
-epN
-aWc
-aWc
-gjM
-aWc
+xtB
+xtB
+xtB
+xtB
+xtB
+ftQ
+ftQ
+ftQ
+aFm
+pZL
 qdc
-aWc
+iWx
 kRD
-iPa
-aWc
+piT
+vXz
 vJo
 gwA
 hEu
 aWc
 sxA
-oqg
+moH
 gYn
 jzM
 lIN
 wQB
 tVs
-gth
+xoK
 lls
-eNR
+sZa
 ngh
 eNR
 mlF
@@ -165186,8 +164418,8 @@ maY
 pfg
 tuJ
 vST
-rKv
 biy
+fKH
 gTK
 uoB
 pYL
@@ -165384,41 +164616,41 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-mvD
-aaa
-aaa
+qYo
 uHd
 aaa
-aFn
+aaa
+dhT
+lAB
+rJE
+fcD
+vXz
 tqQ
 gVl
 ylM
-sUl
-nYc
+aKV
+ocm
 ptD
-jwS
-nYc
+aKV
+iNP
 nVs
-jwS
+vXz
 nYc
-rJC
+jwS
 jwS
 jTB
 aXK
-mgz
+moH
 jiF
-aFn
+hCH
 gfr
 npZ
 bhb
-emX
-iSH
-iSH
-iSH
-iSH
+lls
+ifD
+xNS
+xNS
+xNS
 ooK
 gHu
 mst
@@ -165439,17 +164671,17 @@ eqb
 eqb
 eIn
 gfW
-iSH
+xNS
 wWj
-xmS
+xNS
 iSH
 iUx
-qVt
+thl
 thl
 iVb
 tAm
 cqh
-bJc
+tpa
 cte
 cuG
 bHq
@@ -165641,39 +164873,39 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-uHd
-qYo
 qYo
 uHd
-qYo
-xtB
-xtB
+aaa
+aaa
+dhT
+hMw
+lan
+kwb
+vXz
+oQe
 wDB
-xtB
-xtB
-jXO
-xtB
-xtB
-xAz
-xtB
-xtB
+haq
+aKV
+aKV
+aKV
+aKV
+iNP
+piT
+vXz
 nUf
-xtB
-xtB
-qNq
-xtB
-vEx
-nai
+pXI
+nXH
+aWc
+lpM
+moH
+ixE
 afs
-gfr
+uxa
 viz
 kqL
 svG
-ldu
-ldu
+pJC
+xoK
 ldu
 ldu
 uJm
@@ -165695,8 +164927,8 @@ tns
 tns
 tns
 jDw
-vMz
-evk
+xNZ
+ewD
 pHy
 vMz
 evk
@@ -165705,8 +164937,8 @@ ckl
 uDH
 qjm
 wLE
+fka
 clA
-tiQ
 ctf
 cuH
 bHq
@@ -165898,35 +165130,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+qYo
 uHd
 aaa
 aaa
-uHd
-aaa
-xtB
+dhT
+eiZ
+iGI
+xqc
+vXz
 nKS
 uef
-vXz
-fVa
+kfW
+aKV
 qdS
-vXz
+aKV
 fVa
-wkZ
+iNP
+nqS
 vXz
-fVa
-jsm
 vXz
-nKS
-pDd
+vXz
+vXz
 xtB
+aUx
 ewn
-nai
 aFm
 aFm
-obA
+aFm
+aFm
 bhd
 bhd
 bhe
@@ -165956,16 +165188,16 @@ tvi
 bFP
 bFL
 dlI
-biy
+ydN
 bgZ
 bgZ
-coQ
+bgZ
 cno
 coQ
+jVP
 clA
-uKS
-bJe
-fNd
+xrw
+mBL
 bHq
 cxt
 czc
@@ -166155,44 +165387,44 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-uHd
-aaa
-aaa
+qYo
 uHd
 qYo
+qYo
 xtB
-mdG
+vXz
+aWj
+gRt
+vXz
+vXz
 nbd
-vXz
-sfb
+wBg
+aKV
 fIc
-vXz
+aKV
 sfb
-pUT
-vXz
+iNP
+nqS
 mdG
 aQZ
-vXz
+eYZ
 aUv
-qcf
-xtB
-vEx
-nai
-aFm
-apH
+ixE
+mkq
+moH
+bfR
+bfR
+bfR
 bfR
 bhd
 hXF
 qUm
-vdp
+ldR
 vqs
 ldR
 xuz
 uLV
-xRW
+npz
 iqd
 laG
 kWt
@@ -166215,14 +165447,14 @@ bFP
 kJl
 sym
 kRm
+uOp
 bgZ
 bhY
-ewO
+gfi
 vpv
 clA
-mBL
-xrw
-mBL
+slG
+eMA
 bHq
 cnf
 czd
@@ -166411,45 +165643,45 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+qYo
+uHd
+qYo
 qYo
 aaa
-aaa
-qYo
 aaa
 xtB
+kZN
+hew
+xjZ
 tXx
 xjZ
-vXz
+xcU
 nZp
-igd
-vXz
-opR
-pJw
-vXz
-gyu
-qAZ
-vXz
+kRD
+lCx
+iNP
+kRD
+iNP
+kGL
+kGL
+kGL
 syA
-igd
-xtB
-nph
+moH
+moH
+moH
 hNs
-aFm
+bet
 bet
 bfS
 bhe
-ibL
-vyd
-gdG
-gdG
-qmm
+npz
 jrr
-nSC
-xrY
+jrr
+jrr
+jrr
+jrr
+uLV
+npz
 viN
 laG
 gLE
@@ -166469,15 +165701,15 @@ lhg
 nKy
 tHi
 xvG
-tNj
-pOt
+xoK
+iSH
 iqZ
+mkl
 bgZ
 nIq
-ewO
+gfi
 vre
 clA
-lNL
 cth
 cuK
 bHq
@@ -166668,42 +165900,42 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+uHd
 aaa
 qYo
-vVc
-vVc
-qYo
-aaa
+mCf
+mCf
+mCf
 xtB
-vXz
+dxk
+wKn
 mIv
-vXz
-vXz
-vSS
-vXz
-vXz
+mIv
+mIv
+rJG
+piT
+piT
+aWm
+gFT
 aMf
-vXz
-vXz
+piT
+rSF
 aRb
-vXz
-vXz
+piT
+yaI
 aWf
-xtB
-vEx
-nai
-aFm
-aFm
-aFn
-bhd
-mSf
+moH
+ixE
+hIH
+eQm
+eQm
+vez
+rbP
+npz
 kTw
 joB
-xhK
-tRX
+lEZ
+lEZ
 lEZ
 icR
 qDs
@@ -166727,14 +165959,14 @@ kVx
 lBr
 bFP
 xZs
-xNU
+iSH
 vfM
+rtV
 bgZ
 bhZ
-xjv
+gfi
 gPJ
 clA
-bHq
 cti
 bHq
 bHq
@@ -166925,45 +166157,45 @@ aaa
 aaa
 aaa
 aaa
+uHd
 aaa
-aaa
-aaa
-aaa
-qYo
-aaa
-aaa
-qYo
-aFm
-aFm
+vVc
+kQT
+kjf
+mfL
+jBA
+yfl
+wKn
+inU
 xPp
 aJA
-fXw
-gtl
-uKf
-eRq
-aZL
-nqS
-xsf
-jhf
-aRc
-aWr
-rJa
+aKV
+aKV
+aKV
+aKV
+aKV
+aKV
+aKV
+oXe
+oXe
+oXe
+aFm
 oTt
-aFm
+moH
 vEx
-nai
-vlU
-aFm
-aaa
+bfR
+bfR
+bfR
+eNh
 bhd
 oVf
-kTw
+feB
 vtY
 pYw
 pNZ
 xLb
 qTK
-qDs
+ssh
 oSj
 laG
 byN
@@ -166986,12 +166218,12 @@ bLs
 jeN
 pad
 sUU
-bgZ
-cnp
+rvp
+biy
+coW
 coW
 cnr
 clA
-aaa
 aaa
 aad
 cti
@@ -167182,45 +166414,45 @@ aaa
 aaa
 aaa
 aaa
+uHd
 aaa
-aaa
-aaa
-qYo
-qYo
-aFm
-aFm
-aFm
-aFm
+vVc
+kQT
+kvR
+uCI
+oYW
+wKn
+wKn
 hAI
 gsB
-aJA
-isb
+pqD
+uSW
 aGI
-aIe
+fYh
 uox
 aKW
 aMh
-pPP
-sea
-vTW
-tFH
-mEZ
+aKV
+aKV
+aKV
+aKV
+aFm
 aWq
-aUA
-slw
-iFW
-hmI
-aFn
-aad
+moH
+aKV
+aKV
+aFm
+mZm
+mZm
 bhd
 lEO
-xRW
+feB
 aiM
 blU
 xSR
 xRW
 gSL
-blU
+ssh
 vVS
 laG
 gLE
@@ -167243,12 +166475,12 @@ bLs
 rDl
 qKW
 lIb
-biy
-wbx
-coU
-kXx
+izw
+bgZ
+cnp
+cnp
+cnp
 clA
-aad
 aad
 cuL
 cuL
@@ -167439,41 +166671,41 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 uHd
 aaa
-aUA
+vVc
+kQT
+sSm
+gQU
 lGy
 nFI
-qSL
+hew
 fiN
-aWc
-ibY
-tWA
-piT
+oft
+aJA
+uSW
+kbO
 aIf
-vXz
+aIe
 hCX
-vXz
-vXz
-vXz
+iXw
 aKV
-aSG
+rIQ
+tFH
+tFH
 aUz
-aMi
-aUA
-vEx
-nai
-qAN
+jiF
+moH
+sxF
+gzd
 aFm
-aaa
+qYo
+qYo
 bhe
 iQQ
 nOM
 wJA
-vYx
+ivg
 sjU
 ivg
 wMZ
@@ -167497,15 +166729,15 @@ oEx
 vpL
 wmi
 xiN
-vjz
+xoK
 pad
-eAR
-bgZ
-cnr
-pPH
-coW
-qTe
-aaa
+sUU
+rvp
+xRc
+nCp
+coU
+kXx
+clA
 aaa
 cuL
 cwd
@@ -167696,46 +166928,46 @@ aaa
 aaa
 aaa
 aaa
-aaa
 uHd
 qYo
-uHd
-aaa
-aUA
+qYo
+kQT
+eHr
+ndl
 mio
 fBg
-nAj
-msh
-axs
+xjZ
 yfl
-uiM
-piT
+yfl
+yfl
+uSW
+rby
 aIg
-vXz
+gpR
 aKY
-aMj
-hQh
-ceq
+iXw
 aKV
-tsM
-pZz
+aPn
+tFH
+piT
+aUA
 lgw
+moH
 aFm
-vEx
-gcZ
-aKV
 aFm
-aad
-bhd
+aFm
+eqU
+qYo
+rbP
 pEw
-xPA
-uRm
-odH
+npz
+npz
+npz
 uta
-jgW
-omg
-xPA
-xRW
+npz
+uLV
+npz
+npz
 bxr
 byP
 bAt
@@ -167754,15 +166986,15 @@ ayI
 lnX
 xVJ
 cds
-lIC
-nYF
+xoK
+pad
 uIu
-biy
-lKV
+obS
+bgZ
+cnr
+pPH
 coW
-iPg
-clA
-aad
+qTe
 aad
 cuM
 cwd
@@ -167953,45 +167185,45 @@ aaa
 aaa
 aaa
 aaa
-aaa
 uHd
 aaa
-uHd
-aaa
-aUA
+vVc
+kQT
+fmK
+fmK
 vjn
 mNS
-ubI
+xjZ
 ilu
-piT
-xvZ
-whJ
+yfl
+yfl
+uSW
 aGL
 aIh
-vXz
+tSX
 olN
-vXz
-gNA
+jRQ
+aKV
 aPo
-aKV
-aKV
-doJ
-aKV
-aFm
-vEx
-nai
-cdy
-aFm
-aaa
-bhd
+uNB
+nFp
+oql
+aJl
+moH
+mZm
+qYo
+qYo
+qYo
+qYo
+rbP
 whW
-pkw
-pkw
-pkw
+npz
+npz
+npz
 ogK
 xuc
 rch
-psa
+sBL
 sBL
 bxs
 byQ
@@ -168011,15 +167243,15 @@ pcy
 uCU
 kpQ
 bLs
-lUK
-iSH
-oPJ
-bgZ
-clA
-qTe
-clA
-clA
-aaa
+xoK
+xNS
+sUU
+xoK
+xRc
+fOD
+coW
+iPg
+wYd
 aaa
 cuM
 cwd
@@ -168210,36 +167442,36 @@ aaa
 aaa
 aaa
 aaa
+uHd
 aaa
-xTK
-aaa
-qYo
-aaa
-aUA
+vVc
+kQT
+uRZ
+uRZ
 lce
-mNS
+yfl
 mzo
 jrh
 wQu
 kxv
-sXx
-piT
-lpW
-vXz
-vXz
-vXz
-vXz
-vXz
 aKV
-fJc
-pZz
-mws
+vvE
+lpW
+xUg
+qUC
+qnh
+aKV
+iDb
+aKV
+iDb
 aFm
-vEx
-rfh
-eqG
-aFn
-aad
+ixE
+moH
+aFm
+aaa
+aaa
+eqU
+qYo
 bhd
 biO
 bky
@@ -168268,15 +167500,15 @@ bXR
 bZY
 cbL
 bLs
-jtC
+rvp
 gFW
-jtC
+rvp
+naN
 bgZ
-aaa
-aad
-aaa
-aaa
-cns
+wYd
+wYd
+wYd
+wYd
 aaa
 cuM
 cwf
@@ -168467,36 +167699,36 @@ aaa
 aaa
 aaa
 aaa
-aaa
 uHd
 aaa
-uHd
-aaa
-aUA
+vVc
+kQT
+hQA
+vmv
 ihX
 uKf
-xeR
-poi
-bNa
-nqS
+hew
+yfl
+yfl
+yfl
 vXr
-piT
-ijr
-tKa
-sVY
+ood
+pJb
+nkV
+wAy
 aMm
-ver
-aPq
 aKV
-aPn
-pZz
+aPq
 piT
-aUA
-vEx
-nai
-err
+tHM
 aFm
-aaa
+aFn
+hDo
+aFm
+aFm
+aFm
+qYo
+qYo
 bhd
 biP
 biP
@@ -168529,7 +167761,7 @@ bgZ
 biy
 bgZ
 bgZ
-aaa
+bgZ
 aad
 aad
 ajr
@@ -168724,36 +167956,36 @@ aaa
 aaa
 aaa
 aaa
-aaa
 uHd
+aaa
 qYo
-uHd
-aaa
-aUA
-lMM
+mCf
+mCf
+mCf
+xtB
 rJj
-adw
-fiN
-sgI
-aWr
-qBC
-sgm
-tFH
+xjZ
+xcU
+xcU
+jyg
+xcU
 iua
-nkV
+iua
+iua
 aMn
-aWr
-xxj
-aKV
+aMn
+vna
+ujd
+gKy
 eEX
-dAD
-nFp
-oql
-vEx
+aFm
+sSG
+moH
+gVB
 uIb
-aFm
-aFm
-aad
+eda
+aaa
+qYo
 aad
 biP
 bkz
@@ -168981,36 +168213,36 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+qYo
+uHd
 qYo
 qYo
-aFm
-aFm
-aFm
-aFm
+aaa
+aaa
+xtB
+uKf
+hew
 ubH
 iMR
-qCu
+yfl
 wKn
 utK
-hwc
-tKa
-nlR
+wAy
+iua
+xxj
 aMo
-iAx
-oEY
 aKV
-iDb
-aKV
-iDb
 aFm
-fta
-uPf
+aFm
+aFm
+aFm
+kwM
+moH
+gVB
+uIb
 aFn
 aaa
-aad
+qYo
 aaa
 biQ
 bkA
@@ -169239,35 +168471,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aad
-aaa
-aaa
-aaa
-aaa
-aFm
-aFm
-aKV
-aKV
+uHd
+qYo
+qYo
+xtB
+vXz
+jWj
+iPV
+vXz
+vXz
+oLW
 dnm
-aKV
-aKV
-aKV
-pJb
+vXz
+wFg
+rLe
+pcD
 aMp
-wAy
+uSW
 aPt
-aKV
-ggt
-piT
-ggt
+fgQ
+fbZ
 aFm
+ggt
+moH
 eXa
 rfh
 aFn
-aad
-aad
+qYo
+qYo
 aad
 biQ
 bkB
@@ -169496,35 +168728,35 @@ aaa
 aaa
 aaa
 aaa
-vVc
 qYo
 uHd
-uHd
-uHd
-uHd
-qYo
-qYo
-aUA
+aaa
+aaa
+iPw
+jPv
+guM
+ghQ
+vXz
 fDA
 sdP
 yfD
-gZX
+vXz
 vyv
-aKV
+wtx
 wDi
 rwd
-rjE
+uSW
 iCN
-aKV
+npn
 aSJ
-iAK
-aWm
-aXR
-hxr
-wnL
+aFm
+jvj
+moH
+gVB
+uIb
 aFn
 aaa
-aad
+qYo
 aaa
 biQ
 bkC
@@ -169753,35 +168985,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 qYo
+uHd
 aaa
 aaa
-aaa
-aUA
+iPw
+lan
+lan
+eDO
+vXz
 bzW
-qsj
-gEN
-aWr
+wDB
+haq
+vXz
 gRM
-aKV
-oBa
 wtx
-wAy
+wtx
+wtx
+itB
 aPu
-aKZ
-aKZ
-aKZ
-aKZ
-aKZ
-oPl
-rdP
+iUR
+wIO
 aFm
-aad
-aad
+rmM
+moH
+oPl
+uIb
+aFm
+qYo
+qYo
 aad
 biP
 bkD
@@ -170010,35 +169242,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aGH
-aaa
+qYo
 uHd
 aaa
 aaa
-aaa
-aUA
+iPw
+oiv
+sNa
+vqA
+vXz
 fCE
 jwH
 pmV
-piT
+vXz
 uoy
-aKV
-obd
+kPg
+wDi
 plN
-syv
-mbQ
 aKZ
-vOt
-nbL
-kOb
 aKZ
-sif
+aKZ
+aKZ
+aKZ
 aFn
+bZW
 aFm
-aad
+aFm
+aFm
 aaa
+qYo
 aad
 biP
 biP
@@ -170265,37 +169497,37 @@ aaa
 aaa
 aaa
 aaa
+aGH
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-uHd
 qYo
 uHd
 qYo
-aFm
-aFm
-aUA
-aUA
-aUA
-aFm
-aFm
+qYo
+xtB
+xtB
+xtB
+xtB
+xtB
+kjj
+kjj
+kjj
+vXz
+fqv
+ewc
+iry
+cyT
 aKZ
-aKZ
-aKZ
-aKZ
-aKZ
+taU
+pmq
 jar
-btk
-sQU
-xYy
-kzD
-bbp
-aFm
-aFm
-aFm
+aKZ
+ixE
+moH
+ixE
+eda
+qYo
+qYo
+qYo
 aad
 aaa
 biP
@@ -170524,35 +169756,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+qYo
+qYo
 uHd
+qYo
+qYo
 aaa
 aaa
 aaa
+qYo
 aaa
 aaa
 aaa
-aaa
-aaa
-oCf
-qjI
-uBf
-aMr
-mNI
-syn
-uKn
-rYt
 aKZ
-ier
-gfr
-hGT
-gOU
-rYu
+aKZ
+aKZ
+aKZ
+aKZ
+aKZ
+naj
+odB
+syn
+xYy
+rYt
+hkM
+aFm
+aFm
+aFm
+vVc
+vVc
 abj
 aaa
 biP
@@ -170784,9 +170016,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+fdw
 uHd
 qYo
 vVc
@@ -170795,21 +170025,23 @@ vVc
 qYo
 qYo
 aaa
-aaa
+swR
 oCf
+qjI
+lRT
 aMr
-qsy
-elQ
+mNI
+lkn
 meZ
 wNW
-fgv
-vzh
 aKZ
-gLf
-aFn
-aFm
-aKV
-aFm
+lIN
+vmN
+hGT
+gOU
+rYu
+vVc
+vVc
 aad
 aad
 biP
@@ -171042,9 +170274,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-qYo
+uHd
 aaa
 aaa
 aaa
@@ -171054,19 +170284,21 @@ aad
 aaa
 aaa
 oCf
-qxy
+aMr
+tqY
+elQ
 jud
-eIr
-uKr
+syn
+meZ
 rgs
-nkc
-unK
 aKZ
-qyo
-rlh
-nTk
+mZm
+fYi
+aFm
 aKV
-aaa
+aFm
+vVc
+vVc
 aad
 aaa
 biP
@@ -171299,31 +170531,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 qYo
 uHd
 uHd
 uHd
-qYo
+uHd
 aFo
 aad
 aad
 aad
+oCf
+qxy
+pNN
+eIr
+uKr
+nbx
+ouZ
+wyx
 aKZ
-aKZ
-aKZ
-aKZ
-aKZ
-rVw
-xve
-aSO
-aKZ
+aWq
+lZy
 aZJ
-tUG
-myL
-aFn
-aaa
+aKV
+qYo
+qYo
+qYo
 aad
 aaa
 biP
@@ -171561,25 +170793,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ajr
 ajr
 ajr
-aaa
-qYo
-qYo
-qYo
 aaa
 aKZ
-wmk
-rFP
-mwm
 aKZ
-tij
+aKZ
+aKZ
+aKZ
+rVw
+pxS
+aSO
+aKZ
 aWr
-aZL
-aKV
+uoA
+tij
+aFn
+aaa
+aaa
 aaa
 aad
 aaa
@@ -171820,8 +171052,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 qYo
 qYo
 ajr
@@ -171829,15 +171059,17 @@ ajr
 ajr
 aaa
 aKZ
+wmk
+nhK
+uTv
 aKZ
-aKZ
-aKZ
-aKZ
-uSW
-mTM
-uSW
+lHP
+aWr
+aZL
 aKV
-aad
+qYo
+qYo
+qYo
 ajr
 ajr
 ajr
@@ -172077,23 +171309,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 vVc
 vVc
 aaa
 aaa
 qYo
 qYo
-qYo
-aaa
-aaa
-aad
+aKZ
+aKZ
+aKZ
+aKZ
+aKZ
+uSW
+qok
+uSW
 aKV
-pIf
-pIf
-npG
-aKV
+eqU
+aaa
 aaa
 aaa
 aaa
@@ -172338,8 +171570,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 vVc
 vVc
 vVc
@@ -172347,11 +171577,13 @@ aaa
 ajr
 aad
 aKV
-xZM
-shb
-xZM
+pIf
+pIf
+npG
 aKV
-aad
+qYo
+qYo
+qYo
 aad
 ajr
 ajr
@@ -172599,15 +171831,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ajr
 aad
 aKV
-aaa
-aaa
-aaa
+xZM
+shb
+xZM
 aKV
+eqU
+aaa
 aaa
 aaa
 aaa
@@ -172858,13 +172090,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-qYH
+aKV
 aaa
 aaa
 aaa
-qYH
+aKV
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -173115,11 +172347,11 @@ aaa
 aaa
 aaa
 aaa
+qYH
 aaa
 aaa
 aaa
-aaa
-aaa
+qYH
 aaa
 aaa
 aaa
@@ -173375,8 +172607,8 @@ aaa
 aaa
 aaa
 aaa
+eqU
 aaa
-fOT
 aaa
 aaa
 aaa
@@ -173622,7 +172854,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aab
 aaa
 aaa
@@ -173632,6 +172863,7 @@ aaa
 aaa
 aaa
 aaa
+kbG
 aaa
 aaa
 aaa


### PR DESCRIPTION
Ports the changes to security and the prison from the previous build:

Includes the prison remapping which essentially expanded the permabrig, added essentials like a kitchen and hydro tools, more lounging areas and a better isolation cell. Nothing new here
![image](https://user-images.githubusercontent.com/43841046/113773268-aa5a1780-96da-11eb-9823-fbf317fdfedc.png)

Ports changes to medical and the meeting room by Floofy
![image](https://user-images.githubusercontent.com/43841046/113773276-af1ecb80-96da-11eb-822b-f7504b99bd54.png)

Includes changes to the sec prep room to make it bigger and have 8 lockers, while also making the shooting range a little bigger.
![image](https://user-images.githubusercontent.com/43841046/113773303-b514ac80-96da-11eb-951b-9a9fe4f013f3.png)

Also makes all the tiles dark instead of grey again. Proof of functionality: I ran build and played it, and nothing catastrophic happened with atmospherics. All pipes were properly connected, maybe smart pipes aren't entirely annoying.
![image](https://user-images.githubusercontent.com/43841046/113773326-be057e00-96da-11eb-899d-e40101577196.png)

### Changelog
🆑
add: Re-added Deltastation's security and prison changes from before the map reset. Decently stocked kitchen and non-cramped sec locker room are a go
/🆑