### PR TITLE
[MODULAR] Adds jukebox to cargo and removes ID lock from it

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -364,6 +364,13 @@
                     /obj/item/flashlight,)
 	crate_name = "emergency lighting crate"
 
+/datum/supply_pack/service/jukebox
+	name = "Jukebox Crate"
+	desc = "Wanting to amp up your bar or club with some sick tunes? This is the crate for you! Contains one jukebox."
+	cost = CARGO_CRATE_VALUE * 30
+	contains = list(/obj/machinery/jukebox)
+	crate_name = "jukebox crate"
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Materials & Sheets //////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/modular_skyrat/modules/jukebox/code/controllers/subsystem/game/machinery/dance_machine.dm
+++ b/modular_skyrat/modules/jukebox/code/controllers/subsystem/game/machinery/dance_machine.dm
@@ -5,7 +5,7 @@
 	icon_state = "jukebox"
 	verb_say = "states"
 	density = TRUE
-	req_access = list(ACCESS_BAR)
+	req_access = list()
 	var/active = FALSE
 	var/list/rangers = list()
 	var/stop = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
To save the admins some ahelps for it, you can now buy the jukebox from cargo for the (currently) price of 6000 credits. I have also removed the requirement to have bar access to use it.
If anyone feels like the price should be decreased/increased leave a message.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Saves admins time and sanity when they get ahelped for another jukebox.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Jukeboxes are now available to be ordered through cargo!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
