### PR TITLE
Metastation map port (Security)

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -47,7 +47,7 @@
 /area/space)
 "aaw" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aax" = (
 /turf/closed/wall/r_wall,
@@ -59,13 +59,13 @@
 /obj/item/clothing/mask/muzzle,
 /obj/item/electropack,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aaA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -73,9 +73,8 @@
 /area/security/execution/education)
 "aaB" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aaC" = (
@@ -92,12 +91,21 @@
 	dir = 4;
 	pixel_x = -32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aaE" = (
-/obj/item/toy/plush/beeplushie{
-	desc = "Maybe hugging this will make you feel better about yourself.";
-	name = "Therabee"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -105,24 +113,24 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "aaG" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/execution/education)
 "aaH" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
 /area/security/execution/education)
 "aaI" = (
 /obj/machinery/door/window/brigdoor{
@@ -144,7 +152,10 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -237,7 +248,12 @@
 	pixel_y = 26;
 	req_access_txt = "3"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aaQ" = (
@@ -251,7 +267,15 @@
 /obj/item/storage/fancy/cigarettes,
 /obj/item/assembly/flash/handheld,
 /obj/item/reagent_containers/spray/pepper,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aaS" = (
@@ -260,12 +284,25 @@
 	name = "old sink";
 	pixel_y = 28
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aaT" = (
 /obj/structure/closet/secure_closet/injection{
 	name = "educational injections";
 	pixel_x = 2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
@@ -307,14 +344,14 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "abb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "abc" = (
@@ -337,13 +374,8 @@
 /turf/closed/wall,
 /area/security/prison)
 "abf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/obj/effect/spawner/randomcolavend,
+/turf/open/floor/iron/dark/blue/side,
 /area/security/prison)
 "abn" = (
 /obj/item/radio/intercom{
@@ -357,18 +389,19 @@
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "abo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "abp" = (
@@ -380,13 +413,13 @@
 	pixel_x = -4;
 	pixel_y = -25
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "abr" = (
@@ -398,13 +431,14 @@
 	req_access_txt = "3"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/execution/education)
 "abu" = (
 /obj/docking_port/stationary{
@@ -437,6 +471,12 @@
 	prison_radio = 1
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/security/prison)
 "abC" = (
@@ -445,8 +485,19 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "abD" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/storage/bag/trash,
+/obj/item/mop,
+/obj/item/pushbroom,
+/obj/item/storage/box/masks,
+/obj/item/storage/box/gloves,
+/obj/item/stack/medical/gauze/twelve,
+/obj/item/stack/medical/splint/twelve,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 4
+	},
 /area/security/prison/safe)
 "abF" = (
 /obj/machinery/meter,
@@ -454,7 +505,6 @@
 	dir = 1;
 	name = "gas ports"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "abG" = (
@@ -474,30 +524,49 @@
 /turf/closed/wall,
 /area/security/execution/education)
 "abK" = (
-/obj/structure/chair/stool,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
 /area/security/prison)
 "abL" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/prison)
 "abM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "abN" = (
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "abO" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -510,13 +579,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "abZ" = (
-/obj/item/storage/bag/trash,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 8
+	},
 /area/security/prison/safe)
 "aca" = (
 /obj/item/tank/internals/oxygen/red{
@@ -547,7 +619,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "acb" = (
@@ -562,7 +633,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "ace" = (
@@ -628,6 +698,8 @@
 	name = "Cleaning Closet"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
 "acv" = (
@@ -674,14 +746,13 @@
 	pixel_y = 24;
 	prison_radio = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "acI" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "acJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -691,7 +762,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "acK" = (
 /obj/structure/grille/broken,
@@ -727,7 +798,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 26
 	},
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/security/prison)
 "acS" = (
 /obj/structure/closet/crate/necropolis{
@@ -756,13 +827,9 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Cell 4"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue,
 /area/security/prison/safe)
 "adb" = (
 /turf/open/floor/iron/dark/side{
@@ -772,7 +839,7 @@
 "add" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/beach_ball/holoball,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "ade" = (
 /obj/machinery/door/airlock/security/glass{
@@ -780,31 +847,34 @@
 	req_access_txt = "2"
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "adg" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "adh" = (
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
 /area/security/prison)
 "adi" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/iron,
+/obj/structure/curtain/bounty,
+/turf/open/floor/iron/dark/blue,
 /area/security/prison)
 "adk" = (
 /obj/structure/disposalpipe/segment{
@@ -826,8 +896,14 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "adr" = (
@@ -860,14 +936,13 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "adw" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "adx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -881,6 +956,9 @@
 /obj/structure/plasticflaps/opaque{
 	name = "Prisoner Transfer"
 	},
+/obj/machinery/door/window/brigdoor{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "ady" = (
@@ -889,15 +967,21 @@
 	dir = 4;
 	network = list("ss13","prison")
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/security/prison)
 "adA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 4
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "adB" = (
 /obj/structure/cable,
@@ -914,7 +998,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "adF" = (
 /obj/docking_port/stationary{
@@ -928,20 +1012,14 @@
 /turf/open/space/basic,
 /area/space)
 "adG" = (
-/obj/machinery/computer/bookmanagement,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
-"adM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 8
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "adO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -956,19 +1034,23 @@
 "adS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "adW" = (
-/obj/structure/rack,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
-/turf/open/floor/iron,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
 /area/security/prison)
 "adY" = (
 /turf/closed/wall/r_wall,
@@ -999,46 +1081,45 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Cell 3"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue,
 /area/security/prison/safe)
 "aej" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison)
-"ael" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/landmark/start/prisoner,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 4
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "aem" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "aen" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "aep" = (
@@ -1053,6 +1134,12 @@
 /obj/machinery/suit_storage_unit/security_peacekeeper,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"aes" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/security/prison)
 "aey" = (
 /turf/closed/wall,
 /area/security/range)
@@ -1072,49 +1159,15 @@
 "aeJ" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/safe)
-"aeU" = (
-/obj/structure/chair/stool,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"aeX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/iron,
-/area/security/brig)
-"aeZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
-"afa" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/structure/cable,
-/obj/item/instrument/harmonica,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "afd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 8
+	},
 /area/security/prison)
 "aff" = (
 /obj/structure/filingcabinet/security{
@@ -1130,12 +1183,15 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "afh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "afD" = (
 /turf/open/floor/engine{
@@ -1157,9 +1213,9 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Cell 1"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue,
 /area/security/prison/safe)
 "afL" = (
 /obj/structure/table/glass,
@@ -1185,8 +1241,15 @@
 /turf/open/floor/iron,
 /area/medical/treatment_center)
 "afM" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 4
+	},
 /area/security/prison)
 "afN" = (
 /obj/machinery/suit_storage_unit/security,
@@ -1230,25 +1293,23 @@
 	name = "Security Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/security/brig)
-"afS" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "Security Blast Door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "afT" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "afU" = (
-/obj/structure/table,
-/turf/open/floor/iron/dark/side,
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/prisoner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 8
+	},
 /area/security/prison)
 "afW" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -1329,6 +1390,7 @@
 	departmentType = 5;
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "agb" = (
@@ -1458,8 +1520,8 @@
 /area/security/brig)
 "agK" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -1473,16 +1535,15 @@
 	pixel_x = 26;
 	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "agN" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
 /area/security/prison)
 "agQ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -1501,13 +1562,13 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "agT" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "agU" = (
 /obj/item/radio/intercom{
@@ -1516,13 +1577,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "agV" = (
 /obj/structure/lattice/catwalk,
@@ -1607,65 +1665,38 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "ahu" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/structure/cable,
+/obj/structure/disposaloutlet{
+	dir = 8;
+	name = "Prisoner Delivery"
 	},
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
+/obj/structure/disposalpipe/trunk{
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/blue/side,
 /area/security/prison)
 "ahx" = (
 /turf/closed/wall,
 /area/security/brig)
 "ahy" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/machinery/turnstile{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ahz" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/structure/window/reinforced{
+/obj/effect/spawner/randomarcade{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/iron/dark/blue/side,
 /area/security/prison)
 "ahA" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/turnstile,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ahD" = (
 /obj/item/stack/rods,
@@ -1676,22 +1707,38 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
+	},
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/head/bio_hood/security,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ahF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/trimline/darkblue/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ahH" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/cargo/sorting)
+"ahQ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "ahR" = (
 /obj/item/cigbutt,
 /turf/open/floor/plating,
@@ -1808,26 +1855,16 @@
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aiv" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Laundry";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/structure/window/reinforced{
+/obj/effect/spawner/randomarcade{
 	dir = 1
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/light,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
 /area/security/prison)
 "aiw" = (
 /obj/structure/sign/warning/pods{
@@ -1835,7 +1872,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/arrows/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aix" = (
 /obj/structure/closet{
@@ -1849,6 +1892,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -1876,6 +1925,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "aiz" = (
@@ -1889,6 +1941,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -1906,7 +1961,13 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aiE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2014,6 +2075,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "ajr" = (
@@ -2027,7 +2091,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "ajt" = (
@@ -2048,6 +2114,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "aju" = (
@@ -2058,9 +2127,6 @@
 /area/maintenance/disposal/incinerator)
 "ajv" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
@@ -2111,13 +2177,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"ajU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "akd" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -2243,7 +2302,7 @@
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "akv" = (
 /obj/machinery/light/small,
@@ -2253,7 +2312,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "akw" = (
 /obj/machinery/door/airlock/security/glass{
@@ -2267,24 +2326,25 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
-"aky" = (
+"akz" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig)
-"akz" = (
-/obj/structure/chair/stool,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "akA" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -2297,12 +2357,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "akB" = (
@@ -2318,6 +2379,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -2341,9 +2405,6 @@
 "akD" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/corner,
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -2380,9 +2441,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "akV" = (
@@ -2539,12 +2598,6 @@
 	dir = 1
 	},
 /area/security/prison)
-"alQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "alR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -2627,35 +2680,17 @@
 /obj/item/storage/crayons,
 /turf/open/space/basic,
 /area/space/nearstation)
-"amD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "amH" = (
 /obj/machinery/door/airlock/external{
 	req_one_access_txt = "13,8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"amI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+"amJ" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/security/brig)
-"amJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "amN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2803,13 +2838,24 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "ani" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera{
+	c_tag = "Prison Central";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/security/prison)
 "anl" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -2875,8 +2921,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -2905,13 +2951,10 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "anB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "anD" = (
 /obj/machinery/door/airlock/maintenance{
@@ -2936,7 +2979,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "anM" = (
 /obj/machinery/space_heater,
@@ -3102,20 +3146,15 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aos" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aou" = (
 /obj/structure/rack,
@@ -3149,6 +3188,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aov" = (
@@ -3316,7 +3356,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "apm" = (
 /turf/closed/wall,
@@ -3410,12 +3450,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "apF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "apG" = (
 /obj/effect/turf_decal/stripes/line,
@@ -3446,10 +3486,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "apP" = (
@@ -3726,16 +3762,17 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Brig - Hallway - Port"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "arb" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -3780,12 +3817,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "arf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Armory";
-	req_access_txt = "3"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -3796,8 +3827,16 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "armory";
+	name = "armory shutters"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "arh" = (
@@ -4043,88 +4082,92 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asn" = (
-/obj/structure/closet/crate,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/onion,
-/obj/item/food/grown/onion,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
+/obj/effect/decal/cleanable/food/flour,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "asp" = (
 /obj/structure/closet/bombcloset/security,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/head/bomb_hood/security,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "asq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/security/brig)
-"ass" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"ass" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ast" = (
 /obj/machinery/camera{
 	c_tag = "Brig - Hallway - Entrance"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "asv" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig)
-"asw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
-"asz" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
+"asw" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"asz" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "asB" = (
 /obj/machinery/light/small{
@@ -4134,11 +4177,23 @@
 /area/maintenance/starboard/fore)
 "asC" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
+"asO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Workshop"
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/security/prison)
 "asP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
@@ -4357,7 +4412,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "atM" = (
 /obj/structure/disposalpipe/segment,
@@ -4365,27 +4421,31 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "atN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "atO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "atP" = (
 /obj/structure/disposalpipe/segment{
@@ -4589,12 +4649,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "auV" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "auW" = (
 /obj/structure/sign/warning/pods,
@@ -4617,29 +4677,38 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "auZ" = (
 /obj/machinery/computer/shuttle/labor{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ava" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "avb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "avc" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -4658,46 +4727,49 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "avf" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "avh" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "avi" = (
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 8;
 	pixel_x = 30
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "avj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -4914,60 +4986,72 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "avZ" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "awa" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+	dir = 10
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "awb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 10
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "awc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "awe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+	dir = 10
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "awf" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "awg" = (
 /obj/structure/chair/office{
@@ -4977,7 +5061,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "awi" = (
 /mob/living/simple_animal/bot/secbot/beepsky{
@@ -4986,14 +5070,17 @@
 	maxHealth = 45;
 	name = "Officer Beepsky"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "awj" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "awl" = (
 /obj/structure/disposalpipe/segment{
@@ -5003,7 +5090,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "awo" = (
 /obj/structure/cable,
@@ -5020,24 +5107,25 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "awr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "awt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "awu" = (
 /obj/machinery/door/firedoor,
@@ -5190,7 +5278,10 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "awZ" = (
 /obj/structure/disposalpipe/segment,
@@ -5238,7 +5329,7 @@
 /obj/machinery/computer/prisoner/management{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "axi" = (
 /obj/structure/cable,
@@ -5262,7 +5353,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "axn" = (
 /obj/structure/cable,
@@ -5282,7 +5374,8 @@
 /area/security/courtroom)
 "axr" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "axs" = (
 /obj/machinery/airalarm{
@@ -5294,19 +5387,26 @@
 	c_tag = "Brig - Hallway - Starboard";
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "axt" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "axv" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "axw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -5412,7 +5512,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "axS" = (
 /obj/structure/disposalpipe/segment{
@@ -5453,7 +5556,8 @@
 	name = "Cell 1";
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ayw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -5476,12 +5580,13 @@
 	},
 /obj/effect/landmark/event_spawn,
 /obj/machinery/light,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ayy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "ayz" = (
 /obj/structure/cable,
@@ -5489,7 +5594,7 @@
 /obj/structure/bed/dogbed/mcgriff,
 /obj/machinery/power/apc/auto_name/north,
 /mob/living/simple_animal/pet/dog/pug/mcgriff,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "ayB" = (
 /obj/structure/cable,
@@ -5497,7 +5602,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "ayC" = (
 /obj/structure/cable,
@@ -5634,27 +5739,35 @@
 	pixel_x = 32;
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "azD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+	dir = 10
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "azE" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/secure_closet/warden,
 /obj/item/gun/energy/laser,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "azN" = (
 /obj/machinery/door/firedoor,
@@ -5665,22 +5778,27 @@
 	req_access_txt = "63"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "azO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "azP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "azQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -5823,6 +5941,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aAs" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/wood,
+/area/security/prison)
 "aAx" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Aft";
@@ -5865,9 +5987,12 @@
 	name = "Cell 1"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aAT" = (
 /obj/machinery/door/window/brigdoor/security/cell{
@@ -5875,9 +6000,12 @@
 	name = "Cell 2"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aAV" = (
 /obj/machinery/door/airlock/external{
@@ -5913,9 +6041,14 @@
 	name = "Cell 3"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aAY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5924,7 +6057,10 @@
 	name = "Cell 1 Locker"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aBa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5933,13 +6069,16 @@
 	name = "Cell 3 Locker"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aBb" = (
 /obj/effect/landmark/start/warden,
 /obj/structure/chair/office,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "aBc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -5952,8 +6091,13 @@
 /area/security/warden)
 "aBe" = (
 /obj/machinery/holopad,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aBf" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -5970,7 +6114,7 @@
 /area/hallway/primary/central)
 "aBi" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aBj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5978,7 +6122,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aBk" = (
 /obj/structure/disposalpipe/segment,
@@ -6140,7 +6284,7 @@
 	req_access_txt = "2"
 	},
 /obj/item/key/security,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "aCj" = (
 /obj/structure/table,
@@ -6170,7 +6314,7 @@
 	pixel_y = 7;
 	req_access_txt = "63"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "aCk" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6195,8 +6339,10 @@
 /obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aCp" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6227,7 +6373,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aCs" = (
 /obj/structure/table,
@@ -6355,18 +6501,23 @@
 	req_access_txt = "2"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aDv" = (
 /turf/closed/wall,
 /area/hallway/primary/fore)
 "aDw" = (
-/obj/effect/landmark/start/junior_officer,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aDy" = (
 /obj/structure/chair/stool,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aDz" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6376,21 +6527,29 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/landmark/start/junior_officer,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aDB" = (
 /obj/structure/cable,
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aDC" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aDE" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "aDF" = (
 /obj/machinery/flasher{
@@ -6402,7 +6561,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aDH" = (
 /obj/structure/closet/secure_closet/brig,
@@ -6504,7 +6663,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aEH" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6518,18 +6677,21 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aEJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aEK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aEL" = (
 /obj/machinery/light/small{
@@ -6537,13 +6699,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aET" = (
 /obj/machinery/navbeacon{
@@ -6551,15 +6713,22 @@
 	location = "0-SecurityDesk"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aEV" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aEX" = (
 /obj/effect/landmark/event_spawn,
@@ -6589,7 +6758,8 @@
 /area/maintenance/fore)
 "aFt" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/landmark/start/junior_officer,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aFK" = (
 /obj/machinery/computer/security/mining{
@@ -6631,14 +6801,15 @@
 	network = list("prison");
 	pixel_x = -30
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "aGb" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aGd" = (
 /obj/machinery/firealarm{
@@ -6646,25 +6817,20 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aGf" = (
 /obj/machinery/light,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aGg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aGh" = (
 /obj/item/radio/intercom{
@@ -6683,50 +6849,38 @@
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aGj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aGl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aGn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
-"aGo" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
+"aGo" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aGq" = (
 /obj/machinery/door/firedoor,
@@ -6744,9 +6898,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aGr" = (
 /obj/structure/rack,
@@ -6767,7 +6926,7 @@
 /obj/item/restraints/handcuffs,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aGu" = (
 /obj/structure/filingcabinet,
@@ -6895,7 +7054,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aHt" = (
 /obj/structure/cable,
@@ -6923,13 +7082,8 @@
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aHx" = (
 /turf/closed/wall/r_wall,
@@ -6950,7 +7104,8 @@
 /turf/closed/wall,
 /area/security/courtroom)
 "aHE" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aHH" = (
 /obj/machinery/door/airlock/maintenance{
@@ -7057,13 +7212,8 @@
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aIu" = (
 /obj/structure/cable,
@@ -7133,7 +7283,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aIL" = (
 /obj/structure/closet/secure_closet/courtroom,
@@ -7233,7 +7383,7 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aJv" = (
 /obj/effect/turf_decal/stripes/line,
@@ -7278,7 +7428,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aJV" = (
 /obj/effect/turf_decal/tile/red,
@@ -7286,7 +7436,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aJW" = (
 /obj/machinery/door/firedoor,
@@ -7518,7 +7668,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aLz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7551,6 +7701,22 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard/fore)
+"aLT" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Gear Room";
+	req_one_access_txt = "1;4"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "aLZ" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating{
@@ -7637,7 +7803,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aMK" = (
 /obj/machinery/firealarm{
@@ -7735,6 +7901,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "aNC" = (
@@ -7756,14 +7925,23 @@
 	network = list("isolation");
 	pixel_y = 31
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aNL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aNS" = (
 /obj/structure/cable,
@@ -8013,7 +8191,7 @@
 	location = "16-Fore"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aPA" = (
 /obj/machinery/firealarm{
@@ -8027,7 +8205,7 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aPB" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -8081,6 +8259,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"aPN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 4
+	},
+/area/security/prison)
 "aPS" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/fyellow,
@@ -8094,6 +8290,11 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
+"aQj" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "aQl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
@@ -8183,7 +8384,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aQF" = (
 /obj/structure/cable,
@@ -8320,7 +8521,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aRX" = (
 /obj/machinery/door/firedoor,
@@ -8495,10 +8696,11 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aTb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9137,10 +9339,8 @@
 "aVG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aVM" = (
 /obj/machinery/door/airlock/mining{
@@ -10788,7 +10988,12 @@
 /obj/structure/bed,
 /obj/item/bedsheet/red,
 /obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
 /area/security/prison/safe)
 "bca" = (
 /obj/machinery/door/poddoor{
@@ -10827,6 +11032,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
+"bcf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "bcg" = (
 /turf/closed/wall,
 /area/maintenance/central)
@@ -10874,6 +11083,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"bcy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
+/area/security/prison/safe)
 "bcO" = (
 /obj/structure/easel,
 /turf/open/floor/plating{
@@ -11556,6 +11772,15 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
+"bgX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/security/prison)
 "bhe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -12268,10 +12493,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bkx" = (
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
-/turf/open/floor/iron/white,
+/obj/structure/table,
+/obj/item/storage/fancy/egg_box,
+/turf/open/floor/iron/dark/yellow/side,
 /area/security/prison)
 "bky" = (
 /obj/machinery/door/firedoor,
@@ -14355,6 +14579,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"bxa" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/security/prison)
 "bxn" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -14729,6 +14958,12 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"bAC" = (
+/obj/machinery/vending/wardrobe/peacekeeper_wardrobe,
+/obj/structure/cable,
+/obj/effect/turf_decal/bot_blue,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "bAJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -14920,6 +15155,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"bBU" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/prison)
+"bCu" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "bCz" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
@@ -16027,6 +16280,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"bId" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "bIj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -16060,12 +16320,13 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "bIL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/light_switch{
 	pixel_x = -24;
 	pixel_y = -24
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "bJg" = (
@@ -16606,6 +16867,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"bNP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/security/prison)
 "bNX" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -16672,18 +16941,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bOL" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/light_switch{
+	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "bON" = (
 /obj/structure/sign/warning/securearea{
@@ -16703,6 +16965,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"bOQ" = (
+/obj/structure/chair/sofa/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "bOS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16864,6 +17136,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"bQs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/bed/roller,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "bQx" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Gateway Maintenance";
@@ -19873,12 +20157,18 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cdY" = (
-/obj/structure/lattice,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -32
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "ced" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20788,6 +21078,25 @@
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"chq" = (
+/obj/item/implanter{
+	pixel_x = 5;
+	pixel_y = 12
+	},
+/obj/item/storage/box/evidence{
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/obj/item/toy/crayon/white{
+	pixel_y = -4
+	},
+/obj/item/toy/crayon/white{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "chC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21703,6 +22012,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"clD" = (
+/obj/structure/table/wood,
+/obj/item/camera_film{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/camera{
+	pixel_y = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "clK" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Psychology Maintenance";
@@ -22373,14 +22696,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"cpk" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "cpC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -23007,6 +23322,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"csL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "csT" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable,
@@ -23405,7 +23724,9 @@
 /obj/structure/toilet/greyscale{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
 /area/security/prison/safe)
 "cwc" = (
 /obj/effect/turf_decal/stripes/line,
@@ -24025,6 +24346,12 @@
 /area/medical/medbay/central)
 "cBe" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/security/prison)
 "cBr" = (
@@ -24637,12 +24964,16 @@
 	},
 /area/engineering/atmos)
 "cFu" = (
-/obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/servingdish,
-/obj/machinery/light{
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
 /area/security/prison)
 "cFv" = (
 /obj/structure/chair{
@@ -24827,11 +25158,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"cGs" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "cGA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/reinforced,
@@ -24929,6 +25255,23 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
+"cGT" = (
+/obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/food/flour,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "cGU" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -26006,6 +26349,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"cLM" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "cLN" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -26761,6 +27114,12 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cPK" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "cPO" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Port Aft";
@@ -26876,14 +27235,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "cQz" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Security - Gear Room";
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/vending/wardrobe/peacekeeper_wardrobe,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "cQJ" = (
@@ -27086,10 +27444,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"cTB" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/security/range)
 "cTG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -27126,7 +27480,10 @@
 	name = "Cell 2 Locker"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "cUW" = (
 /obj/machinery/door/airlock/atmos/glass{
@@ -27453,6 +27810,7 @@
 	pixel_y = 6
 	},
 /obj/structure/table,
+/obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "cYJ" = (
@@ -27551,27 +27909,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"cZk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Weapon Distribution";
-	req_access_txt = "3"
-	},
-/obj/item/paper,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/door/window/southleft{
-	name = "Requests Window"
-	},
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
 "cZq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -27615,10 +27952,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "dah" = (
@@ -27823,6 +28160,16 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"dfb" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/machinery/camera{
+	c_tag = " Prison - Library";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "dfo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/line,
@@ -27989,7 +28336,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "dha" = (
 /obj/structure/lattice,
@@ -28043,7 +28390,7 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "dhw" = (
 /obj/structure/closet,
@@ -28298,8 +28645,10 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "diF" = (
 /obj/structure/disposalpipe/segment,
@@ -28541,7 +28890,7 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "dnd" = (
 /obj/structure/closet/firecloset,
@@ -28595,7 +28944,7 @@
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "dnO" = (
 /obj/machinery/space_heater,
@@ -28671,10 +29020,18 @@
 /turf/closed/wall,
 /area/service/library)
 "doZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "dpk" = (
 /obj/item/cigbutt,
@@ -28749,15 +29106,27 @@
 "dqB" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/office)
+"dqO" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "dqT" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
+"dqW" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "drf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -28983,9 +29352,14 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "dua" = (
 /obj/structure/table,
@@ -29234,6 +29608,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"dxl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison)
 "dxt" = (
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron,
@@ -29490,6 +29872,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/item/gun/energy/laser/practice,
+/obj/item/gun/energy/laser/practice,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "dAC" = (
@@ -29593,11 +29981,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "dCh" = (
 /obj/machinery/firealarm{
@@ -29624,7 +30009,7 @@
 	pixel_x = -10;
 	pixel_y = -6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "dCi" = (
 /obj/structure/closet,
@@ -29923,7 +30308,11 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/secateurs,
+/obj/item/seeds/pumpkin,
+/obj/item/storage/bag/plants,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "dGb" = (
 /obj/structure/window/reinforced{
@@ -29935,11 +30324,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
-"dGI" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "dGP" = (
 /obj/structure/training_machine,
 /turf/open/floor/engine,
@@ -30102,19 +30486,17 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "dKN" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/pen,
-/obj/item/storage/box/prisoner,
 /obj/machinery/camera{
 	c_tag = "Prison Hallway Port";
 	dir = 1;
 	network = list("ss13","prison")
 	},
-/turf/open/floor/iron,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
 /area/security/prison)
 "dKO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -30270,6 +30652,16 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"dPK" = (
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/obj/effect/landmark/start/prisoner,
+/obj/item/wirecutters,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/security/prison/safe)
 "dPP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -30557,16 +30949,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
-"dXp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "dXq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -30603,7 +30985,7 @@
 "dYn" = (
 /obj/item/paper_bin/carbon,
 /obj/item/pen/fountain,
-/obj/structure/table,
+/obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "dYB" = (
@@ -30627,6 +31009,21 @@
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/engine,
 /area/science/cytology)
+"dZb" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Prison Laundry";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "dZe" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
@@ -30732,8 +31129,9 @@
 /area/space/nearstation)
 "ece" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/caution/stand_clear/blue,
+/obj/effect/turf_decal/bot_blue,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ecf" = (
 /obj/machinery/light{
@@ -30798,28 +31196,26 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"ecR" = (
-/obj/structure/table,
-/obj/item/clothing/under/rank/prisoner/skirt{
-	pixel_x = -13;
-	pixel_y = 5
+"ecN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Weapon Distribution";
+	req_access_txt = "3"
 	},
-/obj/item/clothing/under/rank/prisoner/skirt{
-	pixel_x = 9;
-	pixel_y = 5
-	},
-/obj/item/clothing/under/rank/prisoner{
-	pixel_x = -2;
-	pixel_y = 5
-	},
+/obj/item/paper,
+/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/window/southleft{
+	name = "Requests Window"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/turf/closed/wall/r_wall,
+/area/ai_monitored/security/armory)
+"ecR" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "ecY" = (
 /obj/structure/window/reinforced{
@@ -30840,8 +31236,9 @@
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "eda" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "edf" = (
@@ -30907,7 +31304,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "eeq" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -30988,6 +31385,13 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"eeV" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "efd" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -31064,6 +31468,12 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/commons/locker)
+"ehM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/side,
+/area/security/prison)
 "ehQ" = (
 /obj/structure/window/reinforced,
 /obj/structure/table,
@@ -31113,9 +31523,15 @@
 "ejE" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "ekh" = (
@@ -31281,6 +31697,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"eos" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "eoF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding,
@@ -31291,11 +31713,16 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "eoT" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/caution/stand_clear/blue,
+/obj/effect/turf_decal/bot_blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "eoW" = (
 /obj/machinery/light/small{
@@ -31349,7 +31776,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "eqe" = (
@@ -31468,6 +31897,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
+"etf" = (
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/wood,
+/area/security/prison)
 "etj" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -31550,18 +31983,6 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"evw" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
-/obj/machinery/door/airlock/security/glass{
-	name = "Gear Room";
-	req_one_access_txt = "1;4"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "evB" = (
 /obj/machinery/door/window/brigdoor{
 	name = "Command Desk";
@@ -31662,6 +32083,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"exe" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "exh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31715,6 +32143,13 @@
 /obj/machinery/computer/rdconsole,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"exP" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/security_peacekeeper,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "exS" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -31834,6 +32269,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
+"ezO" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "ezS" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
@@ -31975,21 +32419,27 @@
 	pixel_y = -30
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/structure/table,
+/obj/machinery/syndicatebomb/training,
+/obj/item/screwdriver{
+	pixel_x = -2;
+	pixel_y = 10
+	},
+/obj/item/wirecutters,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "eCv" = (
-/obj/structure/rack,
-/obj/item/vending_refill/security,
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "eCw" = (
@@ -32103,6 +32553,16 @@
 /obj/structure/toilet/greyscale{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/security/prison)
 "eEi" = (
@@ -32159,6 +32619,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"eFd" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
+/area/security/prison/safe)
 "eFy" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -32777,11 +33246,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"eRF" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "eRH" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -32812,8 +33276,14 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "eSd" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 4
+	},
 /area/security/prison)
 "eSm" = (
 /obj/effect/turf_decal/stripes/line,
@@ -33141,6 +33611,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
+"eYJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "eYQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -33192,6 +33677,21 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
+"eZQ" = (
+/obj/structure/table,
+/obj/machinery/newscaster{
+	pixel_x = -30
+	},
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = -6
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 9
+	},
+/area/security/prison)
 "eZS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -33420,6 +33920,15 @@
 /obj/machinery/navbeacon/wayfinding,
 /turf/open/floor/engine/cult,
 /area/service/library)
+"fgb" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "fgi" = (
 /obj/structure/tank_dispenser,
 /obj/machinery/light{
@@ -33495,6 +34004,19 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"fgZ" = (
+/obj/structure/rack,
+/obj/item/vending_refill/security_peacekeeper,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/flashbangs{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "fhc" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -33666,14 +34188,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"fjy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "fjA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -33696,16 +34210,17 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fjF" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -4;
-	pixel_y = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "fjG" = (
 /obj/structure/rack,
@@ -33912,37 +34427,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
-"fon" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/box/drinkingglasses,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "foq" = (
 /turf/open/floor/wood,
 /area/service/lawoffice)
@@ -33988,6 +34472,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
+"fpP" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -27
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "fqi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -34023,7 +34517,10 @@
 	pixel_x = 27
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "fqO" = (
 /obj/structure/sink{
@@ -34135,16 +34632,39 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "ftV" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/machinery/camera{
 	c_tag = "Prison Isolation Cell";
 	dir = 8;
 	network = list("ss13","prison","isolation")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
+/area/security/prison)
+"fud" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 16
+	},
+/obj/machinery/dish_drive,
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 5
+	},
 /area/security/prison)
 "fui" = (
 /obj/effect/turf_decal/stripes/line,
@@ -34224,8 +34744,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "fvz" = (
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/blue,
 /area/security/prison)
 "fvQ" = (
 /obj/machinery/door/airlock/engineering{
@@ -34346,12 +34865,10 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "fyo" = (
-/obj/structure/table,
-/obj/item/storage/box/prisoner{
-	pixel_y = 8
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 8
 	},
-/obj/item/storage/box/prisoner,
-/turf/open/floor/iron,
 /area/security/prison)
 "fys" = (
 /obj/structure/table/glass,
@@ -34505,13 +35022,6 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"fBP" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "fCe" = (
 /obj/machinery/door/airlock/security{
 	name = "Court Cell";
@@ -34579,7 +35089,7 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "fCX" = (
 /obj/item/radio/intercom{
@@ -34886,6 +35396,13 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/service/bar)
+"fJu" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/flasher/portable,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "fJA" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
@@ -34913,8 +35430,9 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "fJX" = (
-/obj/machinery/light_switch{
-	pixel_y = 26
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/freezer,
 /area/security/prison)
@@ -35005,6 +35523,7 @@
 	},
 /area/engineering/atmos)
 "fKX" = (
+/obj/machinery/light,
 /obj/machinery/button/door{
 	id = "PermaLockdown";
 	name = "Panic Button";
@@ -35012,31 +35531,8 @@
 	pixel_y = -24;
 	req_access_txt = "2"
 	},
-/obj/structure/cable,
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/blue/side,
 /area/security/prison)
-"fLj" = (
-/obj/structure/table,
-/obj/item/folder/red{
-	pixel_x = 14
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "fLC" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/purple/corner,
@@ -35197,6 +35693,12 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron/white,
 /area/maintenance/aft/secondary)
+"fNU" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "fOq" = (
 /obj/machinery/computer/robotics{
 	dir = 4
@@ -35439,24 +35941,14 @@
 	},
 /area/medical/treatment_center)
 "fUv" = (
-/obj/machinery/flasher/portable,
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = 30
-	},
-/obj/machinery/camera{
-	c_tag = "Security - Secure Gear Storage";
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -35570,6 +36062,30 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"fWv" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/item/clothing/gloves/color/orange,
+/obj/item/clothing/gloves/color/orange,
+/obj/item/clothing/gloves/color/orange,
+/obj/item/clothing/gloves/color/orange,
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "fWQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -35589,9 +36105,14 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "fXG" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 8
+	},
 /area/security/prison)
 "fXV" = (
 /obj/structure/disposalpipe/segment{
@@ -35876,9 +36397,8 @@
 /turf/open/floor/carpet,
 /area/service/theater)
 "geQ" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/dark/blue/side,
 /area/security/prison)
 "geT" = (
 /obj/structure/disposalpipe/segment{
@@ -35887,11 +36407,19 @@
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "gfP" = (
-/obj/structure/table,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/rice,
-/turf/open/floor/iron/white,
+/obj/machinery/chem_master/condimaster,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 4
+	},
 /area/security/prison)
 "gfU" = (
 /turf/closed/wall/r_wall,
@@ -35991,6 +36519,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"ghE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood,
+/area/security/prison)
 "ghG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/chapel{
@@ -36421,7 +36953,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "gnA" = (
 /obj/structure/window/reinforced{
@@ -36722,19 +37254,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"gtR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "gtU" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -36763,7 +37282,8 @@
 /area/science/mixing)
 "guu" = (
 /obj/structure/table,
-/turf/open/floor/iron/white,
+/obj/item/reagent_containers/food/condiment/milk,
+/turf/open/floor/iron/dark/yellow/side,
 /area/security/prison)
 "gux" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36785,12 +37305,14 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "guP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "guQ" = (
@@ -36814,14 +37336,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"gvK" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/sec{
-	pixel_y = 7
-	},
-/obj/item/storage/backpack/duffelbag/sec,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "gwb" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/purple{
@@ -36845,6 +37359,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"gwQ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "gxk" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -36959,18 +37483,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
-"gyR" = (
-/obj/structure/disposaloutlet{
-	dir = 8;
-	name = "Prisoner Delivery"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "gyU" = (
 /obj/structure/table/wood,
 /obj/item/paper,
@@ -37061,7 +37573,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "gAh" = (
@@ -37116,7 +37627,10 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gCa" = (
 /obj/structure/table,
@@ -37206,8 +37720,11 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "gDo" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
 /obj/effect/landmark/start/security_sergeant,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "gDt" = (
 /obj/machinery/camera{
@@ -37630,6 +38147,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
+"gJX" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/airlock/security/glass{
+	name = "Equipment Room";
+	req_access_txt = "1"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "gKe" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -37659,6 +38191,16 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/command/gateway)
+"gKI" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "gKO" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -37698,16 +38240,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "gMA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -37761,15 +38298,47 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "gNS" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/storage/box/drinkingglasses,
 /obj/item/radio/intercom{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
 	},
-/turf/open/floor/iron/white,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 5
+	},
 /area/security/prison)
 "gNT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -37798,6 +38367,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
+"gOr" = (
+/obj/structure/rack,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "gOu" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
@@ -37871,6 +38453,12 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"gPJ" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "gPS" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/blue,
@@ -37884,9 +38472,16 @@
 /area/medical/surgery/room_c)
 "gPT" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "gPV" = (
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -37947,6 +38542,12 @@
 /obj/structure/training_machine,
 /turf/open/floor/iron/dark,
 /area/security/range)
+"gRw" = (
+/obj/structure/chair/sofa,
+/obj/structure/cable,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/wood,
+/area/security/prison)
 "gRO" = (
 /obj/machinery/button/door{
 	id = "hosprivacy";
@@ -37979,20 +38580,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/bar)
-"gSc" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "gSe" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"gSJ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "gSV" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -38052,21 +38649,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
-"gTW" = (
-/obj/machinery/camera{
-	c_tag = "Security - Office - Port";
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "gTZ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "gUe" = (
 /obj/effect/turf_decal/stripes/line{
@@ -38074,6 +38666,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"gUm" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gUu" = (
 /obj/structure/sign/painting/library{
 	pixel_y = -32
@@ -38170,6 +38768,19 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
+"gVr" = (
+/obj/structure/table,
+/obj/item/toy/cards/deck,
+/obj/item/toy/cards/deck/wizoff{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/toy/cards/deck/kotahi{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "gVv" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -38382,12 +38993,14 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/white,
 /area/science/research)
-"haP" = (
-/obj/machinery/modular_computer/console/preset/id{
+"haK" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/security/office)
+/area/security/prison)
 "haS" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/blue{
@@ -38481,6 +39094,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/gateway)
+"hcP" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "hcY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -38658,6 +39280,17 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
+"hgT" = (
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/obj/effect/landmark/start/prisoner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/security/prison/safe)
 "hgX" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -38748,7 +39381,10 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "hjC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -38893,12 +39529,16 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "hlB" = (
-/obj/machinery/light,
-/obj/item/stack/sheet/cardboard{
-	amount = 14
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/trash/chips,
+/obj/item/trash/candy,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/item/stack/package_wrap,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
+	},
 /area/security/prison)
 "hlN" = (
 /obj/structure/table/reinforced,
@@ -39040,11 +39680,11 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "hnP" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Firing Range";
-	req_one_access_txt = "1;4"
-	},
 /obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/airlock/security/glass{
+	name = "Equipment Room";
+	req_access_txt = "1"
+	},
 /turf/open/floor/iron/dark,
 /area/security/range)
 "hnW" = (
@@ -39448,13 +40088,11 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "hyP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
 /area/security/prison)
 "hyY" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -39589,14 +40227,19 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "hAX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/chair{
+/obj/machinery/camera{
+	c_tag = "Security - Office - Port";
 	dir = 4
 	},
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "hAY" = (
 /obj/machinery/door/firedoor,
@@ -39841,6 +40484,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"hHg" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "hHn" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -39867,7 +40520,7 @@
 	codes_txt = "patrol;next_patrol=1.5-Fore-Central";
 	location = "1-BrigCells"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "hHZ" = (
 /obj/machinery/light{
@@ -40097,13 +40750,24 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "hNd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "hNh" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -40421,7 +41085,10 @@
 	pixel_x = -24;
 	pixel_y = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "hWh" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -40550,6 +41217,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
+"hYl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 8
+	},
+/area/security/prison)
 "hYx" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -40626,6 +41306,12 @@
 /obj/machinery/suit_storage_unit/hos,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
+"iac" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "iai" = (
 /obj/machinery/door/airlock{
 	id_tag = "FitnessShower";
@@ -40638,7 +41324,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "ial" = (
 /obj/machinery/vending/autodrobe,
@@ -40747,16 +41433,19 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "ibL" = (
-/obj/machinery/light/small{
-	brightness = 3;
+/mob/living/simple_animal/mouse/brown/tom,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/purple/side{
 	dir = 8
 	},
-/obj/structure/sink{
-	pixel_y = 29
-	},
-/mob/living/simple_animal/mouse/brown/tom,
-/turf/open/floor/plating,
 /area/security/prison/safe)
+"ibS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "ibT" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -40920,6 +41609,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"ifg" = (
+/obj/item/folder/blue{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "ifi" = (
 /obj/effect/loot_site_spawner,
 /obj/effect/decal/cleanable/dirt,
@@ -40970,14 +41667,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
-"igz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/office)
 "igY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -41003,6 +41692,11 @@
 "ihQ" = (
 /turf/closed/wall,
 /area/command/heads_quarters/rd)
+"ihT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "ihY" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -41053,6 +41747,15 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/service/library)
+"ijA" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "ijF" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -41145,22 +41848,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/engine,
 /area/science/cytology)
-"ilm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "ilo" = (
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
+/area/security/prison)
+"ilw" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "ilJ" = (
 /obj/structure/filingcabinet/employment,
@@ -41305,13 +42011,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/mob/living/simple_animal/bot/bulletbot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "ios" = (
 /obj/structure/rack,
@@ -41578,33 +42283,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"ivk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Secure Gear Storage";
-	req_access_txt = "3"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "ivq" = (
 /turf/closed/wall,
 /area/science/cytology)
-"iwv" = (
-/obj/machinery/camera{
-	c_tag = "Prison Central";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "ixc" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -41678,7 +42359,7 @@
 	pixel_y = 24;
 	prison_radio = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "iyV" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -41720,13 +42401,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"izA" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/orange,
-/obj/item/restraints/handcuffs,
-/obj/item/reagent_containers/spray/pepper,
-/turf/open/floor/iron,
-/area/security/prison)
 "izI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -41809,6 +42483,9 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"iBI" = (
+/turf/open/floor/iron/dark/blue/side,
+/area/security/prison)
 "iBL" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -41850,6 +42527,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"iCI" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "iCJ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=14.8-Dorms-Lockers";
@@ -41864,9 +42547,8 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "iCO" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/blue,
 /area/security/prison)
 "iCX" = (
 /obj/machinery/hydroponics/constructable,
@@ -41898,6 +42580,13 @@
 /obj/item/stock_parts/manipulator,
 /turf/open/floor/iron,
 /area/science/lab)
+"iDL" = (
+/obj/structure/table,
+/obj/item/clothing/under/rank/prisoner,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison/safe)
 "iDT" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Fore";
@@ -41989,11 +42678,20 @@
 /area/security/prison)
 "iGJ" = (
 /obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/storage/inflatable,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 6
+	},
 /area/security/prison/safe)
 "iGY" = (
 /obj/structure/table/wood,
@@ -42139,7 +42837,10 @@
 "iKy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "iKI" = (
 /obj/machinery/shower{
@@ -42245,14 +42946,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"iMT" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/vending/security_peacekeeper,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "iMY" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -42428,6 +43121,21 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"iQW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 8
+	},
+/area/security/prison)
 "iRg" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -42529,6 +43237,9 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "iSs" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -42619,6 +43330,9 @@
 	idcheck = 1;
 	name = "Sergeant-at-Armsky";
 	weaponscheck = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -42988,6 +43702,12 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
+"jaM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "jaO" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -43015,15 +43735,13 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jbB" = (
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/security/prison)
 "jbF" = (
 /obj/structure/cable,
@@ -43074,6 +43792,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"jee" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "jer" = (
 /obj/machinery/door/window/northleft{
 	dir = 8;
@@ -43225,9 +43956,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "jgU" = (
@@ -43276,14 +44005,10 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "jib" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/trash/chips,
-/obj/item/trash/candy,
-/obj/machinery/firealarm{
-	pixel_y = 26
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/security/prison/safe)
 "jiH" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -43293,6 +44018,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jiV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "jjg" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/button/door{
@@ -43387,11 +44119,8 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/range)
-"jkP" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+"jkF" = (
+/turf/open/floor/iron/dark/blue/corner,
 /area/security/prison)
 "jkQ" = (
 /obj/structure/table,
@@ -43445,14 +44174,21 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "jlv" = (
-/obj/structure/table/reinforced,
-/obj/machinery/camera{
-	c_tag = "Prison Cafeteria";
-	dir = 4;
-	network = list("ss13","prison")
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/item/food/energybar,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/yellow/corner{
+	dir = 8
+	},
 /area/security/prison)
 "jlx" = (
 /obj/effect/landmark/xeno_spawn,
@@ -43832,25 +44568,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
-"jsu" = (
-/obj/structure/table,
-/obj/item/implanter{
-	pixel_x = 5;
-	pixel_y = 12
-	},
-/obj/item/storage/box/evidence{
-	pixel_x = -5;
-	pixel_y = 12
-	},
-/obj/item/toy/crayon/white{
-	pixel_y = -4
-	},
-/obj/item/toy/crayon/white{
-	pixel_x = -5;
-	pixel_y = -4
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "jsw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -44008,12 +44725,12 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "jvG" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/suit_storage_unit/security_peacekeeper,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -44056,6 +44773,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"jwE" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "jwJ" = (
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
@@ -44319,6 +45045,14 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard)
+"jEE" = (
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/genpop,
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/security/prison)
 "jEJ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -44330,19 +45064,10 @@
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "jEO" = (
-/obj/structure/table,
-/obj/item/folder/blue{
-	pixel_x = -18;
-	pixel_y = 3
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/item/paper_bin{
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = 3;
-	pixel_y = 8
-	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "jEW" = (
@@ -44377,6 +45102,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"jFz" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bottle/morphine,
+/obj/item/storage/box/chemimp{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/storage/box/trackimp,
+/obj/item/storage/lockbox/loyalty,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "jFA" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -44421,6 +45164,13 @@
 "jFP" = (
 /turf/closed/wall/r_wall,
 /area/security/interrogation)
+"jFW" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "jGc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
@@ -44431,7 +45181,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "jGt" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -44545,8 +45301,10 @@
 /area/science/nanite)
 "jHW" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "jIg" = (
 /obj/structure/table,
@@ -44590,11 +45348,6 @@
 	dir = 4
 	},
 /area/science/lab)
-"jIO" = (
-/obj/effect/spawner/randomarcade,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "jIZ" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -44678,7 +45431,7 @@
 /area/service/janitor)
 "jLR" = (
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "jLT" = (
@@ -44746,6 +45499,13 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"jNm" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "jNz" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -44774,6 +45534,16 @@
 "jNJ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/machinery/flasher{
 	id = "IsolationFlash";
 	pixel_y = 28
@@ -44782,6 +45552,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "jNL" = (
@@ -45116,6 +45887,11 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"jSw" = (
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/security/prison)
 "jSM" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/firealarm{
@@ -45132,12 +45908,6 @@
 	dir = 1
 	},
 /area/engineering/main)
-"jSP" = (
-/obj/machinery/photocopier{
-	pixel_y = 3
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "jTg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45177,10 +45947,11 @@
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "jTA" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/machinery/light_switch{
+	pixel_y = 26
 	},
-/turf/open/floor/iron/freezer,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
 /area/security/prison)
 "jTC" = (
 /obj/structure/table/wood,
@@ -45224,6 +45995,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"jVo" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "jVx" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -45320,6 +46097,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"jYc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "jYk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
@@ -45497,9 +46279,14 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "kdr" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "kdA" = (
 /turf/open/floor/iron/dark,
@@ -45536,9 +46323,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/service/cafeteria)
-"keM" = (
-/obj/machinery/light,
-/turf/open/floor/iron/freezer,
+"keZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kfx" = (
 /obj/structure/cable,
@@ -45619,7 +46413,10 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "khj" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "khk" = (
 /obj/structure/disposalpipe/segment,
@@ -45854,6 +46651,16 @@
 "kmq" = (
 /turf/closed/wall/r_wall,
 /area/medical/morgue)
+"kmu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/junior_officer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "kmC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -45937,9 +46744,15 @@
 	pixel_y = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kny" = (
 /obj/structure/table,
@@ -46313,7 +47126,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kvt" = (
 /obj/effect/turf_decal/stripes/line,
@@ -46370,6 +47186,22 @@
 /obj/machinery/bluespace_vendor/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"kwI" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Secure Gear Storage";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "kwS" = (
 /obj/structure/disposalpipe/junction{
 	dir = 2
@@ -46378,34 +47210,9 @@
 /area/cargo/sorting)
 "kxc" = (
 /obj/structure/cable,
-/obj/structure/table,
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = 10
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 1
 	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = -8
-	},
-/obj/item/clothing/under/rank/prisoner{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
 /area/security/prison)
 "kxl" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -46448,6 +47255,8 @@
 /obj/machinery/light_switch{
 	pixel_x = -25
 	},
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "kyp" = (
@@ -46465,11 +47274,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/lab)
-"kyr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/security/prison)
 "kys" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/turf_decal/stripes/line,
@@ -46495,14 +47299,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "kyN" = (
-/obj/structure/table,
-/obj/item/poster/random_official{
-	pixel_y = 13
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/item/poster/random_official{
-	pixel_y = 5
-	},
-/obj/item/poster/random_official,
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "kyT" = (
@@ -46631,12 +47431,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"kCI" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating/airless{
-	icon_state = "panelscorched"
-	},
-/area/space/nearstation)
 "kCM" = (
 /obj/machinery/newscaster{
 	pixel_x = 1;
@@ -46881,6 +47675,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/education)
+"kHL" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "kHQ" = (
 /obj/item/radio/intercom{
 	pixel_y = 28
@@ -46961,13 +47761,14 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "kJj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
 	},
-/turf/open/floor/iron/dark,
 /area/security/prison/safe)
 "kJl" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -47151,7 +47952,7 @@
 "kLT" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "kMr" = (
 /obj/machinery/power/apc/auto_name/east,
@@ -47255,7 +48056,10 @@
 /obj/machinery/airalarm{
 	pixel_y = 28
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "kOK" = (
 /obj/machinery/camera{
@@ -47814,6 +48618,9 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"kZY" = (
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "laj" = (
 /obj/item/radio/intercom{
 	pixel_y = 21
@@ -47913,8 +48720,22 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "lbt" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/item/toy/plush/beeplushie{
+	desc = "Maybe hugging this will make you feel better about yourself.";
+	name = "Therabee"
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -48038,13 +48859,9 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Prison Forestry"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "leV" = (
@@ -48457,6 +49274,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
+"loi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison/safe)
 "lon" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -48480,9 +49304,13 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lqa" = (
-/obj/structure/table/reinforced,
-/obj/item/kitchen/fork/plastic,
-/turf/open/floor/iron/white,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 10
+	},
 /area/security/prison)
 "lqh" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
@@ -48528,6 +49356,13 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
+"lrf" = (
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/security/prison)
 "lrj" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Gravity Generator Area";
@@ -48568,27 +49403,19 @@
 	dir = 8
 	},
 /area/science/lab)
-"lrV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+"lse" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "lsC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"lsQ" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -32
-	},
-/turf/open/space/basic,
-/area/space)
 "lsS" = (
 /obj/machinery/door/airlock{
 	id_tag = "Cabin7";
@@ -48616,6 +49443,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"ltI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/security/prison)
 "lud" = (
 /obj/structure/table,
 /obj/item/paper/guides/jobs/engi/gravity_gen,
@@ -48670,6 +49501,20 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"luX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "lvi" = (
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48752,7 +49597,10 @@
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway Cells"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "lxk" = (
 /obj/structure/disposalpipe/segment{
@@ -48907,6 +49755,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"lAY" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "lBp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -49058,7 +49915,7 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "lEa" = (
 /obj/structure/window/reinforced{
@@ -49128,6 +49985,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/bar)
+"lGo" = (
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "lGu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
@@ -49235,6 +50096,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
+"lIn" = (
+/obj/structure/chair/stool,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 4
+	},
+/area/security/prison/safe)
 "lIo" = (
 /obj/machinery/door/morgue{
 	name = "Chapel Garden"
@@ -49956,6 +50823,14 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
+"lWi" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "lWx" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -50033,6 +50908,10 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"lYp" = (
+/obj/structure/chair/sofa/left,
+/turf/open/floor/wood,
+/area/security/prison)
 "lYv" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -50327,10 +51206,8 @@
 /area/service/bar)
 "meC" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "meE" = (
 /obj/machinery/airalarm{
@@ -50358,6 +51235,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"meT" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "mfd" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/HFR_core,
@@ -50373,16 +51255,17 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "mfG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/item/radio/intercom{
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_y = 23
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mfM" = (
 /turf/open/floor/engine/co2,
@@ -50466,9 +51349,13 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "mgJ" = (
-/obj/structure/chair/stool,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/security/prison)
 "mgW" = (
 /obj/structure/cable,
@@ -50540,6 +51427,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"mhA" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "mhN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -50630,6 +51527,20 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"mjP" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "mjS" = (
 /obj/structure/rack,
 /obj/item/stack/medical/mesh,
@@ -50649,6 +51560,11 @@
 "mjT" = (
 /turf/closed/wall,
 /area/medical/psychology)
+"mki" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "mkk" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
@@ -50922,6 +51838,25 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"mok" = (
+/obj/item/poster/random_official{
+	pixel_y = 13
+	},
+/obj/item/poster/random_official{
+	pixel_y = 5
+	},
+/obj/item/poster/random_official,
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark,
+/area/security/office)
+"mov" = (
+/obj/structure/table/wood,
+/obj/machinery/newscaster{
+	pixel_x = -30
+	},
+/obj/item/storage/photo_album/prison,
+/turf/open/floor/wood,
+/area/security/prison)
 "moz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -50937,7 +51872,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "moP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -50975,13 +51910,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "mpI" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -51450,11 +52379,10 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "mzr" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bottle/ammonia,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/light/small,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark/purple/side,
 /area/security/prison/safe)
 "mzt" = (
 /obj/machinery/airalarm{
@@ -51502,8 +52430,21 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/engineering/main)
+"mzM" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "mAi" = (
-/obj/machinery/rnd/production/techfab/department/security,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 6
+	},
+/obj/machinery/dish_drive/bullet,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "mAB" = (
@@ -51581,15 +52522,6 @@
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/white,
 /area/science/research)
-"mBi" = (
-/obj/structure/table,
-/obj/item/flashlight,
-/obj/item/storage/secure/briefcase{
-	pixel_x = -7;
-	pixel_y = 12
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "mBz" = (
 /obj/structure/lattice/catwalk,
 /obj/item/binoculars,
@@ -51706,7 +52638,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "mEl" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
@@ -51722,7 +52654,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mEp" = (
 /obj/item/reagent_containers/spray/plantbgone{
@@ -51794,6 +52726,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"mGL" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 8
+	},
+/area/security/prison/safe)
 "mGY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
@@ -51845,6 +52787,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
+"mIS" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "mIU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -51985,6 +52937,18 @@
 	},
 /turf/open/floor/carpet,
 /area/command/bridge)
+"mLE" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/vending/security_peacekeeper,
+/obj/effect/turf_decal/bot_blue,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "mLI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -52074,9 +53038,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
 /area/security/prison)
 "mNF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -52163,6 +53128,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"mPo" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/security/prison)
 "mPM" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -52202,11 +53175,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
-"mQt" = (
-/obj/structure/window,
-/obj/effect/decal/cleanable/food/flour,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "mQw" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -52773,7 +53741,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
 /area/security/prison)
 "nav" = (
 /obj/effect/turf_decal/tile/purple,
@@ -52905,6 +53875,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"ncD" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "ndf" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -53004,6 +53986,22 @@
 "nek" = (
 /turf/closed/wall,
 /area/commons/vacant_room/commissary)
+"neD" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "neG" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/blue{
@@ -53074,43 +54072,10 @@
 /turf/closed/wall,
 /area/commons/storage/primary)
 "nge" = (
-/obj/structure/closet/crate/secure/weapon{
-	desc = "A secure clothing crate.";
-	name = "formal uniform crate";
-	req_access_txt = "3"
-	},
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/under/rank/security/warden/formal,
-/obj/item/clothing/suit/security/warden,
-/obj/item/clothing/under/rank/security/head_of_security/formal,
-/obj/item/clothing/suit/security/hos,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navywarden,
-/obj/item/clothing/head/beret/sec/navyhos,
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "ngf" = (
@@ -53189,16 +54154,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/dark,
 /area/commons/locker)
-"ngy" = (
-/obj/structure/chair/stool,
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "ngD" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -53261,6 +54216,9 @@
 	pixel_x = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "nhJ" = (
@@ -53515,12 +54473,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "nnS" = (
-/obj/item/radio/intercom{
-	pixel_x = -29;
-	pixel_y = 4
-	},
 /obj/item/storage/box/deputy,
-/obj/structure/table,
+/obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "nnW" = (
@@ -53599,7 +54553,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "npN" = (
 /obj/structure/disposalpipe/segment,
@@ -53615,10 +54569,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"npX" = (
-/obj/machinery/vending/sustenance,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "nqb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -53663,7 +54613,7 @@
 /area/service/lawoffice)
 "nrn" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "nrt" = (
 /obj/effect/turf_decal/stripes/line{
@@ -53705,7 +54655,7 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "nsH" = (
 /obj/structure/disposalpipe/segment{
@@ -53724,6 +54674,10 @@
 /obj/structure/statue/snow/snowman,
 /turf/open/floor/grass/snow/safe,
 /area/maintenance/port/aft)
+"nta" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/wood,
+/area/security/prison)
 "ntj" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -53891,10 +54845,10 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
 "nvU" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "nwT" = (
 /obj/structure/disposalpipe/segment{
@@ -53909,30 +54863,8 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "nxb" = (
-/obj/structure/table,
-/obj/item/folder/red,
-/obj/item/restraints/handcuffs,
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/structure/cable,
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "nxk" = (
@@ -54022,6 +54954,9 @@
 /area/engineering/supermatter)
 "nAm" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -54130,6 +55065,17 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"nCu" = (
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = " Prison - Cafeteria";
+	dir = 5;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "nDc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/closed/wall/r_wall,
@@ -54140,6 +55086,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"nDP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "nDT" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -54240,6 +55195,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"nGb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "nGe" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -54250,6 +55210,17 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"nGi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell11";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "nGu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -54263,6 +55234,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"nGH" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 9
+	},
+/area/security/prison)
 "nGI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54332,6 +55309,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/construction/storage_wing)
+"nId" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/security/prison)
 "nIf" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -54394,14 +55375,9 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "nIW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
 /area/security/prison)
 "nJz" = (
 /obj/item/flashlight/lamp,
@@ -54416,7 +55392,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/landmark/start/junior_officer,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "nKc" = (
 /obj/machinery/door/firedoor,
@@ -54469,6 +55446,25 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
+"nKu" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Armory";
+	req_access_txt = "3"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "nKv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
@@ -54841,19 +55837,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"nPM" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/airalarm{
-	pixel_y = 28
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "nPS" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -55017,6 +56000,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"nUp" = (
+/obj/structure/table,
+/obj/item/storage/box/matches,
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/wood,
+/area/security/prison)
 "nUC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55218,7 +56207,11 @@
 /area/engineering/atmos)
 "nZE" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner,
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "nZQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -55279,9 +56272,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "obg" = (
@@ -55519,6 +56511,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"ogV" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/security/prison)
 "ohh" = (
 /obj/item/flashlight/lantern{
 	pixel_y = 7
@@ -55709,9 +56711,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "olk" = (
@@ -55761,6 +56761,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
+"omi" = (
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/security/prison)
 "omn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -55793,12 +56798,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"omJ" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "omN" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -55851,13 +56850,10 @@
 /obj/machinery/computer/warrant{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "opc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -55977,13 +56973,25 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"orI" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "orL" = (
 /obj/machinery/biogenerator,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "orS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -56032,6 +57040,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
+"osH" = (
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "osJ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -56095,6 +57108,17 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"otL" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "otW" = (
 /turf/open/floor/wood,
 /area/service/bar)
@@ -56753,20 +57777,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
-"oFh" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "oFi" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -56791,18 +57801,6 @@
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/engineering/main)
-"oFQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera{
-	c_tag = "Prison Workshop";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "oGi" = (
 /turf/open/floor/engine,
 /area/command/heads_quarters/rd)
@@ -56935,12 +57933,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"oIZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "oJa" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -57000,6 +57992,7 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "oJx" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/camera{
 	c_tag = "Prison Cell Block 1";
 	dir = 1;
@@ -57047,6 +58040,12 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"oKL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "oKP" = (
 /obj/item/toy/cards/deck,
 /obj/structure/table/wood/poker,
@@ -57274,6 +58273,11 @@
 	},
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
+"oPG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "oPN" = (
 /obj/item/toy/figure/roboticist,
 /obj/effect/turf_decal/tile/neutral,
@@ -57561,6 +58565,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
+"oUe" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "oUn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -57738,6 +58751,13 @@
 /obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
+"oXH" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "oXY" = (
 /obj/structure/rack,
 /obj/item/radio/off{
@@ -57748,7 +58768,10 @@
 	pixel_x = -6;
 	pixel_y = 7
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "oYa" = (
 /obj/machinery/door/window{
@@ -57849,6 +58872,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"oZo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "oZD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
@@ -58065,6 +59102,18 @@
 	},
 /turf/open/floor/carpet,
 /area/service/theater)
+"pcG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "pcO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58222,6 +59271,9 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "pfe" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -58295,6 +59347,24 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
+"pgq" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_x = 26
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "pgC" = (
 /obj/machinery/door/window/southleft{
 	dir = 1;
@@ -58379,15 +59449,13 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "piK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
+/obj/item/stack/sheet/cardboard{
+	amount = 14
 	},
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
+/obj/item/stack/package_wrap,
 /turf/open/floor/iron,
 /area/security/prison)
 "pjB" = (
@@ -58532,10 +59600,12 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "pna" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
 /area/security/prison)
 "pnc" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
@@ -58583,8 +59653,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "poo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "pox" = (
 /turf/closed/wall/r_wall,
@@ -58631,6 +59700,11 @@
 "ppp" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"pps" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/light,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "ppt" = (
 /obj/machinery/power/emitter/welded,
 /obj/structure/cable,
@@ -58773,11 +59847,11 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "psm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
 /area/security/prison/safe)
 "psC" = (
 /obj/structure/window/reinforced{
@@ -58786,6 +59860,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"ptc" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "ptF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -58971,21 +60051,45 @@
 /obj/machinery/computer/crew{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "pvO" = (
-/obj/structure/table,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -6;
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron/dark,
+/area/security/office)
+"pvS" = (
+/obj/structure/table,
+/obj/item/folder/red,
+/obj/item/restraints/handcuffs,
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/assembly/flash/handheld{
-	pixel_x = 6;
-	pixel_y = 13
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Security - Gear Room";
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -59007,9 +60111,17 @@
 	},
 /area/holodeck/rec_center)
 "pwh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "pwi" = (
@@ -59042,19 +60154,18 @@
 	req_one_access_txt = "1;4"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/delivery/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "pwv" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "pwM" = (
 /obj/structure/girder,
@@ -59085,10 +60196,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "pxo" = (
 /obj/structure/cable,
@@ -59302,24 +60413,19 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "pAv" = (
-/obj/structure/table,
-/obj/structure/window,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
+/obj/machinery/processor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 4
+	},
 /area/security/prison)
 "pAA" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -59487,6 +60593,22 @@
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"pCI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "pCN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -59579,15 +60701,15 @@
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "pES" = (
-/obj/structure/table,
-/obj/item/folder,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/photo_album/prison,
-/obj/item/camera,
-/obj/machinery/light,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/structure/chair,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/obj/effect/landmark/start/prisoner,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
 /area/security/prison)
 "pFV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59599,6 +60721,15 @@
 	icon_state = "wood-broken6"
 	},
 /area/command/corporate_showroom)
+"pGE" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 1
+	},
+/area/security/prison)
 "pGP" = (
 /obj/structure/closet/bombcloset,
 /obj/effect/turf_decal/stripes/line{
@@ -59678,6 +60809,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"pID" = (
+/obj/structure/chair/sofa,
+/turf/open/floor/wood,
+/area/security/prison)
 "pIS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -60089,12 +61224,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"pSL" = (
-/obj/machinery/door/window/southleft{
-	name = "Permabrig Kitchen"
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "pSX" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Escape Airlock"
@@ -60104,6 +61233,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"pTi" = (
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/obj/effect/landmark/start/prisoner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/security/prison/safe)
 "pTC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron/dark,
@@ -60136,6 +61274,9 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "pUs" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
 /obj/machinery/light,
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -60446,8 +61587,19 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/security/prison)
 "pZZ" = (
@@ -60484,19 +61636,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"qbz" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/freezer,
-/area/security/prison)
 "qbA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -60519,6 +61658,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
+"qbS" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "qbU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
@@ -60607,11 +61753,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"qcZ" = (
-/obj/structure/table,
-/obj/item/toy/cards/deck,
-/turf/open/floor/iron,
-/area/security/prison)
 "qdm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -60664,13 +61805,14 @@
 	dir = 4;
 	sortType = 7
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "qeb" = (
 /obj/item/target,
@@ -60692,6 +61834,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/bot_blue,
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -60791,17 +61934,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"qhc" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "qhe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -61017,17 +62149,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
-"qlv" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/iron,
-/area/security/office)
+"qmq" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "qmt" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -61130,10 +62255,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "qoj" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/grass,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron/dark/green,
 /area/security/prison)
 "qok" = (
 /obj/machinery/seed_extractor,
@@ -61144,7 +62268,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "qpc" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -61279,11 +62403,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_c)
-"qsk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "qsE" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61292,6 +62411,7 @@
 /area/commons/dorms)
 "qsK" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/bot_blue,
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -61723,6 +62843,11 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/grimy,
 /area/tcommsat/computer)
+"qAm" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "qAp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -61931,13 +63056,24 @@
 "qCH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "qCO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -61983,6 +63119,20 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/engineering/main)
+"qEQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "qEU" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/virology/glass{
@@ -62055,7 +63205,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
 /area/security/prison/safe)
 "qFH" = (
 /obj/effect/turf_decal/bot_white,
@@ -62274,9 +63430,17 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "qLm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "qLx" = (
@@ -62439,7 +63603,10 @@
 	pixel_y = -3
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "qOZ" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -62508,6 +63675,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"qQE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/security/prison)
 "qRd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -62676,7 +63851,9 @@
 /obj/structure/toilet/greyscale{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
 /area/security/prison/safe)
 "qTT" = (
 /obj/structure/table/glass,
@@ -62735,6 +63912,13 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"qWk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "qWn" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon{
@@ -62760,17 +63944,36 @@
 /area/cargo/qm)
 "qWF" = (
 /obj/structure/cable,
-/obj/structure/bed/roller,
-/turf/open/floor/iron,
-/area/security/prison)
-"qWL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
+/obj/structure/table,
+/obj/item/storage/box/bodybags{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/clothing/gloves/color/orange,
+/obj/item/restraints/handcuffs,
+/obj/item/reagent_containers/spray/pepper,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
+/area/security/prison)
+"qWL" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/structure/closet/bombcloset/security,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/head/bomb_hood/security,
+/obj/item/clothing/head/bomb_hood/security,
+/turf/open/floor/iron/dark,
 /area/security/office)
+"qXD" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/security/prison)
 "qXH" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/bar{
@@ -62873,6 +64076,46 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"qZW" = (
+/obj/structure/closet/crate/secure/weapon{
+	desc = "A secure clothing crate.";
+	name = "formal uniform crate";
+	req_access_txt = "3"
+	},
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/under/rank/security/warden/formal,
+/obj/item/clothing/suit/security/warden,
+/obj/item/clothing/under/rank/security/head_of_security/formal,
+/obj/item/clothing/suit/security/hos,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navywarden,
+/obj/item/clothing/head/beret/sec/navyhos,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "rac" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -62885,6 +64128,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"raj" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/airlock/security/glass{
+	name = "Gear Room";
+	req_one_access_txt = "1;4"
+	},
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "ram" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -62967,12 +64220,15 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/security/prison)
 "rcM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "rcO" = (
 /obj/structure/rack,
@@ -63044,10 +64300,12 @@
 	pixel_y = -25;
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "rdB" = (
@@ -63243,6 +64501,15 @@
 "rhT" = (
 /turf/closed/wall,
 /area/maintenance/department/science/xenobiology)
+"rid" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "rig" = (
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
@@ -63396,7 +64663,7 @@
 /obj/structure/sign/departments/court{
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rkF" = (
 /obj/structure/lattice,
@@ -63589,7 +64856,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "rpD" = (
 /obj/structure/sign/warning/securearea,
@@ -63613,7 +64880,9 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rqf" = (
 /turf/closed/wall,
@@ -63647,7 +64916,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rqS" = (
 /obj/machinery/light/small/broken{
@@ -63883,11 +65153,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"ruv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "ruD" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -63965,9 +65230,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "rwn" = (
-/obj/machinery/newscaster/security_unit,
-/turf/closed/wall/r_wall,
+/obj/structure/table,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
+"rwN" = (
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/wood,
+/area/security/prison)
 "rwO" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -64027,6 +65299,17 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"rxQ" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "ryi" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -64249,6 +65532,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/command/bridge)
+"rBf" = (
+/obj/structure/table,
+/obj/item/instrument/piano_synth,
+/obj/item/storage/pill_bottle/dice,
+/turf/open/floor/wood,
+/area/security/prison)
 "rBn" = (
 /obj/item/crowbar,
 /turf/open/floor/plating{
@@ -64377,6 +65666,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "rEd" = (
@@ -64400,6 +65692,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"rEp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/rack,
+/turf/open/floor/iron,
+/area/security/prison)
 "rEq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -64526,12 +65826,16 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rHi" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Visitation"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "rHA" = (
@@ -64765,6 +66069,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_c)
+"rMz" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space,
+/area/solars/port/fore)
 "rMU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -65044,6 +66353,28 @@
 "rRu" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"rRy" = (
+/obj/machinery/airalarm{
+	pixel_y = 28
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/electrical,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "rRF" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -65056,6 +66387,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"rRW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "rSe" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -65280,6 +66616,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "rVn" = (
@@ -65342,6 +66680,15 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"rWX" = (
+/obj/structure/table,
+/obj/item/candle{
+	pixel_x = -5
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison/safe)
 "rXb" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
@@ -65515,6 +66862,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"rZU" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "sad" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -65622,7 +66975,8 @@
 	pixel_y = -28
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "sbE" = (
 /turf/open/floor/plating/airless{
@@ -65660,14 +67014,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "scv" = (
 /obj/structure/closet/crate,
@@ -65876,10 +67227,20 @@
 /area/medical/medbay/central)
 "sfJ" = (
 /obj/item/clothing/suit/straight_jacket,
-/obj/item/electropack,
 /obj/structure/table,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/item/storage/box/prisoner{
+	pixel_y = 8
+	},
+/obj/item/storage/box/prisoner,
+/obj/item/electropack,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "sfQ" = (
 /obj/structure/closet,
@@ -65894,6 +67255,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"shg" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "sht" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -66010,6 +67382,35 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/bar)
+"skI" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/book/manual/chef_recipes,
+/obj/machinery/camera{
+	c_tag = "Prison Cafeteria";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 8
+	},
+/area/security/prison)
 "skJ" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -66029,22 +67430,19 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "skU" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
 	},
-/obj/structure/rack,
-/obj/effect/turf_decal/tile/blue,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/item/storage/box/chemimp{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/storage/box/trackimp,
-/obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/structure/closet/l3closet/security,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/head/bio_hood/security,
+/obj/item/clothing/head/bio_hood/security,
+/obj/item/clothing/head/bio_hood/security,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "slf" = (
@@ -66099,6 +67497,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"smj" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/turf/open/floor/wood,
+/area/security/prison)
 "smn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66108,6 +67515,35 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/bar)
+"sms" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
+"smB" = (
+/obj/item/folder/blue{
+	pixel_x = -18;
+	pixel_y = 3
+	},
+/obj/item/paper_bin{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/pen{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "smG" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Fuel Pipe"
@@ -66169,6 +67605,11 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
 /area/maintenance/aft/secondary)
+"snh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/wood,
+/area/security/prison)
 "snv" = (
 /obj/machinery/teleport/station,
 /obj/machinery/firealarm{
@@ -66180,7 +67621,7 @@
 "snF" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "snH" = (
 /obj/structure/window/reinforced,
@@ -66222,17 +67663,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "soJ" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/item/inspector{
-	pixel_x = -5;
-	pixel_y = 12
-	},
-/obj/item/inspector{
-	pixel_x = 5
-	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "soO" = (
@@ -66283,6 +67714,13 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"spW" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "sqe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -66408,6 +67846,14 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/service/chapel/main)
+"srq" = (
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Armory External";
+	dir = 8
+	},
+/turf/open/space,
+/area/space/nearstation)
 "srs" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -67347,6 +68793,12 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"sNi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "sNv" = (
 /obj/structure/statue/sandstone/assistant,
 /turf/open/floor/plating,
@@ -67357,6 +68809,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"sOd" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "sOe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -67523,7 +68985,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
 /area/security/prison/safe)
 "sQu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67686,6 +69150,13 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
+"sTb" = (
+/obj/effect/turf_decal/arrows/blue,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "sTj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -67751,17 +69222,15 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "sUd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "sUh" = (
 /obj/structure/rack,
@@ -67826,14 +69295,12 @@
 	name = "Prison Cafeteria"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "sWz" = (
 /obj/structure/showcase/mecha/marauder,
@@ -68211,6 +69678,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"teZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "tfe" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Quartermaster Maintenance";
@@ -68235,15 +69711,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"tfm" = (
-/obj/machinery/camera{
-	c_tag = "Prison Common Room";
-	dir = 1;
-	network = list("ss13","prison")
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "tfp" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -68522,6 +69989,7 @@
 	req_one_access_txt = "1;4"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "tlg" = (
@@ -68570,6 +70038,9 @@
 /turf/open/floor/wood,
 /area/service/library)
 "tmL" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /obj/structure/cable,
 /obj/machinery/light{
 	dir = 8
@@ -68605,6 +70076,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"tmW" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "tns" = (
 /obj/structure/sign/map/right{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -68725,7 +70201,7 @@
 	info = "<i>Hey, assholes. We don't need a couch in the meeting room, I threw it out the airlock. I don't care if it's real leather, go patrol like you're paid to do instead of cycling through cameras all shift!";
 	name = "old, crumpled note"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "tpX" = (
 /obj/machinery/exodrone_launcher,
@@ -68803,10 +70279,8 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "trJ" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron/dark/green,
 /area/security/prison)
 "trV" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -68828,9 +70302,16 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "trZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "tsg" = (
@@ -68938,10 +70419,6 @@
 /obj/machinery/destructive_scanner,
 /turf/open/floor/iron/white,
 /area/hallway/primary/central)
-"ttQ" = (
-/obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "ttZ" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/table,
@@ -68952,16 +70429,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/storage)
-"tum" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
-/obj/machinery/door/airlock/security/glass{
-	name = "Gear Room";
-	req_one_access_txt = "1;4"
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "tuP" = (
 /turf/closed/wall,
 /area/cargo/miningoffice)
@@ -69122,6 +70589,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"tzw" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"tzT" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/bookmanagement,
+/turf/open/floor/wood,
+/area/security/prison)
 "tzV" = (
 /obj/item/toy/beach_ball{
 	name = "Nanotrasen-branded beach ball"
@@ -69192,6 +70670,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"tBO" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
+/area/security/prison)
 "tBR" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/northleft{
@@ -69250,6 +70732,13 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"tCW" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "tDb" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -69412,16 +70901,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
-"tFS" = (
-/obj/structure/table,
-/obj/item/wirecutters,
-/obj/item/screwdriver{
-	pixel_x = -2;
-	pixel_y = 10
-	},
-/obj/machinery/syndicatebomb/training,
-/turf/open/floor/iron,
-/area/security/office)
 "tFU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69782,16 +71261,6 @@
 "tMV" = (
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
-"tMX" = (
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "tNa" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -69824,8 +71293,9 @@
 	name = "Isolation Cell";
 	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/delivery/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "tNB" = (
@@ -69883,23 +71353,30 @@
 "tOw" = (
 /obj/structure/sink{
 	dir = 8;
-	pixel_x = 11
+	pixel_x = 12
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "tOL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "PermaLockdown";
 	name = "Lockdown Shutters"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permaouter";
+	name = "Permabrig Transfer";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue,
 /area/security/prison)
 "tPg" = (
 /obj/structure/rack,
@@ -69956,6 +71433,9 @@
 /turf/open/floor/wood,
 /area/security/office)
 "tPW" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -70654,6 +72134,22 @@
 /obj/effect/spawner/lootdrop/gambling,
 /turf/open/floor/wood,
 /area/service/bar)
+"ueI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "ufa" = (
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/window/plasma/reinforced,
@@ -70724,9 +72220,18 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "ugv" = (
-/obj/machinery/hydroponics/soil,
 /obj/item/shovel/spade,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/machinery/hydroponics/soil{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -2;
+	self_sustaining = 1
+	},
 /turf/open/floor/grass,
 /area/security/prison)
 "ugD" = (
@@ -70743,6 +72248,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/main)
+"ugQ" = (
+/obj/structure/chair,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "uha" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -70796,10 +72308,8 @@
 /area/science/server)
 "uhk" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uhm" = (
 /obj/structure/table,
@@ -70888,9 +72398,14 @@
 	dir = 8;
 	pixel_x = 28
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uiW" = (
 /obj/machinery/newscaster{
@@ -71266,6 +72781,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
+"uql" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "uqB" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/item/soap/deluxe,
@@ -71501,6 +73020,9 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "uvm" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -71528,7 +73050,10 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "uvI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -71585,11 +73110,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science)
-"uxb" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/space,
-/area/space/nearstation)
 "uxi" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -71688,6 +73208,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"uzt" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "uzx" = (
 /obj/effect/turf_decal/trimline/brown/warning,
 /obj/effect/turf_decal/trimline/brown/warning,
@@ -72083,7 +73607,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uJw" = (
-/obj/structure/table,
+/obj/item/poster/wanted/missing,
+/obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "uJy" = (
@@ -72237,14 +73762,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
-"uLt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/office)
 "uLw" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/bot{
@@ -72296,8 +73813,22 @@
 	req_access_txt = "63"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
 /area/security/brig)
+"uNn" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "uNx" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/security,
@@ -72638,6 +74169,17 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
+"uUg" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "uUq" = (
 /obj/machinery/door/airlock/research{
 	glass = 1;
@@ -72875,13 +74417,20 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "uYG" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -72965,8 +74514,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
+"vav" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "vaw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Visitation"
@@ -73008,6 +74571,20 @@
 /obj/structure/cable,
 /turf/open/floor/goonplaque,
 /area/hallway/primary/port)
+"vaW" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
+/area/security/prison/safe)
 "vaY" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -73133,9 +74710,9 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Cell 2"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue,
 /area/security/prison/safe)
 "vcS" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -73185,6 +74762,26 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engineering/main)
+"veq" = (
+/obj/machinery/camera{
+	c_tag = "Security - Secure Gear Storage";
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "vey" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -73771,8 +75368,20 @@
 	},
 /area/service/kitchen)
 "voJ" = (
-/obj/machinery/vending/cola/red,
-/turf/open/floor/iron/white,
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 4
+	},
 /area/security/prison)
 "voL" = (
 /obj/effect/turf_decal/stripes/line{
@@ -73781,6 +75390,12 @@
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
 /turf/open/floor/engine,
 /area/engineering/main)
+"voY" = (
+/obj/machinery/griddle,
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 10
+	},
+/area/security/prison)
 "vpO" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap{
@@ -74464,6 +76079,35 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
+"vEm" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
+"vEq" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner/skirt,
+/obj/item/clothing/under/rank/prisoner/skirt,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner/skirt,
+/obj/item/clothing/under/rank/prisoner/skirt,
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "vEB" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	name = "plasma mixer"
@@ -74794,7 +76438,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "vKK" = (
 /obj/structure/rack,
@@ -75144,6 +76788,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"vRd" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 8
+	},
+/area/security/prison)
 "vRp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -75169,7 +76824,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "vSE" = (
 /obj/machinery/light/small,
@@ -75190,7 +76845,10 @@
 	pixel_y = 4
 	},
 /obj/structure/table,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "vTe" = (
 /obj/structure/rack,
@@ -75245,25 +76903,12 @@
 /turf/open/floor/wood,
 /area/security/office)
 "vTQ" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "PermaLockdown";
-	name = "Lockdown Shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permaouter";
-	name = "Permabrig Transfer";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/machinery/turnstile{
+	dir = 8;
+	req_one_access_txt = "2;63;81"
+	},
+/turf/open/floor/iron/dark/blue,
 /area/security/prison)
 "vTZ" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -75315,7 +76960,8 @@
 /obj/machinery/light_switch{
 	pixel_y = 26
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "vVn" = (
 /obj/structure/table/wood/fancy/royalblue,
@@ -75332,8 +76978,13 @@
 /area/service/library)
 "vVt" = (
 /obj/structure/table,
-/obj/item/storage/bag/tray/cafeteria,
-/turf/open/floor/iron/white,
+/obj/machinery/reagentgrinder{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 6
+	},
 /area/security/prison)
 "vVC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -75368,7 +77019,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "vVS" = (
 /obj/structure/window/reinforced{
@@ -75446,13 +77097,16 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "vXG" = (
-/obj/structure/table,
-/obj/item/folder/blue{
-	pixel_x = -2;
-	pixel_y = 3
-	},
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
+"vXM" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -75679,6 +77333,12 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"wbH" = (
+/obj/structure/cable,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/security/prison)
 "wcz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -75932,9 +77592,6 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -29
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "wij" = (
@@ -75975,8 +77632,17 @@
 	dir = 8;
 	pixel_y = -4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/curtain,
 /turf/open/floor/iron/freezer,
+/area/security/prison)
+"wiD" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/security/prison)
 "wiZ" = (
 /obj/machinery/door/airlock/external{
@@ -76113,6 +77779,16 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"wlr" = (
+/obj/structure/cable,
+/obj/machinery/button/door{
+	id = "armory";
+	name = "Armory Shutters";
+	pixel_y = -28;
+	req_access_txt = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "wlG" = (
 /obj/machinery/sparker{
 	id = "Xenobio";
@@ -76143,6 +77819,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"wnx" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "wnQ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -76175,7 +77860,8 @@
 "wow" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "woz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -76554,6 +78240,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"wwt" = (
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 6;
+	pixel_y = 13
+	},
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "wwz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -76594,6 +78296,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"wxj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "wxk" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -77082,6 +78794,16 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
+"wHk" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "wHC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -77221,14 +78943,16 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "wLi" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "wLC" = (
@@ -77259,6 +78983,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"wLN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 4
+	},
+/area/security/prison)
 "wLP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77337,11 +79075,18 @@
 /area/command/heads_quarters/hop)
 "wMV" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "wNe" = (
 /obj/effect/turf_decal/tile/brown{
@@ -77362,6 +79107,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"wNx" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "wNJ" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/tile/neutral{
@@ -77408,10 +79163,6 @@
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/iron,
 /area/engineering/main)
-"wOj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/office)
 "wOk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -77777,6 +79528,19 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"wTV" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "wTY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -78087,6 +79851,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/service/bar)
+"xaN" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "xaY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/water_vapor,
@@ -78136,10 +79907,16 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "xbP" = (
-/obj/machinery/hydroponics/soil,
 /obj/item/cultivator,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/hydroponics/soil{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -2;
+	self_sustaining = 1
+	},
 /turf/open/floor/grass,
 /area/security/prison)
 "xcj" = (
@@ -78202,7 +79979,11 @@
 	pixel_x = -8;
 	pixel_y = 3
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "xdo" = (
 /obj/structure/window/reinforced/tinted{
@@ -78268,12 +80049,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/commons/locker)
-"xee" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "xel" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -78307,6 +80082,18 @@
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"xeQ" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "xeV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -78319,8 +80106,19 @@
 	},
 /area/service/chapel/main)
 "xeX" = (
-/obj/structure/chair,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "xfo" = (
 /obj/structure/disposalpipe/segment,
@@ -78493,6 +80291,17 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"xhN" = (
+/obj/item/inspector{
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/obj/item/inspector{
+	pixel_x = 5
+	},
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "xhO" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -78528,13 +80337,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+	dir = 10
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xjq" = (
 /obj/effect/turf_decal/bot_white/left,
@@ -78759,6 +80566,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"xog" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "xoi" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/turf_decal/siding/purple{
@@ -78782,10 +80598,15 @@
 /area/maintenance/department/science/xenobiology)
 "xoL" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xoM" = (
 /obj/machinery/light,
@@ -78801,8 +80622,16 @@
 "xoR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/security/prison)
 "xoZ" = (
@@ -79031,7 +80860,21 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/prisoner,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "xuA" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -79070,7 +80913,13 @@
 /obj/machinery/light_switch{
 	pixel_x = 20
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xwA" = (
 /obj/item/radio/intercom{
@@ -79164,6 +81013,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"xyU" = (
+/obj/item/storage/backpack/duffelbag/sec{
+	pixel_y = 7
+	},
+/obj/item/storage/backpack/duffelbag/sec,
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "xyV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -79202,10 +81059,10 @@
 /area/command/heads_quarters/hos)
 "xzM" = (
 /obj/effect/turf_decal/box,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "xzU" = (
@@ -79582,10 +81439,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery/blue,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "xGh" = (
@@ -79666,6 +81523,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/main)
+"xIJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 1
+	},
+/area/security/prison)
 "xIK" = (
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
@@ -79751,17 +81616,8 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "xKy" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Prison Workshop"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/prison)
 "xKW" = (
 /obj/structure/table/wood,
@@ -79883,6 +81739,13 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"xNR" = (
+/obj/machinery/suit_storage_unit/security_peacekeeper,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "xNX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -79905,15 +81768,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"xON" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "xPb" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -80078,6 +81932,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"xRq" = (
+/obj/structure/sink{
+	pixel_y = 29
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/ammonia,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 5
+	},
+/area/security/prison)
 "xRx" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -80166,6 +82031,9 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"xSW" = (
+/turf/open/floor/wood,
+/area/security/prison)
 "xSZ" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -80260,17 +82128,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
-"xVh" = (
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/folder/red{
-	pixel_x = -5
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "xVl" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -80421,7 +82278,6 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "xXB" = (
-/obj/machinery/hydroponics/soil,
 /obj/machinery/camera{
 	c_tag = "Prison Forestry";
 	dir = 4;
@@ -80430,6 +82286,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/hydroponics/soil{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -2;
+	self_sustaining = 1
 	},
 /turf/open/floor/grass,
 /area/security/prison)
@@ -80669,10 +82532,16 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "ybE" = (
-/obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/item/plant_analyzer,
+/obj/machinery/hydroponics/soil{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -2;
+	self_sustaining = 1
+	},
 /turf/open/floor/grass,
 /area/security/prison)
 "ybM" = (
@@ -80683,13 +82552,9 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "yce" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -80700,6 +82565,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"ycF" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "ycH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -80809,14 +82680,13 @@
 	},
 /area/command/gateway)
 "yeu" = (
-/obj/machinery/shower{
+/obj/machinery/plate_press,
+/obj/machinery/camera{
+	c_tag = "Prison Workshop";
 	dir = 8;
-	pixel_y = -4
+	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron,
 /area/security/prison)
 "yeM" = (
 /obj/structure/disposalpipe/segment,
@@ -80839,8 +82709,11 @@
 "yfi" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "yfk" = (
@@ -80898,16 +82771,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
-"yfT" = (
-/obj/machinery/camera/motion{
-	active_power_usage = 0;
-	c_tag = "Armory - External";
-	dir = 1;
-	network = list("security");
-	use_power = 0
-	},
-/turf/open/space/basic,
-/area/space)
 "yga" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -81014,16 +82877,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"yiw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/bluespace_vendor/south,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "yiz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -81095,6 +82948,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"yju" = (
+/obj/structure/chair/sofa/left,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "yjD" = (
 /obj/structure/sink{
 	pixel_y = 22
@@ -81194,11 +83054,30 @@
 /turf/open/floor/wood,
 /area/service/cafeteria)
 "ylH" = (
-/obj/structure/chair{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/closet/secure_closet/freezer/meat{
+	req_access = null
+	},
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/yellow/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
 /area/security/prison)
 "ylT" = (
 /obj/effect/turf_decal/tile/red{
@@ -99538,19 +101417,19 @@ aaa
 aaa
 aaa
 aaa
+gJK
+gJK
+gJK
+gJK
+gJK
+gJK
+gJK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-fwb
 aaa
 lMJ
 aaa
+vrW
+aaa
 aaa
 aaa
 aep
@@ -99560,10 +101439,10 @@ aax
 aax
 aax
 aaa
-bin
+rMz
 aaa
 aaa
-aaa
+aaf
 aaa
 aee
 bbo
@@ -99792,23 +101671,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-fwb
-aaa
+gJK
+gJK
+gJK
 lMJ
-aaa
-aaa
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+fwb
+lMJ
+lMJ
+lMJ
+vrW
+lMJ
+lMJ
 aep
 aep
 xbP
@@ -99817,7 +101696,7 @@ xXB
 ugv
 aax
 aaa
-bin
+rMz
 aaa
 aaa
 aee
@@ -100047,23 +101926,23 @@ aaa
 aaa
 aaa
 aaa
+gJK
+gJK
+aQj
+lMJ
+lMJ
+lMJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-kCI
-fwb
-fwb
-nYJ
-fwb
-nYJ
-fwb
-fwb
-ebZ
 aaa
 lMJ
+aaa
+aaa
+aaa
+vrW
+vrW
+vrW
+vrW
 aaa
 aaa
 aep
@@ -100074,9 +101953,9 @@ kvf
 aST
 aax
 aaa
-bin
-bin
-bin
+rMz
+rMz
+rMz
 aef
 aeG
 afE
@@ -100303,30 +102182,30 @@ aaa
 aaa
 aaa
 aaa
+gJK
+lMJ
+lMJ
+aQj
 aaa
 aaa
+lMJ
 aaa
-aaa
+aax
+aep
+aep
+aep
+aax
 aaa
 aaa
 aaa
 lMJ
 aaa
-aaa
-aaa
-aaa
-lMJ
-aaa
-aaa
-lMJ
-aaa
-lMJ
 aaa
 aaa
 aep
 qok
-adh
-adh
+csL
+lGo
 aaw
 meC
 aax
@@ -100560,38 +102439,38 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-lMJ
-aaa
-aaa
-aaa
-aaa
-lMJ
-aaa
-aaa
+gJK
 lMJ
 aaa
 lMJ
 aaa
 aaa
+aax
+aax
+aax
+ugQ
+nUp
+mPo
+aax
+aep
+aax
+aax
+aax
+aax
+aax
+aax
 aax
 dFK
 tOw
 dgX
 vSn
-meC
+ilw
 trJ
 aax
 vrW
 vrW
-nYJ
-fwb
+lMJ
+aaf
 fwb
 aee
 bbo
@@ -100817,26 +102696,26 @@ aaa
 aaa
 aaa
 aaa
+gJK
+lMJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-fwb
-aaa
-aaa
-aaa
-aaa
+lMJ
+lMJ
+lMJ
 aax
-aep
-aax
-aax
-aax
-aax
-aax
-aax
+bOQ
+nCu
+ltI
+snh
+bNP
+nId
+rxQ
+eZQ
+haK
+iQW
+hYl
+skI
+voY
 aax
 abe
 abe
@@ -100847,7 +102726,7 @@ qoj
 aep
 aaa
 aaj
-aaa
+aav
 aaa
 aaa
 aaa
@@ -101074,37 +102953,37 @@ aaa
 aaa
 aaa
 aaa
+gJK
+lMJ
+aaa
+lMJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-nYJ
-aaa
-aaa
-aep
-aep
 aax
+pID
+gVr
+omi
+ltI
+aes
+ltI
 pES
-abe
+pGE
 asn
-fon
-mQt
-npX
+xeX
+xeX
+xeX
 jlv
-cFu
+vRd
 cFu
 lqa
 abe
 vVl
 ybN
-ugv
+trJ
 aep
 aaa
 vrW
-aaa
+aav
 aaa
 aaa
 aaa
@@ -101331,26 +103210,26 @@ aaa
 aaa
 aaa
 aaa
+gJK
+lMJ
+aaa
+lMJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-fwb
-aaa
-aaa
-aep
+aax
+yju
+rBf
+omi
+dxl
 adG
 agN
-aaw
-abe
-omJ
-eYo
-pSL
-eYo
-eYo
+cLM
+pGE
+xeX
+cGT
+xeX
+pCI
+pCI
 abM
 xuw
 bkx
@@ -101588,22 +103467,22 @@ aaa
 aaa
 aaa
 aaa
+gJK
+aQj
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-fwb
 lMJ
+aep
 aax
 aax
+ghE
+oKL
+bId
+uUg
 eSd
-adh
-aaw
-abe
-cGs
+iBI
+xaN
+fud
+wLN
 gfP
 pAv
 voJ
@@ -101612,13 +103491,13 @@ hNd
 xeX
 guu
 aep
-iSs
-guP
+sOd
+shg
 agH
-qTO
-qFw
+iDL
+vaW
 agH
-qTO
+rWX
 qFw
 aeJ
 aaa
@@ -101845,37 +103724,37 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-fwb
+gJK
+lMJ
 aaa
 aep
+aep
+mov
+clD
+etf
+xSW
+tBO
 pna
 afd
-adh
-tfm
-abe
-abe
+iBI
+fvz
+aep
+aep
 aep
 abe
 abe
 gNS
-guP
-xeX
+aPN
+wLN
 vVt
 abe
-iSs
-guP
+gwQ
+uNn
 agH
-bbT
-kJj
+dPK
+bcy
 agH
-bbT
+pTi
 kJj
 aeJ
 aaa
@@ -102102,37 +103981,37 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-fwb
-aaa
+gJK
+lMJ
+lMJ
 aep
-aaw
-aeU
-mgJ
-aaw
+tzT
+ptc
+qXD
+etf
+ltI
+tBO
 pna
-eYo
-iSs
-eYo
+eSd
+iBI
+lAY
+ijA
+ijA
+bBU
+oUe
 abe
 abe
 sVR
-abe
+aep
 abe
 abe
 abz
-guP
+dqO
 agH
-iZo
+nGi
 acX
 agH
-iZo
+nGi
 aei
 aeJ
 aeJ
@@ -102359,37 +104238,37 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-fwb
+gJK
 lMJ
-aax
-ngy
-cpk
-qcZ
+aaa
+aep
+aAs
+xSW
+xSW
+xSW
+xSW
+xSW
+pna
+afd
+iBI
 mgJ
-adh
 eYo
-iSs
 eYo
+oPG
+wiD
 ilo
-eYo
-guP
-eYo
-eYo
-eYo
-iSs
-guP
+ijA
+wTV
+wHk
+ncD
+ijA
+wNx
+otL
 cBe
-iSs
+mzM
 guP
 ady
-iSs
+mzM
 guP
 pUs
 aeJ
@@ -102616,39 +104495,39 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-nYJ
+gJK
 lMJ
-aax
+aaa
+aep
+gRw
+bxa
+nId
+nId
+wbH
+nId
 abK
-afa
+eSd
 ahu
 akz
 ani
-iwv
+xoR
 xoR
 uYG
-pZR
 xoR
 xoR
 xoR
+pgq
 xoR
 xoR
 pZR
 adS
 ejE
-xoR
+adS
 adS
 adq
+orI
 aej
-aej
-iSs
+mki
 iZo
 bbT
 qTO
@@ -102873,26 +104752,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-fwb
+gJK
+lMJ
 aaa
 aep
-adh
+lYp
+xSW
+iCI
+nta
+ltI
+rwN
+pna
 fXG
 geQ
-aaw
-adr
 abe
 abe
 vNf
 abe
 abe
+xKy
+asO
 xKy
 abe
 abe
@@ -102901,7 +104780,7 @@ agH
 agH
 agH
 xsq
-adh
+anc
 adr
 pgX
 aem
@@ -103130,38 +105009,38 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-fwb
+gJK
+lMJ
 aaa
 aep
-jIO
+aep
+dfb
+smj
+nta
+ltI
+rwN
+pna
 afM
 abf
-jkP
-gyR
 abe
-jTA
+fpP
 rQw
-jTA
+fpP
 abe
+jTA
+tih
 piK
-fBP
-oGS
-agH
+abe
+nGH
+mGL
 ibL
 abZ
 acq
-aaw
-adh
+ujI
+anc
 ads
 adO
-ael
+aem
 oJx
 agH
 agH
@@ -103387,30 +105266,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bpB
+gJK
+aQj
+lMJ
+lMJ
+aep
+aax
+aax
+fWv
 cdY
-aax
-aax
+mjP
+hHg
 afU
 ahz
-gSc
-bOL
 abe
-fJX
+bOL
 puI
-keM
+fJX
 abe
 jbB
-kyr
+rEp
+jbB
+abe
 hlB
-agH
+jaM
 jib
 mzr
 agH
@@ -103421,8 +105300,8 @@ htR
 aem
 bIL
 afI
-psm
-sQs
+loi
+eFd
 aeJ
 aaa
 aaa
@@ -103644,30 +105523,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gJK
+fwb
 aaa
 aaa
 aaa
 aaa
 aax
-aax
+jee
+dZb
+vEq
+jSw
+ogV
 aiv
-oFh
-qhc
 abe
 wiy
-qbz
-yeu
+wiy
+wiy
 abe
-tMX
-oFQ
+yeu
+gOr
 oGS
-agH
+abe
+xRq
+lIn
 abD
 iGJ
 agH
@@ -103675,10 +105554,10 @@ acF
 nkV
 adt
 alL
-ilm
-iSs
+aem
+mki
 iZo
-bbT
+hgT
 cvX
 aeJ
 aaa
@@ -103901,18 +105780,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+fwb
+gUm
+gJK
+gJK
+gJK
 aax
+aax
+aax
+aep
+aep
+aep
 aax
 aax
 aax
@@ -103932,8 +105811,8 @@ acI
 poo
 vVP
 alL
-ilm
-pUs
+aem
+pps
 agH
 agH
 agH
@@ -104159,21 +106038,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+lMJ
+lMJ
+aQj
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+aaf
+lMJ
 kHF
 epU
 gAf
@@ -104186,18 +106065,18 @@ eII
 wqm
 acv
 acH
-poo
-vVP
+ihT
+lse
 adR
-fjy
-nyH
+aem
+hcP
 rHi
-nyH
-nAm
+xog
+wxj
 tmL
 nAm
 pfe
-eYo
+kHL
 aio
 aol
 anb
@@ -104430,7 +106309,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaf
 kHF
 oaq
 aay
@@ -104445,16 +106324,16 @@ acv
 acI
 add
 vVP
-alL
+qWk
 aen
-tPW
+cPK
 vaw
-tPW
+cPK
 tPW
 uvm
 iSs
-eYo
-eYo
+cPK
+rZU
 aio
 aol
 apD
@@ -104686,24 +106565,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aaf
+aaf
 kHF
 tiy
 pVK
 aaC
 aaI
+mIS
 abb
-abb
-dXp
+abo
 abG
 acb
 acv
 acJ
 lDT
 adw
-alL
-nIW
+qQE
+adb
 ajm
 ajm
 ajm
@@ -104943,7 +106822,7 @@ aaa
 bMa
 agC
 agC
-agC
+lMJ
 acv
 acv
 acv
@@ -105201,8 +107080,8 @@ lMJ
 lMJ
 lMJ
 lMJ
-lMJ
-lMJ
+lAu
+aaf
 aax
 eEe
 aaE
@@ -105241,7 +107120,7 @@ aAW
 eYX
 aDu
 uvH
-nrn
+eeV
 aHx
 aaa
 aaa
@@ -105457,9 +107336,9 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
-aaa
-aaa
+aaf
 aax
 lbt
 qLm
@@ -105473,8 +107352,8 @@ nyH
 jgM
 ade
 hyP
-adh
-nIW
+xIJ
+iBI
 ahx
 afP
 gFy
@@ -105498,7 +107377,7 @@ ajm
 ajm
 aDv
 aEI
-nrn
+dqW
 aHy
 aaa
 aaa
@@ -105714,23 +107593,23 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
-aaa
-aaa
+aaf
 aax
 jNJ
 ftV
-eda
+eYJ
 tNn
 knx
-ujI
+mhA
 abe
 ace
 acx
 acM
 aep
-tih
-adh
+osH
+ibS
 fKX
 ahx
 ahx
@@ -105745,7 +107624,7 @@ aoq
 gEY
 aqZ
 ahx
-aHE
+tzw
 awV
 avZ
 axR
@@ -105755,7 +107634,7 @@ aHp
 aCk
 aDy
 aDC
-nrn
+dqW
 aHx
 aaa
 aJS
@@ -105971,38 +107850,38 @@ aaa
 aaa
 aaa
 aaa
-aaa
-uxb
-lMJ
+aox
+ack
+aox
 rch
 aax
 aax
 urv
 urv
 aNJ
-tih
+ezO
 abe
 aep
 aep
 aep
 aep
 ecR
-adh
-nIW
-aeX
-afR
-aFt
+ibS
+iBI
 ahy
-aHE
-aFt
-asw
-alQ
+afR
+uql
+ahy
+sTb
+bCu
+fNU
+anB
 apE
 aor
 apE
 dCg
 agT
-aHE
+ycF
 auU
 awa
 axt
@@ -106010,7 +107889,7 @@ aAN
 azD
 aAY
 aCk
-aDC
+jVo
 hHJ
 aGb
 aHx
@@ -106228,7 +108107,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aox
 aaa
 aaa
 aaa
@@ -106236,27 +108115,27 @@ aaa
 wOY
 kxJ
 aax
-aaw
-adM
+bQs
+ezO
 abL
 nvU
-nvU
-izA
+fyo
+fyo
 fyo
 kxc
-aaw
-nIW
-aiq
+ibS
+ehM
+pcG
 rpQ
-aFt
-aiq
-aFt
-aFt
-aky
-aFt
-aFt
+sNi
+oZo
+jwE
+uql
+uql
+uql
+uql
 uhk
-aFt
+uql
 aos
 apF
 atM
@@ -106268,8 +108147,8 @@ aiq
 aiq
 ajm
 hjl
-aDC
-nrn
+kZY
+dqW
 aHx
 aaa
 aJS
@@ -106485,7 +108364,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aox
 xcN
 aaa
 aaa
@@ -106493,29 +108372,29 @@ aaa
 abu
 xBL
 iND
-aaw
-tih
-adh
-adh
-adh
-adh
-adh
+keZ
+ezO
+rRW
+jiV
+jYc
+jYc
+jYc
 pwv
-anc
-xON
-aeZ
-afS
+jYc
+iBI
+ahA
+afR
 agM
 ahA
 aiw
 dtX
-lrV
-anB
+kdr
+atN
 uiS
 atN
-kdr
-ajU
-kdr
+atN
+atN
+atN
 atN
 kdr
 awc
@@ -106524,7 +108403,7 @@ aiq
 aEJ
 aJi
 aCk
-aDy
+tCW
 aEK
 aGd
 aHx
@@ -106742,7 +108621,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aox
 aaa
 aaa
 aaa
@@ -106753,12 +108632,12 @@ aax
 qWF
 adg
 abN
-ujI
+bgX
 mNE
-ujI
-ujI
+jEE
+lrf
 adA
-adh
+jkF
 dKN
 ajm
 afT
@@ -106781,8 +108660,8 @@ aAT
 xjc
 cTY
 aCk
-aDC
-aDC
+jVo
+bcf
 asC
 aHx
 aaa
@@ -106999,9 +108878,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-quc
-lMJ
+aox
+aox
+aox
 rch
 aax
 aax
@@ -107013,12 +108892,12 @@ abe
 aci
 abe
 acO
-adh
+abe
 naq
 adW
 aep
 ajm
-aaa
+lMJ
 aaa
 ajm
 aNA
@@ -107039,7 +108918,7 @@ aiq
 aiq
 ajm
 hjl
-kLT
+eos
 aGf
 aHx
 aaf
@@ -107256,12 +109135,12 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
 aaa
 aaa
-aaa
-pvI
+lMJ
 aaa
 aax
 aep
@@ -107275,7 +109154,7 @@ iCO
 aep
 aep
 aaa
-aaa
+lMJ
 aaa
 ajm
 aiy
@@ -107284,8 +109163,8 @@ ajr
 akK
 anl
 aou
-apJ
-arb
+apM
+aeq
 asq
 ava
 anB
@@ -107295,8 +109174,8 @@ aiq
 aEJ
 dhv
 aCk
-aDy
-nrn
+tCW
+nGb
 aGg
 aHx
 aaa
@@ -107513,12 +109392,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
 aaa
 aaa
 aaa
@@ -107531,9 +109410,9 @@ aax
 aep
 aep
 lMJ
+aaa
 lMJ
-lMJ
-lMJ
+aaa
 ajm
 aiz
 ajt
@@ -107542,8 +109421,8 @@ aff
 aeq
 aga
 apJ
-arb
-asw
+nKu
+jFW
 ahF
 auY
 avb
@@ -107552,8 +109431,8 @@ aAX
 aEL
 aBa
 aCk
-aDC
-nrn
+jVo
+nGb
 aGh
 aHx
 aaa
@@ -107775,21 +109654,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aox
-aox
-aox
-aaa
-aaa
-aaa
-aaa
+aaf
 lMJ
+lMJ
+aaf
+aaa
+lAu
+ack
+lAu
+aaa
+aaf
 aaa
 aaa
+aaf
+aaa
+aaf
 aaa
 aeq
 aeq
@@ -107799,9 +109678,9 @@ aeq
 aeq
 agb
 apL
-aeq
+ecN
 ass
-nJH
+luX
 adY
 axi
 ajx
@@ -107810,7 +109689,7 @@ ajx
 ajx
 adY
 lxj
-nrn
+nGb
 aHw
 aHy
 aaa
@@ -108040,14 +109919,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+aaf
+srq
 lMJ
-aaa
-aaa
-aaa
+lMJ
+lMJ
+lMJ
+lMJ
 aeq
 aer
 bgB
@@ -108055,7 +109934,7 @@ akC
 alU
 ann
 agc
-apM
+wlr
 aeq
 ast
 avY
@@ -108066,8 +109945,8 @@ aCh
 aFR
 dnM
 adY
-aDw
-nrn
+jVo
+nGb
 aIr
 aHx
 aHy
@@ -108298,24 +110177,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-mQN
-aaa
-aaa
-yfT
+aaf
+rmG
+rmG
+rmG
+fNA
+fNA
+rmG
 aeq
 aiA
 akD
-ano
-agK
+gSJ
+qmq
 ano
 agK
 apN
-cZk
-kdr
-nJH
+arb
+ass
+luX
 ajx
 awf
 aDE
@@ -108323,8 +110202,8 @@ aDE
 roZ
 pvK
 aBc
-aDw
-nrn
+jVo
+nGb
 aGj
 aJT
 moO
@@ -108555,24 +110434,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-lMJ
-aaa
-aaa
-aaa
+aaf
+rmG
+qAm
+lWi
+grJ
+qZW
+jFz
 aeq
 xVU
 ajv
 akE
 alW
 iUC
-alW
-akE
+vav
+xeQ
 arf
 asv
-awc
+qEQ
 azb
 ayB
 ayy
@@ -108581,8 +110460,8 @@ npx
 aBb
 hql
 aDw
+nGb
 nrn
-asC
 nrn
 aIJ
 nrn
@@ -108812,13 +110691,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-lMJ
-aaa
-aaa
-aaa
+aaf
+rmG
+fJu
+vEm
+veq
+neD
+fgZ
 aeq
 bLT
 bgB
@@ -108828,8 +110707,8 @@ anq
 agd
 aoy
 anl
-asw
-nJH
+amJ
+luX
 ajx
 awg
 axh
@@ -108838,7 +110717,7 @@ mDQ
 dmU
 yej
 aDA
-nrn
+nGb
 aGl
 nrL
 adD
@@ -109069,12 +110948,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-lsQ
+aaf
 rmG
-fNA
-fNA
+rmG
+rmG
+rmG
+kwI
 rmG
 rmG
 aeq
@@ -109086,7 +110965,7 @@ aeq
 aeq
 aeq
 agU
-nJH
+luX
 adY
 ayE
 ajx
@@ -109326,32 +111205,32 @@ aaa
 aaa
 aaa
 aaa
-dGI
-lMJ
+aaf
 rmG
-rmG
-grJ
+qbS
+teZ
+sms
 eCv
 skU
 rmG
 qep
 qsK
-ttQ
-ttQ
+nxb
+nxb
 rVj
 kyo
 nxb
 fNA
-asw
-nJH
+amJ
+ueI
 aaD
 awi
-aHE
+iac
 uNe
 ece
 ece
 rqO
-nrn
+spW
 aET
 aGn
 aHD
@@ -109583,34 +111462,34 @@ aaa
 aaa
 aaa
 aaa
-fwb
-aaa
+aaf
 fNA
+jNm
 nge
-ruv
-qsk
+cQz
+cQz
 qWL
-ivk
-uLt
+rmG
+trZ
 pwh
-pwh
-pwh
-pwh
+trZ
+trZ
+trZ
 qCO
 trZ
-evw
-kdr
+kel
+amJ
 aiB
 apF
 awj
 aHE
 ayC
-aBi
+wnx
 aBe
 aCp
-nrn
-aDC
-yiw
+ahQ
+nDP
+aGn
 aHD
 aIM
 aIR
@@ -109840,27 +111719,27 @@ aaa
 aaa
 aaa
 aaa
-lMJ
-lMJ
+aaf
 rmG
-rmG
+xNR
+exP
 jvG
 wLi
 fUv
-rmG
-nPM
-qsK
-ttQ
-tVp
-iMT
-eRF
+gJX
 cQz
-fNA
+cQz
+cQz
+cQz
+cQz
+cQz
+cQz
+aLT
 asz
 fjF
-anB
+gKI
 aCn
-axt
+rid
 azN
 eoT
 eoT
@@ -110097,21 +111976,21 @@ aaa
 aaa
 aaa
 aaa
-cTB
 aiJ
 aiJ
-cTB
+aiJ
+aiJ
 aiJ
 hnP
-cTB
 aiJ
-rmG
+aiJ
+rRy
 rwn
-fNA
-tum
-wZI
-fNA
-wZI
+tmW
+tVp
+mLE
+bAC
+pvS
 hbe
 fNA
 wZI
@@ -110361,14 +112240,14 @@ gib
 qBy
 oCD
 eeq
-akW
-oIZ
-wOj
-xee
-nZE
-gTW
-khj
-tFS
+aiJ
+rmG
+rmG
+fNA
+raj
+wZI
+fNA
+wZI
 wZI
 tZX
 wZI
@@ -110621,13 +112500,13 @@ cZZ
 xFX
 wMV
 doZ
-igz
+rcM
 gTZ
 hAX
 rcM
 pwX
 hVM
-cpe
+gPJ
 fNA
 asw
 nJH
@@ -110878,8 +112757,8 @@ nIg
 aey
 wZI
 jGf
-khj
-jsu
+cpe
+kyN
 kyN
 vXG
 scq
@@ -110887,8 +112766,8 @@ diD
 yfi
 pwt
 xoL
-avb
-axt
+kmu
+exe
 mEn
 azO
 apk
@@ -111136,12 +113015,12 @@ aey
 jLR
 khj
 cpe
-cpe
-cpe
+chq
+mok
 jEO
 gMs
-nZE
-cpe
+tVp
+uzt
 tkS
 avh
 aFt
@@ -111392,10 +113271,10 @@ jkv
 aey
 jLR
 gDo
-jSP
-uJw
 cpe
-mBi
+uJw
+ifg
+jEO
 gMs
 nZE
 mAi
@@ -111648,17 +113527,17 @@ kdA
 jkv
 aey
 jLR
-khj
+gDo
 lyV
 nnS
-cpe
-cpe
+smB
+jEO
 ioj
 eCu
 wZI
 wZI
 mfG
-aFt
+uql
 axs
 ayF
 ayF
@@ -111906,15 +113785,15 @@ jkv
 aey
 jLR
 gDo
-haP
-dYn
 cpe
-fLj
+dYn
+xhN
+jEO
 gMs
 wow
 tpR
 kel
-amD
+asw
 awq
 aHE
 ayG
@@ -112164,16 +114043,16 @@ aey
 wZI
 kOp
 cpe
-cpe
-cpe
-xVh
+xyU
+wwt
+jEO
 gMs
-nZE
+meT
 iaj
 kel
-amI
+asw
 awr
-axt
+fgb
 ayH
 aCu
 aCu
@@ -112420,11 +114299,11 @@ akW
 aiJ
 cYH
 khj
-khj
-gvK
+cpe
+pvO
 pvO
 soJ
-gtR
+gMs
 sbp
 wZI
 wZI
@@ -112679,10 +114558,10 @@ nhv
 iKy
 jHW
 mpE
-qlv
+dqB
 dqB
 sUd
-nZE
+oXH
 qOR
 fNA
 avi
@@ -112923,10 +114802,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+aaf
+aaf
+lMJ
 jVV
 jVV
 hyY
@@ -112937,9 +114816,9 @@ fqM
 qCH
 qdW
 xvZ
-khj
+vXM
 vST
-nZE
+vXM
 oXY
 rmG
 ajm


### PR DESCRIPTION
Ports the permabrig and security map from the previous build of metastation, and includes changes from https://github.com/Skyrat-SS13/Skyrat-tg/pull/4687.
![image](https://user-images.githubusercontent.com/43841046/113782681-6f121580-96e7-11eb-9236-e1745762bf68.png)

Re-added prison, same as it was before but with a slightly bigger janitor closet and a windows in the license plate room.

![image](https://user-images.githubusercontent.com/43841046/113782705-76392380-96e7-11eb-9315-d612e5e69ab4.png)

Made security's tiles black again, and (ported from #4687)
1. Moved EVA equipment from security prep to its own room, using the Gear Storage door used on Icebox station's EVA storage. Also adds bio and bomb suit lockers. Adds practice laser carbines
2. Expanded locker room width by one tile. All lockers are on one side, toolboxes and tables moved on the other side, with added crowbars and hand labeller
3. Moved the shutters to the armoury so that they'd enter to the two tile wide space, for better traffic flow