### PR TITLE
[FUCK] M45A5 Elite and .460 Rowland Magnum HP rebalance

### DIFF
--- a/modular_skyrat/modules/blueshield/code/modules/projectiles/guns/ballistic/ballistic.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/projectiles/guns/ballistic/ballistic.dm
@@ -8,25 +8,25 @@
 
 /obj/projectile/bullet/advanced/b10mm/b460
 	name = ".460 RM JHP bullet"
-	damage = 42
-	stamina = 15
-	wound_bonus = 30
-	armour_penetration = -30
-	speed = 1
+	damage = 36
+	stamina = 12
+	wound_bonus = 35
+	armour_penetration = -75
+	speed = 2.25
 
 /obj/item/gun/ballistic/automatic/pistol/blueshield
 	name = "\improper M45A5 Elite"
-	desc = "A hand-assembled custom sporting handgun by Alpha Centauri Armories, chambered in .460 Rowland Magnum. This model has modular caliber magazines, to accomodate  for ammo costs."
+	desc = "A hand-assembled custom sporting handgun by Alpha Centauri Armories, chambered in .460 Rowland Magnum. This model has a highly modular structure, to acommodate for ammo costs."
 	icon = 'modular_skyrat/modules/blueshield/icons/obj/guns/M45A5.dmi'
 	icon_state = "m45a5"
 	w_class = WEIGHT_CLASS_NORMAL
 	mag_type = /obj/item/ammo_box/magazine/multi_sprite/ladon/blueshield
 	can_suppress = FALSE
-	fire_delay = 3
-	fire_sound_volume = 30
+	fire_delay = 1.75
+	fire_sound_volume = 60 //Handgun equivalent of .44 with a muzzle brake lmao
 	spread = 2
-	force = 12 //Not really meant to be used as a melee weapon; but heavy construction and extended mag.
-	recoil = 0.5
+	force = 8 //There's heavier guns that dealt less damage on melee than this so we're reducing it from the original 12
+	recoil = 1
 	realistic = TRUE
 	dirt_modifier = 0.1
 	can_flashlight = TRUE
@@ -34,13 +34,13 @@
 	fire_sound = 'modular_skyrat/modules/sec_haul/sound/dp_fire.ogg'
 
 /obj/item/ammo_box/magazine/multi_sprite/ladon/blueshield
-	name = "ACA 460-10 modular magazine"
-	desc = "A magazine normally chambered in .460, able to chamber Peacekeeper 10mm rounds as an alternative by its length switch. Made for the M45A5, as it's the only available sidearm with a smart multi-caliber mechanism."
+	name = "ACA modular magazine"
+	desc = "A magazine able to chamber .460 Rowland Magnum and Peacekeeper 10mm rounds as an alternative by its length switch. Made for the M45A5, as it's the only available sidearm with a smart multi-caliber mechanism."
 	icon = 'modular_skyrat/modules/blueshield/icons/obj/guns/M45A5.dmi'
 	icon_state = "rowlandmodular"
 	ammo_type = /obj/item/ammo_casing/b10mm
 	caliber = "10mm"
-	max_ammo = 15 //Tactical mags.
+	max_ammo = 10 //Increased length single stacks.
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 	possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_HOLLOWPOINT, AMMO_TYPE_RUBBER, AMMO_TYPE_IHDF, ".460")
 


### PR DESCRIPTION
## About The Pull Request

Hi, I rebalanced the Blueshield's gun.

## Why It's Good For The Game

I don't want a broken gun roundstart, also I need to be able to make these compete for when I inevitably give them a choice beacon again.

## Changelog
:cl:
spellcheck: Changed some wording related to the M45A5-E and its modular magazines.
balance: .460 Rowland Magnum damage nerfed to 36 from 45 and 15 to 12 respectively. (Brute/Stam)
balance: .460 Rowland Magnum speed nerfed from 1 to 2.25.
balance: Drastically reduced armor penetration status of .460 Rowland hollow points, but increased their wound bonus.
balance: Buffed firing speed of M45A5-E to 1.75ds from 3ds. In return, increased recoil to 1 from 0.5.
balance: Nerfed M45A5-E melee damage to 8 from 12.
balance: Reduced M45A5-E magazine capacity from 15 to 10 rounds.
/:cl: