### PR TITLE
[Modular Removal] Deletes alien monkeycube.

### DIFF
--- a/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
@@ -7,8 +7,3 @@
 	throwforce = 3
 	w_class = WEIGHT_CLASS_NORMAL
 
-/obj/item/food/monkeycube/beno
-	name = "alien cube"
-	desc = "Don't let corporate crooks slip this into your lunch."
-	tastes = list("the jungle" = 1, "acid" = 1)
-	spawned_mob = /mob/living/carbon/alien/humanoid/hunter //This is catatonic.


### PR DESCRIPTION
## About The Pull Request

Deletes Alien Monkeycube from the game.
This is pretty much a revert of: https://github.com/Skyrat-SS13/Skyrat-tg/pull/4317

## Why It's Good For The Game

Because being able to turn yourself into a xeno pretty much every single shift isn't good for role play. This item is really only used by a single person (who added it) for something that is debatably power gaming, just because they aren't happy being a normal xeno-hybrid and instead need to be a feral who runs around in vents. I have seen a number of people asking for it to be removed, so I went ahead and made the PR to host the debate about it.

## Changelog
:cl:
fix: Fixed being able to turn yourself into a xeno hunter every shift.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
