### PR TITLE
Metastation sec hotterfix

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -362,7 +362,10 @@
 /turf/closed/wall,
 /area/security/prison)
 "abf" = (
-/obj/effect/spawner/randomcolavend,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/blue/side,
 /area/security/prison)
 "abn" = (
@@ -465,6 +468,7 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "abC" = (
@@ -707,7 +711,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "acH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -894,7 +898,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "adv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1632,16 +1636,12 @@
 /area/maintenance/solars/port/fore)
 "ahu" = (
 /obj/structure/cable,
-/obj/structure/disposaloutlet{
-	dir = 8;
-	name = "Prisoner Delivery"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/iron/dark/blue/side,
 /area/security/prison)
@@ -1678,6 +1678,8 @@
 	},
 /obj/item/clothing/suit/bio_suit/security,
 /obj/item/clothing/head/bio_hood/security,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "ahF" = (
@@ -12445,6 +12447,11 @@
 "bkx" = (
 /obj/structure/table,
 /obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/storage/box/ingredients/fruity,
+/obj/item/storage/box/ingredients/grains,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/wildcard,
 /turf/open/floor/iron/dark/yellow/side,
 /area/security/prison)
 "bky" = (
@@ -14909,9 +14916,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bAC" = (
-/obj/machinery/vending/wardrobe/peacekeeper_wardrobe,
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_blue,
+/obj/machinery/vending/security_peacekeeper,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "bAJ" = (
@@ -16578,11 +16585,6 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"bMa" = (
-/obj/structure/grille/broken,
-/obj/item/bouquet/poppy,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "bMo" = (
 /obj/machinery/airalarm/server{
 	dir = 4;
@@ -18339,6 +18341,18 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"bWV" = (
+/obj/structure/closet/athletic_mixed,
+/obj/item/clothing/gloves/boxing,
+/obj/item/clothing/gloves/boxing/blue,
+/obj/item/clothing/gloves/boxing/green,
+/obj/item/clothing/gloves/boxing/yellow,
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/turf/open/floor/iron,
+/area/security/prison)
 "bWY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -23244,7 +23258,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "csL" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "csT" = (
@@ -28254,6 +28268,7 @@
 /turf/open/floor/wood,
 /area/service/theater)
 "dgX" = (
+/obj/item/reagent_containers/glass/bucket,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
@@ -29038,6 +29053,7 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "dqT" = (
@@ -29510,6 +29526,16 @@
 "dwL" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/secondary)
+"dwO" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/effect/spawner/randomcolavend,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "dwQ" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
@@ -30214,25 +30240,28 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "dFK" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/item/seeds/onion,
-/obj/item/seeds/garlic,
-/obj/item/seeds/potato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/secateurs,
+/obj/item/secateurs,
+/obj/item/wrench,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/crowbar,
+/obj/item/plant_analyzer,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/secateurs,
-/obj/item/seeds/pumpkin,
-/obj/item/storage/bag/plants,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "dGb" = (
@@ -32336,13 +32365,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
-/obj/structure/table,
-/obj/machinery/syndicatebomb/training,
-/obj/item/screwdriver{
-	pixel_x = -2;
-	pixel_y = 10
-	},
-/obj/item/wirecutters,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "eCv" = (
@@ -36328,7 +36350,16 @@
 /turf/open/floor/carpet,
 /area/service/theater)
 "geQ" = (
-/obj/machinery/vending/coffee,
+/obj/structure/disposaloutlet{
+	dir = 4;
+	name = "Prisoner Delivery"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/blue/side,
 /area/security/prison)
 "geT" = (
@@ -37213,7 +37244,7 @@
 /area/science/mixing)
 "guu" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/extinguisher/mini,
 /turf/open/floor/iron/dark/yellow/side,
 /area/security/prison)
 "gux" = (
@@ -38597,12 +38628,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"gUm" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "gUu" = (
 /obj/structure/sign/painting/library{
 	pixel_y = -32
@@ -39474,7 +39499,7 @@
 /turf/open/floor/iron/dark/purple/side{
 	dir = 1
 	},
-/area/security/prison)
+/area/security/prison/safe)
 "hlN" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
@@ -40025,6 +40050,9 @@
 "hyP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/blue/side{
 	dir = 9
 	},
@@ -42877,6 +42905,22 @@
 	dir = 1
 	},
 /area/command/gateway)
+"iMA" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "iMQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_white,
@@ -43650,6 +43694,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/item/toy/plush/rouny,
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
 "jaO" = (
@@ -47526,6 +47571,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "kDT" = (
@@ -47661,10 +47707,11 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "kHL" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
+/obj/machinery/computer/cryopod{
+	dir = 1;
+	pixel_y = -24
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kHQ" = (
 /obj/item/radio/intercom{
@@ -49747,6 +49794,7 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 9
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "lBp" = (
@@ -49798,6 +49846,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
+"lCy" = (
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "lCF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -50120,6 +50174,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
+"lJc" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "lJj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -50861,6 +50920,12 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
+"lXo" = (
+/obj/structure/table,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/box/matches,
+/turf/open/floor/iron/dark/blue,
+/area/security/prison)
 "lXu" = (
 /obj/item/radio/intercom{
 	pixel_y = -29
@@ -52929,8 +52994,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/vending/security_peacekeeper,
 /obj/effect/turf_decal/bot_blue,
+/obj/machinery/vending/wardrobe/peacekeeper_wardrobe,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "mLI" = (
@@ -54381,7 +54446,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "nla" = (
 /obj/structure/disposalpipe/segment{
@@ -54662,6 +54727,11 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/wood,
 /area/security/prison)
+"ntb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space)
 "ntj" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -55223,7 +55293,7 @@
 /turf/open/floor/iron/dark/purple/side{
 	dir = 9
 	},
-/area/security/prison)
+/area/security/prison/safe)
 "nGI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55283,6 +55353,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "nIa" = (
@@ -55865,6 +55936,16 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/science/genetics)
+"nQi" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "nQm" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
@@ -56004,8 +56085,15 @@
 /area/engineering/atmos)
 "nUp" = (
 /obj/structure/table,
-/obj/item/storage/box/matches,
-/obj/item/storage/fancy/candle_box,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
 /turf/open/floor/wood,
 /area/security/prison)
 "nUC" = (
@@ -56210,9 +56298,6 @@
 "nZE" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/darkblue/filled/corner,
-/obj/machinery/photocopier{
-	pixel_y = 3
-	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "nZQ" = (
@@ -57119,6 +57204,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "otW" = (
@@ -57153,6 +57239,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"ouF" = (
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#00ff00";
+	name = "green"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "ouX" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
@@ -58574,6 +58670,7 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "oUn" = (
@@ -59276,7 +59373,7 @@
 /area/engineering/break_room)
 "pfe" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -60065,36 +60162,11 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "pvS" = (
-/obj/structure/table,
-/obj/item/folder/red,
-/obj/item/restraints/handcuffs,
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 32
 	},
-/obj/machinery/camera{
-	c_tag = "Security - Gear Room";
-	dir = 8
-	},
+/obj/effect/turf_decal/bot_blue,
+/obj/machinery/vending/security_peacekeeper,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "pvT" = (
@@ -63602,6 +63674,32 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
+"qPf" = (
+/obj/structure/table,
+/obj/item/folder/red,
+/obj/item/restraints/handcuffs,
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "qPR" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot{
@@ -63898,6 +63996,7 @@
 "qWk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -65220,6 +65319,10 @@
 /obj/item/reagent_containers/spray/pepper/empty,
 /obj/item/reagent_containers/spray/pepper/empty,
 /obj/item/reagent_containers/spray/pepper/empty,
+/obj/machinery/camera{
+	c_tag = "Security - Gear Room";
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "rwN" = (
@@ -66548,6 +66651,16 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"rUo" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "rUF" = (
 /obj/machinery/status_display/evac{
 	pixel_y = -32
@@ -67269,6 +67382,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "sht" = (
@@ -69307,6 +69421,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"sWw" = (
+/obj/item/bouquet/poppy,
+/turf/open/space/basic,
+/area/space)
 "sWz" = (
 /obj/structure/showcase/mecha/marauder,
 /obj/structure/window/reinforced{
@@ -71362,11 +71480,33 @@
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "tOw" = (
-/obj/structure/sink{
+/obj/structure/closet/crate/hydroponics,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/seeds/onion,
+/obj/item/seeds/garlic,
+/obj/item/seeds/potato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/carrot,
+/obj/item/seeds/grass,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/seeds/tower,
+/obj/item/seeds/chili,
+/obj/item/seeds/corn,
+/obj/item/seeds/cotton,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/tomato/blood,
+/obj/item/seeds/tea,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/cabbage,
+/obj/structure/water_source{
 	dir = 8;
-	pixel_x = 12
+	name = "sink";
+	pixel_x = 12;
+	pixel_y = -6
 	},
-/obj/item/reagent_containers/glass/bucket,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
@@ -71904,6 +72044,16 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
+"tZt" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#00ff00";
+	name = "green"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "tZT" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/machinery/airalarm{
@@ -72231,7 +72381,6 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "ugv" = (
-/obj/item/shovel/spade,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -73354,6 +73503,16 @@
 "uDv" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/rd)
+"uDG" = (
+/obj/structure/table,
+/obj/machinery/syndicatebomb/training,
+/obj/item/screwdriver{
+	pixel_x = -2;
+	pixel_y = 10
+	},
+/obj/item/wirecutters,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "uDK" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
@@ -73832,6 +73991,7 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "uNx" = (
@@ -76987,6 +77147,9 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
 /turf/open/floor/iron/dark/yellow/side{
 	dir = 6
 	},
@@ -79120,6 +79283,7 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/corner{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "wNJ" = (
@@ -79908,19 +80072,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
-"xbP" = (
-/obj/item/cultivator,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/hydroponics/soil{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "dirt";
-	layer = 2.0001;
-	plane = -2;
-	self_sustaining = 1
-	},
-/turf/open/floor/grass,
-/area/security/prison)
 "xcj" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -80902,6 +81053,11 @@
 /obj/structure/closet/wardrobe/grey,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xvH" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/space/basic,
+/area/space)
 "xvL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -81944,7 +82100,7 @@
 /turf/open/floor/iron/dark/purple/side{
 	dir = 5
 	},
-/area/security/prison)
+/area/security/prison/safe)
 "xRx" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -82465,10 +82621,7 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "xZD" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
-/turf/open/space/basic,
+/turf/closed/wall/r_wall,
 /area/space)
 "xZT" = (
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -82536,7 +82689,6 @@
 "ybE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/item/plant_analyzer,
 /obj/machinery/hydroponics/soil{
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "dirt";
@@ -83060,23 +83212,26 @@
 /obj/structure/closet/secure_closet/freezer/meat{
 	req_access = null
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/item/food/meat/slab/monkey,
 /obj/item/food/meat/slab/monkey,
-/obj/item/food/meat/rawbacon,
-/obj/item/food/meat/rawbacon,
-/obj/item/food/meat/rawbacon,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
 /turf/open/floor/iron/dark/yellow/corner{
 	dir = 4
 	},
@@ -101692,7 +101847,7 @@ lMJ
 lMJ
 aep
 aep
-xbP
+ybE
 ybE
 xXB
 ugv
@@ -103739,7 +103894,7 @@ tBO
 pna
 afd
 iBI
-fvz
+lXo
 aep
 aep
 aep
@@ -103997,8 +104152,8 @@ pna
 eSd
 iBI
 lAY
-ijA
-ijA
+dwO
+rUo
 bBU
 oUe
 abe
@@ -104263,7 +104418,7 @@ ijA
 wTV
 wHk
 ncD
-ijA
+nQi
 wNx
 otL
 cBe
@@ -104521,7 +104676,7 @@ xoR
 pgq
 xoR
 nHF
-xoR
+iMA
 kDQ
 ejE
 adS
@@ -104775,8 +104930,8 @@ abe
 xKy
 asO
 xKy
-abe
-abe
+agH
+agH
 agH
 jAY
 agH
@@ -105032,13 +105187,13 @@ abe
 jTA
 tih
 piK
-abe
+agH
 nGH
 mGL
 ibL
 abZ
 agH
-anc
+bWV
 anc
 ads
 adO
@@ -105289,7 +105444,7 @@ abe
 jbB
 rEp
 jbB
-abe
+agH
 hlB
 jaM
 jib
@@ -105526,10 +105681,10 @@ aaa
 aaa
 aaa
 gJK
-fwb
+lMJ
 aaa
 aaa
-aaa
+lMJ
 aaa
 aax
 jee
@@ -105546,7 +105701,7 @@ abe
 yeu
 gOr
 oGS
-abe
+agH
 xRq
 lIn
 abD
@@ -105562,8 +105717,8 @@ fQi
 hgT
 cvX
 aeJ
-aaa
-aaa
+ntb
+ntb
 xZD
 dne
 awS
@@ -105782,12 +105937,12 @@ aaa
 aaa
 aaa
 aaa
-lMJ
 fwb
-gUm
-gJK
-gJK
-gJK
+lMJ
+aaa
+aaa
+lMJ
+aaa
 aax
 aax
 aax
@@ -105819,9 +105974,9 @@ agH
 agH
 agH
 aeJ
-aep
-aep
-aax
+tZt
+tZt
+tZt
 aio
 dne
 dne
@@ -106039,7 +106194,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+fwb
 lMJ
 lMJ
 lMJ
@@ -106296,19 +106451,19 @@ aaa
 aaa
 aaa
 aaa
+fwb
+lMJ
+aaa
+aaa
+lMJ
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaf
@@ -106334,8 +106489,8 @@ cPK
 tPW
 uvm
 iSs
-cPK
 rZU
+ouF
 aio
 aol
 apD
@@ -106553,19 +106708,19 @@ aaa
 aaa
 aaa
 aaa
+fwb
+lMJ
+aaa
+aaa
+lMJ
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
 aaa
 aaf
 aaf
@@ -106810,20 +106965,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bMa
-agC
-agC
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
 lMJ
 acv
 acv
@@ -107067,20 +107222,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-lMJ
-lMJ
-lMJ
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
 lMJ
 lAu
 aaf
@@ -107332,7 +107487,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+sWw
 aaa
 aaa
 aaa
@@ -107850,8 +108005,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+xvH
+auC
 aox
 ack
 aox
@@ -108878,8 +109033,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+xvH
+auC
 aox
 aox
 aox
@@ -109916,11 +110071,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+lMJ
+aox
+aox
+aox
 aaf
 aaf
 srq
@@ -110948,8 +111103,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lJc
+auC
 aaf
 rmG
 rmG
@@ -111205,10 +111360,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaf
-rmG
+lJc
+auC
+brO
+kel
 qbS
 teZ
 sms
@@ -111462,9 +111617,9 @@ aav
 aaa
 aaa
 aaa
-aaa
-aaa
-aaf
+lJc
+auC
+brO
 fNA
 jNm
 nge
@@ -111719,10 +111874,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaf
-rmG
+lJc
+auC
+brO
+kel
 xNR
 exP
 jvG
@@ -111976,8 +112131,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lJc
+auC
 aiJ
 aiJ
 aiJ
@@ -112233,7 +112388,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+auC
 aaa
 aiJ
 duf
@@ -112490,7 +112645,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+auC
 aaa
 daI
 dAA
@@ -112747,7 +112902,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+auC
 aaf
 aiJ
 dBI
@@ -113014,7 +113169,7 @@ kdA
 oHs
 opc
 aey
-jLR
+lCy
 khj
 cpe
 chq
@@ -113271,7 +113426,7 @@ kdA
 kdA
 jkv
 aey
-jLR
+qPf
 gDo
 cpe
 uJw
@@ -113528,7 +113683,7 @@ kdA
 kdA
 jkv
 aey
-jLR
+uDG
 gDo
 lyV
 nnS


### PR DESCRIPTION
Adds in and corrects stuff in metastation prison/sec that I forgot to in the last map PR, such as the fact that the prison didn't have cryopods.

![image](https://user-images.githubusercontent.com/43841046/114319938-727f1580-9ac8-11eb-9fe9-a667902c5095.png)

1. Adds cryopods at the end of the prison hall
2. removes extra light placed on top of the door, adds boxing gloves and dodgeball locker and gives the court dark tiles to match the rest of it.
3. places all the botany tools onto a rack, added deltastation seeds
4. adds ingredients boxes and a mini extinguisher to the kitchen, replaces bacon with fish fillet
5. moves vendors into the main hallway to tuck the delivery chute out of the way
6. makes the lattice around security a little prettier because why not. Re-adds the decorative markers by the escape pod. Grille shield extended to cover east side of prison and sec equipment windows.
7. Moved traffic cone table and practice bomb table to where the sec locker landmarks used to be. Added a second sec equipment vendor.