### PR TITLE
Tramstation sec/prison map tweak

### DIFF
--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -234,7 +234,7 @@
 "aaz" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aaA" = (
 /obj/machinery/button/door{
@@ -302,7 +302,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aaG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -436,7 +436,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aaU" = (
 /obj/machinery/washing_machine,
@@ -462,7 +462,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aaX" = (
 /obj/structure/cable,
@@ -481,7 +481,7 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aaZ" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -495,7 +495,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aba" = (
 /obj/machinery/door/firedoor,
@@ -733,7 +733,7 @@
 /obj/machinery/door/airlock/glass_large{
 	name = "Prison Common Room"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aby" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -768,7 +768,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "abC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -845,7 +845,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "abK" = (
 /obj/structure/chair/comfy/black,
@@ -955,7 +955,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "abW" = (
 /turf/closed/wall,
@@ -988,7 +988,7 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "acb" = (
 /obj/structure/ladder,
@@ -1229,7 +1229,7 @@
 	name = "prison intercom";
 	prison_radio = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "acB" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -1256,7 +1256,7 @@
 	name = "prison intercom";
 	prison_radio = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "acE" = (
 /obj/machinery/door/airlock/hatch{
@@ -2243,7 +2243,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aeK" = (
 /turf/open/floor/wood,
@@ -2440,7 +2440,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "afk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -2487,7 +2487,7 @@
 	name = "prison intercom";
 	prison_radio = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "afp" = (
 /obj/machinery/door/airlock{
@@ -2542,7 +2542,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "afw" = (
 /obj/machinery/light/small{
@@ -2564,7 +2564,7 @@
 	},
 /obj/structure/filingcabinet,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "afA" = (
 /obj/structure/table,
@@ -2820,7 +2820,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "afY" = (
 /obj/structure/closet/secure_closet/hydroponics,
@@ -2997,7 +2997,7 @@
 	name = "prison intercom";
 	prison_radio = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "ags" = (
 /obj/machinery/door/airlock/security{
@@ -3009,7 +3009,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "agt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -3380,7 +3380,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "ahf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3487,7 +3487,7 @@
 	pixel_y = 8
 	},
 /obj/item/storage/box/prisoner,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "ahr" = (
 /obj/machinery/airalarm/directional/north,
@@ -3584,7 +3584,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ahC" = (
 /obj/structure/beebox,
@@ -4402,7 +4402,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "ajy" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -4445,7 +4445,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "ajC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5152,7 +5152,7 @@
 	dir = 10
 	},
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "akW" = (
 /obj/machinery/holopad,
@@ -6076,7 +6076,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "amH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -6229,7 +6229,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "and" = (
 /obj/structure/destructible/cult/tome,
@@ -6533,7 +6533,7 @@
 	name = "Cell 2";
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "anK" = (
 /obj/item/kirbyplants/random,
@@ -6583,7 +6583,7 @@
 	name = "Cell 3";
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "anR" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -6591,7 +6591,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "anS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -6901,7 +6901,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "aoB" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -6915,7 +6915,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aoC" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -6989,7 +6989,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aoJ" = (
 /obj/machinery/computer/prisoner/management{
@@ -7025,7 +7025,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aoN" = (
 /obj/effect/spawner/structure/window,
@@ -7068,7 +7068,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aoT" = (
 /obj/structure/railing{
@@ -7127,7 +7127,7 @@
 	},
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aoY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -7158,7 +7158,7 @@
 	network = list("ss13","Security")
 	},
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "apb" = (
 /obj/machinery/hydroponics/constructable,
@@ -7322,7 +7322,7 @@
 	name = "prison intercom";
 	prison_radio = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "app" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -7432,7 +7432,7 @@
 "apA" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "apB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
@@ -7605,7 +7605,7 @@
 	name = "prison intercom";
 	prison_radio = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "apQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -7698,7 +7698,7 @@
 	name = "prison intercom";
 	prison_radio = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aqc" = (
 /obj/structure/cable,
@@ -7765,7 +7765,7 @@
 	name = "prison intercom";
 	prison_radio = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aqi" = (
 /obj/machinery/computer/monitor{
@@ -12436,7 +12436,7 @@
 	network = list("ss13","Security")
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "azG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -12584,7 +12584,7 @@
 "azX" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "azY" = (
 /obj/machinery/vending/hydronutrients,
@@ -12631,7 +12631,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aAf" = (
 /obj/effect/turf_decal/tile/blue{
@@ -12652,7 +12652,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aAh" = (
 /obj/effect/turf_decal/tile/blue{
@@ -12688,7 +12688,7 @@
 	dir = 10
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aAk" = (
 /obj/structure/table/glass,
@@ -18852,7 +18852,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aPF" = (
 /obj/effect/turf_decal/tile/red{
@@ -20589,7 +20589,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aVZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -21156,7 +21156,7 @@
 /area/maintenance/fore/secondary)
 "bag" = (
 /obj/structure/chair/stool,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "bah" = (
 /obj/structure/railing{
@@ -21234,7 +21234,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/junior_officer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "bbP" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
@@ -21326,7 +21326,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "bex" = (
 /obj/machinery/door/firedoor,
@@ -21399,7 +21399,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "bgH" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -21428,9 +21428,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "bgU" = (
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 11
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -21502,7 +21502,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "bhZ" = (
 /obj/structure/table/wood,
@@ -21545,12 +21545,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "bjd" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "bjv" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -21568,7 +21568,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "bjY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -21653,7 +21653,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "blR" = (
 /obj/structure/disposaloutlet,
@@ -22074,7 +22074,7 @@
 /obj/structure/table,
 /obj/item/folder/red,
 /obj/item/pen,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "byg" = (
 /turf/open/floor/circuit,
@@ -22545,7 +22545,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "bJZ" = (
 /obj/structure/table,
@@ -23068,7 +23068,7 @@
 /obj/machinery/computer/security/telescreen/prison{
 	pixel_y = 32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "bXe" = (
 /obj/structure/closet/l3closet/virology,
@@ -23386,7 +23386,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding/sec,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "cea" = (
 /obj/structure/railing{
@@ -23406,7 +23406,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "cex" = (
 /obj/machinery/power/terminal{
@@ -23586,9 +23586,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "cii" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "cit" = (
@@ -23883,7 +23881,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "cov" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
@@ -24068,7 +24066,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "csS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24127,7 +24125,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "cuD" = (
 /obj/effect/turf_decal/stripes{
@@ -24447,7 +24445,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "cDK" = (
 /obj/structure/cable,
@@ -24639,7 +24637,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "cHW" = (
 /obj/machinery/status_display/evac{
@@ -24774,7 +24772,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "cKo" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -24904,7 +24902,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "cNT" = (
 /turf/open/floor/iron/dark,
@@ -24997,7 +24995,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "cRb" = (
 /obj/effect/turf_decal/stripes/line{
@@ -25486,7 +25484,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "cYj" = (
 /obj/structure/table/wood,
@@ -25700,7 +25698,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "dcy" = (
 /obj/machinery/modular_computer/console/preset/research{
@@ -25759,7 +25757,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "deg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -25859,7 +25857,7 @@
 /obj/structure/table,
 /obj/item/assembly/flash/handheld,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "dhf" = (
 /obj/structure/disposalpipe/segment{
@@ -25889,7 +25887,7 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "dhD" = (
 /obj/effect/turf_decal/stripes/line,
@@ -26160,7 +26158,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "doA" = (
 /obj/structure/reagent_dispensers/cooking_oil,
@@ -26191,6 +26189,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"doP" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "dpc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -26449,7 +26453,7 @@
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "dtZ" = (
 /obj/machinery/door/airlock/highsecurity{
@@ -26545,7 +26549,7 @@
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = -32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "dwh" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -26557,7 +26561,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "dwi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -26575,7 +26579,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "dxx" = (
 /obj/effect/turf_decal/tile/blue{
@@ -27094,7 +27098,7 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "dHJ" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
@@ -27187,7 +27191,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "dJh" = (
 /obj/effect/turf_decal/bot,
@@ -27318,7 +27322,7 @@
 /obj/effect/turf_decal/trimline/green/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "dLe" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -27331,7 +27335,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "dLY" = (
 /obj/effect/turf_decal/siding/wood,
@@ -27524,18 +27528,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "dPU" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Security - Equipment Room";
-	dir = 6;
-	network = list("ss13","Security")
-	},
-/obj/machinery/vending/security_peacekeeper,
+/obj/structure/table,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "dQI" = (
@@ -27780,7 +27776,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "dVo" = (
 /obj/item/pickaxe/rusted,
@@ -28460,7 +28456,7 @@
 /obj/item/book/manual/wiki/security_space_law,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "ejF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
@@ -28487,7 +28483,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ekA" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -28960,7 +28956,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "euP" = (
 /obj/effect/turf_decal/stripes{
@@ -29255,7 +29251,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "eBP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29263,7 +29259,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "eBS" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -29323,7 +29319,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "eCF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -29425,7 +29421,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "eFj" = (
 /obj/effect/turf_decal/stripes/line{
@@ -29859,7 +29855,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "ePJ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -29948,7 +29944,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "eRz" = (
 /obj/machinery/computer/teleporter{
@@ -30316,7 +30312,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "eYz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -31380,7 +31376,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "ftL" = (
 /obj/machinery/mass_driver/toxins{
@@ -31621,7 +31617,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "fzc" = (
 /obj/structure/girder,
@@ -31692,7 +31688,7 @@
 	dir = 9
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "fAE" = (
 /obj/item/stack/ore/iron,
@@ -32116,7 +32112,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "fLg" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -32137,7 +32133,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "fLB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -32199,7 +32195,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "fNC" = (
 /obj/structure/chair/stool,
@@ -32542,13 +32538,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"fTx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/security/office)
 "fTN" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -32600,12 +32589,6 @@
 "fUq" = (
 /turf/closed/wall/rust,
 /area/maintenance/central)
-"fUw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/office)
 "fVf" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
@@ -33157,7 +33140,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "glg" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -33180,7 +33163,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "glw" = (
 /obj/structure/table/wood,
@@ -33469,13 +33452,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"grL" = (
-/obj/structure/sign/poster/official/safety_report{
-	pixel_y = 32
-	},
-/obj/machinery/gun_vendor,
-/turf/open/floor/iron/showroomfloor,
-/area/security/office)
 "gsb" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Storage";
@@ -33529,7 +33505,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gsV" = (
 /obj/machinery/hydroponics/soil,
@@ -33537,7 +33513,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gta" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -33691,7 +33667,7 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "gwB" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "gwG" = (
 /obj/structure/closet/crate,
@@ -33794,7 +33770,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "gyL" = (
 /obj/structure/table/wood,
@@ -33807,7 +33783,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "gyY" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -33966,7 +33942,7 @@
 	dir = 9;
 	network = list("ss13","Security")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gBy" = (
 /obj/effect/turf_decal/tile/bar,
@@ -34033,10 +34009,10 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "gCm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30
 	},
+/obj/machinery/vending/security_peacekeeper,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "gCq" = (
@@ -34135,7 +34111,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gEb" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
@@ -34611,7 +34587,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gMk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
@@ -34664,7 +34640,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "gNY" = (
 /obj/structure/lattice,
@@ -34689,7 +34665,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gOg" = (
 /obj/structure/disposalpipe/segment{
@@ -34712,7 +34688,7 @@
 "gOk" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gOs" = (
 /obj/structure/disposalpipe/segment{
@@ -34732,7 +34708,7 @@
 "gOy" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gOG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
@@ -34952,7 +34928,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gTq" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -35077,7 +35053,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "gVz" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
@@ -35099,6 +35075,10 @@
 "gXl" = (
 /turf/closed/wall/r_wall,
 /area/construction/mining/aux_base)
+"gXs" = (
+/obj/machinery/griddle,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "gXR" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -35222,7 +35202,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "hbZ" = (
 /obj/structure/window/reinforced{
@@ -35437,7 +35417,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "hgv" = (
 /obj/item/clothing/head/cone{
@@ -35947,6 +35927,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
+"hrj" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/security_peacekeeper,
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "hrn" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -35983,7 +35968,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "hrI" = (
 /obj/structure/disposalpipe/segment,
@@ -36050,7 +36035,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "htT" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -36134,7 +36119,7 @@
 /area/service/hydroponics/garden)
 "hvy" = (
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "hvD" = (
 /obj/structure/chair/sofa/corner{
@@ -36195,7 +36180,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "hzh" = (
 /obj/effect/turf_decal/tile/bar,
@@ -36249,7 +36234,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "hzL" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -36258,7 +36243,7 @@
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/assembly/signaler,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "hzU" = (
 /obj/structure/cable,
@@ -36269,7 +36254,7 @@
 	dir = 9
 	},
 /obj/machinery/duct,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "hAf" = (
 /obj/machinery/power/smes{
@@ -36493,7 +36478,7 @@
 "hEv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "hEA" = (
 /obj/structure/cable,
@@ -36897,7 +36882,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "hPR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -37390,21 +37375,12 @@
 /area/maintenance/starboard/secondary)
 "ieo" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 4;
+	pixel_y = 5
 	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/item/book/manual/chef_recipes,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/glass/rag,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "iep" = (
@@ -37555,7 +37531,8 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "ihD" = (
-/obj/effect/landmark/secequipment,
+/obj/structure/cable,
+/obj/machinery/dish_drive/bullet,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
@@ -37850,7 +37827,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ipa" = (
 /obj/machinery/light{
@@ -37897,7 +37874,7 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ipX" = (
 /obj/machinery/light,
@@ -37915,6 +37892,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"iqd" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "iqm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -38153,7 +38137,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "iwe" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -38283,7 +38267,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "izj" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -38357,7 +38341,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "iAV" = (
 /obj/item/stack/ore/glass,
@@ -38413,7 +38397,7 @@
 "iCq" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "iCv" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -38582,7 +38566,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "iFZ" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -38720,7 +38704,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "iJD" = (
 /obj/effect/turf_decal/bot,
@@ -38761,7 +38745,7 @@
 "iJY" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "iLa" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -38892,7 +38876,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "iMU" = (
 /obj/effect/turf_decal/stripes/line,
@@ -39021,7 +39005,7 @@
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/light,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "iPO" = (
 /obj/machinery/door/airlock/mining/glass{
@@ -39167,7 +39151,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "iRZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -39497,7 +39481,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jcG" = (
 /obj/structure/disposalpipe/segment{
@@ -39676,7 +39660,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jiz" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -39693,7 +39677,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jiW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39808,7 +39792,7 @@
 "jld" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jls" = (
 /obj/machinery/power/rad_collector/anchored,
@@ -39828,7 +39812,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jmg" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -39842,7 +39826,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jmu" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -39931,7 +39915,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jog" = (
 /obj/structure/disposalpipe/segment,
@@ -40488,7 +40472,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jBG" = (
 /obj/machinery/flasher{
@@ -40568,7 +40552,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jFc" = (
 /obj/machinery/light_switch{
@@ -40706,7 +40690,7 @@
 	dir = 6;
 	network = list("ss13","Security")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jIG" = (
 /obj/structure/closet,
@@ -40988,7 +40972,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jQs" = (
 /obj/structure/chair/office/light{
@@ -41524,7 +41508,7 @@
 /area/ai_monitored/command/nuke_storage)
 "kcp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kct" = (
 /obj/effect/turf_decal/tile/bar,
@@ -41830,7 +41814,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kii" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -41862,6 +41846,11 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"kjb" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "kjt" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -42576,7 +42565,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kAK" = (
 /obj/structure/disposalpipe/segment{
@@ -42592,7 +42581,7 @@
 "kAQ" = (
 /obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "kAS" = (
 /obj/structure/table,
@@ -42618,6 +42607,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"kBf" = (
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "kBI" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/status_display/evac{
@@ -42764,7 +42761,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kFg" = (
 /obj/structure/disposalpipe/segment{
@@ -42918,6 +42915,10 @@
 /obj/item/pen,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"kJy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "kJG" = (
 /obj/machinery/light{
 	dir = 8
@@ -42987,7 +42988,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "kKS" = (
 /obj/effect/turf_decal/loading_area,
@@ -43199,7 +43200,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "kPz" = (
 /obj/structure/cable,
@@ -43414,7 +43415,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kUQ" = (
 /obj/structure/chair,
@@ -43481,7 +43482,8 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "kVU" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/bot,
+/obj/machinery/gun_vendor,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "kWc" = (
@@ -43636,7 +43638,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "kYC" = (
 /obj/structure/cable,
@@ -43692,7 +43694,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kZF" = (
 /obj/machinery/computer/station_alert{
@@ -43737,7 +43739,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "lar" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44297,7 +44299,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "lnQ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -44435,7 +44437,7 @@
 /obj/item/instrument/harmonica,
 /obj/item/pen,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "lrD" = (
 /obj/machinery/door/airlock/research{
@@ -44557,7 +44559,7 @@
 /area/engineering/atmos)
 "lus" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "luw" = (
 /obj/effect/turf_decal/stripes/line,
@@ -44810,7 +44812,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "lAC" = (
 /obj/structure/chair,
@@ -44965,7 +44967,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "lFn" = (
 /obj/machinery/door/window/southleft{
@@ -44993,6 +44995,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
+"lGt" = (
+/obj/structure/sign/poster/official/safety_report{
+	pixel_y = 32
+	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/bot,
+/obj/machinery/camera{
+	c_tag = "Security - Equipment Room";
+	dir = 6;
+	network = list("ss13","Security")
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "lGB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -45377,7 +45392,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "lRL" = (
 /obj/effect/turf_decal/tile/bar,
@@ -45422,7 +45437,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "lSz" = (
 /obj/effect/turf_decal/stripes/line{
@@ -45700,7 +45715,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "lZo" = (
 /obj/structure/disposalpipe/junction{
@@ -45799,7 +45814,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mcB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -45826,7 +45841,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mcH" = (
 /obj/structure/disposalpipe/segment,
@@ -45941,6 +45956,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
+"mfY" = (
+/obj/machinery/processor,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "mge" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -45948,7 +45967,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mgz" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -46011,7 +46030,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mik" = (
 /obj/effect/turf_decal/stripes/line{
@@ -46114,7 +46133,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/junior_officer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mku" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -46464,7 +46483,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mtq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -46617,7 +46636,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mxq" = (
 /obj/structure/cable,
@@ -46627,7 +46646,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mxE" = (
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
@@ -46962,7 +46981,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mFg" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -47019,7 +47038,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mGs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -47116,7 +47135,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mJg" = (
 /obj/effect/turf_decal/sand/plating,
@@ -47237,7 +47256,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mLq" = (
 /turf/open/floor/engine/hull/reinforced,
@@ -47259,7 +47278,7 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mMK" = (
 /obj/effect/turf_decal/trimline/green/corner{
@@ -47305,7 +47324,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mNs" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -47330,7 +47349,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mNz" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -47476,7 +47495,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mPT" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -47689,7 +47708,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mUL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -47753,7 +47772,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "mVs" = (
 /turf/open/floor/iron/white,
@@ -47927,7 +47946,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "mZg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48028,6 +48047,31 @@
 /obj/structure/disposalpipe/trunk/multiz,
 /turf/closed/wall,
 /area/cargo/miningdock)
+"nap" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
+	},
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/fruity,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	list_reagents = list(/datum/reagent/consumable/enzyme = 500);
+	name = "universe-sized universal enyzyme";
+	volume = 500
+	},
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "naz" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -48242,7 +48286,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "nfp" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
@@ -48817,7 +48861,7 @@
 	dir = 10
 	},
 /obj/machinery/syndicatebomb/training,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "nvj" = (
 /obj/structure/bed,
@@ -49040,14 +49084,14 @@
 	dir = 6
 	},
 /obj/machinery/duct,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "nBV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "nCd" = (
 /obj/structure/table/glass,
@@ -49234,7 +49278,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "nGf" = (
 /obj/machinery/camera/emp_proof{
@@ -49286,7 +49330,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "nIb" = (
 /obj/structure/chair{
@@ -49394,7 +49438,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "nKT" = (
 /turf/open/floor/engine/vacuum,
@@ -49471,7 +49515,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "nNB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
@@ -49677,7 +49721,7 @@
 /obj/item/seeds/pumpkin,
 /obj/effect/spawner/lootdrop/prison_contraband,
 /obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "nQY" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -49707,7 +49751,7 @@
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "nSw" = (
 /obj/effect/turf_decal/siding/wood{
@@ -49788,7 +49832,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "nUi" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -50236,6 +50280,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"ofr" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "ofx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -50380,7 +50432,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "oiT" = (
 /obj/machinery/door/airlock{
@@ -50564,7 +50616,7 @@
 	dir = 4
 	},
 /obj/machinery/duct,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "omp" = (
 /obj/structure/table/glass,
@@ -51096,6 +51148,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"oAG" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "oAH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -51119,7 +51176,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "oBZ" = (
 /obj/effect/loot_site_spawner,
@@ -51313,7 +51370,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "oFv" = (
 /obj/structure/window/reinforced,
@@ -51467,7 +51524,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "oJR" = (
 /obj/item/stack/ore/glass,
@@ -51840,7 +51897,7 @@
 	dir = 1;
 	network = list("ss13","Security","prison")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "oRG" = (
 /obj/item/soap,
@@ -51860,7 +51917,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "oSV" = (
 /obj/machinery/disposal/delivery_chute{
@@ -51877,7 +51934,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "oTo" = (
 /obj/machinery/duct,
@@ -51927,7 +51984,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "oUJ" = (
 /obj/effect/turf_decal/tile/bar,
@@ -52352,7 +52409,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "pcR" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -52478,7 +52535,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "phj" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -52528,7 +52585,7 @@
 	departmentType = 5;
 	pixel_y = 30
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "phM" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -52897,7 +52954,7 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "pol" = (
 /obj/machinery/door/firedoor,
@@ -53477,7 +53534,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "pBr" = (
 /obj/structure/disposalpipe/segment{
@@ -53676,7 +53733,7 @@
 	dir = 6;
 	network = list("ss13","Security","prison")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "pFx" = (
 /obj/structure/chair/pew/left{
@@ -53834,7 +53891,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/mouse/brown/tom,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "pJm" = (
 /obj/structure/bodycontainer/morgue,
@@ -54028,7 +54085,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "pNu" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -54074,6 +54131,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
+"pOL" = (
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "pOP" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -54159,7 +54219,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "pQD" = (
 /obj/structure/cable,
@@ -54170,7 +54230,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "pQR" = (
 /obj/structure/chair/plastic{
@@ -54287,7 +54347,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "pTw" = (
 /obj/structure/table,
@@ -54547,7 +54607,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "pZZ" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -54601,7 +54661,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "qbH" = (
 /obj/machinery/light,
@@ -54650,7 +54710,7 @@
 	pixel_x = 32
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "qcC" = (
 /obj/structure/disposalpipe/segment{
@@ -54694,7 +54754,7 @@
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "qdM" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -55002,7 +55062,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "qkE" = (
 /obj/effect/turf_decal/trimline/white/corner{
@@ -55037,7 +55097,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "qlv" = (
 /obj/effect/turf_decal/trimline/purple/line,
@@ -55536,7 +55596,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "qyE" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -55562,13 +55622,6 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"qyZ" = (
-/obj/structure/table,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/rice,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "qzb" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -55577,7 +55630,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "qze" = (
 /turf/closed/wall,
@@ -55794,7 +55847,7 @@
 /area/security/checkpoint/science)
 "qCN" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "qCQ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -56120,7 +56173,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "qIH" = (
 /obj/machinery/announcement_system,
@@ -56166,7 +56219,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "qLb" = (
 /obj/structure/industrial_lift/tram{
@@ -56320,7 +56373,7 @@
 	dir = 6;
 	network = list("ss13","Security")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "qSf" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -56459,7 +56512,7 @@
 /area/engineering/atmos)
 "qVl" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "qVu" = (
 /obj/machinery/computer/security/qm{
@@ -56503,7 +56556,7 @@
 	dir = 10
 	},
 /obj/machinery/navbeacon/wayfinding/dockescpod2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "qWg" = (
 /obj/structure/table,
@@ -56534,7 +56587,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "qXE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -56641,7 +56694,7 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "qZT" = (
-/obj/machinery/vending/security_ammo,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "rak" = (
@@ -56755,12 +56808,27 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"rcy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/office)
 "rcN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"rdb" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/camera{
+	c_tag = "Security - Prison Cafeteria";
+	dir = 1;
+	network = list("ss13","Security","prison")
+	},
+/obj/machinery/griddle,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "rdv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
@@ -56938,7 +57006,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rgO" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -56997,7 +57065,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "riD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -57053,7 +57121,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "rjs" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -57274,6 +57342,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
+"rmF" = (
+/obj/machinery/vending/security_ammo,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "rmG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -57680,7 +57753,7 @@
 	name = "sorting disposal pipe (Security)";
 	sortType = 7
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "rwq" = (
 /obj/machinery/door/poddoor{
@@ -57783,7 +57856,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rxL" = (
 /obj/machinery/porta_turret/ai{
@@ -57972,7 +58045,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "rCB" = (
 /obj/effect/spawner/lootdrop/garbage_spawner,
@@ -58028,7 +58101,7 @@
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rEt" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -58058,7 +58131,7 @@
 	dir = 4;
 	network = list("ss13","Security")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rFc" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -58068,7 +58141,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "rFp" = (
 /obj/machinery/power/solar_control{
@@ -58175,7 +58248,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rIE" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -58212,7 +58285,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "rJa" = (
 /obj/machinery/disposal/bin{
@@ -58319,7 +58392,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "rLb" = (
 /obj/structure/closet/crate/bin,
@@ -58519,8 +58592,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "rQP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "rQZ" = (
@@ -58550,7 +58624,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "rRy" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -58593,7 +58667,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "rTw" = (
 /obj/structure/bed,
@@ -58716,7 +58790,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "rXO" = (
 /obj/structure/cable,
@@ -58731,7 +58805,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "rYa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -58952,10 +59026,9 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "scU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "scX" = (
@@ -59279,7 +59352,7 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "skq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -59480,7 +59553,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "sod" = (
 /obj/structure/rack,
@@ -60167,13 +60240,13 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "sCo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "sCD" = (
 /obj/structure/table/reinforced,
@@ -60514,6 +60587,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"sKD" = (
+/obj/structure/table,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/iron/showroomfloor,
+/area/security/office)
 "sKW" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -60538,6 +60621,11 @@
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"sLo" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/office)
 "sLq" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -60649,7 +60737,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "sNt" = (
 /obj/effect/turf_decal/stripes/line{
@@ -60743,7 +60831,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "sPO" = (
 /obj/machinery/light{
@@ -60780,7 +60868,7 @@
 	dir = 1;
 	network = list("ss13","Security","prison")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "sQj" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
@@ -61012,7 +61100,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "sVZ" = (
 /obj/effect/turf_decal/tile/blue{
@@ -61114,7 +61202,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "sYh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -61223,7 +61311,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "tcl" = (
 /obj/structure/sign/warning/securearea{
@@ -61499,7 +61587,7 @@
 /area/engineering/atmos)
 "thm" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "thz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -61584,7 +61672,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "tiz" = (
 /obj/machinery/airalarm/directional/north,
@@ -61704,7 +61792,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "tkL" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -62072,6 +62160,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/commons/lounge)
+"tqA" = (
+/obj/machinery/smartfridge,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "tqL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -62143,7 +62235,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "tsK" = (
 /obj/effect/turf_decal/trimline/white/line,
@@ -62201,7 +62293,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "ttN" = (
 /turf/open/openspace,
@@ -62277,7 +62369,7 @@
 "tuD" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "tuJ" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -62295,7 +62387,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "tuP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -62436,11 +62528,20 @@
 /area/hallway/secondary/exit)
 "txB" = (
 /obj/structure/table,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/camera{
-	c_tag = "Security - Prison Cafeteria";
-	dir = 1;
-	network = list("ss13","Security","prison")
+/obj/item/book/manual/chef_recipes,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -62820,7 +62921,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "tHN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63076,7 +63177,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "tQH" = (
 /obj/machinery/monkey_recycler,
@@ -63203,7 +63304,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/junior_officer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "tTu" = (
 /obj/structure/table,
@@ -63370,7 +63471,7 @@
 	dir = 5
 	},
 /obj/machinery/duct,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "tXz" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -63392,7 +63493,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "tXJ" = (
 /obj/effect/turf_decal/loading_area,
@@ -63536,7 +63637,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "uaf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -63678,7 +63779,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "udR" = (
 /obj/effect/turf_decal/bot,
@@ -63715,7 +63816,7 @@
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ufj" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -63762,7 +63863,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "ufN" = (
 /obj/effect/turf_decal/trimline/purple/corner{
@@ -63834,7 +63935,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ugp" = (
 /obj/structure/table,
@@ -64028,7 +64129,7 @@
 	dir = 1;
 	network = list("ss13","Security","prison")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "uji" = (
 /obj/structure/disposalpipe/segment{
@@ -64168,7 +64269,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "ulD" = (
 /obj/effect/turf_decal/sand/plating,
@@ -64336,7 +64437,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "upP" = (
 /obj/structure/chair,
@@ -64505,7 +64606,7 @@
 	pixel_x = -8;
 	pixel_y = 3
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "utv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -64561,7 +64662,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uvE" = (
 /obj/structure/cable,
@@ -64794,7 +64895,7 @@
 	dir = 1;
 	network = list("ss13","Security","prison")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "uBp" = (
 /obj/machinery/computer/pandemic,
@@ -64918,7 +65019,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uGS" = (
 /obj/machinery/door/airlock/command/glass{
@@ -65099,7 +65200,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uJw" = (
 /obj/structure/disposalpipe/segment,
@@ -65172,7 +65273,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uLB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -65268,7 +65369,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "uNb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -65427,7 +65528,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "uPu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65554,7 +65655,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "uRv" = (
 /obj/machinery/door/airlock/engineering{
@@ -65732,7 +65833,7 @@
 /obj/item/clothing/gloves/color/orange,
 /obj/item/restraints/handcuffs,
 /obj/item/reagent_containers/spray/pepper,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "uWf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -65938,7 +66039,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "vbx" = (
 /obj/structure/disposalpipe/segment{
@@ -66050,7 +66151,7 @@
 	dir = 8;
 	network = list("ss13","Security")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vdg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
@@ -66323,7 +66424,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vjC" = (
 /obj/structure/closet/emcloset,
@@ -66654,7 +66755,7 @@
 	name = "sorting disposal pipe (Head of Security's Office)";
 	sortType = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "vsH" = (
 /obj/effect/turf_decal/stripes/line{
@@ -66858,7 +66959,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/security_sergeant,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "vzt" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -67252,7 +67353,7 @@
 	dir = 1;
 	network = list("ss13","Security")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vGU" = (
 /obj/effect/turf_decal/stripes/line{
@@ -67437,7 +67538,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vJP" = (
 /obj/structure/table,
@@ -67760,7 +67861,7 @@
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "vRS" = (
 /obj/structure/cable,
@@ -67833,7 +67934,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "vTa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -67997,7 +68098,7 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "vWv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -68149,7 +68250,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wdc" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -68248,7 +68349,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "weT" = (
 /obj/machinery/modular_computer/console/preset/command{
@@ -68302,7 +68403,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "wgo" = (
 /obj/structure/disposalpipe/segment,
@@ -68339,7 +68440,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "whV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -68518,13 +68619,13 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wob" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "woj" = (
 /obj/structure/cable,
@@ -68687,7 +68788,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "wrI" = (
 /obj/effect/turf_decal/delivery,
@@ -68941,14 +69042,14 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wyd" = (
 /obj/structure/closet/secure_closet/security/med,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wyq" = (
 /obj/machinery/door/firedoor,
@@ -69070,7 +69171,7 @@
 /area/science/mixing)
 "wAj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wAx" = (
 /obj/machinery/door/airlock/security/glass{
@@ -69200,7 +69301,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wCV" = (
 /obj/docking_port/stationary{
@@ -69360,7 +69461,7 @@
 	},
 /obj/structure/rack,
 /obj/item/restraints/handcuffs,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wHi" = (
 /obj/structure/cable,
@@ -69536,7 +69637,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "wLX" = (
 /obj/effect/decal/cleanable/chem_pile,
@@ -69556,13 +69657,13 @@
 "wMq" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/closet/secure_closet/brig,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wMv" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/light,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wNf" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -69654,7 +69755,6 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "wOX" = (
-/obj/structure/closet/l3closet/security,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "wOZ" = (
@@ -69800,7 +69900,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wTg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -69949,7 +70049,7 @@
 /obj/item/assembly/timer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "wUT" = (
 /obj/structure/fluff/tram_rail/anchor{
@@ -69993,7 +70093,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "wWv" = (
 /obj/effect/turf_decal/sand/plating,
@@ -70200,7 +70300,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xav" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -70460,7 +70560,7 @@
 	},
 /obj/structure/table,
 /obj/item/electropack,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "xfX" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -70767,7 +70867,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "xlA" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -71079,7 +71179,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xsG" = (
 /obj/effect/turf_decal/sand/plating,
@@ -71134,7 +71234,7 @@
 	name = "Prison Wing";
 	req_access_txt = "2"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "xvf" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -71149,7 +71249,7 @@
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "xvk" = (
 /obj/effect/turf_decal/stripes,
@@ -71346,7 +71446,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xAh" = (
 /obj/effect/turf_decal/trimline/white/line{
@@ -71706,7 +71806,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xGU" = (
 /obj/machinery/door/firedoor,
@@ -71717,7 +71817,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xHg" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -71749,7 +71849,7 @@
 "xHE" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "xHR" = (
 /obj/machinery/telecomms/processor/preset_four,
@@ -72579,7 +72679,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xZC" = (
 /obj/effect/turf_decal/siding/wood{
@@ -72654,7 +72754,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ybg" = (
 /obj/machinery/door/airlock/public/glass{
@@ -72734,6 +72834,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
+"ycz" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	dir = 4;
+	name = "old sink";
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "ycF" = (
 /obj/structure/chair{
 	dir = 8
@@ -72777,7 +72887,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "yec" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
@@ -72822,6 +72932,7 @@
 /area/service/kitchen)
 "yfG" = (
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
@@ -73031,6 +73142,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"yjS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 11
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "ykx" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
@@ -100436,7 +100555,7 @@ nTn
 nTn
 nTn
 pFk
-rWZ
+pOL
 iJY
 eTY
 bek
@@ -102502,12 +102621,12 @@ iNc
 eXn
 dGa
 qvj
-dIe
-kDG
+nap
+tqA
 nTn
 nTn
-aae
-aae
+nTn
+nTn
 aae
 aae
 aGF
@@ -102761,10 +102880,10 @@ pPW
 laM
 vPp
 vPp
-qyZ
+rge
+oAG
+mfY
 nTn
-aae
-aae
 aae
 aae
 aGF
@@ -103017,11 +103136,11 @@ itU
 pPW
 kuQ
 vPp
+vPp
+yjS
 jRn
-rge
+wTn
 nTn
-aae
-aae
 aae
 aae
 aGF
@@ -103274,11 +103393,11 @@ rWZ
 xzs
 jvO
 jRn
-vPp
+kDG
+wTn
+jRn
 wTn
 nTn
-aae
-aae
 aae
 aae
 aGF
@@ -103531,11 +103650,11 @@ duQ
 nfv
 yle
 jRn
-vPp
+dIe
 txB
+jRn
+rdb
 nTn
-aae
-aae
 aae
 aae
 aGF
@@ -103789,10 +103908,10 @@ gly
 eLS
 jRn
 vPp
-rge
+ycz
+jRn
+gXs
 nTn
-aae
-aae
 aGF
 aGF
 aGF
@@ -104047,9 +104166,9 @@ laM
 jRn
 vPp
 ieo
+wTn
+wTn
 nTn
-aae
-aae
 aGF
 rXw
 mzH
@@ -104301,12 +104420,12 @@ fet
 ycF
 scz
 bZm
-vPp
+iqd
 bgU
 nTn
 nTn
-aae
-aae
+nTn
+nTn
 aGF
 vLw
 aGF
@@ -106595,7 +106714,7 @@ nTn
 nTn
 nTn
 qky
-hCu
+kJy
 sCo
 kcp
 ccM
@@ -106612,8 +106731,8 @@ qFh
 ccM
 ccM
 doy
-hCu
-hCu
+kJy
+kJy
 qCN
 pBl
 nTn
@@ -106850,7 +106969,7 @@ aae
 aae
 nTn
 jmi
-faK
+doP
 wob
 xHE
 kZD
@@ -106869,7 +106988,7 @@ ccM
 ccM
 ccM
 ahe
-rWZ
+pOL
 qIG
 iJY
 aca
@@ -107107,8 +107226,8 @@ aae
 aae
 nTn
 hxy
-rWZ
-hCu
+pOL
+kJy
 jld
 gOk
 xlj
@@ -107126,7 +107245,7 @@ gls
 gOc
 afX
 vbv
-hCu
+kJy
 ufL
 lus
 agr
@@ -107364,8 +107483,8 @@ aae
 aae
 nTn
 acA
-rWZ
-hCu
+pOL
+kJy
 lrc
 jmb
 bjP
@@ -107880,7 +107999,7 @@ nTn
 nTn
 nTn
 qky
-rWZ
+pOL
 rBY
 hEv
 ccM
@@ -166229,7 +166348,7 @@ xRI
 rJF
 mNk
 ded
-rWZ
+pOL
 dIZ
 wMq
 nTn
@@ -166485,8 +166604,8 @@ nTn
 xjx
 wKp
 mZf
-rWZ
-rWZ
+pOL
+pOL
 dIZ
 wMv
 nTn
@@ -166743,7 +166862,7 @@ mjJ
 eOy
 iFO
 mIU
-rWZ
+pOL
 dIZ
 bjd
 nTn
@@ -167000,7 +167119,7 @@ nTn
 nTn
 nTn
 xfN
-rWZ
+pOL
 dIZ
 ahq
 nTn
@@ -167514,7 +167633,7 @@ icN
 qiW
 sck
 bek
-rWZ
+pOL
 dIZ
 bjd
 ktC
@@ -170069,12 +170188,12 @@ aBM
 aBM
 aBM
 aBM
-aBM
-aBM
 bcm
-bcm
-bcm
-bcm
+rcy
+sLo
+sLo
+rcy
+rcy
 hNf
 qEJ
 qEJ
@@ -170326,10 +170445,10 @@ aBM
 aBM
 aBM
 aBM
-aae
-aBM
 bcm
 jdK
+wOX
+wOX
 gBH
 yfG
 hNf
@@ -170583,10 +170702,10 @@ aBM
 aBM
 aBM
 aBM
-aae
-aae
 bcm
 oZm
+wOX
+kBf
 cii
 yfG
 hNf
@@ -170840,12 +170959,12 @@ aBM
 aBM
 aBM
 aae
-aae
-aae
 bcm
 jdK
+wOX
+kjb
 cii
-ihD
+yfG
 hNf
 aoC
 egF
@@ -171097,12 +171216,12 @@ aBM
 aBM
 aBM
 aae
-aae
-aae
 bcm
+ofr
+wOX
 dPU
 cii
-ihD
+yfG
 hNf
 erD
 cJU
@@ -171354,10 +171473,10 @@ aBM
 aBM
 aBM
 aae
-aae
-aae
 bcm
-grL
+lGt
+wOX
+wOX
 cii
 ihD
 hNf
@@ -171611,12 +171730,12 @@ aBM
 aae
 aBM
 aae
-aae
-aae
 bcm
+sKD
+wOX
 qZT
 scU
-fUw
+rQP
 wOX
 hNf
 hNf
@@ -171868,12 +171987,12 @@ aBM
 aae
 aae
 aae
-aae
-aae
 bcm
+rmF
+hrj
 kVU
 gCm
-fTx
+rQP
 rQP
 vyh
 ulr
@@ -172125,7 +172244,7 @@ aBM
 aae
 aae
 aae
-aae
+bcm
 cso
 cso
 cso


### PR DESCRIPTION
Makes the grey tiles dark in prison and sec. Also adds changes from https://github.com/Skyrat-SS13/Skyrat-tg/pull/4694

![image](https://user-images.githubusercontent.com/43841046/113787817-90c3ca80-96f0-11eb-8447-b2dc5d48e679.png)

From #4694 :
Expands the room's depth by 2 tiles and ups the number of peacekeeper lockers from 8 (what kind of station only has lockers for 3 officers?). Moves vendors to the back of the room, adds table in the center with a hand labeler and crowbars.


![image](https://user-images.githubusercontent.com/43841046/113787861-a33e0400-96f0-11eb-9fab-2bb5bae192f6.png)

Also expands permabrig kitchen because why not, makes cooking a lot more viable beyond just having a microwave. Adds enough equipment to cook most things, including 2 griddles, a food processor, a grinder, dispensers, and a smart fridge.