### PR TITLE
Fixes a whoopsie with the Particle Accelerator and Teslas!

### DIFF
--- a/modular_skyrat/modules/singularity_engine/code/particle_accelerator/particle.dm
+++ b/modular_skyrat/modules/singularity_engine/code/particle_accelerator/particle.dm
@@ -38,6 +38,9 @@
 		else if(istype(A, /obj/singularity))
 			var/obj/singularity/S = A
 			S.energy += energy
+		else if(istype(A, /obj/energy_ball))
+			var/obj/energy_ball/E = A
+			E.energy += energy
 		else if(istype(A, /obj/structure/blob))
 			var/obj/structure/blob/B = A
 			B.take_damage(energy*0.6)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns out at some point they made the energy ball not a subtype of the singularity.

## Changelog
:cl:
fix: Teslas will now actually be affected by field particles emitted from the Particle Accelerator.
/:cl:

