### PR TITLE
Icebox Sec/Prison map port

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -68,12 +68,6 @@
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"aau" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "aav" = (
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
@@ -115,9 +109,22 @@
 /turf/closed/wall,
 /area/security/execution/transfer)
 "abd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown4";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "prisonlockdown4";
+	name = "Lockdown";
+	pixel_x = -24;
+	req_access_txt = "63"
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "abk" = (
 /obj/machinery/keycard_auth{
@@ -221,6 +228,17 @@
 "abz" = (
 /turf/closed/wall,
 /area/security/prison/safe)
+"abA" = (
+/obj/structure/bed/maint,
+/obj/machinery/flasher{
+	id = "IsolationFlash";
+	pixel_y = 28
+	},
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 5
+	},
+/area/security/prison)
 "abH" = (
 /obj/structure/table,
 /obj/item/storage/box/chemimp{
@@ -555,13 +573,6 @@
 	},
 /turf/open/floor/plating/icemoon,
 /area/security/execution/transfer)
-"acC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/command/heads_quarters/hos)
 "acH" = (
 /obj/structure/table,
 /turf/open/floor/carpet,
@@ -597,14 +608,14 @@
 /area/command/heads_quarters/hos)
 "acR" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	on = 0;
-	pixel_x = -3;
-	pixel_y = 8
-	},
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
+	},
+/obj/item/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -4;
+	pixel_y = 10
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
@@ -644,12 +655,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"acX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/security/interrogation)
 "adh" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -784,24 +789,8 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "adN" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side,
 /area/security/prison)
-"adP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/carpet,
-/area/command/heads_quarters/hos)
 "adR" = (
 /turf/closed/wall/r_wall,
 /area/security/office)
@@ -930,8 +919,6 @@
 	req_access_txt = "58"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "aeC" = (
@@ -993,6 +980,17 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"aeZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 9
+	},
+/area/security/prison/safe)
 "afn" = (
 /turf/open/floor/plating,
 /area/security/office)
@@ -1148,44 +1146,30 @@
 /obj/machinery/computer/security/mining,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"agH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+"agB" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown1";
+	name = "Lockdown"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/security/interrogation)
+/area/security/prison)
 "agI" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "agJ" = (
 /obj/item/cigbutt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"agK" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Forestry";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "agL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -1214,10 +1198,10 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "agZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -1430,26 +1414,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "aiC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "aiE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "aiI" = (
@@ -1560,6 +1533,14 @@
 "ajc" = (
 /turf/open/floor/plating/icemoon,
 /area/hallway/secondary/entry)
+"ajd" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "ajm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1700,7 +1681,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
-/turf/open/floor/plating/snowed/icemoon,
+/turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors)
 "ajX" = (
 /obj/machinery/computer/teleporter{
@@ -1922,9 +1903,7 @@
 	pixel_x = -26;
 	pixel_y = -8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -1947,6 +1926,7 @@
 /area/security/brig)
 "alB" = (
 /obj/machinery/computer/secure_data,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "alD" = (
@@ -2014,11 +1994,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "amc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "amd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -2048,8 +2026,8 @@
 	pixel_y = 5;
 	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -2073,7 +2051,7 @@
 	},
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -2450,7 +2428,7 @@
 /area/security/courtroom)
 "anV" = (
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -2907,6 +2885,31 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet,
 /area/commons/dorms)
+"apZ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/machinery/camera{
+	c_tag = " Prison - Janitorial";
+	network = list("ss13","prison")
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "aqa" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3395,11 +3398,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
-"arS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool,
-/turf/open/floor/iron,
-/area/security/prison)
 "arT" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase,
@@ -3911,10 +3909,8 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "atu" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/smartfridge,
+/turf/closed/wall/rust,
 /area/security/prison)
 "atv" = (
 /obj/structure/table,
@@ -4827,11 +4823,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "awi" = (
-/obj/machinery/shower{
-	dir = 4
-	},
+/obj/machinery/light,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bucket/wooden,
 /obj/structure/cable,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
 /area/security/prison/safe)
 "awj" = (
 /obj/machinery/door/airlock/maintenance{
@@ -5011,13 +5009,12 @@
 /area/hallway/secondary/entry)
 "awO" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
 /area/security/prison)
 "awP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5033,11 +5030,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "awR" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/security{
+	name = "Permabrig Visitation"
+	},
+/obj/effect/turf_decal/delivery/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "awS" = (
 /obj/structure/chair/stool{
@@ -5079,15 +5078,16 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "awX" = (
-/obj/machinery/door/airlock/security{
-	name = "Permabrig Visitation"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Prison - Visitation (Prisoner)";
+	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "awY" = (
@@ -5911,12 +5911,15 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "azu" = (
-/obj/structure/cable,
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 9
+	},
+/area/security/prison/safe)
 "azw" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -5984,23 +5987,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "azJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/purple/side,
 /area/security/prison/safe)
 "azK" = (
 /obj/machinery/light{
@@ -6437,18 +6430,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
-"aAN" = (
-/obj/machinery/door/airlock/security{
-	name = "Prison Forestry"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "aAO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -7489,13 +7470,9 @@
 /area/maintenance/starboard/fore)
 "aEh" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aEj" = (
 /obj/effect/turf_decal/bot_white,
@@ -7542,11 +7519,12 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "aEs" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/flasher{
+	id = "transferflash";
+	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -7786,6 +7764,12 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"aFi" = (
+/obj/machinery/door/airlock/freezer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "aFj" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/blue{
@@ -8202,8 +8186,17 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
 "aGu" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/iron,
+/obj/machinery/camera{
+	c_tag = "Prison Isolation Cell";
+	dir = 9;
+	network = list("ss13","prison","isolation")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 6
+	},
 /area/security/prison)
 "aGv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8355,10 +8348,11 @@
 /area/hallway/secondary/service)
 "aGK" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "aGO" = (
 /obj/structure/cable,
@@ -8396,10 +8390,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGS" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "aGU" = (
@@ -8426,17 +8418,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aGX" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "aGY" = (
 /obj/machinery/airalarm{
 	pixel_y = 25
@@ -9051,21 +9032,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
-"aIG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "aIH" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -9628,11 +9594,16 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aKb" = (
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
 	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/security/prison)
 "aKc" = (
 /obj/machinery/door/firedoor,
@@ -10988,14 +10959,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"aOu" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Permabrig Maintenance";
-	req_access_txt = "1"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "aOv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -13430,6 +13393,7 @@
 	name = "Armoury Shutter"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
 "aWr" = (
@@ -21263,6 +21227,17 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"brr" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell3";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "brs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -23515,6 +23490,17 @@
 "bxu" = (
 /turf/closed/wall,
 /area/cargo/qm)
+"bxv" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/machinery/light/small/red,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "bxy" = (
 /turf/closed/wall,
 /area/cargo/miningdock)
@@ -23677,12 +23663,10 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "bxY" = (
-/obj/structure/chair/stool,
-/obj/structure/cable,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "bya" = (
 /obj/item/transfer_valve{
@@ -23795,11 +23779,8 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "byK" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Cafeteria"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
 /area/security/prison)
 "byN" = (
 /obj/machinery/newscaster{
@@ -24438,6 +24419,13 @@
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/iron,
 /area/service/janitor)
+"bAW" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/maintenance/space_hut/cabin)
 "bAX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -24743,12 +24731,20 @@
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bCa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
 	},
-/turf/open/floor/iron,
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 20;
+	prison_radio = 1
+	},
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
+	},
 /area/security/prison)
 "bCd" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -24805,7 +24801,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "bCo" = (
 /obj/structure/table,
@@ -26371,14 +26367,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"bGP" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/freezer,
-/area/security/prison/safe)
 "bGS" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
@@ -26691,10 +26679,10 @@
 	},
 /obj/item/storage/firstaid/regular,
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -28436,6 +28424,13 @@
 /obj/structure/closet/wardrobe/grey,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"bND" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/red{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "bNH" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -30530,7 +30525,7 @@
 	pixel_x = -3;
 	pixel_y = -2
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "bWo" = (
 /obj/machinery/door/firedoor/heavy,
@@ -31095,13 +31090,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/misc_lab)
-"bYk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "bYl" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -31723,6 +31711,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"cav" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "caw" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -32366,11 +32362,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"ccO" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "ccP" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -32841,6 +32832,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cff" = (
+/turf/open/genturf,
+/area/icemoon/surface/outdoors)
 "cfg" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -33791,7 +33785,10 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "cjY" = (
 /obj/structure/table/reinforced,
@@ -33838,6 +33835,13 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"ckh" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
+/area/security/prison/safe)
 "cko" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -34068,6 +34072,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"clC" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "clJ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -34238,8 +34251,10 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "cmS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "cmU" = (
 /obj/machinery/light/small,
@@ -34381,14 +34396,11 @@
 	id = "Cell 3";
 	name = "Cell 3"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/bot_blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "cop" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
@@ -34401,16 +34413,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cow" = (
-/obj/structure/filingcabinet,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "coA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34849,14 +34857,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"crc" = (
-/obj/machinery/door/airlock/security{
-	name = "Prison Yard"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/security/prison)
 "crd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -36422,6 +36422,14 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"cxm" = (
+/obj/machinery/camera{
+	c_tag = " Prison - Library";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "cxG" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -36637,6 +36645,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"czb" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "cze" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -36665,6 +36681,14 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"czu" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "czy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -36673,9 +36697,12 @@
 	req_one_access_txt = "1;4"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/delivery/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "czE" = (
 /obj/structure/cable,
@@ -36918,10 +36945,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -37365,14 +37390,12 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "cDf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "cDg" = (
 /obj/effect/turf_decal/stripes/line{
@@ -37609,11 +37632,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
-"cEj" = (
-/obj/structure/table,
-/obj/item/toy/cards/deck,
-/turf/open/floor/iron,
-/area/security/prison)
 "cEk" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -38175,21 +38193,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"cHi" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "cHj" = (
 /obj/machinery/power/emitter/welded{
 	dir = 8
@@ -38515,12 +38518,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cKX" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "cKZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38547,17 +38544,10 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter)
 "cMX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "cNr" = (
 /obj/effect/turf_decal/trimline/blue/corner,
@@ -38693,27 +38683,16 @@
 	dir = 4;
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/prison)
-"cQn" = (
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "cQo" = (
 /obj/machinery/computer/prisoner/management,
@@ -38727,13 +38706,12 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "cQt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "cQL" = (
 /obj/machinery/gulag_item_reclaimer{
@@ -38742,7 +38720,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "cRi" = (
 /obj/machinery/door/firedoor,
@@ -38808,6 +38786,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/hallway/secondary/service)
+"cSp" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "cSE" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
@@ -39093,8 +39076,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "cUl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/firealarm{
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side,
 /area/security/prison)
 "cVb" = (
 /turf/closed/wall,
@@ -39145,6 +39133,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"cXT" = (
+/obj/structure/table,
+/obj/item/soap,
+/obj/item/storage/bag/tray,
+/obj/item/storage/box/condimentbottles{
+	pixel_y = 10
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
 "cYY" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -39172,10 +39173,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "cZr" = (
 /obj/machinery/computer/warrant{
@@ -39184,52 +39183,36 @@
 /obj/structure/sign/departments/court{
 	pixel_y = 32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
-"daR" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 4"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
-"dbz" = (
-/obj/structure/bed,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/bedsheet/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
-"ddf" = (
+"cZP" = (
+/obj/structure/bed/maint,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = 32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/security/prison)
+"cZZ" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot_blue,
+/turf/open/floor/iron/dark,
+/area/security/office)
+"ddf" = (
+/obj/structure/table,
+/obj/machinery/computer/libraryconsole{
+	pixel_y = 8
+	},
+/obj/machinery/button/curtain{
+	id = "prisonlibrarycurtain";
+	pixel_x = -24
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "ddy" = (
 /obj/machinery/door/window/westleft{
@@ -39242,9 +39225,12 @@
 /turf/open/floor/engine,
 /area/science/genetics)
 "deg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Prison - Visition (Visitor)";
+	dir = 1;
+	network = list("ss13","prison")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "deK" = (
@@ -39261,15 +39247,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"dgs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"dgl" = (
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	desc = "If you want to pump gas into just the prison, isolate it with the nearby valve before pumping! Otherwise the entire distribution pipenet will get the gas.";
+	dir = 8;
+	name = "Connectors to Distribution"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/prison)
+"dgs" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "dgP" = (
 /obj/structure/cable,
@@ -39302,7 +39293,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "djF" = (
 /obj/structure/table/wood/poker,
@@ -39316,11 +39307,14 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "dka" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
+/obj/machinery/firealarm{
+	pixel_y = 18
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "dkH" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -39363,23 +39357,18 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "dlN" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "dlO" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/bot_blue,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "dmq" = (
 /obj/machinery/computer/secure_data{
@@ -39418,6 +39407,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dod" = (
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/head/hardhat/red,
+/obj/item/clothing/mask/gas,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/prison)
 "doz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side{
@@ -39450,6 +39448,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/medical/cryo)
+"dqk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "dqL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -39476,6 +39480,13 @@
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"dtT" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "dul" = (
 /obj/structure/filingcabinet,
 /obj/machinery/airalarm{
@@ -39507,9 +39518,8 @@
 "dvG" = (
 /obj/effect/landmark/start/head_of_security,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "dvO" = (
 /obj/structure/extinguisher_cabinet{
@@ -39538,16 +39548,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"dxg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+"dxm" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = -6
+	},
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
+"dyd" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/carpet/green,
+/area/maintenance/space_hut/cabin)
 "dyj" = (
 /obj/machinery/light,
 /turf/open/floor/engine,
@@ -39557,6 +39572,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"dyM" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/security/old{
+	glass = 1;
+	name = "Garden"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "dyN" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
@@ -39581,10 +39606,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"dBX" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "dCe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/east,
@@ -39663,6 +39684,15 @@
 "dGF" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"dHf" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "dHE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
@@ -39704,15 +39734,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"dIH" = (
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "dJg" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
@@ -39728,22 +39749,15 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness)
 "dJo" = (
-/obj/structure/toilet/greyscale{
-	dir = 8;
-	open = 1
+/obj/machinery/button/curtain{
+	id = "prisoncell3";
+	pixel_y = 21
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
 /area/security/prison/safe)
 "dJx" = (
 /obj/structure/disposalpipe/segment{
@@ -39758,23 +39772,6 @@
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall,
 /area/hallway/secondary/service)
-"dJZ" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
 "dMb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -39813,10 +39810,8 @@
 	c_tag = "Fore Primary Hallway West";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "dPz" = (
 /obj/structure/table,
@@ -39827,6 +39822,21 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
+"dQy" = (
+/obj/structure/table/wood,
+/obj/item/kirbyplants{
+	icon_state = "plant-17";
+	pixel_y = 26
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/machinery/light/small,
+/turf/open/floor/carpet/green,
+/area/maintenance/space_hut/cabin)
 "dQC" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -39854,31 +39864,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"dRE" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permaouter";
-	name = "Permabrig Transfer";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/prison)
 "dSj" = (
 /obj/machinery/dish_drive/bullet{
 	succrange = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "dSk" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/effect/landmark/start/junior_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "dSx" = (
 /obj/effect/turf_decal/plaque{
@@ -39887,6 +39884,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"dTe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "dUe" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/door/firedoor,
@@ -39899,30 +39903,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"dUz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "dUO" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "dVr" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/landmark/start/prisoner,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/security/prison)
 "dWG" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -39930,6 +39925,18 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/engine,
 /area/science/genetics)
+"dXp" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
+"dXA" = (
+/obj/machinery/flasher{
+	id = "visitorflash";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "dXW" = (
 /obj/machinery/light,
 /obj/machinery/power/apc/auto_name/south,
@@ -39939,9 +39946,11 @@
 /area/cargo/office)
 "dYg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
+	},
 /area/security/prison)
 "dYh" = (
 /obj/structure/disposalpipe/segment{
@@ -39958,12 +39967,19 @@
 "dYq" = (
 /turf/closed/wall,
 /area/science/nanite)
+"dYx" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Prison Atmospherics Control";
+	req_one_access_txt = "1;2;24;32;63"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "dYM" = (
 /obj/structure/cable,
-/obj/machinery/holopad/secure,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/item/pen/blue,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "dZn" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -39982,6 +39998,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"eaq" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permaouter";
+	name = "Permabrig Transfer";
+	req_access_txt = "2"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "eat" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -40005,10 +40034,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "ebu" = (
 /obj/machinery/atmospherics/components/binary/valve{
@@ -40050,11 +40077,8 @@
 	dir = 1;
 	pixel_y = -27
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "efT" = (
 /obj/structure/disposalpipe/segment,
@@ -40082,14 +40106,26 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
+"eio" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "eiK" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -40144,6 +40180,15 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron,
 /area/medical/virology)
+"emn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/command/heads_quarters/hos)
 "emq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -40156,25 +40201,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"enl" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Laundry"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "eoi" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/meeting_room)
+"eos" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "eoI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -40227,15 +40266,13 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "erO" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "esn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
@@ -40283,9 +40320,10 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "euL" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permainner";
-	name = "Permabrig Transfer"
+/obj/machinery/camera{
+	c_tag = " Prison - Central";
+	dir = 1;
+	network = list("ss13","prison")
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -40303,7 +40341,7 @@
 "evX" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "ewk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40332,13 +40370,13 @@
 	},
 /obj/machinery/iv_drip,
 /obj/item/reagent_containers/blood,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue/darkblue,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "exZ" = (
@@ -40360,6 +40398,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"eyf" = (
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "eys" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -40373,7 +40415,11 @@
 /area/science/misc_lab)
 "eyQ" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "ezU" = (
 /obj/item/clothing/gloves/boxing/green,
@@ -40403,21 +40449,6 @@
 	icon_state = "wood-broken"
 	},
 /area/maintenance/port/aft)
-"eBE" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"eCK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "eDG" = (
 /obj/structure/table/glass,
 /obj/item/storage/fancy/candle_box,
@@ -40425,6 +40456,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
+"eFj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	name = "Airmix Reserve to Distribution"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "eFD" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/disks{
@@ -40457,15 +40498,14 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "eIO" = (
-/obj/machinery/camera{
-	c_tag = "Prison Common Room";
-	dir = 8;
-	network = list("ss13","prison")
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "eIS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -40489,12 +40529,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
 "eJB" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "eKA" = (
@@ -40507,6 +40543,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
+"eLs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "eNr" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -40539,20 +40580,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"ePs" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "ePK" = (
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "eQL" = (
 /obj/structure/chair{
@@ -40567,44 +40612,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
-"eQZ" = (
-/obj/structure/toilet/greyscale{
-	dir = 4;
-	open = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
-"eRd" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 1"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
 "eRH" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -40627,7 +40636,7 @@
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "eTo" = (
 /obj/structure/cable,
@@ -40649,10 +40658,18 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "eVr" = (
-/obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/servingdish,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/button/curtain{
+	id = "prisoncell9";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 1
+	},
+/area/security/prison/safe)
 "eVL" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -40668,12 +40685,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "eWy" = (
 /obj/effect/spawner/randomsnackvend,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "eZk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -40683,7 +40700,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "fak" = (
 /obj/effect/turf_decal/stripes/line{
@@ -40723,6 +40743,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"fdm" = (
+/obj/machinery/camera/motion{
+	c_tag = "Armory - External";
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "fep" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens Observation - Starboard Aft";
@@ -40753,6 +40780,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"feS" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "ffa" = (
 /obj/structure/tank_holder/oxygen/red,
 /turf/open/floor/plating,
@@ -40783,6 +40818,17 @@
 /obj/item/storage/fancy/cigarettes,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"fio" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/interrogation{
+	name = "isolation room monitor";
+	network = list("isolation");
+	pixel_y = 31
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "fjm" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Dorm";
@@ -40806,22 +40852,31 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "fjE" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown3";
+	name = "Lockdown"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/machinery/button/door{
+	id = "prisonlockdown3";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access_txt = "63"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "fjY" = (
-/obj/structure/sign/warning/securearea{
-	pixel_y = -32
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell6";
+	name = "curtain"
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "fka" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -40853,8 +40908,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/caution/stand_clear/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/processing)
+"fms" = (
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
 "fnz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40873,22 +40936,19 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"foi" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig South";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "fox" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/office)
+"foS" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/security/prison)
 "fpc" = (
 /obj/structure/cable,
 /mob/living/simple_animal/sloth/paperwork,
@@ -40904,6 +40964,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"fpt" = (
+/obj/structure/holohoop{
+	density = 0;
+	pixel_y = 18
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 1;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "fpx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40913,6 +40987,33 @@
 	},
 /turf/open/floor/plating,
 /area/security/office)
+"fqg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "icehut2";
+	name = "curtain"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/space_hut/cabin)
+"fqu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = -20
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "fqQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40940,8 +41041,34 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
+"frT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/wirecutters,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/secateurs,
+/obj/item/secateurs,
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
+	},
+/area/security/prison)
 "fsg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40957,17 +41084,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/misc_lab)
-"fsI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/office)
 "fsQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -41002,42 +41118,39 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/storage)
-"fwh" = (
-/obj/structure/table,
-/obj/item/clothing/under/rank/prisoner/skirt{
-	pixel_x = -13;
-	pixel_y = 5
+"fvo" = (
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/clothing/gloves/color/blue,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/mop,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/item/clothing/under/rank/prisoner/skirt{
-	pixel_x = 9;
-	pixel_y = 5
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/item/clothing/under/rank/prisoner{
-	pixel_x = -2;
-	pixel_y = 5
+/obj/item/storage/bag/trash,
+/turf/open/floor/iron/kitchen{
+	dir = 1
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "fxr" = (
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "fxH" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/pinpointer_dispenser,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"fxV" = (
-/obj/machinery/camera{
-	c_tag = "Prison Cell Block North";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
 "fxY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -41059,48 +41172,52 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "fzj" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
-"fzz" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/obj/effect/turf_decal/tile/neutral{
+"fzm" = (
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/turf/open/floor/iron/kitchen{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/area/security/prison)
+"fzz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell1";
+	name = "curtain"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/security/prison/safe)
+"fzF" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "fzG" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "fAq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -41108,6 +41225,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"fAT" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell10";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "fBf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -41153,31 +41280,28 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "fBH" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/firealarm{
+	pixel_y = 18
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
+"fBI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "fBM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "fDD" = (
 /obj/item/assembly/mousetrap,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"fEC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/cola/red,
-/turf/open/floor/iron,
-/area/security/prison)
 "fEF" = (
 /obj/machinery/light{
 	dir = 4
@@ -41185,10 +41309,11 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "fFU" = (
 /obj/structure/chair{
@@ -41203,7 +41328,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "fGg" = (
 /obj/effect/turf_decal/tile/blue{
@@ -41219,22 +41344,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"fGj" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red{
+"fGq" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security/brig)
+/area/security/prison)
 "fHZ" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/icemoon,
@@ -41257,14 +41376,11 @@
 	name = "Brig";
 	req_access_txt = "63; 42"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "fKY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -41290,7 +41406,7 @@
 /obj/item/pen,
 /obj/item/hand_labeler,
 /obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "fMP" = (
 /obj/structure/extinguisher_cabinet{
@@ -41317,37 +41433,39 @@
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "fNJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
+"fNM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/cardboard,
+/obj/item/weldingtool/mini,
+/obj/item/grown/cotton/durathread,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/reagent_containers/hypospray/medipen/oxandrolone,
+/obj/item/stack/sheet/glass{
+	amount = 10
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/obj/item/stack/sheet/iron/twenty,
+/turf/open/floor/plating,
+/area/security/prison)
 "fPh" = (
 /obj/structure/sign/painting/library,
 /turf/closed/wall,
 /area/hallway/secondary/service)
 "fPO" = (
 /obj/machinery/power/apc/auto_name/east,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "fPV" = (
 /obj/structure/chair{
@@ -41357,16 +41475,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "fQA" = (
 /obj/machinery/airalarm{
@@ -41399,10 +41511,10 @@
 	dir = 4;
 	name = "Brig Infirmary"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue/darkblue,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "fRv" = (
@@ -41452,13 +41564,10 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "fSV" = (
 /obj/machinery/gun_vendor,
@@ -41513,6 +41622,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/fitness)
+"fXF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "fXM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -41565,13 +41687,23 @@
 /area/commons/vacant_room/commissary)
 "fZk" = (
 /obj/structure/table,
-/obj/machinery/recharger,
 /obj/machinery/airalarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 18
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/item/storage/toolbox/drone,
+/turf/open/floor/iron/dark,
 /area/security/warden)
+"fZr" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = -6;
+	reclaim_rate = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
 "fZs" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -41579,10 +41711,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "gaj" = (
 /obj/structure/bed,
@@ -41592,7 +41724,7 @@
 	pixel_x = -28
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "gby" = (
 /obj/machinery/light{
@@ -41610,22 +41742,30 @@
 "gbO" = (
 /turf/closed/wall,
 /area/medical/surgery)
+"gbS" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/kitchen/rollingpin,
+/obj/machinery/button/curtain{
+	id = "icehut3";
+	pixel_x = 10;
+	pixel_y = 21
+	},
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "gbT" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"gcz" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/shovel/spade,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
+"gcB" = (
+/obj/structure/bed/maint,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/security/prison)
 "gcG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -41674,6 +41814,17 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
+"gfn" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell6";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "gfO" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Lockers";
@@ -41698,9 +41849,10 @@
 	name = "Equipment Room";
 	req_access_txt = "1"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/delivery/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "ghh" = (
 /obj/structure/cable,
@@ -41709,6 +41861,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"giF" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell8";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "giQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41737,6 +41900,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"gjc" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/layer4,
+/obj/structure/cable,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/prison)
 "gjC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -41755,14 +41925,10 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "gkv" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "gkC" = (
 /obj/structure/closet/l3closet/virology,
@@ -41788,19 +41954,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"glM" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/security/office)
+"glN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/security/prison)
 "glY" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "gnf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "gnX" = (
 /obj/effect/turf_decal/stripes/line{
@@ -41845,7 +42024,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "gqg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -41883,11 +42062,11 @@
 "guf" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "guI" = (
 /obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "gwd" = (
 /obj/effect/turf_decal/stripes/line{
@@ -41903,20 +42082,12 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "gxj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Prison Cell Block Central";
-	dir = 1;
-	network = list("ss13","prison")
+/obj/machinery/shower{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/freezer,
+/area/security/prison/safe)
 "gyr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -41926,13 +42097,29 @@
 /obj/structure/sign/departments/cargo,
 /turf/closed/wall,
 /area/cargo/office)
+"gyF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "gyW" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
 	name = "Cell 3 Locker"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "gzQ" = (
 /obj/structure/disposalpipe/segment{
@@ -41940,58 +42127,30 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"gAn" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron,
-/area/security/prison)
 "gAK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
+/obj/machinery/button/flasher{
+	id = "IsolationFlash";
+	pixel_x = 21;
+	pixel_y = 21
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"gAX" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
-"gBc" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig)
+/area/security/prison)
 "gBt" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/kitchen/diner)
+"gBy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "gBO" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Stbd";
@@ -42021,6 +42180,25 @@
 /obj/item/target/syndicate,
 /turf/open/floor/plating,
 /area/security/office)
+"gDb" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison/safe)
 "gDr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -42034,19 +42212,15 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "gEc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gEp" = (
 /turf/open/openspace/icemoon,
@@ -42122,37 +42296,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"gHU" = (
-/obj/structure/table,
-/obj/item/folder,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/photo_album/prison,
-/obj/item/camera,
+"gIk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
-"gIe" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 7"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
 "gIB" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -42175,8 +42324,18 @@
 	dir = 4
 	},
 /obj/machinery/suit_storage_unit/hos,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
+"gKf" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "gKq" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -42213,7 +42372,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "gNi" = (
@@ -42229,10 +42390,10 @@
 /area/commons/toilet/locker)
 "gNu" = (
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -42294,9 +42455,17 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "gRA" = (
-/obj/structure/table,
-/obj/item/kitchen/fork/plastic,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = " Prison - (East) Brown Wing";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
 /area/security/prison)
 "gRS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -42315,9 +42484,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"gSU" = (
-/turf/open/floor/iron,
-/area/security/office)
 "gSY" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -42339,13 +42505,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "gUV" = (
 /obj/machinery/computer/crew{
@@ -42374,27 +42536,6 @@
 	},
 /turf/open/openspace,
 /area/commons/storage/mining)
-"gVZ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Prison Laundry";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "gWd" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -42407,9 +42548,17 @@
 /turf/open/floor/carpet,
 /area/service/chapel/main)
 "gWI" = (
-/obj/effect/spawner/randomarcade,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/kitchen,
 /area/security/prison)
 "gWZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -42420,11 +42569,19 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "gXi" = (
-/obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/item/pen,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/obj/machinery/computer/security,
+/turf/open/floor/iron/dark,
 /area/security/office)
+"gXY" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "gYm" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -42470,6 +42627,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/storage/mining)
+"hbb" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"hbx" = (
+/obj/structure/flora/tree/dead,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "hcB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -42520,19 +42687,26 @@
 /obj/structure/closet/secure_closet/cytology,
 /turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
+"hfx" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "hgj" = (
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/security/brig)
@@ -42554,15 +42728,15 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
+"hgQ" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
+/area/security/prison)
 "hhs" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -42571,6 +42745,22 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"his" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/cardboard{
+	amount = 10
+	},
+/obj/item/stack/sheet/cloth/ten,
+/turf/open/floor/plating,
+/area/security/prison)
+"hiC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "hjk" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
@@ -42586,16 +42776,13 @@
 	name = "Labor Shuttle";
 	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "hjZ" = (
 /turf/open/floor/iron/white,
@@ -42629,17 +42816,27 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
 "hnO" = (
-/obj/machinery/camera{
-	c_tag = "Prison Cafeteria";
-	dir = 8;
-	network = list("ss13","prison")
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 6
+	},
+/area/security/prison/safe)
 "hnW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
+"hoc" = (
+/obj/structure/bookcase/random/fiction,
+/obj/machinery/firealarm{
+	pixel_y = 18
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "hpN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -42654,30 +42851,14 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/processing)
-"hrn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "hrZ" = (
 /obj/item/radio/intercom{
 	pixel_y = -29
 	},
-/obj/machinery/computer/security{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "hte" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -42691,9 +42872,14 @@
 /turf/open/openspace/icemoon,
 /area/science/server)
 "hty" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/old{
+	name = "Kitchen"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "huk" = (
 /obj/item/screwdriver{
@@ -42722,6 +42908,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
+"huy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/security/prison)
 "huA" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white/side{
@@ -42735,7 +42926,7 @@
 /obj/structure/closet/secure_closet/courtroom,
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/gavelhammer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "hwE" = (
 /obj/effect/landmark/start/hangover,
@@ -42776,6 +42967,16 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"hyQ" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 6;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison)
 "hzQ" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -42785,6 +42986,20 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"hAl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "hAr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -42891,33 +43106,45 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
-"hEP" = (
-/obj/effect/turf_decal/tile/red{
+"hEL" = (
+/obj/item/grown/log,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/food/grown/peas,
+/obj/item/food/grown/onion,
+/obj/item/food/grown/garlic,
+/obj/item/food/grown/harebell,
+/obj/item/food/grown/poppy/lily,
+/obj/item/food/grown/poppy/geranium,
+/obj/item/food/grown/poppy,
+/obj/item/grown/cotton,
+/obj/machinery/light/small{
 	dir = 1
 	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/security/prison)
+"hEP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "hET" = (
-/obj/structure/table,
-/obj/item/folder/red,
-/obj/item/pen,
-/obj/item/inspector,
-/turf/open/floor/iron,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "hFg" = (
 /obj/machinery/door/airlock/external{
@@ -42931,17 +43158,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "hFS" = (
 /obj/machinery/vending/boozeomat/all_access,
@@ -42956,10 +43174,13 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "hGl" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "hGo" = (
@@ -42976,24 +43197,14 @@
 	dir = 8
 	},
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/security/brig)
-"hGw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "hGx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
@@ -43035,42 +43246,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"hIc" = (
-/obj/structure/table,
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = 10
+"hIg" = (
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = -8
-	},
-/obj/item/clothing/under/rank/prisoner{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"hIw" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/security/prison)
 "hIM" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "hIZ" = (
 /obj/effect/turf_decal/tile/green{
@@ -43117,6 +43303,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"hNw" = (
+/obj/item/pickaxe,
+/obj/structure/flora/grass/both,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "hOx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -43130,11 +43321,9 @@
 /area/science/storage)
 "hOM" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "hPF" = (
 /obj/effect/landmark/event_spawn,
@@ -43148,10 +43337,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"hQA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
-/area/security/office)
 "hQC" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -43188,10 +43373,18 @@
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "hSE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "isolationshutter"
+	},
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/security/prison)
+"hTf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "hTU" = (
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
@@ -43211,16 +43404,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"hUr" = (
+"hVs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
+"hVx" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/security/processing)
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "hVD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -43270,12 +43466,17 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "hXd" = (
-/obj/machinery/light{
-	dir = 8
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 20;
+	prison_radio = 1
 	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "hXw" = (
 /obj/structure/window/reinforced,
@@ -43303,14 +43504,8 @@
 	c_tag = "Security Office";
 	dir = 1
 	},
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "hZS" = (
 /obj/structure/industrial_lift{
@@ -43351,13 +43546,10 @@
 /obj/machinery/camera{
 	c_tag = "Brig East"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ibL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -43443,7 +43635,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "ifj" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -43466,20 +43658,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"ify" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 18
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "ifF" = (
 /obj/machinery/camera{
 	c_tag = "Labor Shuttle Dock South";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "ihi" = (
 /obj/effect/turf_decal/tile/red{
@@ -43498,19 +43695,18 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "ihy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "iiz" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "iiC" = (
 /obj/machinery/power/apc/auto_name/west,
@@ -43543,19 +43739,6 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"ijh" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "ijG" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -43591,11 +43774,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"imX" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/security/prison)
 "ink" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -43639,6 +43817,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"ipa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "ipA" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
@@ -43676,17 +43860,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"isl" = (
-/obj/structure/closet/crate,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/onion,
-/obj/item/food/grown/onion,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "isK" = (
 /obj/machinery/door/window/eastright{
 	name = "Bar Access"
@@ -43705,17 +43878,17 @@
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"isU" = (
-/obj/effect/turf_decal/tile/blue{
+"isV" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "isY" = (
 /obj/structure/disposalpipe/segment{
@@ -43744,35 +43917,38 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "itT" = (
-/obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/bedsheet/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/table,
+/obj/item/paper_bin/carbon{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/item/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -4;
+	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/turf/open/floor/plating,
+/area/security/prison)
 "itY" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/item/storage/box/donkpockets/donkpocketberry,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/item/pen,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "iuR" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/freezer,
+/area/security/prison/safe)
 "ivU" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -43801,18 +43977,8 @@
 "ixq" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
-"iyN" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "izp" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=QM";
@@ -43840,14 +44006,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"iAp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "iAM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -43883,6 +44041,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/mixing)
+"iEy" = (
+/obj/machinery/light,
+/turf/open/water/overlay{
+	desc = "It's a pool for swimming in!";
+	icon_state = "hotspring_tile";
+	name = "pool"
+	},
+/area/security/prison)
 "iEH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
@@ -43906,13 +44072,16 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"iGp" = (
+/obj/structure/chair/office,
+/turf/open/floor/wood,
+/area/security/prison)
 "iGX" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "iHd" = (
 /obj/machinery/power/apc/auto_name/west,
@@ -43955,28 +44124,6 @@
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
-"iKn" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/item/seeds/onion,
-/obj/item/seeds/garlic,
-/obj/item/seeds/potato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/iron,
-/area/security/prison)
 "iKz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -44002,7 +44149,7 @@
 /area/service/kitchen)
 "iNo" = (
 /obj/machinery/computer/security/labor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "iOI" = (
 /obj/structure/rack,
@@ -44027,17 +44174,18 @@
 /area/command/heads_quarters/rd)
 "iPI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
-"iQk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"iQk" = (
+/obj/structure/table,
+/obj/item/assembly/signaler,
+/obj/item/clothing/suit/straight_jacket,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/item/electropack,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "iQF" = (
 /obj/structure/disposalpipe/segment,
@@ -44107,6 +44255,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"iWJ" = (
+/obj/machinery/light,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "iXm" = (
 /obj/item/stack/cable_coil{
 	amount = 5
@@ -44135,6 +44290,14 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"iYE" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "iZi" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/requests_console{
@@ -44167,7 +44330,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "iZH" = (
 /obj/structure/cable,
@@ -44205,7 +44368,7 @@
 "jbV" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "jcy" = (
 /obj/structure/table,
@@ -44225,26 +44388,36 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/commons/storage/mining)
+"jdF" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permainner";
+	name = "Permabrig Transfer";
+	req_access_txt = "2"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "jdH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jei" = (
-/obj/structure/table,
-/obj/item/storage/box/hug{
-	pixel_x = 4;
-	pixel_y = 3
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/structure/closet/secure_closet/genpop,
+/obj/machinery/light_switch{
+	pixel_y = -23
 	},
-/obj/item/razor{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"jgG" = (
+/obj/machinery/processor,
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/light,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jgM" = (
 /obj/effect/turf_decal/tile/blue{
@@ -44284,9 +44457,13 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
+"jhm" = (
+/obj/structure/flora/grass/both,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "jhD" = (
 /obj/machinery/computer/security,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "jhG" = (
 /obj/effect/turf_decal/tile/red,
@@ -44357,11 +44534,8 @@
 	name = "Cell 2";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jkd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -44375,11 +44549,10 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "jkz" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jkG" = (
 /obj/machinery/power/apc/auto_name/south,
@@ -44406,10 +44579,27 @@
 "jlY" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 18
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/processing)
+"jmf" = (
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 20;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 5
+	},
+/area/security/prison/safe)
+"jmA" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "jni" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44430,10 +44620,10 @@
 /area/science/xenobiology)
 "jnk" = (
 /obj/structure/table,
-/obj/item/pen,
-/obj/structure/cable,
-/obj/item/instrument/harmonica,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "joe" = (
 /obj/structure/cable,
@@ -44448,14 +44638,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "joT" = (
 /obj/structure/lattice/catwalk,
@@ -44498,6 +44684,27 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
+"jqz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
+"jqP" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/security/old{
+	name = "Janitorial"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"jrl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/security/prison)
 "jrH" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd2";
@@ -44537,7 +44744,7 @@
 /obj/machinery/camera{
 	c_tag = "Labor Shuttle Dock North"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "jtQ" = (
 /obj/effect/turf_decal/tile/red,
@@ -44557,31 +44764,34 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "jud" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
-"jvu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/structure/toilet{
+	pixel_y = 16
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 5
+	},
 /area/security/prison/safe)
+"jvh" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/openspace/icemoon,
+/area/icemoon/surface/outdoors)
 "jvR" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -44627,6 +44837,15 @@
 /obj/item/hand_labeler,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"jxl" = (
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/effect/landmark/start/prisoner,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 6
+	},
+/area/security/prison/safe)
 "jxt" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/turf_decal/bot,
@@ -44649,14 +44868,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"jxP" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "jyF" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/iron/dark,
@@ -44678,6 +44889,11 @@
 	dir = 9
 	},
 /area/science/research)
+"jAx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
 "jAK" = (
 /obj/machinery/rnd/server,
 /obj/structure/lattice/catwalk,
@@ -44710,14 +44926,15 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "jCT" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
+/obj/machinery/button/curtain{
+	id = "prisoncell4";
+	pixel_y = 21
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
 	dir = 1
 	},
-/turf/open/floor/iron/freezer,
 /area/security/prison/safe)
 "jCV" = (
 /obj/structure/cable,
@@ -44743,12 +44960,10 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "jFl" = (
 /obj/machinery/mechpad,
@@ -44781,10 +44996,36 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
+"jFV" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "jGi" = (
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"jHl" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "jHt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -44808,10 +45049,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "jHW" = (
 /obj/structure/table,
@@ -44919,6 +45158,27 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"jNa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
+"jNJ" = (
+/obj/machinery/hydroponics/soil{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -2;
+	self_sustaining = 1
+	},
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
+	},
+/area/security/prison)
 "jPn" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -44926,19 +45186,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"jPv" = (
-/obj/machinery/door/airlock{
-	name = "Permabrig Showers"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/security/prison/safe)
 "jPE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -44958,6 +45205,12 @@
 	},
 /turf/open/floor/iron,
 /area/science/storage)
+"jQh" = (
+/obj/structure/table,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
+/area/security/prison/safe)
 "jQp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -44967,20 +45220,13 @@
 /area/medical/medbay/aft)
 "jQY" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jRs" = (
 /obj/structure/table/glass,
@@ -45013,12 +45259,19 @@
 	dir = 10
 	},
 /area/science/research)
+"jSK" = (
+/obj/structure/curtain/cloth,
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "jST" = (
 /obj/machinery/button/flasher{
 	id = "cell4";
 	pixel_x = 24
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jTr" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -45038,12 +45291,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "jUh" = (
-/obj/structure/chair{
-	dir = 8
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell9";
+	name = "curtain"
 	},
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "jUA" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/cable,
@@ -45056,19 +45312,13 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "jUG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jUW" = (
 /obj/structure/cable,
@@ -45139,28 +45389,30 @@
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "jXa" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jXG" = (
-/obj/machinery/door/airlock/security{
-	name = "Cell Block"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
 /area/security/prison)
 "jXT" = (
-/obj/machinery/button/flasher{
-	id = "transferflash";
-	pixel_y = 24
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "prison blast door"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jYM" = (
 /obj/structure/chair/office,
@@ -45209,6 +45461,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"kce" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown4";
+	name = "Lockdown"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "kcg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -45221,12 +45482,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "kcm" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Central";
-	dir = 8;
-	network = list("ss13","prison")
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/security/prison)
 "kct" = (
 /obj/machinery/button/door{
@@ -45247,7 +45506,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kcz" = (
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "kcL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -45283,13 +45545,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
+"kcZ" = (
+/obj/item/seeds/tomato,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
+	},
+/area/security/prison)
 "kdi" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Control";
 	req_access_txt = "3"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "kdq" = (
 /obj/item/radio/intercom{
@@ -45303,7 +45573,10 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "kdI" = (
 /obj/docking_port/stationary{
@@ -45321,6 +45594,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"kdV" = (
+/obj/item/trash/chips,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "ken" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -45340,8 +45621,8 @@
 /obj/item/radio/intercom{
 	pixel_y = -29
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "kfh" = (
 /obj/structure/window/reinforced{
@@ -45370,12 +45651,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "kiA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/machinery/light,
 /turf/open/floor/iron,
 /area/security/prison)
 "kjH" = (
@@ -45439,6 +45720,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/fitness)
+"kmZ" = (
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 20;
+	prison_radio = 1
+	},
+/obj/item/trash/popcorn,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 9
+	},
+/area/security/prison/safe)
 "knx" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -45470,25 +45767,19 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "kpe" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "2"
+/obj/structure/cable,
+/obj/machinery/firealarm{
+	pixel_y = 18
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kpl" = (
 /obj/machinery/gulag_teleporter,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "kpM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45503,6 +45794,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"krE" = (
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/meter/atmos/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "krJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -45530,22 +45826,9 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"ksN" = (
-/obj/effect/turf_decal/delivery/blue,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24;
-	pixel_y = 3
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "ktd" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/timer,
-/turf/open/floor/iron,
+/obj/effect/landmark/start/security_sergeant,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "ktt" = (
 /obj/item/reagent_containers/glass/bottle/nutrient/empty{
@@ -45576,8 +45859,10 @@
 /area/medical/surgery)
 "kuA" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "kuW" = (
 /obj/effect/landmark/start/hangover,
@@ -45593,6 +45878,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"kvD" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/blue/side,
+/area/security/prison/safe)
 "kvF" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -45604,13 +45900,14 @@
 "kwn" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
+/area/security/office)
+"kwy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "kwA" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
@@ -45684,11 +45981,8 @@
 	name = "Cell 3";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "kyZ" = (
 /obj/structure/disposalpipe/segment,
@@ -45745,6 +46039,24 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
+"kAg" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
+"kAE" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/item/reagent_containers/hypospray/medipen,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "kAK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -45781,18 +46093,6 @@
 	dir = 10
 	},
 /area/science/research)
-"kCq" = (
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/office)
-"kCH" = (
-/obj/structure/table,
-/obj/item/assembly/flash/handheld,
-/turf/open/floor/iron,
-/area/security/office)
 "kDo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -45806,6 +46106,16 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"kDp" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisonlibrarycurtain";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "kDt" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -45821,6 +46131,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/mixing)
+"kFx" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "kFE" = (
 /obj/structure/chair{
 	dir = 8;
@@ -45833,7 +46152,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "kFN" = (
 /obj/structure/table/glass,
@@ -45865,7 +46184,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "kGt" = (
 /obj/structure/table,
@@ -45906,6 +46225,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/genetics)
+"kHy" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Visitation";
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "kHN" = (
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
@@ -45928,6 +46257,19 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"kLc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/structure/lattice/catwalk{
+	layer = 2.5;
+	plane = -1
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors)
 "kLd" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -45959,13 +46301,9 @@
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "kNm" = (
 /obj/structure/table/wood,
@@ -45979,6 +46317,15 @@
 /obj/item/kirbyplants/fullysynthetic,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
+"kNP" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "kOw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	dir = 4
@@ -46006,11 +46353,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "kQl" = (
-/obj/structure/cable,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kQq" = (
 /obj/effect/turf_decal/stripes/line,
@@ -46044,6 +46392,15 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"kRj" = (
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/bedsheet/purple,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 6
+	},
+/area/security/prison/safe)
 "kRC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -46118,14 +46475,10 @@
 	dir = 4;
 	name = "Prosecution"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "kXX" = (
 /obj/machinery/firealarm{
@@ -46137,42 +46490,21 @@
 	dir = 9
 	},
 /area/science/research)
-"kYU" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permaouter";
-	name = "Permabrig Transfer";
-	req_access_txt = "2"
+"kZK" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell8";
+	name = "curtain"
 	},
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
-"kYY" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Cafeteria"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "kZR" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"lat" = (
-/obj/effect/landmark/start/security_officer,
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "laS" = (
 /obj/effect/landmark/start/blueshield,
 /obj/structure/chair/office{
@@ -46224,11 +46556,13 @@
 /area/hallway/primary/central)
 "lfG" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "lfH" = (
 /obj/machinery/light,
@@ -46237,11 +46571,8 @@
 	name = "Cell 1";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "lhu" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -46294,6 +46625,17 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"liY" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "ljx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -46314,15 +46656,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/genetics)
-"lma" = (
-/obj/structure/window,
-/obj/effect/decal/cleanable/food/flour,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "lmU" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/showroomfloor,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "loq" = (
 /obj/structure/chair/office,
@@ -46338,13 +46679,15 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "lqk" = (
 /obj/structure/mineral_door/wood,
@@ -46382,6 +46725,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"lts" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/laser/practice,
+/obj/item/gun/energy/laser/practice,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "ltG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -46398,13 +46753,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "luH" = (
 /obj/structure/sign/warning/securearea{
@@ -46483,6 +46837,10 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
+"lyS" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "lzo" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -46520,6 +46878,10 @@
 /mob/living/simple_animal/pet/dog/pug/mcgriff,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"lzO" = (
+/obj/structure/curtain/cloth,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "lAB" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
@@ -46531,6 +46893,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"lBM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "lCi" = (
 /obj/docking_port/stationary/public_mining_dock{
 	dir = 8
@@ -46542,6 +46912,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/mixing)
+"lCI" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "lCT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -46561,14 +46938,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"lEH" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/mob/living/simple_animal/mouse/brown/tom,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "lEW" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/effect/turf_decal/delivery,
@@ -46578,6 +46947,14 @@
 	},
 /turf/open/floor/iron,
 /area/science/storage)
+"lFg" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "lFP" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
@@ -46638,25 +47015,15 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"lHS" = (
-/obj/machinery/door/airlock/security{
-	name = "Cell Block"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/prison)
 "lHY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/table,
+/obj/item/clothing/gloves/color/orange,
+/obj/item/restraints/handcuffs,
+/obj/item/reagent_containers/spray/pepper,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "lIm" = (
 /obj/effect/turf_decal/stripes/line,
@@ -46668,11 +47035,23 @@
 "lIZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
+"lJt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/security/prison)
+"lJw" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 18
+	},
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "lJA" = (
 /obj/structure/closet/bombcloset,
 /obj/effect/turf_decal/stripes/corner{
@@ -46689,6 +47068,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"lJN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/trashcart,
+/obj/item/seeds/tower/steel,
+/obj/item/grown/log/bamboo,
+/obj/item/crowbar/red,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/plating,
+/area/security/prison)
 "lKc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -46719,8 +47107,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
+"lKB" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "lLp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -46729,11 +47124,23 @@
 /turf/open/floor/iron,
 /area/science/nanite)
 "lLN" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
+"lNd" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "lNo" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -46749,6 +47156,15 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/security/office)
+"lNX" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "lOw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -46807,9 +47223,12 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/effect/turf_decal/delivery/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "lQm" = (
 /obj/machinery/camera{
@@ -46846,6 +47265,17 @@
 "lRC" = (
 /turf/closed/wall/mineral/wood,
 /area/maintenance/space_hut/cabin)
+"lRK" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell8";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison/safe)
 "lRS" = (
 /turf/open/floor/iron/white/side{
 	dir = 4
@@ -46868,22 +47298,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"lSG" = (
-/obj/structure/table,
-/obj/item/assembly/signaler,
-/obj/item/clothing/suit/straight_jacket,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Hallway East";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/security/prison)
 "lST" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -46950,6 +47364,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"lVN" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
+/area/security/prison/safe)
+"lVT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "lWd" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
@@ -46988,6 +47417,20 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/bar)
+"lYw" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "lZo" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -47017,18 +47460,14 @@
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "mam" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/iron,
-/area/security/prison)
-"maA" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/plant_analyzer,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/machinery/light,
+/obj/structure/chair{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/brown/side,
+/area/security/prison/safe)
 "mbf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -47036,16 +47475,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"mcc" = (
-/obj/machinery/door/airlock/security{
-	name = "Isolation Cell";
-	req_access_txt = "2"
+"mbz" = (
+/obj/machinery/camera{
+	c_tag = " Prison - Entrance";
+	dir = 10;
+	network = list("ss13","prison")
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "mdh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -47085,9 +47525,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/item/stack/package_wrap,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "mgw" = (
 /obj/effect/landmark/blobstart,
@@ -47111,16 +47551,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"mhu" = (
-/obj/machinery/flasher{
-	id = "visitorflash";
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "mhJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47149,11 +47579,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
-"mhY" = (
-/obj/structure/table,
-/obj/item/food/energybar,
-/turf/open/floor/iron,
-/area/security/prison)
 "mib" = (
 /obj/machinery/light{
 	dir = 4
@@ -47164,15 +47589,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "miU" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/prison)
 "miW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -47214,7 +47638,6 @@
 "mlh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "mlw" = (
@@ -47223,13 +47646,14 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "mnV" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/shower{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison/safe)
 "mpJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -47271,6 +47695,17 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
+"mrk" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell5";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "mrM" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -47288,22 +47723,17 @@
 /area/engineering/main)
 "mtn" = (
 /obj/machinery/computer/prisoner/gulag_teleporter_computer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "mtK" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
 "mue" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "muj" = (
 /obj/structure/lattice/catwalk,
@@ -47320,16 +47750,23 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "mwi" = (
-/obj/structure/cable,
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -30;
-	prison_radio = 1
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown1";
+	name = "Lockdown"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/button/door{
+	id = "prisonlockdown1";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"mwM" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
 /area/security/prison)
 "mwN" = (
 /obj/machinery/power/apc/auto_name/east,
@@ -47344,16 +47781,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
-"mxO" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "myc" = (
 /obj/machinery/smartfridge/chemistry,
 /obj/structure/disposalpipe/segment,
@@ -47367,14 +47794,9 @@
 	id = "brigentry";
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/caution/stand_clear/blue,
+/obj/effect/turf_decal/bot_blue,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mzr" = (
 /obj/effect/landmark/start/hangover,
@@ -47383,18 +47805,26 @@
 	},
 /area/service/chapel/main)
 "mAa" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/sign/departments/court{
 	pixel_x = 32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
+"mAq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/structure/lattice/catwalk{
+	layer = 2.5;
+	plane = -1
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors)
 "mAr" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -47408,13 +47838,9 @@
 	req_access_txt = "2"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mBm" = (
 /obj/effect/turf_decal/stripes/line{
@@ -47443,10 +47869,24 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"mCx" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "mDj" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"mDW" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "mEM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -47454,7 +47894,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "mEX" = (
 /obj/effect/turf_decal/stripes/line{
@@ -47466,25 +47906,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/carpet,
 /area/maintenance/space_hut/cabin)
-"mFh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
 "mFq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -47535,14 +47956,19 @@
 /turf/open/floor/plating,
 /area/crew_quarters/cryopod)
 "mGO" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
+"mGU" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "mHR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -47571,7 +47997,7 @@
 /area/medical/surgery/room_b)
 "mIJ" = (
 /obj/machinery/computer/secure_data,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "mJd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -47605,16 +48031,18 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness)
 "mLn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/kitchen,
 /area/security/prison)
+"mLu" = (
+/obj/machinery/door/airlock/wood{
+	desc = "The... what?";
+	name = "Warm Paws Cozy Cabin"
+	},
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "mLY" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -47637,26 +48065,24 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/medical/chemistry)
+"mMx" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "mMA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
-"mMC" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera{
-	c_tag = "Prison Isolation Cell";
-	dir = 8;
-	network = list("ss13","prison");
-	view_range = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "mME" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
@@ -47676,6 +48102,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"mMX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner,
+/area/security/prison)
 "mNa" = (
 /obj/item/target,
 /obj/item/target,
@@ -47713,15 +48145,6 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
-"mOB" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "mPh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -47744,10 +48167,19 @@
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "mPt" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/plate_press,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/prison)
+"mPG" = (
+/obj/machinery/griddle,
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "mQN" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Locker Room Maintenance";
@@ -47782,12 +48214,13 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "mRF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/beach_ball/holoball,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/machinery/firealarm{
+	pixel_y = -28
+	},
+/turf/open/floor/iron/dark/side,
 /area/security/prison)
 "mSf" = (
 /obj/structure/chair/office{
@@ -47799,17 +48232,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "mSB" = (
 /obj/machinery/light{
@@ -47832,26 +48256,24 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "mUB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/button/curtain{
+	id = "prisoncell2";
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/structure/chair,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/iron/dark/purple/side{
+	dir = 8
+	},
+/area/security/prison/safe)
 "mVz" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/box/blue,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mVU" = (
 /obj/structure/chair/stool{
@@ -47859,6 +48281,12 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
+"mWd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/processing)
 "mWw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -47881,7 +48309,10 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "mXr" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "mXH" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -47913,7 +48344,7 @@
 	pixel_x = -28
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mYY" = (
 /obj/effect/turf_decal/tile/blue,
@@ -47937,13 +48368,10 @@
 /turf/open/floor/iron,
 /area/medical/surgery)
 "naf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "naT" = (
 /obj/machinery/status_display/evac{
@@ -48048,8 +48476,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "ngw" = (
+/obj/effect/turf_decal/bot_blue,
 /obj/machinery/vending/security_peacekeeper,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "niL" = (
 /obj/structure/disposalpipe/segment,
@@ -48098,6 +48527,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"nlM" = (
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/carpet,
+/area/security/prison)
 "nlN" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -48127,18 +48560,20 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "nlW" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/large,
+/obj/item/wrench,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/effect/spawner/lootdrop/maintenance/seven,
+/turf/open/floor/plating,
+/area/security/prison)
 "nmv" = (
 /obj/machinery/camera{
 	c_tag = "Brig West";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "nmA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -48172,6 +48607,10 @@
 /obj/structure/girder,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"npw" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "npF" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -48205,15 +48644,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
-"nrW" = (
-/obj/structure/cable,
-/obj/machinery/holopad/secure,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "nsl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -48278,15 +48708,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/crew_quarters/cryopod)
-"nvR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Permabrig North";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "nwJ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -48295,15 +48716,6 @@
 /obj/machinery/vending/modularpc,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"nwT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/brig)
 "nxx" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -48324,15 +48736,15 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "nxy" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 12
+/obj/structure/bookcase/random/religion,
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
 	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bottle/ammonia,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/turf/open/floor/wood,
+/area/security/prison)
 "nxD" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -48392,15 +48804,18 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
 "nyx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/button/curtain{
+	id = "prisoncell1";
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/structure/chair,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/iron/dark/purple/side{
+	dir = 8
+	},
+/area/security/prison/safe)
 "nyF" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
@@ -48423,21 +48838,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "nzq" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/area/security/prison)
 "nzH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -48454,6 +48858,27 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"nzU" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = -4
+	},
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 4
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/prison)
 "nAk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -48469,22 +48894,10 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "nCr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/processing)
-"nCH" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "nCP" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -48510,6 +48923,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"nDg" = (
+/obj/structure/closet/l3closet/security,
+/obj/effect/turf_decal/bot_blue,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/head/bio_hood/security,
+/obj/item/clothing/head/bio_hood/security,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "nDp" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
@@ -48530,6 +48952,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"nEM" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "nEN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -48595,15 +49022,29 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "nGB" = (
-/obj/structure/table,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/security/prison)
 "nHu" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"nHO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/security/prison)
 "nIb" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -48612,6 +49053,25 @@
 /obj/machinery/processor/slime,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"nJL" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 5
+	},
+/area/security/prison/safe)
 "nJN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -48626,14 +49086,6 @@
 	},
 /turf/open/openspace,
 /area/science/xenobiology)
-"nLn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "nLS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -48653,20 +49105,15 @@
 /area/science/xenobiology)
 "nNO" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
-"nNQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
+"nNQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/warden)
-"nOb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/processing)
 "nOl" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -48686,7 +49133,7 @@
 	name = "Cell 1 Locker"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "nOR" = (
 /obj/machinery/door/airlock/external{
@@ -48794,14 +49241,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"nRP" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/item/screwdriver{
-	pixel_y = 10
+"nRK" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/office)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/janitorialcart{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "nSw" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -48835,13 +49289,24 @@
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "nUo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
+"nWo" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/computer/cryopod{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/landmark/start/prisoner/latejoin,
+/obj/effect/turf_decal/delivery/white{
+	color = "#00ff00";
+	name = "green"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "nWA" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Air Supply Maintenance";
@@ -48903,20 +49368,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nYn" = (
+/obj/effect/loot_site_spawner,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
+"nYr" = (
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "nZo" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /obj/structure/bed/dogbed/lia,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/mob/living/simple_animal/hostile/carp/lia,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
-"obu" = (
-/obj/structure/bed,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "obK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -48924,8 +49395,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"ocV" = (
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/structure/sign/warning/securearea{
+	pixel_y = -32
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "prison blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "oeg" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "oeT" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
@@ -48977,18 +49463,29 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
+"oht" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell6";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison/safe)
 "ojY" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/bed,
 /obj/item/clothing/suit/straight_jacket,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue,
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/security/brig)
@@ -49023,6 +49520,11 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/mining)
+"ome" = (
+/obj/structure/cable,
+/obj/structure/grille,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors)
 "omI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -49030,6 +49532,15 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/icemoon,
 /area/science/server)
+"omW" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/office)
 "onG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -49038,18 +49549,15 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ooJ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/door/window/brigdoor/security/holding{
 	id = "Holding Cell";
 	name = "Holding Cell"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/bot_blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ooQ" = (
 /obj/machinery/cryopod{
@@ -49066,6 +49574,18 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"oqb" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "oqQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -49098,11 +49618,11 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "osx" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "otc" = (
 /obj/machinery/light{
@@ -49134,15 +49654,15 @@
 /area/maintenance/space_hut/cabin)
 "otu" = (
 /obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/darkblue,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"otA" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "otB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -49177,6 +49697,16 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"ouI" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Equipment Room";
+	req_access_txt = "1"
+	},
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "ova" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -49187,36 +49717,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"ovp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/security/processing)
-"ovu" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 2"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+"ovx" = (
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
-"ovx" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "ovC" = (
@@ -49256,50 +49762,81 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ozK" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+"ozq" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
+"ozK" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "visitation";
+	name = "Visitation Shutters";
+	pixel_x = 6;
+	pixel_y = 25;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/flasher{
+	id = "visitorflash";
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "oAk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
-"oAN" = (
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/office)
-"oBr" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
+/area/security/brig)
+"oAx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"oAN" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
+"oAU" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 1;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
+"oAX" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"oBk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
+"oBr" = (
+/obj/machinery/light,
+/obj/structure/table,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
 /area/security/prison/safe)
 "oCP" = (
 /obj/structure/flora/tree/pine,
@@ -49309,17 +49846,31 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/engineering/main)
-"oFm" = (
+"oFG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/junior_officer,
-/turf/open/floor/iron,
-/area/security/brig)
+/turf/open/floor/plating,
+/area/security/prison)
 "oFI" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"oGM" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell5";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
+	},
+/area/security/prison/safe)
 "oGZ" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -49348,35 +49899,67 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"oIA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/brig)
 "oIB" = (
 /obj/machinery/light_switch{
 	pixel_y = -23
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/office)
+"oJE" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/security/prison)
+"oKu" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
+	},
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/italian,
+/obj/item/storage/box/ingredients/fruity,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/american,
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 600);
+	name = "Premium All-Purpose Flour (16KG)";
+	volume = 600
+	},
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	list_reagents = list(/datum/reagent/consumable/enzyme = 500);
+	name = "universe-sized universal enyzyme";
+	volume = 500
+	},
+/obj/item/reagent_containers/food/condiment/rice{
+	list_reagents = list(/datum/reagent/consumable/rice = 150);
+	name = "Basmati Rice Sack (4KG)";
+	volume = 150
+	},
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
+"oKN" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "oLN" = (
 /obj/structure/table,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "oMd" = (
 /turf/open/floor/engine,
 /area/science/genetics)
-"oMM" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "oMN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -49415,17 +49998,10 @@
 /turf/closed/wall,
 /area/commons/vacant_room/commissary)
 "oPw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side,
 /area/security/prison)
 "oQa" = (
 /obj/machinery/door/airlock/security/glass{
@@ -49433,9 +50009,10 @@
 	req_access_txt = "3"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/delivery/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "oQe" = (
 /obj/structure/chair/office/light{
@@ -49444,13 +50021,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"oQi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "oQj" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -49487,6 +50057,20 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"oSm" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 10;
+	name = "blue line"
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 18
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/security/prison)
 "oTb" = (
 /obj/machinery/camera{
 	c_tag = "Tech Storage"
@@ -49495,19 +50079,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"oTX" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Common Room"
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "oUf" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing";
 	req_access_txt = "2"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "oUq" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -49520,35 +50101,22 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"oXm" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"oXf" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "icehut3";
+	name = "curtain"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plating,
+/area/maintenance/space_hut/cabin)
+"oXz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
 	},
 /turf/open/floor/iron/dark,
-/area/security/prison/safe)
-"oXz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
 /area/security/processing)
 "oXE" = (
 /obj/structure/disposalpipe/segment{
@@ -49589,6 +50157,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
+"oYc" = (
+/obj/machinery/button/door{
+	id = "isolationshutter";
+	name = "Isolation Shutter";
+	pixel_y = 23;
+	req_access_txt = "63" 
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "oYv" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -49632,15 +50214,26 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
+"oZI" = (
+/obj/item/soap/nanotrasen,
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/structure/curtain/cloth,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
+"oZV" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "paU" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "pbb" = (
 /obj/structure/window/reinforced/fulltile/ice{
@@ -49648,6 +50241,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/space_hut/cabin)
+"pbl" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/security/old{
+	glass = 1;
+	name = "Cafeteria"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"pbq" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 6
+	},
+/area/security/prison/safe)
 "pbT" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -49659,14 +50276,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"pcp" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/trash/sosjerky,
-/obj/item/trash/boritos,
-/obj/item/trash/can,
-/turf/open/floor/iron,
-/area/security/prison)
 "pdW" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -49679,6 +50288,16 @@
 	},
 /turf/open/floor/iron,
 /area/science/storage)
+"pee" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 8;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 8
+	},
+/area/security/prison)
 "peL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/warning/coldtemp{
@@ -49714,27 +50333,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"pga" = (
-/obj/machinery/button/flasher{
-	id = "visitorflash";
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/button/door{
-	id = "visitation";
-	name = "Visitation Shutters";
-	pixel_x = 6;
-	pixel_y = 25;
-	req_access_txt = "2"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "pgb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
@@ -49742,20 +50340,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"pgl" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar,
+/turf/open/floor/iron,
+/area/security/prison)
 "pgP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
-"phe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "phz" = (
 /obj/effect/turf_decal/trimline/blue/end{
 	dir = 1
@@ -49782,14 +50380,16 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "piB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell5";
+	name = "curtain"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "piD" = (
 /obj/machinery/light{
 	dir = 8
@@ -49831,16 +50431,6 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/port/aft)
-"pkd" = (
-/obj/structure/closet/bombcloset/security,
-/turf/open/floor/iron/showroomfloor,
-/area/security/office)
-"pkL" = (
-/obj/machinery/door/window/southleft{
-	name = "Permabrig Kitchen"
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "plW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
@@ -49854,13 +50444,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"pmK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/security/prison)
 "pmL" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "pnj" = (
 /obj/machinery/light{
@@ -49870,16 +50462,13 @@
 /area/science/xenobiology)
 "pns" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/item/storage/box/prisoner{
 	pixel_y = 8
 	},
 /obj/item/storage/box/prisoner,
 /obj/machinery/light,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "pnD" = (
 /obj/structure/table/glass,
@@ -49901,29 +50490,31 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"poE" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
+"poL" = (
+/obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
-"poL" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/iron,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "poM" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"poQ" = (
+/obj/structure/curtain/bounty,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "ppZ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
@@ -49946,15 +50537,21 @@
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "pqJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
+"prz" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell11";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "prA" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral{
@@ -49964,11 +50561,21 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "prV" = (
-/turf/open/floor/iron/white,
-/area/security/prison)
+/obj/machinery/button/curtain{
+	id = "prisoncell11";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 1
+	},
+/area/security/prison/safe)
 "psh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -50009,22 +50616,15 @@
 /area/science/genetics)
 "psS" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+	pixel_y = 18
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "psY" = (
 /obj/structure/disposalpipe/segment{
@@ -50041,7 +50641,7 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "ptl" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "ptB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -50109,6 +50709,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"pyC" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
+/area/security/prison/safe)
 "pyG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -50133,18 +50741,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/start/security_officer,
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
-"pzH" = (
+"pzU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
 /area/security/prison)
 "pAr" = (
 /obj/machinery/cryopod,
@@ -50212,13 +50817,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/item/inspector,
-/turf/open/floor/iron,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "pBU" = (
 /obj/structure/disposalpipe/segment{
@@ -50243,30 +50846,15 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "pCn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncel4";
+	name = "curtain"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"pCO" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison/safe)
 "pDu" = (
 /obj/machinery/computer/nanite_cloud_controller,
@@ -50303,28 +50891,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"pFa" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 8"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
 "pFk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50333,25 +50899,12 @@
 /area/maintenance/port)
 "pFw" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "pFO" = (
 /obj/machinery/camera{
@@ -50362,10 +50915,16 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
+"pGf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "pGO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/mob/living/simple_animal/bot/bulletbot,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "pHl" = (
 /obj/item/kirbyplants/random,
@@ -50376,6 +50935,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"pIx" = (
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 6
+	},
+/area/security/prison/safe)
+"pIM" = (
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "pIS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -50418,8 +50988,20 @@
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "pLk" = (
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown2";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "prisonlockdown1";
+	name = "Lockdown";
+	pixel_x = -24;
+	req_access_txt = "63"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "pLn" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -50427,6 +51009,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"pLL" = (
+/obj/effect/turf_decal/delivery/blue,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24;
+	pixel_y = 3
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "pMv" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/depsec/science,
@@ -50511,29 +51105,27 @@
 "pQs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
-"pRb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
-"pRf" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 3"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+"pQt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
+"pRb" = (
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 20;
+	prison_radio = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 9
+	},
 /area/security/prison/safe)
 "pRs" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -50552,10 +51144,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"pRB" = (
-/obj/effect/landmark/start/warden,
-/turf/open/floor/iron,
-/area/security/office)
 "pSb" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -50658,13 +51246,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "pWN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -50672,12 +51259,45 @@
 	},
 /turf/open/floor/iron,
 /area/science/misc_lab)
-"pXm" = (
+"pXl" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
 /obj/structure/table,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/rice,
-/turf/open/floor/iron/white,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/machinery/light,
+/turf/open/floor/iron,
+/area/security/prison)
+"pXm" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 5
+	},
+/area/security/prison/safe)
+"pXo" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "pXw" = (
 /obj/structure/ladder,
@@ -50699,10 +51319,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay)
-"pXM" = (
-/obj/machinery/vending/wardrobe/peacekeeper_wardrobe,
-/turf/open/floor/iron/showroomfloor,
-/area/security/office)
 "pXN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -50719,7 +51335,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "pZN" = (
 /obj/effect/turf_decal/tile/blue{
@@ -50764,7 +51380,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "qcV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -50772,6 +51392,11 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
+"qdc" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "qde" = (
 /obj/item/crowbar,
 /obj/item/wrench,
@@ -50818,13 +51443,14 @@
 	},
 /area/maintenance/space_hut/cabin)
 "qdH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "qdT" = (
 /obj/machinery/camera{
@@ -50854,13 +51480,22 @@
 	},
 /turf/open/floor/iron,
 /area/science/nanite)
-"qff" = (
-/obj/effect/turf_decal/tile/red{
+"qfa" = (
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
+"qff" = (
 /obj/structure/bed/roller,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "qfR" = (
 /obj/structure/disposalpipe/segment,
@@ -50870,6 +51505,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
+"qgw" = (
+/obj/structure/table,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "qgF" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -50907,6 +51546,36 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"qil" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/office)
+"qjg" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/seeds/banana,
+/obj/item/seeds/carrot,
+/obj/item/seeds/carrot/parsnip,
+/obj/item/seeds/chili,
+/obj/item/seeds/lemon,
+/obj/item/seeds/lime,
+/obj/item/seeds/orange,
+/obj/item/seeds/pineapple,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/wheat/oat,
+/obj/item/seeds/wheat/rice,
+/obj/item/seeds/eggplant,
+/obj/item/seeds/berry,
+/obj/item/seeds/cherry/blue,
+/obj/item/seeds/cherry,
+/obj/item/seeds/grape,
+/obj/item/seeds/grape/green,
+/obj/item/seeds/grass,
+/obj/item/seeds/pumpkin,
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
+	},
+/area/security/prison)
 "qjL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -50927,6 +51596,18 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"qlk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
+"qln" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "qmt" = (
 /obj/structure/chair/stool,
 /obj/structure/disposalpipe/segment,
@@ -50949,18 +51630,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"qnY" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "qps" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -50994,34 +51663,12 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "qpF" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
+/turf/open/floor/iron/dark,
 /area/security/processing)
-"qqP" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/security/prison)
 "qre" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
@@ -51051,14 +51698,13 @@
 /turf/open/floor/engine,
 /area/science/genetics)
 "qrN" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "qrU" = (
 /obj/machinery/disposal/bin,
@@ -51073,6 +51719,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"qtk" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue/side,
+/area/security/prison/safe)
 "qtI" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
@@ -51098,14 +51755,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
-"quZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
 "qvC" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -51113,6 +51762,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"qwy" = (
+/obj/structure/flora/grass/brown,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "qxh" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -51123,12 +51776,17 @@
 /obj/item/storage/box/armament_tokens_energy,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"qxr" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark,
+/area/security/warden)
 "qyg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
+/obj/machinery/atmospherics/components/binary/valve/on/layer4{
+	desc = "Used to isolate the prison's airmix distribution pipeline from the station's main one.";
+	dir = 4;
+	name = "Distro Cutoff Valve"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/security/prison)
 "qyN" = (
@@ -51139,7 +51797,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "qyX" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -51158,10 +51816,20 @@
 	name = "Interrogation";
 	req_access_txt = "63"
 	},
+/obj/effect/turf_decal/delivery/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"qzU" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 5
+	},
+/obj/machinery/button/flasher{
+	id = "transferflash";
+	pixel_y = 24
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "qCr" = (
 /obj/machinery/research/explosive_compressor,
 /obj/effect/turf_decal/bot,
@@ -51178,7 +51846,7 @@
 	c_tag = "Courtroom North"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "qDg" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -51200,14 +51868,25 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
 "qEg" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"qEv" = (
+/obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/security/brig)
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Prison Hallway West";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "qEJ" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L2"
@@ -51215,6 +51894,30 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"qEN" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
+"qGo" = (
+/obj/machinery/camera{
+	c_tag = " Prison - (North-West) Blue Wing";
+	dir = 9;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
+"qGB" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/carpet/green,
+/area/maintenance/space_hut/cabin)
 "qGG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -51248,26 +51951,35 @@
 /obj/machinery/computer/security/telescreen/interrogation{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
-"qJT" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"qJO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
+"qJT" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3;
+	pixel_y = 16
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "qJV" = (
@@ -51309,6 +52021,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
+"qNz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "qNQ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
@@ -51329,15 +52050,27 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"qOz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+"qOd" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = " Prison - Cafeteria";
+	dir = 5;
+	network = list("ss13","prison")
 	},
 /turf/open/floor/iron,
+/area/security/prison)
+"qOz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/mob/living/simple_animal/bot/bulletbot,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "qOQ" = (
 /obj/item/stack/sheet/glass,
@@ -51358,6 +52091,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/lab)
+"qPr" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
+	},
+/area/security/prison)
 "qPT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -51381,10 +52120,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "qQF" = (
 /obj/machinery/camera{
@@ -51400,15 +52137,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"qRY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "qSS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -51430,11 +52158,9 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "qUj" = (
-/obj/machinery/door/airlock{
-	name = "Cleaning Closet"
-	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/security/prison)
 "qVn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -51473,22 +52199,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"qWI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/freezer,
-/area/security/prison/safe)
 "qWJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
+"qXC" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "qXW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51513,6 +52235,38 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"qZu" = (
+/obj/machinery/button/door{
+	id = "permaouter";
+	name = "Outer Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 6;
+	pixel_y = 25;
+	req_access_txt = "2";
+	specialfunctions = 4
+	},
+/obj/machinery/button/door{
+	id = "permainner";
+	name = "Inner Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -6;
+	pixel_y = 25;
+	req_access_txt = "2";
+	specialfunctions = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"qZJ" = (
+/obj/structure/curtain/bounty,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "rat" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -51523,19 +52277,10 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "raE" = (
 /obj/machinery/navbeacon{
@@ -51554,16 +52299,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rbk" = (
 /obj/machinery/door/airlock/external{
@@ -51592,9 +52331,10 @@
 /area/security/interrogation)
 "rdl" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rdH" = (
 /obj/effect/landmark/start/assistant,
@@ -51609,27 +52349,14 @@
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
 "ref" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 6"
+/obj/machinery/firealarm{
+	pixel_y = -28
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "rfL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -51689,6 +52416,12 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"rhU" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "rid" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -51698,11 +52431,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"riD" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "rjh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -51759,11 +52487,34 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/cargo/office)
+"rmb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "rmX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"rnN" = (
+/obj/machinery/door_timer{
+	id = "isolation";
+	name = "Solitary Timer";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
+"roA" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side,
+/area/security/prison)
 "roJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
 	dir = 6
@@ -51779,18 +52530,17 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"rpk" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
-/turf/open/floor/iron,
-/area/security/prison)
 "rqU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/purple/side{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "rrc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -51816,24 +52566,31 @@
 	dir = 4;
 	sortType = 8
 	},
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/inspector,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "rrE" = (
-/obj/machinery/camera{
-	c_tag = "Prison Cell Block East";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"rrX" = (
-/obj/structure/window/reinforced/tinted{
+/obj/machinery/cryopod{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/landmark/start/prisoner/latejoin,
+/obj/effect/turf_decal/delivery/white{
+	color = "#00ff00";
+	name = "green"
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "rsb" = (
-/obj/structure/bookcase/random,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "rsM" = (
@@ -51843,7 +52600,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "rtf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -51864,6 +52621,33 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"rut" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
+	},
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/italian,
+/obj/item/storage/box/ingredients/fruity,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/american,
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 600);
+	name = "Premium All-Purpose Flour (16KG)";
+	volume = 600
+	},
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	list_reagents = list(/datum/reagent/consumable/enzyme = 500);
+	name = "universe-sized universal enyzyme";
+	volume = 500
+	},
+/obj/item/reagent_containers/food/condiment/rice{
+	list_reagents = list(/datum/reagent/consumable/rice = 150);
+	name = "Basmati Rice Sack (4KG)";
+	volume = 150
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "ruy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -51881,7 +52665,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rye" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ryQ" = (
 /obj/structure/training_machine,
@@ -51911,16 +52701,16 @@
 /turf/open/floor/plating,
 /area/medical/morgue)
 "rzp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "rzu" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -51977,6 +52767,26 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"rAF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/built,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/security/prison)
+"rBQ" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "rBV" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/bot,
@@ -51996,14 +52806,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "rDX" = (
 /obj/machinery/door/window/southleft{
@@ -52015,7 +52822,8 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "rET" = (
 /obj/structure/cable,
@@ -52028,6 +52836,27 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"rGy" = (
+/obj/structure/closet/secure_closet/freezer/meat{
+	req_access = null
+	},
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "rGG" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -52036,25 +52865,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"rHf" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/structure/sign/warning/securearea{
-	pixel_y = -32
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "rHn" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -52069,6 +52879,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"rIo" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "rJl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -52106,9 +52930,14 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "rLw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 4;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
 /area/security/prison)
 "rLK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -52121,30 +52950,17 @@
 /obj/structure/closet/secure_closet/medical3,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
-"rLW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "rMl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/processing)
-"rMv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/freezer,
-/area/security/prison/safe)
 "rMz" = (
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/showroomfloor,
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "rNh" = (
 /obj/effect/turf_decal/tile/blue{
@@ -52164,10 +52980,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
-"rNU" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/security/brig)
 "rOk" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -52183,6 +52995,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"rOV" = (
+/obj/machinery/door/airlock/security/old{
+	name = "Jail Cell"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue,
+/area/security/prison/safe)
 "rOY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -52191,6 +53011,13 @@
 	},
 /turf/open/floor/iron,
 /area/science/misc_lab)
+"rPi" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "rPt" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -52207,12 +53034,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "rRS" = (
-/obj/machinery/vending/sustenance,
+/obj/item/trash/energybar,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 1
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "rRX" = (
 /obj/machinery/computer/rdconsole{
@@ -52249,39 +53076,30 @@
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "rSv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rSI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/light,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "rSY" = (
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/security/prison)
 "rTE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -52338,14 +53156,20 @@
 /obj/machinery/camera,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"rXi" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/maintenance/space_hut/cabin)
 "rXY" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "rYh" = (
 /obj/effect/turf_decal/tile/red{
@@ -52366,24 +53190,24 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rZD" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "rZH" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "rZR" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -52408,14 +53232,11 @@
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "sbQ" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "sbS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -52430,9 +53251,10 @@
 	codes_txt = "patrol;next_patrol=EVA";
 	location = "Security"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "scW" = (
 /obj/effect/turf_decal/tile/red,
@@ -52446,14 +53268,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
-"sdA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "sed" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -52599,31 +53413,16 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "snm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/caution/stand_clear/blue,
+/obj/effect/turf_decal/bot_blue,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "snU" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/clothing/gloves/color/orange,
-/obj/item/restraints/handcuffs,
-/obj/item/reagent_containers/spray/pepper,
-/turf/open/floor/iron,
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "snY" = (
 /obj/machinery/dish_drive/bullet{
@@ -52631,6 +53430,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"sol" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/plating,
+/area/security/prison)
 "sox" = (
 /obj/structure/closet/secure_closet/injection,
 /obj/machinery/power/apc/auto_name/east,
@@ -52656,21 +53464,12 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "soI" = (
-/obj/structure/toilet/greyscale{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/turf/open/floor/plating,
+/area/security/prison)
 "soJ" = (
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Monitor";
@@ -52701,39 +53500,27 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"sre" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/security/prison)
 "srx" = (
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "srG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "srU" = (
 /obj/structure/tank_holder,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"sso" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Isolation Cell";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
-"ssB" = (
-/obj/machinery/flasher{
-	id = "transferflash";
-	pixel_y = 28
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "stP" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	color = "#ff0000";
@@ -52800,6 +53587,26 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"swY" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 18
+	},
+/turf/open/floor/iron,
+/area/security/prison)
+"sxf" = (
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/structure/curtain/cloth,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "sxQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -52814,14 +53621,12 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "szh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/holohoop{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = " Prison - East Hallway";
+	dir = 1;
+	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side,
 /area/security/prison)
 "szO" = (
 /obj/structure/window/reinforced{
@@ -52836,6 +53641,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/locker)
+"sAb" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell7";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison/safe)
 "sAD" = (
 /obj/effect/turf_decal/trimline/white/line,
 /obj/item/kirbyplants/fullysynthetic,
@@ -52851,6 +53667,9 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
+"sCd" = (
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "sCZ" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -52864,13 +53683,19 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "sDq" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"sDW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "sGc" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -52931,6 +53756,11 @@
 	},
 /turf/open/floor/iron,
 /area/science/misc_lab)
+"sHl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/security/prison)
 "sHm" = (
 /obj/structure/cable,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -52981,6 +53811,15 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"sKc" = (
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	pixel_y = -28
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "sKS" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -53006,29 +53845,29 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "sLm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "sLw" = (
-/obj/machinery/computer/bookmanagement,
-/obj/structure/table,
-/obj/machinery/newscaster{
-	pixel_x = -32
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/structure/table,
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 20;
+	prison_radio = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "sLX" = (
@@ -53071,6 +53910,17 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
+"sOx" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "sOP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/hangover,
@@ -53094,8 +53944,9 @@
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
-/obj/item/toy/plush/moth,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/vending/wardrobe/peacekeeper_wardrobe,
+/obj/effect/turf_decal/bot_blue,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "sQV" = (
 /obj/machinery/restaurant_portal/restaurant,
@@ -53129,6 +53980,11 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"sSH" = (
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/security/prison)
 "sSX" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -53146,6 +54002,12 @@
 /obj/machinery/atmospherics/pipe/color_adapter,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
+"sUP" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "sUX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -53177,29 +54039,19 @@
 	},
 /turf/open/floor/plating,
 /area/security/office)
-"sXW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/interrogation)
 "sYU" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "sZb" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "sZn" = (
 /obj/effect/turf_decal/bot,
@@ -53231,6 +54083,16 @@
 	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
+"taL" = (
+/obj/machinery/door/airlock/security{
+	name = "Prison Library"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "taM" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes{
@@ -53268,16 +54130,13 @@
 /area/science/misc_lab)
 "tbC" = (
 /obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+	pixel_y = 18
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "tbT" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -53306,10 +54165,6 @@
 /obj/machinery/dna_scannernew,
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"tdO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "tej" = (
 /obj/machinery/destructive_scanner,
 /obj/effect/turf_decal/stripes/end,
@@ -53324,6 +54179,17 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/kitchen/diner)
+"tet" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 6
+	},
+/obj/machinery/camera{
+	c_tag = "Prison Hallway East";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "teG" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -53349,6 +54215,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"teK" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 6
+	},
+/area/security/prison/safe)
 "tge" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large{
@@ -53481,29 +54357,41 @@
 	id = "Cell 2";
 	name = "Cell 2"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/bot_blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "tkC" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"tld" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/security/prison)
 "tll" = (
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron/dark,
 /area/security/office)
+"tlZ" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "icehut1";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/maintenance/space_hut/cabin)
 "tma" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -53525,12 +54413,24 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"tmz" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
+/area/security/prison/safe)
 "tmI" = (
 /obj/machinery/piratepad/civilian,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron,
 /area/cargo/office)
+"tnc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
 "tnw" = (
 /turf/closed/wall,
 /area/medical/surgery/room_b)
@@ -53541,26 +54441,23 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
-"tpb" = (
-/obj/machinery/biogenerator,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "tpv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"tpK" = (
+/obj/structure/cable,
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "tqd" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -53612,19 +54509,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"tqI" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "trt" = (
 /obj/structure/railing,
 /obj/structure/window/reinforced,
@@ -53638,17 +54522,6 @@
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"trY" = (
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "tsw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -53670,6 +54543,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/crew_quarters/cryopod)
+"ttn" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "tto" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/chem_dispenser/drinks,
@@ -53697,7 +54579,7 @@
 /area/security/checkpoint/auxiliary)
 "tuM" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "tvd" = (
 /obj/structure/table,
@@ -53727,19 +54609,22 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "twM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "twO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue/darkblue,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "twX" = (
@@ -53754,10 +54639,10 @@
 	},
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -53788,13 +54673,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
-"tyX" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/trash/chips,
-/obj/item/trash/candy,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "tzz" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -53809,12 +54687,28 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"tzY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+"tAA" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell7";
+	name = "curtain"
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison/safe)
+"tBk" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell7";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "tBp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -53841,16 +54735,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/medical/virology)
+"tCd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/security/prison)
 "tCX" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
-"tDs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "tDw" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -53877,11 +54772,11 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "tEH" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/closet/secure_closet/security_medic,
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/security_medic,
+/obj/effect/turf_decal/tile/blue/darkblue,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "tEN" = (
@@ -53896,6 +54791,12 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
+"tFo" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/dirt/planet{
+	icon_state = "oldsmoothdirt"
+	},
+/area/security/prison)
 "tGE" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
@@ -53912,13 +54813,9 @@
 "tGP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "tHT" = (
 /obj/structure/closet/secure_closet/brig{
@@ -53926,7 +54823,7 @@
 	name = "Cell 2 Locker"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "tIw" = (
 /obj/structure/disposalpipe/segment,
@@ -53937,29 +54834,19 @@
 /mob/living/simple_animal/pet/cat/runtime,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"tJU" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Common Room"
-	},
-/obj/structure/cable,
+"tJW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/security/prison)
 "tJZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/processing)
-"tKf" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/bluespace_vendor/south,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "tKp" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral,
@@ -53969,7 +54856,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "tKG" = (
 /obj/machinery/light/small{
@@ -53985,34 +54872,73 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/locker)
+"tLG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
+/area/security/prison/safe)
+"tLN" = (
+/obj/machinery/door/airlock/security/old{
+	name = "Jail Cell"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/brown,
+/area/security/prison/safe)
 "tMd" = (
 /obj/structure/table,
 /obj/machinery/syndicatebomb/training,
 /obj/item/gun/energy/laser/practice,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "tMl" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
-"tNk" = (
+"tMN" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
+/area/security/prison/safe)
+"tMV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen,
 /area/security/prison)
+"tNk" = (
+/obj/machinery/door/window/brigdoor/security/cell/northleft{
+	id = "isolation";
+	name = "Isolation Cell";
+	opacity = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"tOF" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "tPr" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "tQk" = (
 /obj/machinery/camera{
@@ -54030,20 +54956,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"tQB" = (
-/obj/machinery/camera{
-	c_tag = "Prison Visitation";
-	dir = 1;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "tQM" = (
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/power/apc/auto_name/north,
@@ -54101,6 +55013,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
+"tRQ" = (
+/obj/item/toy/plush/beeplushie{
+	desc = "Maybe hugging this will make you feel better about yourself.";
+	name = "Therabee"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
+/area/security/prison)
 "tSO" = (
 /obj/structure/sink{
 	dir = 8;
@@ -54118,6 +55041,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"tTU" = (
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
 "tUV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54125,15 +55051,12 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "tVr" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "tXK" = (
 /obj/structure/table,
@@ -54169,17 +55092,13 @@
 	pixel_x = 26;
 	pixel_y = -6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "uaA" = (
 /obj/structure/cable,
@@ -54210,15 +55129,32 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"ubX" = (
-/obj/structure/chair{
+"ubO" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/seeds/aloe,
+/obj/item/seeds/apple,
+/obj/item/seeds/cabbage,
+/obj/item/seeds/whitebeet,
+/obj/item/seeds/redbeet,
+/obj/item/seeds/sugarcane,
+/obj/item/seeds/sunflower,
+/obj/item/seeds/tea,
+/obj/item/seeds/tea/astra,
+/obj/item/seeds/tobacco,
+/obj/item/seeds/tomato/blood,
+/obj/item/seeds/cocoapod/vanillapod,
+/obj/item/seeds/cocoapod,
+/obj/item/seeds/coffee/robusta,
+/obj/item/seeds/coffee,
+/obj/item/seeds/corn,
+/obj/item/seeds/cotton,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/potato/sweet,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/security/prison)
 "ubZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54233,24 +55169,32 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"ucB" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "udp" = (
 /obj/item/crowbar/large,
 /obj/structure/rack,
 /obj/item/flashlight,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"udx" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/security/prison)
 "udE" = (
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"udT" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "uea" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -54274,11 +55218,19 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "ufm" = (
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
+"ufo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "ufp" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
@@ -54344,12 +55296,20 @@
 /obj/structure/rack,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"uio" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "uiE" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "uiN" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -54386,12 +55346,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"ukX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"ukw" = (
+/obj/structure/bed/maint,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
 	},
-/turf/open/floor/iron,
+/area/security/prison)
+"ukX" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ulo" = (
 /obj/effect/turf_decal/delivery,
@@ -54401,9 +55365,8 @@
 /turf/open/floor/iron,
 /area/science/misc_lab)
 "ulw" = (
-/obj/item/storage/bag/trash,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/turf/open/floor/wood,
+/area/security/prison)
 "uly" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -54413,11 +55376,8 @@
 	name = "Evidence Storage";
 	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "umk" = (
 /obj/item/radio/intercom{
@@ -54431,7 +55391,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "umx" = (
 /obj/structure/chair/sofa/right,
@@ -54448,25 +55408,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "une" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/landmark/start/prisoner,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/security/prison)
 "uoD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54496,20 +55443,28 @@
 /obj/machinery/computer/crew{
 	dir = 8
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "urb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "urc" = (
 /turf/closed/wall/r_wall,
 /area/commons/storage/mining)
+"urm" = (
+/obj/machinery/camera{
+	c_tag = " Prison - Abandoned Yard";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "urC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -54537,14 +55492,28 @@
 /area/science/research)
 "usq" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/prison)
+"usD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
+"utD" = (
+/obj/structure/closet/bombcloset/security,
+/obj/effect/turf_decal/bot_blue,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/head/bomb_hood/security,
+/obj/item/clothing/head/bomb_hood/security,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "uvi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -54557,14 +55526,11 @@
 	id = "Cell 1";
 	name = "Cell 1"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot_blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uwN" = (
 /obj/machinery/airalarm{
@@ -54588,12 +55554,11 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "uxn" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/obj/machinery/computer/secure_data,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "uxs" = (
 /obj/structure/table,
@@ -54636,10 +55601,19 @@
 	},
 /area/science/research)
 "uyG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 9;
+	name = "blue line"
 	},
-/turf/open/floor/iron,
+/obj/machinery/camera{
+	c_tag = " Prison - (West) Purple Wing";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
 /area/security/prison)
 "uyS" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -54656,6 +55630,31 @@
 	},
 /turf/open/floor/iron,
 /area/science/nanite)
+"uzo" = (
+/obj/structure/rack,
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = -6
+	},
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = -6
+	},
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "uzB" = (
 /obj/structure/displaycase/labcage,
 /obj/effect/turf_decal/stripes/end{
@@ -54663,10 +55662,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
+"uzH" = (
+/obj/structure/flora/grass/green,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "uzJ" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
+/area/security/prison)
 "uAu" = (
 /obj/machinery/door/airlock{
 	name = "Port Emergency Storage"
@@ -54679,6 +55683,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"uAQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "uBY" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -54690,10 +55700,19 @@
 /turf/open/floor/iron,
 /area/science/misc_lab)
 "uCC" = (
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/security/prison)
 "uCO" = (
 /obj/machinery/light,
 /obj/machinery/nanite_program_hub,
@@ -54710,14 +55729,8 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uEh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -54740,19 +55753,23 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "uFU" = (
-/obj/structure/bed,
-/obj/item/bedsheet/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/iron/dark/purple/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
 /area/security/prison/safe)
 "uGw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -54815,6 +55832,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"uIu" = (
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "uIv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54828,35 +55856,22 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uKu" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/iron,
-/area/security/processing)
-"uMS" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
+/area/security/processing)
+"uMS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell2";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
 /area/security/prison/safe)
 "uOW" = (
 /obj/structure/railing{
@@ -54912,8 +55927,14 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "uRJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncel4";
+	name = "curtain"
+	},
 /obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "uSc" = (
@@ -54925,17 +55946,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"uSR" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "uTi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54997,12 +56007,17 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "uTN" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown2";
+	name = "Lockdown"
 	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "uUe" = (
 /obj/structure/flora/ausbushes/fernybush{
 	pixel_x = -3;
@@ -55034,28 +56049,10 @@
 /obj/machinery/restaurant_portal/bar,
 /turf/open/floor/iron,
 /area/service/bar)
-"uVQ" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"uWe" = (
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/security/brig)
-"uWe" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permainner";
-	name = "Permabrig Transfer"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
 /area/security/prison)
 "uWp" = (
 /obj/structure/disposalpipe/segment{
@@ -55071,6 +56068,21 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"uWC" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass{
+	dir = 8
+	},
+/obj/structure/grille/broken,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "uXM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55082,9 +56094,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "uXY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "uYS" = (
 /obj/structure/chair/stool,
@@ -55123,6 +56137,13 @@
 /obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"vbj" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "vbu" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
@@ -55174,28 +56195,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
-"vcq" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 5"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
 "vcX" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -55229,6 +56228,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"vgu" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "vhn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -55244,27 +56248,33 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "vhQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"vhZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "vij" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/table,
+/obj/item/storage/box/hug{
+	pixel_x = 4;
+	pixel_y = 3
 	},
-/turf/open/floor/iron,
-/area/security/prison)
-"viQ" = (
-/obj/structure/chair{
-	dir = 8
+/obj/item/razor{
+	pixel_x = -8;
+	pixel_y = 3
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "vki" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
@@ -55277,15 +56287,12 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "vkC" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/bounty_board{
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vkD" = (
 /obj/effect/landmark/event_spawn,
@@ -55298,22 +56305,35 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
-"vlV" = (
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
+"vlg" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance_carpet,
+/obj/item/reagent_containers/hypospray/medipen/atropine,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"vlB" = (
+/obj/machinery/griddle,
+/turf/open/floor/iron/kitchen,
+/area/security/prison)
+"vlV" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "vmG" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "vmV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -55342,6 +56362,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/storage/mining)
+"voM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "vpB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55358,20 +56383,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/locker)
-"vpZ" = (
-/obj/machinery/seed_extractor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+"vqw" = (
+/turf/closed/mineral/snowmountain/icemoon,
+/area/icemoon/surface/outdoors)
 "vqI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55385,6 +56399,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"vsy" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/barricade/wooden/snowed,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "vsA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -55416,22 +56435,26 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"vva" = (
-/obj/machinery/light/small{
+"vtY" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"vul" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/iron/kitchen{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "vvP" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/plating,
@@ -55447,6 +56470,12 @@
 "vwd" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/rd)
+"vwp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 9
+	},
+/area/security/prison)
 "vwX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -55469,16 +56498,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"vyI" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "vyO" = (
 /obj/structure/table/wood,
 /obj/structure/disposalpipe/segment,
@@ -55504,6 +56523,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"vyZ" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "vzp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -55512,10 +56537,11 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "vzO" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 18
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "vAI" = (
 /obj/vehicle/ridden/secway,
@@ -55525,18 +56551,17 @@
 "vBc" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 18
 	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "vCg" = (
 /obj/structure/disposalpipe/segment,
@@ -55555,7 +56580,8 @@
 /area/science/storage)
 "vDt" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/obj/effect/landmark/start/warden,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "vEn" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -55568,7 +56594,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "vEA" = (
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "vEC" = (
 /obj/effect/turf_decal/arrows,
@@ -55581,11 +56607,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"vER" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/security/prison)
 "vET" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/open/floor/plating,
@@ -55620,8 +56641,7 @@
 	pixel_x = -28
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vFm" = (
 /obj/structure/disposalpipe/junction/yjunction{
@@ -55631,7 +56651,6 @@
 /area/hallway/primary/central)
 "vFJ" = (
 /obj/structure/chair/office,
-/obj/effect/landmark/start/warden,
 /obj/machinery/button/door{
 	id = "Prison Gate";
 	name = "Prison Wing Lockdown";
@@ -55645,7 +56664,7 @@
 	pixel_x = -27;
 	pixel_y = -2
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "vFR" = (
 /obj/item/clothing/head/hardhat,
@@ -55681,9 +56700,26 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"vHb" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "vHt" = (
 /turf/open/floor/iron,
 /area/science/misc_lab)
+"vHU" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown3";
+	name = "Lockdown"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "vIU" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light{
@@ -55692,19 +56728,13 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "vJj" = (
-/obj/machinery/door/airlock/security{
-	name = "Prison Yard"
-	},
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/security/old{
+	glass = 1;
+	name = "Cafeteria"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "vJC" = (
 /obj/machinery/camera{
@@ -55720,6 +56750,17 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"vKo" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cable,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "icehut2";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/maintenance/space_hut/cabin)
 "vKD" = (
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
@@ -55754,28 +56795,42 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "vLG" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/security/prison)
 "vLX" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vNp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+"vNb" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 5;
+	name = "blue line"
 	},
-/turf/open/floor/iron,
-/area/security/processing)
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
+/area/security/prison)
 "vOH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"vOR" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "vPt" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -55814,35 +56869,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/medbay/aft)
-"vQX" = (
-/obj/item/stack/sheet/cardboard{
-	amount = 14
-	},
-/obj/item/stack/package_wrap,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Workshop";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
 "vRc" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "vRG" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "vRI" = (
 /obj/structure/closet,
@@ -55851,15 +56886,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"vRM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "vSk" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -55881,13 +56907,21 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"vUt" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"vUa" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/storage/bag/tray,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/rollingpin,
+/obj/machinery/firealarm{
+	pixel_y = -28
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"vUt" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "vUu" = (
 /obj/machinery/power/apc/auto_name/east,
@@ -55900,17 +56934,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"vVk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/start/junior_officer,
-/turf/open/floor/iron,
-/area/security/brig)
 "vVl" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
@@ -55975,10 +56998,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"vZE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/iron,
+"vZV" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "waa" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -56010,6 +57035,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wbB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/warden)
 "wbG" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -56048,6 +57081,21 @@
 /obj/item/newspaper,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"wck" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/inflatable/door,
+/obj/item/clothing/suit/fire/atmos{
+	armor = list("melee" = 20, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 20, "bio" = 10, "rad" = 20, "fire" = 80, "acid" = 50);
+	desc = "An old, reinforced and obviously stolen firesuit. There's an expiry date for the thermal padding, safe to say it's well past the expiration date.";
+	name = "padded firesuit";
+	slowdown = 0.25
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "wds" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/mug/coco{
@@ -56079,25 +57127,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "wek" = (
-/obj/machinery/button/door{
-	id = "permaouter";
-	name = "Outer Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 6;
-	pixel_y = 25;
-	req_access_txt = "2";
-	specialfunctions = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "permainner";
-	name = "Inner Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -6;
-	pixel_y = 25;
-	req_access_txt = "2";
-	specialfunctions = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "weJ" = (
 /obj/structure/closet/secure_closet/chief_medical,
@@ -56146,6 +57179,19 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"wfd" = (
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 20;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/security/prison/safe)
 "wfq" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -56157,7 +57203,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "wfK" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -56201,17 +57247,18 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "wik" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/button/curtain{
+	id = "prisoncell10";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 1
+	},
+/area/security/prison/safe)
 "wiW" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 8
@@ -56223,17 +57270,25 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/chair,
-/obj/effect/landmark/start/security_officer,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "wjR" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/security_sergeant,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "wkN" = (
 /obj/effect/spawner/structure/window,
@@ -56243,6 +57298,10 @@
 	},
 /turf/open/floor/plating,
 /area/science/nanite)
+"wkZ" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/maintenance/space_hut/cabin)
 "wlB" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -56286,6 +57345,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"wlY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
+"wma" = (
+/obj/structure/bookcase/random/adult,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "wmy" = (
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 4
@@ -56300,9 +57373,8 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
 "woJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/turf/open/floor/carpet,
+/area/security/prison)
 "wph" = (
 /obj/docking_port/stationary{
 	dheight = 4;
@@ -56330,6 +57402,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
+"wpl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "wqq" = (
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
@@ -56348,20 +57429,11 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"wtN" = (
-/obj/structure/table,
-/obj/item/electropack,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "wui" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "wuE" = (
 /obj/machinery/camera{
@@ -56408,6 +57480,19 @@
 "wvq" = (
 /turf/closed/wall,
 /area/medical/cryo)
+"wwk" = (
+/obj/structure/curtain/cloth,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
+"wxl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "wxF" = (
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
@@ -56438,6 +57523,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"wzQ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/turnstile{
+	dir = 1;
+	req_one_access_txt = "2;63;81"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "wAb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56450,15 +57544,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"wAK" = (
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Prison Yard";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "wBd" = (
 /obj/structure/railing,
 /turf/open/floor/plating,
@@ -56477,6 +57562,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"wBU" = (
+/obj/structure/table/wood,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/item/reagent_containers/food/drinks/mug/coco{
+	desc = "Still hot!";
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "wCQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -56529,21 +57627,60 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "wFf" = (
-/obj/machinery/door/airlock/security{
-	name = "Prison Workshop"
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
+"wFl" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/button/curtain{
+	id = "icehut1";
+	pixel_y = -21
+	},
+/turf/open/floor/carpet/green,
+/area/maintenance/space_hut/cabin)
+"wFu" = (
+/obj/machinery/light/small{
 	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison)
+"wFw" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/security/prison)
 "wFP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
+"wHa" = (
+/obj/machinery/door/airlock/security/old{
+	name = "Jail Cell"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple,
+/area/security/prison/safe)
+"wHc" = (
+/obj/structure/cable,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "wHs" = (
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
@@ -56579,6 +57716,17 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"wIo" = (
+/obj/machinery/deepfryer,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = " Prison - Kitchen";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "wIx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -56614,10 +57762,10 @@
 	icon_state = "right";
 	name = "Brig Infirmary"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue/darkblue,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "wJm" = (
@@ -56691,14 +57839,17 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"wLU" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Visitation Observation";
-	req_access_txt = "2"
+"wLX" = (
+/obj/structure/barricade/wooden{
+	opacity = 1
 	},
+/obj/structure/barricade/wooden/crude,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/security/prison)
 "wNj" = (
 /obj/structure/sign/warning/securearea{
@@ -56733,26 +57884,16 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"wOE" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "wPv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/processor/slime,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "wPx" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "wPI" = (
 /obj/effect/turf_decal/tile/purple,
@@ -56821,6 +57962,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"wSg" = (
+/obj/structure/table,
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
+"wTn" = (
+/turf/open/water/overlay{
+	desc = "It's a pool for swimming in!";
+	icon_state = "hotspring_tile";
+	name = "pool"
+	},
+/area/security/prison)
 "wTw" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -56837,6 +57989,18 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"wTQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating,
+/area/security/prison)
+"wTY" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "wUr" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -56862,9 +58026,10 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "wVq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wVC" = (
 /turf/closed/wall/r_wall,
@@ -56906,30 +58071,26 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"wYN" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
+"wYY" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/inflatable,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wYZ" = (
 /obj/machinery/power/apc/auto_name/north,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "wZy" = (
 /obj/structure/disposalpipe/segment,
@@ -56948,26 +58109,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"xaO" = (
-/obj/structure/table,
-/obj/structure/window,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "xaZ" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -56988,25 +58129,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xbG" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopod)
 "xcp" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/security/prison)
 "xdk" = (
 /obj/machinery/airalarm{
@@ -57026,6 +58160,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"xeb" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/security/old{
+	glass = 1;
+	name = "Cafeteria"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "xec" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -57037,12 +58182,14 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "xeI" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "xeJ" = (
 /obj/effect/turf_decal/tile/blue,
@@ -57064,12 +58211,13 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "xeM" = (
-/obj/structure/closet/l3closet/security,
 /obj/machinery/camera{
 	c_tag = "Brig Equipment Room";
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xeP" = (
 /obj/effect/turf_decal/tile/purple{
@@ -57084,6 +58232,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"xeW" = (
+/turf/closed/wall,
+/area/maintenance/space_hut/cabin)
 "xfd" = (
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/iron/white/side{
@@ -57155,17 +58306,12 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "xgR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/machinery/light,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "xhV" = (
 /obj/structure/cable,
@@ -57178,14 +58324,13 @@
 /turf/open/floor/plating,
 /area/construction)
 "xiQ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xjt" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -57197,15 +58342,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"xjA" = (
-/obj/machinery/door/airlock/security{
-	name = "Isolation Cell";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+"xjQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "xkx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -57236,25 +58376,20 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "xlx" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xlP" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xmh" = (
 /obj/structure/extinguisher_cabinet{
@@ -57327,6 +58462,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"xqA" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "xqJ" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -57376,28 +58522,32 @@
 	c_tag = "Brig Infirmary";
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "xus" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "xuu" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/turf/open/floor/iron/freezer,
-/area/security/prison/safe)
-"xux" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/purple/side,
+/area/security/prison/safe)
+"xux" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xuM" = (
 /obj/machinery/door/airlock{
@@ -57409,21 +58559,15 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "xwv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"xwG" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/item/flashlight,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/security/prison/safe)
+/area/security/prison)
 "xwN" = (
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
@@ -57434,6 +58578,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"xxV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = " Prison - Pool";
+	dir = 5;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"xzh" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "xzk" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/line,
@@ -57491,14 +58650,21 @@
 /turf/open/openspace,
 /area/science/xenobiology)
 "xAH" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/sign/departments/lawyer{
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
+"xBJ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "xCm" = (
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -57556,6 +58722,14 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"xGI" = (
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/turnstile{
+	dir = 1;
+	req_one_access_txt = "2;63;81"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "xGP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57573,6 +58747,39 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/service)
+"xHh" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/obj/machinery/light/small,
+/turf/open/floor/iron/freezer,
+/area/maintenance/space_hut/cabin)
+"xHG" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/open/floor/iron/freezer,
+/area/security/prison/safe)
+"xHV" = (
+/obj/machinery/camera{
+	c_tag = "Prison - East Exterior";
+	dir = 4;
+	use_power = 0
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors)
 "xIa" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/grille_or_trash,
@@ -57588,15 +58795,25 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/bar)
+"xJW" = (
+/obj/machinery/light,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "xKb" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/prison)
+"xKy" = (
+/obj/machinery/chem_master/condimaster,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 18
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "xKN" = (
 /turf/closed/wall,
@@ -57659,18 +58876,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xOX" = (
-/obj/item/instrument/violin/golden{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "xOZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57703,13 +58908,12 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xQG" = (
 /obj/structure/chair/wood{
@@ -57721,6 +58925,14 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"xRt" = (
+/obj/machinery/space_heater,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "xRV" = (
 /turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
@@ -57868,22 +59080,32 @@
 "xXm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xXp" = (
 /turf/closed/wall,
 /area/medical/break_room)
 "xXv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 4;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/security/prison)
+"xYp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
 /area/security/prison)
 "xYA" = (
 /obj/structure/disposalpipe/segment{
@@ -57891,6 +59113,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"xZn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/prison)
 "xZS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -57927,8 +59153,10 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "yaQ" = (
-/obj/effect/landmark/start/security_sergeant,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/timer,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "yce" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -57970,6 +59198,23 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
+"ydU" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 5
+	},
+/area/security/prison/safe)
 "yeE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -58043,49 +59288,15 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "ygD" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Visitation";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison)
 "ygM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/office)
-"yhO" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "yhU" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -58097,21 +59308,15 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "yis" = (
-/obj/structure/bed,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/bedsheet/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/obj/structure/table,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/iron,
+/area/security/prison)
 "yiT" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -58136,6 +59341,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
+"yjP" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/machinery/button/curtain{
+	id = "icehut2";
+	pixel_x = 21
+	},
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "ykz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58172,16 +59386,10 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "yls" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/light,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/brig)
-"ylv" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "ylY" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens Observation - Port Aft";
@@ -73670,9 +74878,9 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
+syL
+vsy
+syL
 gQb
 gQb
 gQb
@@ -73927,9 +75135,9 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
+xeW
+mLu
+xeW
 gQb
 gQb
 gQb
@@ -74184,9 +75392,9 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
+wkZ
+lKB
+wkZ
 gQb
 gQb
 gQb
@@ -74437,15 +75645,15 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+xeW
+oXf
+xeW
+xeW
+xeW
+qln
+xeW
+xeW
+xeW
 gQb
 gQb
 gQb
@@ -74694,15 +75902,15 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+xeW
+oKu
+dxm
+xeW
+lJw
+kAg
+qGB
+wFl
+xeW
 gQb
 gQb
 gQb
@@ -74951,15 +76159,15 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+xeW
+gbS
+jqz
+qln
+iCl
+kAg
+bAW
+dQy
+tlZ
 gQb
 gQb
 gQb
@@ -75208,15 +76416,15 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+oXf
+wSg
+dqk
+xeW
+xRt
+kAg
+dyd
+dyd
+xeW
 gQb
 gQb
 gQb
@@ -75465,16 +76673,16 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+xeW
+czb
+mPG
+xeW
+xeW
+vgu
+xeW
+xeW
+xeW
+xeW
 gQb
 gQb
 gQb
@@ -75722,16 +76930,16 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+xeW
+xeW
+xeW
+xeW
+hAl
+kAg
+fqu
+jSK
+rXi
+xeW
 gQb
 gQb
 gQb
@@ -75979,16 +77187,16 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+vqw
+nYn
+syL
+vKo
+wBU
+wHc
+yjP
+xeW
+xHh
+xeW
 gQb
 gQb
 gQb
@@ -76235,17 +77443,17 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+vqw
+vqw
+vqw
+vqw
+xeW
+xeW
+fqg
+xeW
+xeW
+xeW
+xeW
 gQb
 gQb
 gQb
@@ -76491,19 +77699,19 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+vqw
+vqw
+vqw
+blq
+blq
+blq
+blq
+mAq
+blq
+vqw
+vqw
+vqw
+vqw
 gQb
 gQb
 boP
@@ -76748,20 +77956,20 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+vqw
+vqw
+blq
+blq
+blq
+blq
+blq
+mAq
+blq
+blq
+vqw
+vqw
+vqw
+vqw
 gQb
 boP
 boP
@@ -77005,24 +78213,24 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+vqw
+blq
+blq
 boP
+hNw
 boP
-boP
+blq
+mAq
+blq
+blq
+blq
+vqw
+vqw
+vqw
+vqw
+blq
+blq
+blq
 boP
 boP
 boP
@@ -77261,28 +78469,28 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+vqw
+vqw
+blq
+blq
 boP
 boP
 boP
-sNY
 boP
-boP
+mAq
+xzh
+blq
+blq
+mDW
+vqw
+vqw
+vqw
+vqw
+vqw
+blq
+blq
+blq
+blq
 boP
 boP
 boP
@@ -77518,29 +78726,29 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-boP
-boP
-boP
-boP
-boP
-boP
-boP
+vqw
+ome
+ome
+ome
+ome
+ome
+ome
+ome
+kLc
+ome
+ome
+ome
+ome
+ome
+ome
+ome
+ome
+vqw
+vqw
+vqw
+vqw
+blq
+blq
 boP
 boP
 boP
@@ -77775,31 +78983,31 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+vqw
+ome
+boP
+boP
+lyS
 boP
 boP
 boP
+mAq
+boP
+blq
+blq
+xzh
+xzh
 boP
 boP
-boP
-boP
-boP
-boP
+ome
+vqw
+blq
+blq
+vqw
+vqw
+vqw
+blq
+blq
 boP
 boP
 boP
@@ -78032,31 +79240,31 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+vqw
+ome
+boP
+oCP
 boP
 boP
+uzH
 boP
+mAq
 boP
+blq
+blq
+blq
+hbx
 boP
-boP
-boP
-boP
-boP
+qwy
+ome
+vqw
+vqw
+blq
+blq
+blq
+vqw
+vqw
+vqw
 boP
 boP
 boP
@@ -78288,33 +79496,33 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+blq
+vqw
+ome
 boP
 boP
 boP
 boP
 boP
 boP
+mAq
 boP
 boP
+blq
+blq
+uzH
 boP
 boP
+ome
+boP
+vqw
+vqw
+vqw
+blq
+blq
+vqw
+vqw
+vqw
 boP
 boP
 aQB
@@ -78541,35 +79749,35 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
-bBM
-bBM
-bBM
-bBM
-bBM
-bBM
-bBM
-bBM
-bBM
-bBM
-bBM
-bBM
-bBM
-bBM
-bBM
-bBM
+aER
+boP
+boP
+blq
+vqw
+ome
+boP
+qwy
+boP
+boP
+hbx
+boP
+mAq
+boP
+jhm
+boP
+blq
+boP
+boP
+oCP
+ome
+boP
+boP
+vqw
+vqw
+blq
+blq
+blq
 afA
 afA
 afA
@@ -78797,36 +80005,36 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 bBM
 boP
 boP
 boP
+blq
+vqw
+ome
 boP
 boP
 boP
 boP
 boP
+npw
+mAq
+boP
+urm
+boP
+blq
+blq
+boP
+boP
+ome
 boP
 boP
 boP
-boP
-boP
-boP
-boP
-boP
+vqw
+vqw
+blq
+blq
 afA
 aWA
 aca
@@ -79053,37 +80261,37 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
+bBM
+boP
+boP
+boP
+boP
+vqw
+aaJ
+aaJ
+kZK
+aaJ
+aaJ
+tAA
+aaJ
+aaJ
 fjY
 aaJ
+aaJ
+mrk
+aaJ
+aaJ
 uRJ
-uRJ
-aaJ
-uRJ
-uRJ
 aaJ
 aaJ
 aaJ
 aaJ
-aaJ
-aaJ
-aaJ
-aaJ
-aaJ
+aai
+aai
+aai
+aai
+aai
 afA
 aWA
 aWA
@@ -79309,36 +80517,36 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 bBM
 boP
+boP
+boP
+boP
+vqw
+vqw
 aaJ
-uTo
+gDb
+tmz
+abz
+gDb
+tmz
+abz
+gDb
+tmz
+abz
+uFU
 awi
-rMv
-awi
-pqf
+abz
+uFU
+pyC
 abz
 uFU
 oBr
 abz
 itT
 dVr
-abz
+his
 miU
 nlW
 afA
@@ -79566,27 +80774,27 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
+boP
+boP
+aai
+aai
+aai
+aai
 aaJ
+lRK
+qtk
+abz
+sAb
+qtk
+abz
+oht
+kvD
+abz
+oGM
 xuu
-bGP
-qWI
+abz
 jCT
 xuu
 abz
@@ -79594,10 +80802,10 @@ dJo
 azJ
 abz
 soI
-jvu
-abz
-eCK
-obu
+xZn
+xZn
+aai
+aai
 afA
 afA
 afA
@@ -79823,42 +81031,42 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-bBM
+aER
 boP
-aaJ
+boP
+boP
+aai
+oZI
+rhU
+sKc
+abz
+wfd
+tMN
+abz
+wfd
+tMN
+abz
+wfd
+tMN
+abz
+jmf
+jxl
+abz
+jmf
+jxl
+abz
+jmf
+pIx
 abz
 abz
-jPv
 abz
 abz
-abz
-abz
-vcq
-abz
-abz
-daR
-abz
-sso
+aai
 woJ
-aaJ
+nlM
 hIM
-lHY
-lHY
+qEv
+kNP
 lHY
 afA
 aXC
@@ -80080,43 +81288,43 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-bBM
-bBM
-bBM
-bBM
 bBM
 boP
-abd
-aaw
+boP
+boP
+aai
+sxf
+pIM
+sKc
+abz
+rOV
+giF
+abz
+rOV
+tBk
+abz
+rOV
+gfn
+abz
+wHa
 piB
-adN
-fxV
+abz
+wHa
 pCn
-wVq
-iAp
-wVq
-wVq
+abz
+wHa
+brr
+abz
 mnV
+pqf
+uTo
+aai
+aai
+aai
 wVq
-xjA
-vva
-mMC
-mcc
-wVq
-dxg
-nfk
-nfk
+sDW
+sDW
+rPi
 aWD
 aXH
 bce
@@ -80337,40 +81545,40 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
 boP
 boP
-boP
-boP
+acd
+sxf
+wFu
+pIM
+lzO
+gBy
+aGK
+aGK
+aGK
+ufo
+aGK
+aGK
+aGK
 abd
-udx
-usq
-iuR
-iuR
-usq
+aGK
+aGK
+lYw
+jNa
+aGK
 aKb
 aGK
-usq
-iuR
+sre
+wwk
 iuR
 gxj
-abz
-abz
-abz
-aaJ
-aaw
+xHG
+aai
+woJ
+nlM
+wVq
 usq
 vhQ
 qff
@@ -80594,41 +81802,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-bBM
-bBM
-bBM
-bBM
 bBM
 boP
+boP
+boP
 aai
-aai
-aai
-aai
-aaJ
-abz
-pFa
-abz
-abz
-gIe
-abz
-abz
+acd
+acd
+acd
+acd
+ify
+iYE
+qGo
+uWe
+hVs
+uWe
+eio
+uWe
+kce
+uWe
+uWe
+uWe
+lBM
+uWe
+uWe
+fms
 ref
 abz
-hSE
-vRM
-pRf
-oXm
-eQZ
-aaJ
-aaw
-usq
+abz
+abz
+abz
+aai
+aai
+aai
+fio
+jFV
 acd
 aai
 afA
@@ -80851,41 +82059,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
 boP
 boP
-boP
-boP
 aai
-mPt
-vQX
-trY
-abz
+xZn
+acd
+wYY
+acd
+acd
+acd
+acd
+oJE
+pbl
+oJE
+acd
+acd
+acd
+hyQ
+pee
+pee
+pee
+pee
+vNb
 nzq
 fNJ
-abz
-gAX
-fNJ
-abz
-nzq
-fNJ
-abz
+wHa
 azu
 mUB
-abz
+jQh
 uMS
-uFU
-aaJ
-aaw
-usq
+blq
+aEr
+wVq
+lNX
 snU
 aai
 boP
@@ -81108,41 +82316,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
-fjY
+boP
+boP
+boP
 aai
-aai
-aai
-aai
-aai
-vzO
+xZn
+bND
+xZn
+vlg
+acd
+mMx
+qOd
+ucB
+ozq
+ucB
 hGl
 rSY
-abz
-uFU
-uMS
-abz
-yis
-une
-abz
-uFU
-uMS
+acd
+oAU
+sCd
+sCd
+sCd
+sCd
+roA
+nzq
+fNJ
 abz
 jud
 rqU
-abz
-abz
-abz
-aaJ
+pIx
+uMS
+blq
+aEr
 iPI
-iGX
+sDW
 vUt
 aEr
 boP
@@ -81365,42 +82573,42 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-bBM
+aER
 boP
-abd
-sLw
-aEx
-rsb
+boP
+boP
+aai
+xZn
+xZn
+xZn
+bxv
 acd
+sLw
+rIo
+rsb
+ozq
 mPt
 qJT
 kiA
+acd
+fpt
+eyf
+sCd
+sCd
+sCd
+roA
+dTe
+iWJ
 abz
 abz
 abz
 abz
 abz
-abz
-abz
-abz
-abz
-abz
-iuR
-vRM
-ovu
-mFh
-pCO
-aaJ
-aaw
-usq
-vUt
+blq
+aai
+oAX
+sDW
+hVx
 aEr
 boP
 boP
@@ -81622,41 +82830,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
+boP
+boP
 aai
-hSE
-aaw
-aaw
+xZn
+xZn
+xZn
+wck
 acd
-acd
-acd
+swY
+wFf
+ucB
+ozq
+ozq
+fGq
 wFf
 acd
-acd
-tpb
-qqP
-uSR
-agK
-gcz
-gAn
-acd
-acd
-wOE
+oAU
+sCd
+sCd
+sCd
+sCd
+roA
+nzq
+fNJ
+wHa
+azu
 nyx
-abz
+jQh
 fzz
-dbz
-aaJ
-aaw
-usq
+blq
+aEr
+wVq
+sDW
 vUt
 aEr
 boP
@@ -81879,41 +83087,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
-abd
-iuR
-arS
-aEx
-aEs
-aaw
-aEr
-mUB
-nvR
+boP
+boP
+aai
 acd
-vpZ
+acd
+acd
+acd
+acd
+czu
+ucB
+ucB
+ucB
+ozq
+oJE
+oJE
+acd
+oSm
+rLw
 xXv
-tdO
+rLw
 rLw
 uyG
-jxP
-acd
-dIH
-iuR
-mUB
+nzq
+lVT
 abz
-abz
-abz
-aaJ
-eBE
-usq
+jud
+rqU
+kRj
+fzz
+blq
+aEr
+wVq
+sDW
 pns
 aai
 boP
@@ -82136,41 +83344,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
+boP
+boP
 aai
+hbb
+eFj
+krE
+foS
+acd
 bxY
-rpk
-cEj
-otA
-cUl
-aEr
-mUB
-aaw
+pgl
+pgl
+pgl
+ozq
+pXo
+rBQ
 acd
-iKn
-mUB
-maA
-nCH
-nCH
+acd
+oJE
+acd
+oJE
+oJE
+acd
 fjE
-acd
-aaw
-iuR
-xwv
-eRd
-oXm
-dJZ
-aaJ
-aaw
-usq
+vHU
+abz
+abz
+abz
+abz
+abz
+aEr
+aai
+ajd
+sDW
 vUt
 aEr
 boP
@@ -82180,7 +83388,7 @@ boP
 aiT
 kpl
 hqB
-flQ
+mWd
 flQ
 rsM
 aiT
@@ -82393,42 +83601,42 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
-abd
+boP
+boP
+aai
+uzo
+dXp
+sHl
+acd
+acd
 atu
 jnk
 itY
 xeI
-aaw
-oTX
-nyx
-vER
+sOx
+pXo
+pXl
 acd
-acd
-aAN
-acd
-acd
-acd
-acd
-acd
-aaw
-iuR
+qPr
+tFo
+jNJ
+jNJ
+jNJ
+oJE
+nzq
+fNJ
 rrE
-abz
+nWo
+rrE
+acd
 une
 yis
-aaJ
-aaw
-usq
-vUt
+aai
+qZu
+sDW
+hVx
 aEr
 boP
 boP
@@ -82650,39 +83858,39 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
+boP
+boP
 aai
-aai
+nzU
+wTQ
+pmK
+qdc
+rmb
+fZr
 mLn
-iuR
+tTU
 cDf
-nfk
-tJU
-nfk
-nfk
+pgl
+pXo
+liY
+acd
 bCa
-nfk
-nfk
-enl
-aGX
-gVZ
+kcZ
+jNJ
+jNJ
+jNJ
+oJE
 dlN
-acd
+nHO
 jXG
-lHS
-acd
-abz
-abz
-abz
-aaJ
+ufo
+ufo
+jdF
+gIk
+gIk
+eaq
 vmG
 hOM
 vUt
@@ -82693,10 +83901,10 @@ boP
 boP
 aiU
 iNo
-hUr
-ovp
-nOb
-vNp
+vRG
+vRG
+vRG
+vRG
 oUf
 erO
 vRG
@@ -82907,48 +84115,48 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-bBM
+aER
 boP
 boP
-abd
+boP
+aai
+acd
+acd
+tpK
+acd
+mGU
+oBk
 gWI
-wYN
+tTU
 eIO
-gHU
-aEr
-usq
-aaw
+pgl
+pXo
+lFg
+dyM
 dYg
-cUl
-adN
+tFo
+jNJ
+jNJ
+jNJ
 acd
-aIG
-isU
 fBH
-acd
+nfk
 aaw
-iuR
+gIk
 euL
-aaw
+acd
 aEs
-hIc
+mFq
 aai
 tPr
-usq
+hOM
 jei
 aai
 rda
 rda
 rda
 rda
-aiV
+aai
 jtK
 vRG
 wfy
@@ -83164,41 +84372,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
-bBM
-fjY
+boP
+boP
+boP
 aai
-aai
-aai
+lJN
+xZn
+lJt
+acd
+vOR
+oBk
+cXT
+pQt
 acd
 acd
-acd
+xeb
 vJj
-crc
 acd
-vzO
-usq
-acd
-acd
+qjg
+tFo
+jNJ
+jNJ
+jNJ
+oJE
 gkv
-gkv
-acd
-aaw
+mMX
+vyZ
 awO
 uWe
-nfk
-quZ
-fwh
-aai
+xGI
+aaw
+aaw
+wzQ
 wek
-usq
+hOM
 vij
 acd
 agL
@@ -83421,44 +84629,44 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
 boP
 boP
 aai
-aaw
-wAK
+fNM
+xZn
+pGf
+acd
+wIo
+oBk
+vlB
+tnc
+jgG
+acd
 hXd
 adN
-aaw
 acd
-aaw
-usq
-pcp
-acd
-acd
-acd
-acd
+frT
+tFo
+jNJ
+jNJ
+jNJ
+oJE
+nzq
+fNJ
 vzO
-usq
+eLs
+sCd
 acd
-ssB
-hrn
-nfk
-kYU
-nfk
-nfk
-vij
+aEu
+mbz
+aai
+qzU
+mCx
+tet
 vbu
-agH
+adG
 ags
 ags
 aiC
@@ -83466,8 +84674,8 @@ agj
 raN
 sLm
 agj
-cHi
-qnY
+mVz
+mVz
 mVz
 aiX
 cQt
@@ -83678,52 +84886,52 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-bBM
-bBM
 bBM
 boP
+boP
+boP
 aai
-aGu
+acd
+acd
+tpK
+acd
+rut
+jAx
+jAx
+tMV
+eLs
 hty
 ihy
 oPw
-rLW
 acd
-cKX
-hrn
-nfk
-nfk
-dxg
+acd
+kDp
+acd
+kDp
+kDp
+acd
 mwi
+agB
+acd
 awR
-nfk
-awR
-aEr
-aaw
-mFq
-aaw
-dRE
-aaw
-usq
-wtN
+acd
+acd
+acd
+acd
+aai
+vtY
+oqb
+acd
 acd
 agI
 ahq
 ahV
-sXW
+aiC
 agj
 wYZ
 paU
 ulQ
-qEg
+rye
 rye
 lfG
 aiX
@@ -83935,56 +85143,56 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
+boP
+boP
 aai
-aaw
-hSE
-dka
-amc
-vZE
+voM
+glN
+uAQ
 acd
+rGy
+eLs
+xKy
+qgw
+vUa
+acd
+dka
+adN
+acd
+hgQ
 kcm
 ddf
-aEu
-aaw
-mUB
-hIw
-aaw
-aaw
-mUB
-aEr
-viQ
+qXC
+cxm
+acd
+nzq
+fNJ
+acd
+aGS
+aEx
+tRb
 eJB
-viQ
+sZT
 aai
 jXT
-usq
-lSG
+ocV
+acd
 acd
 agJ
 ahp
 ahp
-sXW
+aiC
 agj
 psS
 nmv
 agj
-uVQ
-vyI
-ijh
+mVz
+mVz
+mVz
 aiX
-cQt
+gnf
 xAH
 aph
 arT
@@ -84192,44 +85400,44 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
+boP
+boP
 aai
-imX
-iuR
-dka
-amc
-vZE
-abz
-abz
+ukw
+uWC
+wxl
+acd
+acd
+aFi
+acd
+acd
+acd
+acd
+rnN
+xJW
+acd
+wma
+tJW
 qUj
-abz
-aaw
-mUB
-aaw
-foi
+ipa
+vZV
+acd
+dUz
+fNJ
 acd
 awX
-acd
-acd
-acd
-acd
+wFw
+tXK
+vTk
+qEN
 aai
 kpe
 pFw
+clC
 acd
-acd
-acX
+adG
 adG
 ail
 aiE
@@ -84242,7 +85450,7 @@ agj
 aiX
 aiX
 luh
-srG
+jmA
 ard
 are
 cxl
@@ -84449,42 +85657,42 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-bBM
+aER
+boP
+boP
 boP
 aai
-cUl
+acd
+acd
+jrl
+acd
+hEL
+huy
+acd
+vwp
+tRQ
 tNk
-nLn
+ihy
 mRF
-vZE
-abz
-lEH
+acd
+hoc
+tJW
 ulw
-abz
+iGp
 byK
-kYY
 acd
+dUz
+vbj
 acd
-acd
-mUB
-aEx
-tRb
-aEx
+dXA
+kFx
+aBX
+wiW
 deg
 aai
 qdH
-rHf
-acd
+hOM
+hfx
 agj
 agj
 agj
@@ -84492,14 +85700,14 @@ agj
 agj
 agj
 qHR
-tDs
+ukX
 vad
 umk
 gaj
 amQ
-yhU
-cQt
-srG
+oZV
+feS
+jmA
 ard
 gpE
 arX
@@ -84706,41 +85914,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
 boP
+boP
+boP
 aai
+sol
+glN
+qJO
+acd
+tld
+ubO
+acd
+abA
 aGu
 hSE
 gAK
 szh
-bYk
-abz
-tyX
-nxy
-abz
-aaw
-mUB
-rRS
-fEC
 acd
-tqI
-rrX
-tXK
-vTk
+mwM
+tJW
+nxy
+hIg
+gXY
+acd
+rRS
+vbj
+acd
+aaw
+aEx
+aBY
+nEM
 aGS
-aai
+kHy
 kQl
-usq
+hOM
 xgR
 agj
 hgj
@@ -84749,13 +85957,13 @@ xun
 otu
 agj
 jQY
-rdl
+paU
 uvZ
 tGP
 pQs
 amQ
-yhU
-cQt
+tOF
+hTf
 dPi
 aph
 aph
@@ -84963,57 +86171,57 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 bBM
-bBM
+boP
+boP
+boP
 aai
-aaJ
-aOu
-abz
-abz
-abz
-abz
-abz
-abz
-abz
-cQn
-qRY
-aaw
-cUl
+gcB
+cSp
+tCd
 acd
-mhu
-aau
-aBX
-wiW
-tQB
+acd
+acd
+acd
+acd
+acd
+acd
+oYc
+adN
+acd
+acd
+taL
+acd
+acd
+acd
+acd
+vhZ
+cUl
+abz
+abz
+abz
+aaJ
+aai
+aai
 aai
 ozK
 hOM
 rSI
 agj
 bHS
-oIA
-nwT
+ahP
+ahP
 twO
 agj
 xlx
-rNU
+ukX
 vad
 lKx
 nOC
 amQ
 hEP
 xus
-srG
+jmA
 apd
 fBs
 dyN
@@ -85220,41 +86428,41 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 boP
 boP
 boP
-aaJ
+aai
+acd
+acd
+rAF
+acd
+udT
+udT
+udT
+xxV
+poQ
 uzJ
-pLk
-pLk
+xYp
+sSH
 pLk
 lLN
-abz
-rZH
-rZH
-cUl
+eos
+kdV
+wpl
+wlY
 amc
 rZH
-rZH
-acd
-aaw
-aEx
-aBY
-aEx
+fNJ
+tLN
+aeZ
+tLG
+aaJ
+dod
 xwv
 ygD
 wVq
-nfk
+hOM
 iQk
 agj
 txz
@@ -85262,15 +86470,15 @@ ahP
 ioB
 tEH
 agj
-aEh
+xlx
 lfH
 agj
 agj
 agj
 aiX
 urb
-cQt
-srG
+xus
+jmA
 apd
 yay
 mSf
@@ -85477,39 +86685,39 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 boP
-aaJ
+boP
+boP
+aai
+pzU
+glN
+qlk
+wLX
+sDW
+hOM
+hOM
+hOM
+qZJ
 uCC
-xwG
-pLk
+nGB
+uIu
 uTN
-ylv
-abz
 vLG
-mhY
-aaw
+nGB
+vLG
+nGB
+nGB
 twM
 nGB
 gRA
-acd
+abz
+nJL
+pbq
+aaJ
+dgl
 qyg
-qyg
-acd
-qyg
-qyg
-aai
+dYx
 osx
 iGX
 gEc
@@ -85519,15 +86727,15 @@ fRj
 wJa
 ojY
 agj
-aEh
-tDs
+xlx
+ukX
 vad
 umk
 mYO
 amQ
-yhU
-cQt
-srG
+tOF
+xus
+jmA
 apd
 aob
 akl
@@ -85734,57 +86942,57 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
 boP
-aaJ
-aaJ
-aaJ
-aaJ
-abz
-abz
-abz
-ubX
-viQ
-aaw
-amc
-viQ
-jUh
-acd
-mOB
-nGB
-nGB
-nGB
-xcp
+boP
+boP
 aai
-aaw
+cZP
+cSp
+usD
+acd
+isV
+lNd
+gKf
+gKf
+acd
+acd
+jqP
+acd
+abz
+tLN
+prz
+abz
+tLN
+fAT
+abz
+tLN
+jUh
+abz
+abz
+aaJ
+aaJ
+xcp
+xcp
+ygD
+wVq
 qrN
 rXY
 kcV
-jUG
-jUG
-jUG
+dHf
+ttn
+ttn
 jUG
 rYV
-rdl
+xBJ
 rdl
 tkk
-tGP
+oAx
 pQs
 amQ
-yhU
-cQt
-srG
+tOF
+xus
+jmA
 bON
 bLE
 akw
@@ -85991,57 +87199,57 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-boP
+aER
 boP
 boP
 boP
 aai
-isl
-yhO
-lma
-aaw
-pRb
-rLw
-pzH
-aaw
-cUl
+aai
+aai
+aai
+aai
+wTn
+wTn
+wTn
+wTn
 acd
-pga
-sZT
-sZT
-sZT
+nRK
+fXF
+gyF
+abz
+pRb
+ckh
+abz
+pRb
+ckh
+abz
+kmZ
+lVN
+abz
+xZn
+oFG
+gjc
+uio
 xKb
-wLU
+aai
 fSH
 cQl
 jkz
 lTj
-dgs
+sUP
 dgs
 dgs
 dgs
 oAk
 aEh
-rNU
+ukX
 vad
 lKx
 tHT
 amQ
-yhU
-gnf
-nUo
+tOF
+hTf
+fzF
 baV
 ahO
 arb
@@ -86248,33 +87456,33 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
+boP
+boP
+boP
+boP
+boP
+boP
 boP
 aai
-oMM
+wTn
+wTn
+wTn
+iEy
+acd
+apZ
+vul
+kAE
+abz
 prV
-pkL
-cUl
+mam
+abz
 wik
 mam
-eVr
+abz
 eVr
 mam
-aai
+aaJ
 aaZ
 aaZ
 aaZ
@@ -86297,8 +87505,8 @@ agj
 agj
 aiX
 fZs
-cQt
-srG
+hTf
+jmA
 apd
 aqb
 jYO
@@ -86505,33 +87713,33 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
+bBM
+boP
+boP
+boP
+boP
+boP
 boP
 aai
-ccO
+wTn
+wTn
+wTn
+wTn
+acd
+fzm
+jHl
+fvo
+abz
 pXm
-xaO
-aEu
-cUl
+teK
+abz
+ydU
 hnO
-aaw
-cUl
-aaw
-aai
+abz
+ydU
+teK
+aaJ
 boP
 boP
 aaZ
@@ -86547,15 +87755,15 @@ evX
 guf
 aiI
 sbQ
-sdA
-tDs
+aEh
+ukX
 vad
 umk
 vFg
 amQ
-yhU
-cQt
-srG
+tOF
+hTf
+jmA
 apd
 apd
 bON
@@ -86763,33 +87971,33 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-fjY
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
 bBM
+bBM
+boP
+boP
+boP
+boP
+boP
+aai
+aai
+aai
+aai
+aai
+aai
+aai
+aai
+aai
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+aaJ
+boP
 boP
 aaZ
 abH
@@ -86804,15 +88012,15 @@ guI
 oLN
 aIF
 qEg
-qOz
+aEh
 rdl
 coh
 kMX
 pQs
 amQ
-yhU
-cQt
-srG
+tOF
+hTf
+nUo
 xzq
 yhU
 yhU
@@ -87021,19 +88229,8 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
+bBM
 boP
 boP
 boP
@@ -87045,8 +88242,19 @@ boP
 boP
 boP
 boP
+boP
+xHV
+boP
+boP
+boP
+blq
+blq
+blq
+blq
+blq
 boP
 bBM
+boP
 boP
 aaZ
 abn
@@ -87062,13 +88270,13 @@ vFJ
 aiJ
 qEg
 aEh
-rNU
+ukX
 vad
 lKx
 gyW
 amQ
-yhU
-iyN
+ePs
+hTf
 scP
 thD
 tTn
@@ -87279,32 +88487,32 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+bBM
+aER
+bBM
+bBM
+bBM
+bBM
+bBM
+aER
+boP
+qwy
 boP
 boP
 boP
 boP
+boP
+boP
+qfa
+jvh
+jvh
+jvh
+jvh
+jvh
+qfa
 bBM
 boP
+fdm
 aaZ
 abJ
 xoJ
@@ -87325,8 +88533,8 @@ agj
 agj
 aiX
 urb
-cQt
-dBX
+fBI
+nUo
 tXN
 vTE
 mAr
@@ -87544,20 +88752,20 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 boP
 boP
 boP
 boP
+boP
+boP
+boP
+boP
+boP
+blq
+blq
+blq
+blq
+blq
 boP
 bBM
 boP
@@ -87567,7 +88775,7 @@ abI
 xoJ
 qxh
 gLJ
-dRi
+qNz
 rDX
 vEA
 nNQ
@@ -87575,15 +88783,15 @@ dhG
 fMt
 aIF
 qEg
-gBc
+aEh
 mGO
 akU
 alz
 aml
 amT
-yhU
-cQt
-dBX
+poE
+fBI
+jmA
 ahn
 ahn
 ahn
@@ -87801,18 +89009,18 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 boP
 boP
+boP
+oCP
+boP
+boP
+boP
+boP
+boP
+boP
+blq
+abq
 abq
 abq
 abq
@@ -87826,21 +89034,21 @@ vVl
 mlh
 nHu
 lPd
+wbB
 qyT
-nrW
-phe
+qyT
 qyT
 oQa
 fzj
-rdl
+aEh
 pmL
 vad
 alB
 amn
 amV
-yhU
-cQt
-dBX
+poE
+fBI
+jmA
 ahn
 aqf
 wLh
@@ -88059,21 +89267,21 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 boP
 boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+blq
 abq
 hgD
+glM
 ovx
-hgD
+trX
 abq
 boP
 aaZ
@@ -88084,7 +89292,7 @@ uaA
 abN
 avB
 bWl
-vEA
+qxr
 guI
 tuM
 aIF
@@ -88095,8 +89303,8 @@ agj
 alA
 amm
 amU
-yhU
-cQt
+tOF
+fBI
 kfd
 ahn
 aqh
@@ -88316,21 +89524,21 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+boP
+boP
+boP
+boP
+boP
+uzH
+boP
+boP
 boP
 boP
 abq
 hgD
 iVu
-trX
+kwy
+utD
 abq
 boP
 aaZ
@@ -88341,19 +89549,19 @@ kct
 snY
 alt
 fZk
-riD
+vEA
 guI
 frB
 agn
 tbC
 dSk
-snm
+oKN
 pnU
 snm
 snm
 rat
-oQi
-hGw
+poE
+fBI
 fzG
 ahn
 aqh
@@ -88573,21 +89781,21 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
 boP
 abq
-abq
-abq
-dQP
-abo
+hgD
+xjQ
+ygM
+nDg
 abq
 abo
 aaZ
@@ -88602,16 +89810,16 @@ agW
 kdi
 aii
 agn
-xOX
-vVk
-jXa
+qEg
+dSk
+pmL
 vad
 jXa
 jXa
 vad
-oeg
-tzY
-tKf
+tOF
+fBI
+jmA
 ahn
 aqh
 arf
@@ -88831,27 +90039,27 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+boP
+boP
+hbx
+boP
+boP
+boP
+boP
+boP
 boP
 abq
-fSV
-ksN
-iVu
-mNa
+abq
+abq
+ghe
 abo
-lmU
-pkd
+abq
+cZZ
+vHb
 xeM
-kcz
-kcz
-kcz
+vHb
+iVu
+iVu
 ngw
 afQ
 tMd
@@ -88860,14 +90068,14 @@ rDW
 hgP
 adR
 ibI
-vVk
-mxO
-fGj
-dgs
+dSk
+oKN
+pnU
+snm
 mzk
 uDy
-mAr
-tzY
+poE
+fBI
 fyP
 ahn
 aqh
@@ -89088,36 +90296,36 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+boP
+boP
+boP
+boP
+boP
+boP
+boP
+boP
 boP
 abq
-puT
-nli
+fSV
+pLL
+qil
+qil
+ouI
+qil
 iVu
 iVu
-dQP
+iVu
+iVu
 kcz
-kcz
-kcz
-kcz
-kcz
-kcz
-pXM
+iVu
 abo
 tll
 fxr
 egw
 xiQ
 czy
-sZb
-oFm
+xqA
+dSk
 yls
 agj
 agj
@@ -89125,7 +90333,7 @@ agj
 aiX
 rzp
 wui
-dBX
+jmA
 ahn
 aqh
 arf
@@ -89345,42 +90553,42 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+boP
+boP
+boP
+boP
+boP
+boP
+oCP
+boP
 boP
 abq
-pJj
-wbO
-iVu
-iVu
+puT
+nli
+fBM
+mNa
 abo
-kcz
+ygM
+nYr
+lCI
 rMz
-rMz
-rMz
-rMz
+ygM
 ygM
 pGO
 ghe
 tVr
 uXY
-mfT
+egw
 eeU
 adR
 qEg
-vVk
-rye
+aEh
+ukX
 vad
-cjX
+hiC
 cjX
 aiX
-mAr
+tOF
 oeg
 rZD
 ahn
@@ -89603,31 +90811,31 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+boP
+boP
+boP
+jhm
+boP
+boP
+boP
 boP
 abq
-kTl
-nli
-iVu
+pJj
+wbO
+fBM
 iVu
 dQP
-kcz
+iVu
 cmS
-hQA
-hQA
-hQA
+iVu
+iVu
+iVu
 fEF
 sPH
 abo
 wPx
-gSU
-pWp
+iVu
+egw
 oIB
 adR
 qEg
@@ -89637,7 +90845,7 @@ ooJ
 xXm
 lIZ
 aiX
-mAr
+tOF
 oeg
 eWy
 ahn
@@ -89860,31 +91068,31 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+boP
+boP
+boP
+boP
+boP
+boP
+boP
 boP
 abq
-qti
-sni
-sni
+kTl
+cav
+fBM
 iVu
 abo
 dlO
-lmU
-lmU
-lmU
+cZZ
+cZZ
+cZZ
 lmU
 abq
 abq
 abq
 ePK
 fBM
-fsI
+egw
 fox
 adR
 mAa
@@ -90117,18 +91325,18 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+boP
+boP
+qwy
+boP
+boP
+boP
+boP
 boP
 abq
-hWj
-gwO
-gwO
+qti
+sni
+sni
 dSj
 abq
 bpJ
@@ -90139,9 +91347,9 @@ bpJ
 bpJ
 oAN
 vlV
-kCq
-fxr
-pWp
+iVu
+iVu
+egw
 xux
 abq
 wHs
@@ -90375,18 +91583,18 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+boP
+boP
+boP
+boP
+boP
+boP
 boP
 abq
-tRz
-afn
-afn
-lNV
+hWj
+gwO
+gwO
+lts
 abq
 abT
 acs
@@ -90394,9 +91602,9 @@ acR
 ado
 nZo
 mMA
-tll
+wPx
 ktd
-kCH
+poL
 poL
 pWp
 xux
@@ -90632,27 +91840,27 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+boP
+boP
+boP
+boP
+hbx
+boP
 boP
 abq
 tRz
 afn
 afn
 lNV
-abr
+omW
 abS
 acr
 acQ
 adn
-acC
+nIb
 bpJ
 wPx
-pRB
+ktd
 yaQ
 eZH
 loM
@@ -90665,7 +91873,7 @@ sDp
 prA
 amr
 amY
-amY
+dtT
 anV
 ajo
 ajo
@@ -90889,14 +92097,14 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
-gQb
 boP
-abo
+boP
+boP
+boP
+boP
+boP
+boP
+abq
 tRz
 afn
 afn
@@ -90906,7 +92114,7 @@ abV
 nIb
 acS
 adp
-adP
+nIb
 aey
 mue
 dvG
@@ -90917,8 +92125,8 @@ hrZ
 abq
 eQL
 cYZ
-mXr
-mXr
+ajp
+ajp
 iiz
 amr
 amY
@@ -91147,21 +92355,21 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
+boP
+oCP
+boP
+boP
 boP
 boP
 abo
-fpx
+tRz
 afn
 afn
 lNV
 abr
 abU
 act
-acu
+nIb
 acu
 ato
 bpJ
@@ -91169,12 +92377,12 @@ xbF
 vDt
 wjR
 rrx
-pWp
+wiX
 cow
 abq
 fFU
 qQo
-mXr
+ajp
 ixq
 eWj
 amt
@@ -91404,14 +92612,14 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+boP
+boP
+boP
+boP
+boP
 boP
 abo
-bUe
+fpx
 afn
 afn
 lNV
@@ -91423,7 +92631,7 @@ acn
 adh
 adm
 joM
-nRP
+ktd
 hET
 pBI
 xPq
@@ -91431,8 +92639,8 @@ mSu
 abq
 iZw
 jHU
-mXr
-mXr
+ajp
+ajp
 iiz
 amr
 amY
@@ -91661,27 +92869,27 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
-gQb
+boP
+boP
+boP
+uzH
+boP
 boP
 abo
-tRz
+bUe
 afn
 afn
-gDa
+lNV
 abq
 bpJ
 bpJ
+emn
 bpJ
 bpJ
 bpJ
-bpJ
-tll
-lat
-lat
+wPx
+iVu
+iVu
 pzm
 eyQ
 hFp
@@ -91693,7 +92901,7 @@ bCn
 tKp
 amr
 amY
-amY
+wTY
 gNu
 ajo
 hKI
@@ -91919,17 +93127,17 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
-gQb
 boP
-abq
-tRz
-ryQ
-afn
-lNV
+boP
+boP
+boP
+boP
 abo
+tRz
+afn
+afn
+gDa
+abq
 boP
 boP
 boP
@@ -91945,7 +93153,7 @@ hEf
 abq
 ajm
 ajS
-mXr
+ajp
 ife
 kFE
 amr
@@ -92177,15 +93385,15 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
-gQb
+boP
+boP
+boP
 boP
 abq
-tRa
-fak
-rcG
-voA
+tRz
+ryQ
+afn
+lNV
 abo
 boP
 boP
@@ -92435,15 +93643,15 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
+boP
+boP
 boP
 abq
-abq
-abq
-abq
-abq
-abq
+tRa
+fak
+rcG
+voA
+abo
 boP
 ajW
 abq
@@ -92693,16 +93901,16 @@ gQb
 gQb
 gQb
 gQb
-gQb
 boP
 boP
+abq
+abq
+abq
+abq
+abq
+abq
 boP
-boP
-boP
-boP
-boP
-boP
-ufm
+asU
 acU
 adr
 sXy
@@ -92951,7 +94159,7 @@ gQb
 gQb
 gQb
 gQb
-gQb
+boP
 boP
 boP
 boP
@@ -93224,9 +94432,9 @@ ufm
 aHs
 ufm
 abq
-gQb
-gQb
-gQb
+cff
+cff
+cff
 boP
 boP
 boP
@@ -93471,19 +94679,19 @@ gQb
 gQb
 gQb
 gQb
-gQb
-gQb
+cff
+cff
 boP
-gQb
-gQb
+cff
+cff
 adR
-gQb
-gQb
-gQb
+cff
+cff
+cff
 adR
-gQb
-gQb
-gQb
+cff
+cff
+cff
 boP
 boP
 boP


### PR DESCRIPTION
Ports previous build of Icebox's prison and security department, as well as adding changes from https://github.com/Skyrat-SS13/Skyrat-tg/pull/4689

![image](https://user-images.githubusercontent.com/43841046/113786370-d9c64f80-96ed-11eb-91ea-216c65876f83.png)

Icebox's luxury winter prison has returned, with smartpipes installed.

![image](https://user-images.githubusercontent.com/43841046/113786387-e185f400-96ed-11eb-8c94-b748977a322c.png)

Cool blue decals and dark tiles return to security, with the added changes:
1.Expanded gear storage width by 1 tile, moves bio and bomb suits into said room. Adds practice laser carbines
2. Replaced security locker landmarks with actual lockers. Added tables in the center with a hand labeler and crowbars.