### PR TITLE
Helps remedy the seccies commonly lugging better armour than most antagonists problem

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
@@ -57,9 +57,9 @@
 
 /obj/item/clothing/under/rank/security/peacekeeper/tactical
 	name = "tactical peacekeeper uniform"
-	desc = "A tactical peackeeper uniform, we'll get em boys."
+	desc = "A tactical peackeeper uniform, woven with a lightweight layer of kevlar to provide minor ballistic and stab protection."
 	icon_state = "peacekeeper_tac"
-	armor = list(MELEE = 15, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 0, BIO = 0, RAD = 0, FIRE = 30, ACID = 30, WOUND = 10)
+	armor = list(MELEE = 5, BULLET = 5, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 30, ACID = 30, WOUND = 10)
 
 /obj/item/clothing/under/rank/security/peacekeeper/blue
 	name = "blue peacekeeper uniform"


### PR DESCRIPTION
## About The Pull Request
• Tactical seccie jumpsuit is no longer the best jumpsuit in the game par unobtainable space-proof ones.
• Tactical seccie jumpsuit is now a normal seccie jumpsuit, however, you trade 5 melee armour for 5 bullet armour, instead of getting a lot of extra armour for free.

## Why It's Good For The Game
No normally obtainable jumpsuit slot piece of clothing does more than 10 melee armour. Even the tactical turtleneck is only as good as the seccie jumpsuit. Both of which are inferior to the seccie tactical jumpsuit that all seccies get for free roundstart.
Honestly this is just absurd, armour stacks.
As a seccie, you could choose the following statblocks with a single visit to the armoury to get one vest of your choosing.
1. 30% melee resist, 65% bullet resist, 15% laser resist, 15% energy resist.
2. 65% melee resist, 15%  bullet resist, 15% laser resist, 15% energy resist.
I'm getting a little tired of balance PRs involving security and traitors dealing with the respective power levels of each that both focus solely on guns instead of addressing anything else, like this for example.
If I wasn't so busy doing my own PRs I'd have done this two months ago, apologies. I just forgot about this because I haven't been able to play even half a round of over a month now.

## Changelog
:cl:
balance: Security no longer starts with the best obtainable jumpsuit in the game, even better than traitor jumpsuits. The tactical peacekeeper jumpsuit is now a normal security jumpsuit that trades 5 of it's melee armour for 5 bullet armour.
/:cl:
