### PR TITLE
Renames tram_dock to interlink

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -353,7 +353,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "abf" = (
 /obj/machinery/door/airlock/security/old{
 	name = "Arrivals Checkpoint";
@@ -1187,7 +1187,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "adx" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
@@ -1571,7 +1571,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aez" = (
 /obj/structure/table/reinforced,
 /obj/item/melee/transforming/energy/sword/saber/blue,
@@ -1802,7 +1802,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aff" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -1874,7 +1874,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "afp" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
@@ -2003,7 +2003,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "afL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
@@ -2123,7 +2123,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "age" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -2235,13 +2235,13 @@
 	dir = 5
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "agq" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "agr" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/indestructible/hotelwood,
@@ -2261,7 +2261,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "agu" = (
 /obj/machinery/light{
 	dir = 1;
@@ -2523,7 +2523,7 @@
 /area/cruiser_dock/medical)
 "ahc" = (
 /turf/open/floor/iron/dark/green/corner,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ahd" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/door/airlock/multi_tile/glass,
@@ -2670,7 +2670,7 @@
 "ahu" = (
 /obj/effect/landmark/latejoin,
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ahv" = (
 /obj/structure/chair/sofa/bench{
 	dir = 8
@@ -2720,7 +2720,7 @@
 /turf/open/floor/iron/dark/green/corner{
 	dir = 8
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ahz" = (
 /obj/machinery/griddle,
 /turf/open/floor/iron,
@@ -2778,7 +2778,7 @@
 /obj/item/trash/can,
 /obj/item/trash/can,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ahF" = (
 /turf/open/floor/plating/abductor,
 /area/bluespace_locker)
@@ -2832,14 +2832,14 @@
 	name = "Private Security Officer"
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ahM" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ahN" = (
 /obj/machinery/vending/clothing,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -2971,7 +2971,7 @@
 "aie" = (
 /obj/machinery/status_display/ai,
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aif" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -3019,7 +3019,7 @@
 	},
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ain" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -3079,7 +3079,7 @@
 "ait" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aiu" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -3151,7 +3151,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aiF" = (
 /obj/machinery/light,
 /obj/structure/table/glass,
@@ -3217,7 +3217,7 @@
 /area/centcom/holding/cafe)
 "aiL" = (
 /turf/open/floor/carpet/executive,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aiM" = (
 /obj/structure/showcase/fakeid{
 	dir = 4
@@ -3296,7 +3296,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aiX" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -3345,7 +3345,7 @@
 "aje" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ajf" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/cooking_to_serve_man,
@@ -3367,7 +3367,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aji" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/grass,
@@ -3629,7 +3629,7 @@
 /turf/open/floor/iron/brown/side{
 	dir = 1
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ajT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -3750,7 +3750,7 @@
 "akk" = (
 /obj/structure/chair/sofa/bench,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "akl" = (
 /turf/open/floor/iron/showroomfloor,
 /area/cruiser_dock/brig)
@@ -3822,7 +3822,7 @@
 	name = "\improper Jim Norton's Quebecois Coffee"
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "akw" = (
 /obj/machinery/light/cold,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -3849,7 +3849,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/grass,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "akz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -3884,7 +3884,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "akB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -3893,7 +3893,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "akC" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -4055,7 +4055,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "akY" = (
 /turf/open/floor/glass/reinforced,
 /area/cruiser_dock/research)
@@ -4167,7 +4167,7 @@
 /turf/open/floor/iron/brown/corner{
 	dir = 1
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "alo" = (
 /obj/structure/flora/tree/jungle/small{
 	icon_state = "tree5"
@@ -4230,7 +4230,7 @@
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
 /turf/open/floor/eighties,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "alz" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 9
@@ -4551,7 +4551,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "amn" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -4566,7 +4566,7 @@
 /area/cruiser_dock/commons/dorms)
 "amq" = (
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "amr" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -4604,7 +4604,7 @@
 "amv" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "amw" = (
 /obj/effect/turf_decal/caution/stand_clear/red,
 /obj/effect/turf_decal/bot_red,
@@ -4648,7 +4648,7 @@
 	},
 /obj/item/pen,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "amC" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4657,7 +4657,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "amD" = (
 /obj/structure/chair/sofa/right,
 /turf/open/indestructible/hotelwood,
@@ -4713,7 +4713,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "amL" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -4760,7 +4760,7 @@
 	width = 5
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "amP" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -4806,7 +4806,7 @@
 	icon_state = "plant-21"
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "amW" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
@@ -4838,7 +4838,7 @@
 	req_access_txt = "109"
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ana" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/blue{
@@ -4870,7 +4870,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ane" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 8
@@ -4949,7 +4949,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "anm" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 4
@@ -5062,7 +5062,7 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 8
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "anC" = (
 /obj/structure/flora/rock/pile/largejungle{
 	pixel_x = 0;
@@ -5353,7 +5353,7 @@
 "aon" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/floor/plating/ironsand,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aoo" = (
 /obj/machinery/computer/arcade/amputation,
 /obj/effect/decal/cleanable/dirt,
@@ -5387,7 +5387,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aos" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -5460,7 +5460,7 @@
 /turf/open/floor/iron/stairs{
 	dir = 4
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aoA" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -5486,7 +5486,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aoD" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -5571,7 +5571,7 @@
 "aoN" = (
 /obj/effect/turf_decal/trimline/blue/arrow_cw,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aoO" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -5775,7 +5775,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "apn" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -5792,7 +5792,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "app" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -5995,7 +5995,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "apM" = (
 /obj/effect/mob_spawn/human/syndicate/assops/syndicate_assistant{
 	dir = 4
@@ -6038,7 +6038,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "apQ" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs/cable/zipties,
@@ -6057,7 +6057,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "apR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -6195,7 +6195,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aqj" = (
 /obj/structure/closet/secure_closet{
 	icon_state = "cmo";
@@ -6238,7 +6238,7 @@
 /turf/open/floor/iron/brown/side{
 	dir = 8
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aqq" = (
 /obj/structure/closet/secure_closet{
 	icon_state = "hop";
@@ -6367,10 +6367,10 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aqG" = (
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aqH" = (
 /turf/open/floor/circuit/telecomms,
 /area/cruiser_dock/research)
@@ -6401,7 +6401,7 @@
 /turf/open/floor/iron/brown/side{
 	dir = 4
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aqM" = (
 /obj/machinery/light/cold/no_nightlight{
 	dir = 8
@@ -6548,7 +6548,7 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 9
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "arf" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/medihound,
@@ -6722,7 +6722,7 @@
 /obj/effect/turf_decal/trimline/blue/arrow_cw,
 /obj/machinery/light,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "arD" = (
 /turf/open/floor/plating/beach/water,
 /area/cruiser_dock/commons/dorms)
@@ -6736,7 +6736,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "arG" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/green{
@@ -6758,7 +6758,7 @@
 	req_access_txt = "109"
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "arI" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -6775,7 +6775,7 @@
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "arL" = (
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/engineering)
@@ -6889,7 +6889,7 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "asc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7038,7 +7038,7 @@
 "asv" = (
 /obj/machinery/door/poddoor/ert,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "asw" = (
 /turf/closed/indestructible/wood,
 /area/centcom/holding/cafevox)
@@ -7112,7 +7112,7 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 1
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "asJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -7178,7 +7178,7 @@
 /area/cruiser_dock/commons)
 "asP" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "asQ" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder{
@@ -7329,7 +7329,7 @@
 	name = "Arrivals"
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "atj" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/brute,
@@ -7349,7 +7349,7 @@
 	pixel_x = -12
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "atl" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -7544,7 +7544,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "atP" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood,
@@ -7585,7 +7585,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "atV" = (
 /obj/effect/turf_decal/tile/yellow{
 	alpha = 170;
@@ -7730,7 +7730,7 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 1
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aum" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -8259,7 +8259,7 @@
 /area/cruiser_dock/research)
 "avC" = (
 /turf/open/floor/iron/brown/side,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "avD" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,
@@ -8300,7 +8300,7 @@
 	},
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "avK" = (
 /obj/machinery/light/cold/no_nightlight,
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -8317,7 +8317,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "avN" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -8602,7 +8602,7 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 1
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "awx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -8641,7 +8641,7 @@
 /area/centcom/holding/cafe)
 "awC" = (
 /turf/open/floor/mineral/titanium,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "awD" = (
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
@@ -8854,7 +8854,7 @@
 "axe" = (
 /obj/effect/turf_decal/loading_area/red,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "axf" = (
 /turf/open/floor/engine,
 /area/cruiser_dock/research)
@@ -8909,7 +8909,7 @@
 /turf/open/floor/iron/brown/side{
 	dir = 6
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "axo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9021,7 +9021,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "axC" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
@@ -9064,7 +9064,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "axI" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/purple,
@@ -9161,7 +9161,7 @@
 "axU" = (
 /obj/structure/window/spawner/north,
 /turf/open/floor/carpet/orange,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "axV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9269,7 +9269,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ayk" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -9306,7 +9306,7 @@
 /obj/structure/table,
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ayo" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -9438,7 +9438,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ayG" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/effect/turf_decal/delivery/red,
@@ -9886,12 +9886,12 @@
 	},
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "azS" = (
 /turf/open/floor/iron/dark/green/side{
 	dir = 4
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "azT" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -9976,7 +9976,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aAf" = (
 /turf/open/floor/plating/dirt{
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
@@ -10165,7 +10165,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aAz" = (
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/grass/planet,
@@ -10191,7 +10191,7 @@
 	},
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aAD" = (
 /turf/closed/indestructible/syndicate,
 /area/cruiser_dock/heads/cro)
@@ -10326,7 +10326,7 @@
 	icon_state = "plant-22"
 	},
 /turf/open/floor/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aAV" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/structure/cable,
@@ -10338,7 +10338,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aAX" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -10424,7 +10424,7 @@
 /obj/structure/table,
 /obj/item/lighter,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aBk" = (
 /obj/machinery/libraryscanner,
 /turf/open/indestructible/hotelwood,
@@ -10434,7 +10434,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aBn" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Corporate Liaison Quarters";
@@ -10680,7 +10680,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aBP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -10853,7 +10853,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aCm" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -10895,7 +10895,7 @@
 	name = "Central Access"
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aCs" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4
@@ -10933,7 +10933,7 @@
 "aCy" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/ironsand,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aCz" = (
 /turf/closed/indestructible/opsglass,
 /area/cruiser_dock/heads/cmaa)
@@ -10996,7 +10996,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aCI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -11005,7 +11005,7 @@
 /area/cruiser_dock/research)
 "aCJ" = (
 /turf/open/floor/carpet/orange,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aCK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -11124,7 +11124,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aDa" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/beach/sand,
@@ -11201,7 +11201,7 @@
 "aDg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aDh" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien6";
@@ -11237,7 +11237,7 @@
 "aDn" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/eighties,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aDo" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
@@ -11249,7 +11249,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/stairs,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aDq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron{
@@ -11360,7 +11360,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aDI" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
@@ -11387,7 +11387,7 @@
 "aDK" = (
 /obj/machinery/door/poddoor/ert,
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aDL" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/command{
@@ -11413,7 +11413,7 @@
 /turf/open/floor/iron/stairs{
 	dir = 4
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aDP" = (
 /mob/living/simple_animal/chicken,
 /turf/open/floor/plating/grass/planet,
@@ -11536,7 +11536,7 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 1
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aEh" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 1
@@ -11563,7 +11563,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aEk" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
@@ -11593,7 +11593,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aEo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11605,7 +11605,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aEp" = (
 /obj/structure/table/wood,
 /obj/machinery/smartfridge/disks{
@@ -11864,7 +11864,7 @@
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aFc" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -11878,7 +11878,7 @@
 "aFe" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aFf" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -12067,7 +12067,7 @@
 "aFE" = (
 /obj/effect/turf_decal/trimline/white/line,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aFF" = (
 /turf/closed/indestructible/syndicate,
 /area/cruiser_dock/research)
@@ -12139,7 +12139,7 @@
 	},
 /obj/item/phone,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aFP" = (
 /turf/open/floor/plating/grass/planet,
 /area/centcom/holding/cafepark)
@@ -12262,7 +12262,7 @@
 	},
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aGg" = (
 /obj/structure/flora/junglebush/large{
 	icon_state = "bush2"
@@ -12367,7 +12367,7 @@
 /turf/open/floor/iron/brown/side{
 	dir = 10
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aGt" = (
 /obj/structure/rack,
 /obj/item/wirecutters,
@@ -12417,11 +12417,11 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 1
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aGy" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aGz" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -12717,7 +12717,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aHf" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
@@ -12865,7 +12865,7 @@
 /area/cruiser_dock/research)
 "aHC" = (
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aHD" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/beach/coastline_t{
@@ -12904,7 +12904,7 @@
 	},
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aHJ" = (
 /obj/structure/table,
 /obj/item/flashlight{
@@ -12959,7 +12959,7 @@
 "aHQ" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aHR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13259,7 +13259,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aIL" = (
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/service)
@@ -13289,7 +13289,7 @@
 /turf/open/floor/iron/brown/side{
 	dir = 9
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aIR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -13334,7 +13334,7 @@
 	},
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aIY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13448,7 +13448,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aJr" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
@@ -13500,7 +13500,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aJy" = (
 /obj/machinery/shower{
 	dir = 1
@@ -13547,7 +13547,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aJD" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/dark,
@@ -13636,7 +13636,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aJN" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -13648,7 +13648,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aJP" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -13664,7 +13664,7 @@
 "aJQ" = (
 /obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aJR" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -13727,7 +13727,7 @@
 /turf/open/floor/iron/brown/side{
 	dir = 1
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aJZ" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating,
@@ -13757,7 +13757,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aKe" = (
 /turf/open/floor/plating,
 /area/cruiser_dock/engineering)
@@ -13786,7 +13786,7 @@
 /area/cruiser_dock/brig)
 "aKj" = (
 /turf/open/floor/eighties,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aKk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -13922,7 +13922,7 @@
 	pixel_x = -24
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aKD" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/indestructible/hotelwood,
@@ -14057,7 +14057,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aKV" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
@@ -14248,7 +14248,7 @@
 	icon_state = "plant-21"
 	},
 /turf/open/floor/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aLs" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -14342,7 +14342,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aLG" = (
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/security)
@@ -14391,7 +14391,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aLO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -14445,7 +14445,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aLW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -14615,7 +14615,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aMv" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -14839,7 +14839,7 @@
 "aNb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aNc" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -15016,7 +15016,7 @@
 "aNu" = (
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aNv" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
@@ -15058,7 +15058,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aND" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
@@ -15066,7 +15066,7 @@
 "aNE" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aNF" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -15078,7 +15078,7 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 5
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aNH" = (
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/commons)
@@ -15139,7 +15139,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aNT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/vodka{
@@ -15217,7 +15217,7 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 1
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aOf" = (
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
@@ -15575,7 +15575,7 @@
 /area/cruiser_dock/heads/cl)
 "aOT" = (
 /turf/open/floor/carpet/royalblack,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aOU" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
@@ -15634,7 +15634,7 @@
 /turf/open/floor/iron/brown/side{
 	dir = 1
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aPc" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -15652,7 +15652,7 @@
 "aPe" = (
 /obj/machinery/light,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aPf" = (
 /turf/closed/mineral/earth_like,
 /area/centcom/holding/cafepark)
@@ -15720,7 +15720,7 @@
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aPr" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/water_source/puddle,
@@ -15728,7 +15728,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/grass,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aPs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -15818,7 +15818,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/external/glass,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aPF" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/light/cold/no_nightlight,
@@ -15869,7 +15869,7 @@
 "aPM" = (
 /obj/effect/turf_decal/trimline/white/corner,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aPN" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -16113,7 +16113,7 @@
 	},
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aQv" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -16148,7 +16148,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aQA" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -16300,7 +16300,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aQS" = (
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/iron/dark,
@@ -16348,7 +16348,7 @@
 /area/cruiser_dock/bridge)
 "aQY" = (
 /turf/open/floor/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aQZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -16430,7 +16430,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aRh" = (
 /obj/structure/table/wood,
 /obj/machinery/vending/boozeomat{
@@ -16461,7 +16461,7 @@
 "aRk" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aRl" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/indestructible/syndicate,
@@ -16487,7 +16487,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aRq" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -16645,7 +16645,7 @@
 "aRF" = (
 /obj/structure/dresser,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aRG" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -16782,7 +16782,7 @@
 "aRZ" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/executive,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aSa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16877,7 +16877,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aSn" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -16920,7 +16920,7 @@
 	pixel_y = 20
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aSs" = (
 /obj/structure/flora/tree/jungle/small{
 	icon_state = "tree4"
@@ -16950,7 +16950,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aSv" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/purple{
@@ -16983,7 +16983,7 @@
 "aSz" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/plating/ironsand,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aSA" = (
 /obj/machinery/light/warm{
 	dir = 8
@@ -17172,7 +17172,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aSZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -17208,7 +17208,7 @@
 "aTf" = (
 /obj/effect/turf_decal/vg_decals/department/sec,
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aTg" = (
 /obj/machinery/light/cold/no_nightlight,
 /obj/effect/mob_spawn/human/syndicate/assops/heads/station_admiral{
@@ -17221,7 +17221,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aTi" = (
 /turf/closed/indestructible/syndicate,
 /area/cruiser_dock/vault)
@@ -17270,7 +17270,7 @@
 /turf/open/floor/iron/brown/side{
 	dir = 5
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aTo" = (
 /obj/effect/turf_decal/tile/yellow{
 	alpha = 170;
@@ -17516,7 +17516,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aTT" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien3";
@@ -17637,7 +17637,7 @@
 "aUh" = (
 /obj/structure/chair/sofa/bench/right,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aUi" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 4
@@ -17700,7 +17700,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aUt" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -18013,7 +18013,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aVn" = (
 /obj/structure/table,
 /turf/open/floor/iron/dark,
@@ -18050,7 +18050,7 @@
 "aVs" = (
 /obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aVt" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/advanced,
@@ -18085,13 +18085,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aVz" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 26
 	},
 /turf/open/floor/iron/dark/green/side,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aVA" = (
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/floor/plating/grass/planet,
@@ -18145,7 +18145,7 @@
 "aVG" = (
 /obj/machinery/status_display/evac,
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aVH" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4;
@@ -18176,7 +18176,7 @@
 /area/cruiser_dock/heads/cro)
 "aVM" = (
 /turf/open/floor/plating/ironsand,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aVN" = (
 /turf/closed/indestructible/syndicate,
 /area/cruiser_dock/security/armory)
@@ -18298,10 +18298,10 @@
 "aWa" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aWb" = (
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aWc" = (
 /obj/structure/window/reinforced/spawner,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18318,7 +18318,7 @@
 "aWe" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aWf" = (
 /obj/machinery/light{
 	dir = 8
@@ -18656,7 +18656,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/grass,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aXa" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/bookmanagement,
@@ -18685,7 +18685,7 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 4
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aXf" = (
 /obj/structure/chair/sofa/corp{
 	dir = 4
@@ -18707,7 +18707,7 @@
 /obj/effect/turf_decal/bot,
 /obj/item/phone,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aXh" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -18723,7 +18723,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aXj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -18755,7 +18755,7 @@
 /area/centcom/holding/cafe)
 "aXm" = (
 /turf/closed/wall/mineral/titanium,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aXn" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -18844,7 +18844,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aXC" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/chem_pack{
@@ -18898,7 +18898,7 @@
 /area/centcom/holding/cafepark)
 "aXG" = (
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aXH" = (
 /obj/structure/closet/bluespace/internal,
 /turf/open/indestructible{
@@ -18911,7 +18911,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aXJ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -18968,7 +18968,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aXR" = (
 /obj/machinery/button/door{
 	id = "ghostcafecabin3";
@@ -19037,7 +19037,7 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/grass,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aYc" = (
 /obj/effect/turf_decal/bot,
 /turf/open/indestructible/hoteltile{
@@ -19127,7 +19127,7 @@
 	},
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aYo" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/stripes/red/box,
@@ -19180,7 +19180,7 @@
 /obj/item/pen,
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aYx" = (
 /obj/machinery/rnd/destructive_analyzer,
 /turf/open/floor/iron/dark,
@@ -19211,7 +19211,7 @@
 	},
 /obj/machinery/vending/dorms,
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aYD" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -19273,7 +19273,7 @@
 "aYK" = (
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aYL" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -19325,7 +19325,7 @@
 "aYS" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aYT" = (
 /obj/vehicle/sealed/mecha/working/ripley/deathripley/real,
 /obj/effect/turf_decal/stripes/red/full,
@@ -19410,7 +19410,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aZg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19427,7 +19427,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aZi" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -19449,7 +19449,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aZk" = (
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/heads/ceo)
@@ -19489,7 +19489,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/light,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aZq" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -19552,7 +19552,7 @@
 "aZy" = (
 /obj/machinery/cryopod,
 /turf/open/floor/iron/dark/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aZz" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/showcase/machinery/implanter{
@@ -19687,7 +19687,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aZP" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 5
@@ -19772,7 +19772,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "aZZ" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -19785,7 +19785,7 @@
 	},
 /obj/structure/window/spawner/east,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "bfK" = (
 /obj/machinery/button/door{
 	id = "dorm28";
@@ -19795,7 +19795,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "biv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/black,
@@ -19810,18 +19810,18 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "biw" = (
 /obj/structure/toilet{
 	contents = newlist(/obj/item/toy/snappop/phoenix);
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "bnl" = (
 /obj/structure/trash_pile,
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "bot" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	desc = "A simple drain.";
@@ -19832,61 +19832,61 @@
 	dir = 4
 	},
 /turf/open/indestructible/hoteltile,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "bsM" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "btE" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "bDJ" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorm23";
 	name = "Lodge 3"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "bFx" = (
 /obj/structure/flora/ausbushes/brflowers{
 	pixel_y = 12
 	},
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "bFK" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "bSX" = (
 /obj/machinery/light,
 /obj/machinery/vending/snack/blue,
 /turf/open/floor/iron/yellowsiding,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "bTH" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "bZo" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
 /turf/open/floor/plastic,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "chW" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/open/floor/iron/brown/side,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ckW" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -19894,11 +19894,11 @@
 	},
 /obj/effect/landmark/latejoin,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "cmu" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "cnS" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -19911,28 +19911,28 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "cqY" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/iron/stairs,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ctg" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "cvG" = (
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "czK" = (
 /obj/effect/turf_decal/trimline/darkblue/line,
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "cDd" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/under/rank/civilian/curator/treasure_hunter,
@@ -19940,24 +19940,24 @@
 /obj/item/clothing/under/shorts/black,
 /obj/item/clothing/under/pants/track,
 /turf/open/floor/carpet/executive,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "cEt" = (
 /obj/machinery/vending/games,
 /turf/open/floor/iron/yellowsiding,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "cGG" = (
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "cUa" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "cWI" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 8
 	},
 /turf/open/floor/iron/yellowsiding/corner,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "deP" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
@@ -19977,7 +19977,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "dfQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19990,17 +19990,17 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "dFM" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "dJb" = (
 /obj/machinery/computer/security/telescreen/entertainment,
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "dKB" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 1
@@ -20009,7 +20009,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "dMY" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -20030,17 +20030,17 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "dRf" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /turf/open/floor/carpet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "dUZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "dXZ" = (
 /obj/machinery/button/door{
 	id = "dorm27";
@@ -20050,20 +20050,20 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "eaM" = (
 /obj/structure/chair/comfy/brown{
 	color = "#596479";
 	dir = 1
 	},
 /turf/open/floor/carpet/executive,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ehN" = (
 /obj/effect/spawner/randomarcade{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ejQ" = (
 /obj/structure/sign/poster/official/no_erp{
 	pixel_x = -32
@@ -20071,7 +20071,7 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 8
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "eku" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -20083,27 +20083,27 @@
 	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "emM" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "eLV" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 9
 	},
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "eOB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/painting/library{
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "feq" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -20122,20 +20122,20 @@
 	dir = 5
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "fft" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
 /turf/open/floor/iron/yellowsiding,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "fhX" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "fta" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -20143,18 +20143,18 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 8
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ftC" = (
 /obj/effect/turf_decal/trimline/white/corner{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "fwZ" = (
 /turf/open/floor/iron/dark/green/corner{
 	dir = 4
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "fzF" = (
 /obj/machinery/button/door{
 	id = "dorm26";
@@ -20164,13 +20164,13 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "fGr" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "fUk" = (
 /obj/machinery/button/door{
 	id = "dorm23";
@@ -20180,7 +20180,7 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "fXN" = (
 /obj/machinery/light{
 	dir = 1
@@ -20189,7 +20189,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "gdl" = (
 /obj/effect/turf_decal/trimline/white/corner{
 	dir = 1
@@ -20197,26 +20197,26 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 4
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "gvq" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
 	},
 /obj/effect/landmark/latejoin,
 /turf/open/floor/iron/yellowsiding,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "gzZ" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/grass/planet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "gBT" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "gFu" = (
 /obj/item/storage/briefcase{
 	pixel_x = -3;
@@ -20235,7 +20235,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "gKj" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -20257,7 +20257,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "gLI" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -20265,24 +20265,24 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 8
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "gLJ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "gPa" = (
 /obj/structure/window/spawner/west,
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "gVy" = (
 /obj/structure/table/glass,
 /obj/item/paper/pamphlet/centcom/visitor_info{
 	pixel_x = -3
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "gWB" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets/donkpocketpizza{
@@ -20294,12 +20294,12 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "haG" = (
 /turf/open/floor/iron/dark/green/corner{
 	dir = 1
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "hbq" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -20314,24 +20314,24 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "hda" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
 	},
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "hdQ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /turf/open/floor/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "hgr" = (
 /obj/structure/toilet{
 	pixel_y = 13
 	},
 /turf/open/indestructible/hoteltile,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "hpS" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -20344,10 +20344,10 @@
 	dir = 1
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "hvQ" = (
 /turf/open/floor/iron/yellowsiding,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "hxm" = (
 /obj/structure/sink{
 	desc = "Finally, modern amenities.";
@@ -20356,26 +20356,26 @@
 	pixel_x = -12
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "hAq" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "hFE" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/latejoin,
 /turf/open/floor/eighties,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "hIJ" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "idT" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 10
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ieC" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
@@ -20391,7 +20391,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ieL" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
@@ -20410,7 +20410,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ime" = (
 /obj/machinery/washing_machine{
 	pixel_x = 2
@@ -20423,10 +20423,10 @@
 	},
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ixt" = (
 /turf/open/floor/carpet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "iEA" = (
 /obj/machinery/light{
 	dir = 8
@@ -20434,20 +20434,20 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 8
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "iGk" = (
 /obj/structure/chair/sofa/right{
 	dir = 1
 	},
 /obj/machinery/light,
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "iLk" = (
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "iTZ" = (
 /turf/open/indestructible/hoteltile,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "iWd" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -20456,26 +20456,26 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "iZj" = (
 /obj/machinery/shower{
 	dir = 8
 	},
 /turf/open/floor/plastic,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "iZA" = (
 /obj/machinery/shower{
 	dir = 1
 	},
 /obj/structure/curtain,
 /turf/open/floor/material,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jff" = (
 /obj/structure/urinal{
 	pixel_y = -12
 	},
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jgm" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -20487,7 +20487,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jqM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -20501,36 +20501,36 @@
 	},
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jrF" = (
 /obj/machinery/vending/clothing,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jst" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jsx" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/orange,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jwv" = (
 /obj/structure/toilet{
 	pixel_y = 8
 	},
 /obj/effect/landmark/latejoin,
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jzj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jKu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window/preopen,
@@ -20554,7 +20554,7 @@
 	pixel_x = -9
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jMY" = (
 /obj/structure/chair/sofa/left{
 	dir = 1
@@ -20564,11 +20564,11 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jTF" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jTG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -20580,11 +20580,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jUw" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jUz" = (
 /obj/machinery/light{
 	dir = 4;
@@ -20592,21 +20592,21 @@
 	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jUE" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plastic,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jXl" = (
 /obj/effect/turf_decal/trimline/darkblue/warning,
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jXA" = (
 /obj/structure/sign/poster/official/cleanliness,
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "jXY" = (
 /obj/machinery/light{
 	dir = 8
@@ -20615,25 +20615,25 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "khB" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/grass/planet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kiC" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kkN" = (
 /obj/machinery/door/airlock/security/old{
 	name = "Prison";
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "klo" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -20642,27 +20642,27 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "knH" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
 	req_access_txt = "109"
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kqG" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 9
 	},
 /obj/structure/window/spawner/north,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kvj" = (
 /obj/structure/chair/sofa{
 	dir = 4
 	},
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kAy" = (
 /obj/structure/chair/sofa/right{
 	dir = 1
@@ -20671,7 +20671,7 @@
 /turf/open/floor/iron/brown/side{
 	dir = 4
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kGR" = (
 /obj/structure/dresser,
 /obj/structure/plaque/static_plaque/golden/captain{
@@ -20688,21 +20688,21 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kHW" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},
 /obj/structure/window/spawner/north,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kLP" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kQt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -20712,21 +20712,21 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kRW" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kVK" = (
 /obj/structure/chair/stool,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kWH" = (
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kXx" = (
 /obj/machinery/button/door{
 	id = "dorm22";
@@ -20736,28 +20736,28 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "kYL" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "lab" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "lbC" = (
 /obj/machinery/door/window/eastleft,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "lhC" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "lkX" = (
 /obj/structure/sign/poster/contraband/robust_softdrinks{
 	name = "Jim Norton's Quebecois Coffee";
@@ -20769,7 +20769,7 @@
 /turf/open/floor/iron/brown/side{
 	dir = 4
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "lmu" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -20790,13 +20790,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "lmF" = (
 /obj/structure/chair/sofa/corner{
 	dir = 4
 	},
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "luy" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 4
@@ -20805,39 +20805,39 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "lIR" = (
 /obj/item/trash/can,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "lMu" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/carpet/orange,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "lSk" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
 	},
 /turf/open/floor/plastic,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "lUt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "lWQ" = (
 /obj/structure/urinal{
 	pixel_y = -5
 	},
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mih" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mpj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window/preopen,
@@ -20856,18 +20856,18 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mqd" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mro" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "msF" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/siding/blue{
@@ -20877,30 +20877,30 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mtW" = (
 /obj/machinery/vending/games,
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mwo" = (
 /turf/open/floor/iron/dark/green/side{
 	dir = 1
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mBu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mHF" = (
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -12
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mOa" = (
 /obj/structure/fireplace,
 /obj/effect/turf_decal/tile/neutral{
@@ -20914,11 +20914,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mRx" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mRZ" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -20934,7 +20934,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mTn" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -20946,18 +20946,18 @@
 	pixel_x = 12
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mUw" = (
 /obj/structure/dresser,
 /turf/open/floor/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "mZd" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorm27";
 	name = "Cabin 3"
 	},
 /turf/open/floor/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ngD" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/blue{
@@ -20970,28 +20970,28 @@
 	dir = 6
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "nib" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
 	},
 /obj/machinery/door/poddoor/ert,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "niJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "npu" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "nvt" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/orange,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "nwj" = (
 /obj/structure/railing{
 	dir = 4
@@ -21002,25 +21002,25 @@
 	dir = 1
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "nwM" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "nxG" = (
 /obj/structure/closet/secure_closet/genpop{
 	opened = 0
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "nFd" = (
 /turf/closed/indestructible/fakedoor{
 	desc = "Why would you want to go back, you just got here!";
 	name = "Arrivals Hallway"
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "nGK" = (
 /obj/machinery/button/door{
 	id = "dorm25";
@@ -21030,18 +21030,18 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "nHt" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "nKj" = (
 /turf/open/floor/plastic,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "nSr" = (
 /obj/structure/dresser,
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "nSQ" = (
 /obj/item/cardboard_cutout{
 	desc = "This obvious cutout has a stickynote smack in the middle of the visor, which reads: Pick up that can";
@@ -21049,15 +21049,15 @@
 	name = "Private Security Officer"
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "nWY" = (
 /obj/structure/chair/sofa/left,
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "odG" = (
 /obj/structure/dresser,
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ooR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -21067,19 +21067,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "orC" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "osu" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "owj" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light{
@@ -21096,12 +21096,12 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "oyX" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "oGV" = (
 /obj/structure/closet/secure_closet/genpop{
 	opened = 0
@@ -21110,38 +21110,38 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "oQj" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "oQQ" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/under/color/jumpskirt/random,
 /obj/item/clothing/under/color/random,
 /turf/open/floor/carpet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "oVj" = (
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pex" = (
 /obj/machinery/door/airlock/security/old{
 	name = "Jail Cell"
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pmJ" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "poj" = (
 /obj/structure/table/glass,
 /obj/item/food/honeybun,
 /turf/open/floor/iron/brown/side,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pwX" = (
 /obj/structure/table/wood,
 /obj/item/phone{
@@ -21159,12 +21159,12 @@
 	pixel_x = 4.5
 	},
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pxd" = (
 /turf/open/floor/iron/dark/green/side{
 	dir = 8
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pAC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -21173,13 +21173,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pCv" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plastic,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pDF" = (
 /obj/item/clothing/suit/jacket/letterman_nanotrasen{
 	pixel_x = 5;
@@ -21193,11 +21193,11 @@
 /obj/item/soap/nanotrasen,
 /obj/item/bedsheet/nanotrasen,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pGK" = (
 /obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pRy" = (
 /obj/effect/turf_decal/arrows/white{
 	dir = 1
@@ -21208,46 +21208,46 @@
 /turf/open/floor/iron/brown/side{
 	dir = 9
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pUb" = (
 /obj/item/pen,
 /obj/structure/table/glass,
 /obj/item/paper_bin,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pUG" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/plating/grass/planet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pUV" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pWR" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pYq" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "pYQ" = (
 /obj/structure/closet/wardrobe,
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qcv" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/under/color/jumpskirt/random,
 /obj/item/clothing/under/color/random,
 /turf/open/floor/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qcJ" = (
 /obj/structure/urinal{
 	dir = 4;
@@ -21255,11 +21255,11 @@
 	pixel_y = -2
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qdd" = (
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qei" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 8
@@ -21268,11 +21268,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qjI" = (
 /obj/item/kirbyplants/random,
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qkX" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -21293,10 +21293,10 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qlO" = (
 /turf/open/floor/iron/stairs,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qml" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21307,20 +21307,20 @@
 	},
 /obj/effect/landmark/latejoin,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qqd" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
 	},
 /turf/open/floor/plastic,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qqE" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorm22";
 	name = "Lodge 2"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "quD" = (
 /obj/structure/railing{
 	dir = 8
@@ -21330,7 +21330,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qxa" = (
 /obj/structure/closet/crate/bin{
 	pixel_x = -6;
@@ -21338,7 +21338,7 @@
 	},
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qxS" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -21347,21 +21347,21 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qyu" = (
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qAL" = (
 /obj/structure/curtain,
 /turf/open/floor/plastic,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qJT" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorm21";
 	name = "Lodge 1"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qLM" = (
 /obj/structure/mirror{
 	pixel_x = 26;
@@ -21377,7 +21377,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qMC" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -21392,11 +21392,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qQl" = (
 /obj/machinery/light,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "qSf" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -21409,17 +21409,17 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "rjx" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/plating/grass/planet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "rlm" = (
 /obj/machinery/shower{
 	dir = 4
 	},
 /turf/open/floor/plastic,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "rpn" = (
 /obj/structure/mirror{
 	pixel_x = 26
@@ -21434,35 +21434,35 @@
 	dir = 5
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "rwG" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorm25";
 	name = "Cabin 1"
 	},
 /turf/open/floor/carpet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "rxu" = (
 /obj/effect/turf_decal/trimline/darkblue/corner{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "rNg" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
 /turf/open/floor/plastic,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "rNG" = (
 /obj/structure/table/reinforced,
 /obj/item/soap/deluxe,
 /turf/open/indestructible/hoteltile,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "rOF" = (
 /obj/structure/sign/poster/official/walk,
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "rPN" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -21471,63 +21471,63 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "rVP" = (
 /obj/machinery/door/poddoor/ert,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "rZg" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "sbq" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "shf" = (
 /obj/structure/table/wood/poker,
 /turf/open/floor/eighties,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "snU" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "spI" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "sqx" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/coffee,
 /turf/open/floor/iron/brown/side{
 	dir = 4
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "srj" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/under/color/jumpskirt/random,
 /obj/item/clothing/under/color/random,
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "syJ" = (
 /obj/machinery/telecomms/relay/preset/auto,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "szI" = (
 /obj/machinery/light,
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "sKu" = (
 /obj/structure/chair/comfy/brown,
 /obj/machinery/light{
@@ -21537,25 +21537,25 @@
 /turf/open/floor/iron/brown/side{
 	dir = 4
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "sQb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "sSW" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave{
 	pixel_y = 7
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "sTA" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/mug/tea,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "sYI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21566,11 +21566,11 @@
 	},
 /obj/effect/landmark/latejoin,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "taJ" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tbC" = (
 /obj/structure/table/wood/fancy,
 /obj/machinery/light/cold{
@@ -21578,31 +21578,31 @@
 	},
 /obj/item/lipstick/random,
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tcC" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/carpet/orange,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "thU" = (
 /obj/machinery/door/poddoor/ert,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tiU" = (
 /turf/open/floor/iron/yellowsiding{
 	dir = 6
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tiZ" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tpa" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 1
@@ -21615,7 +21615,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "trp" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
@@ -21635,7 +21635,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tym" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face.";
@@ -21648,7 +21648,7 @@
 	pixel_x = -28
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tAx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -21660,24 +21660,24 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tBk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tBE" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/multi_tile/glass,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tGP" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tIu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -21686,12 +21686,12 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tOe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window/preopen,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tPx" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21705,7 +21705,7 @@
 	},
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tXo" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -21714,26 +21714,26 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "tXC" = (
 /obj/structure/chair/sofa/corner{
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ugl" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorm24";
 	name = "Lodge 4"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "uic" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "uie" = (
 /obj/machinery/light{
 	dir = 4
@@ -21744,24 +21744,24 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 4
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ukp" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ukE" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
 	},
 /obj/machinery/door/poddoor/ert,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "upc" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "uvB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21775,19 +21775,19 @@
 	},
 /obj/effect/landmark/latejoin,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "uyr" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "uCW" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/carpet/executive,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "uDv" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21797,7 +21797,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "uGJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21810,17 +21810,17 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "uMK" = (
 /obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "uXJ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "uXL" = (
 /obj/structure/sink{
 	pixel_y = 12
@@ -21829,32 +21829,32 @@
 	pixel_y = 29
 	},
 /turf/open/indestructible/hoteltile,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "uYz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
 /turf/open/floor/carpet/orange,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vaC" = (
 /obj/structure/chair/sofa,
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vfd" = (
 /obj/machinery/cryopod{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vfp" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vhO" = (
 /turf/closed/indestructible/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vje" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
@@ -21863,7 +21863,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vmC" = (
 /obj/machinery/button/door{
 	id = "dorm21";
@@ -21873,7 +21873,7 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vxA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -21887,7 +21887,7 @@
 	},
 /obj/effect/landmark/latejoin,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vyX" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -21902,10 +21902,10 @@
 	dir = 1
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vAp" = (
 /turf/open/floor/iron/dark/green/side,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vEn" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -21915,7 +21915,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vLs" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -21923,7 +21923,7 @@
 	light_color = "#c1caff"
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vLt" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 1
@@ -21931,7 +21931,7 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 10
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vLz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window/preopen,
@@ -21944,21 +21944,21 @@
 	pixel_x = -3
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vTd" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vTA" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/grass/planet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vUk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "vXY" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
@@ -21973,38 +21973,38 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wbR" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/grass/planet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wcp" = (
 /obj/effect/turf_decal/arrows{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wfh" = (
 /obj/effect/landmark/latejoin,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wjm" = (
 /obj/machinery/vending/dorms,
 /turf/open/floor/carpet/green,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wkD" = (
 /obj/structure/table,
 /obj/item/lighter,
 /obj/item/storage/fancy/cigarettes,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wpA" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 9
 	},
 /turf/open/floor/iron/white,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wpT" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -22012,19 +22012,19 @@
 /turf/open/floor/iron/yellowsiding{
 	dir = 6
 	},
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wxw" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/green/side,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wyP" = (
 /obj/machinery/door/window{
 	dir = 1
 	},
 /turf/open/floor/carpet/orange,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wzO" = (
 /obj/machinery/light{
 	dir = 1
@@ -22033,13 +22033,13 @@
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/orange,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wFJ" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wHX" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 5
@@ -22047,17 +22047,17 @@
 /obj/structure/window/spawner/north,
 /obj/structure/window/spawner/east,
 /turf/open/floor/iron,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wUm" = (
 /obj/structure/toilet{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "wXh" = (
 /obj/structure/sign/departments/evac,
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "xga" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -22067,26 +22067,26 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "xuN" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "xEl" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "xEH" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorm28";
 	name = "Cabin 4"
 	},
 /turf/open/floor/carpet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "xMG" = (
 /obj/machinery/light{
 	dir = 1
@@ -22095,15 +22095,15 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "xNb" = (
 /obj/structure/sign/poster/official/nanotrasen_logo,
 /turf/closed/indestructible/riveted,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "xQQ" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/plating/grass/planet,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "xSv" = (
 /obj/machinery/button/door{
 	id = "dorm24";
@@ -22113,39 +22113,39 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "xST" = (
 /obj/item/clothing/under/color/random,
 /obj/item/clothing/under/color/jumpskirt/random,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "yae" = (
 /obj/machinery/vending/dorms,
 /turf/open/floor/carpet/orange,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ybH" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorm26";
 	name = "Cabin 2"
 	},
 /turf/open/floor/iron/grimy,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ydU" = (
 /obj/effect/spawner/structure/window/reinforced/indestructable,
 /turf/open/floor/plating,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "yjR" = (
 /obj/structure/mineral_door/wood,
 /turf/open/indestructible/hotelwood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 "ykr" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
 	req_access_txt = "109"
 	},
 /turf/open/floor/wood,
-/area/centcom/tram_dock)
+/area/centcom/interlink)
 
 (1,1,1) = {"
 aaa

--- a/modular_skyrat/modules/advanced_shuttles/code/areas.dm
+++ b/modular_skyrat/modules/advanced_shuttles/code/areas.dm
@@ -1,5 +1,5 @@
-/area/centcom/tram_dock
-	name = "Tram Dock"
+/area/centcom/interlink
+	name = "The Interlink"
 
 /area/shuttle/escape/no_light
 	dynamic_lighting = DYNAMIC_LIGHTING_IFSTARLIGHT


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

on request

## Changelog
:cl:
fix: The tram dock area has now been renamed to The Interlink to avoid confusion with tramstation.
/:cl: