### PR TITLE
Fix Chameleon runtime! Rejoice CI

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/chameleon.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/chameleon.dm
@@ -17,6 +17,11 @@
 /datum/action/item_action/chameleon/change/
 	var/datum/action/chameleon_slowdown/slowtoggle
 
+/datum/action/item_action/chameleon/change/update_look(mob/user, obj/item/picked_item)
+	. = ..()
+	if(isliving(user))
+		owner.regenerate_icons()
+
 /datum/action/item_action/chameleon/change/update_item(obj/item/picked_item)
 	. = ..()
 	if(istype(target, /obj/item/clothing/))
@@ -40,7 +45,6 @@
 			slowtoggle.target = T
 		else if(slowtoggle)
 			qdel(slowtoggle)
-		owner.regenerate_icons()
 
 /datum/action/item_action/chameleon/change/Grant(mob/M)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So, there's this really weird edge case, where you can have chameleon loot generated randomly in the map. Because this loot doesn't have an owner (the mob its attached to) it runtimes like crazy. Anyway 👏 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Foxtrot (Funce)
fix: Chameleon map loot no longer runtimes!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
