### PR TITLE
[SIMI-MODULAR] Adds a new ladder climing skill-chip!

### DIFF
--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -12,6 +12,7 @@
 #define TRAIT_DETECTIVE "detective_ability" //Given to the detective, if they have this, they can see syndicate special descriptions.
 #define TRAIT_FREE_GHOST "free_ghost" // Can ghost and return freely with this trait
 #define GLUED_ITEM_TRAIT "glued-item" // This is for glued items, undroppable. Syndie glue applies this.
+#define TRAIT_FASTCLIMB "fast-climb" // This lets you climb faster, added by skill-chips.
 /// This makes trait makes it so that the person cannot be infected by the zombie virus.
 #define TRAIT_MUTANT_IMMUNE "mutant_immune"
 

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -10,7 +10,7 @@
 	var/obj/structure/ladder/up     //the ladder above this one
 	var/crafted = FALSE
 	/// Optional travel time for ladder in deciseconds
-	var/travel_time = 0
+	var/travel_time = 100 //SKYRAT EDIT
 
 /obj/structure/ladder/Initialize(mapload, obj/structure/ladder/up, obj/structure/ladder/down)
 	..()
@@ -73,6 +73,9 @@
 /obj/structure/ladder/proc/travel(going_up, mob/user, is_ghost, obj/structure/ladder/ladder)
 	if(!is_ghost)
 		ladder.add_fingerprint(user)
+		var/adjusted_travel_time = travel_time
+		if(HAS_TRAIT(user, TRAIT_FASTCLIMB))
+			adjusted_climb_time *= 0.1
 		if(!do_after(user, travel_time, target = src))
 			return
 		show_fluff_message(going_up, user)

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -75,7 +75,7 @@
 		ladder.add_fingerprint(user)
 		var/adjusted_travel_time = travel_time
 		if(HAS_TRAIT(user, TRAIT_FASTCLIMB))
-			adjusted_climb_time *= 0.1
+			adjusted_travel_time *= 0.1
 		if(!do_after(user, travel_time, target = src))
 			return
 		show_fluff_message(going_up, user)

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -10,7 +10,7 @@
 	var/obj/structure/ladder/up     //the ladder above this one
 	var/crafted = FALSE
 	/// Optional travel time for ladder in deciseconds
-	var/travel_time = 100 //SKYRAT EDIT
+	var/travel_time = 40 //SKYRAT EDIT
 
 /obj/structure/ladder/Initialize(mapload, obj/structure/ladder/up, obj/structure/ladder/down)
 	..()

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -44,6 +44,8 @@
 
 	chameleon_extras = /obj/item/gun/energy/kinetic_accelerator
 
+	skillchips = list(/obj/item/skillchip/fastclimb)
+
 	id_trim = /datum/id_trim/job/shaft_miner
 
 /datum/outfit/job/miner/equipped

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -312,7 +312,7 @@
 	display_name = "Neural Programming"
 	description = "Study into networks of processing units that mimic our brains."
 	prereq_ids = list("biotech", "datatheory")
-	design_ids = list("skill_station","ladder_skill_chip") //SKYRAT EDIT
+	design_ids = list("skill_station")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/cyborg_upg_util

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -312,7 +312,7 @@
 	display_name = "Neural Programming"
 	description = "Study into networks of processing units that mimic our brains."
 	prereq_ids = list("biotech", "datatheory")
-	design_ids = list("skill_station")
+	design_ids = list("skill_station","ladder_skill_chip") //SKYRAT EDIT
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/cyborg_upg_util

--- a/modular_skyrat/modules/integrated_circuits/code/research/designs/skill_chip_designs.dm
+++ b/modular_skyrat/modules/integrated_circuits/code/research/designs/skill_chip_designs.dm
@@ -8,4 +8,3 @@
 	build_path = /obj/item/skillchip/fastclimb
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
-	

--- a/modular_skyrat/modules/integrated_circuits/code/research/designs/skill_chip_designs.dm
+++ b/modular_skyrat/modules/integrated_circuits/code/research/designs/skill_chip_designs.dm
@@ -8,3 +8,4 @@
 	build_path = /obj/item/skillchip/fastclimb
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	

--- a/modular_skyrat/modules/integrated_circuits/code/research/designs/skill_chip_designs.dm
+++ b/modular_skyrat/modules/integrated_circuits/code/research/designs/skill_chip_designs.dm
@@ -1,0 +1,10 @@
+/datum/design/ladder_skill_chip
+	name = "Ladder Lover Skill Chip"
+	desc = "A skill chip designed to increase ladder climbing proformance."
+	id = "ladder_skill_chip"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list (/datum/material/iron = 2500, /datum/material/glass = 800)
+	construction_time = 100
+	build_path = /obj/item/skillchip/fastclimb
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE

--- a/modular_skyrat/modules/integrated_circuits/code/research/designs/skill_chip_nodes.dm
+++ b/modular_skyrat/modules/integrated_circuits/code/research/designs/skill_chip_nodes.dm
@@ -1,0 +1,6 @@
+/datum/techweb_node/skill_chips
+	id = "skill_chips"
+	starting_node = TRUE // Starting node for now, can be unlockable later
+	display_name = "Skill Chips"
+	description = "The technology to produce various skill chips."
+	design_ids = list("ladder_skill_chip")

--- a/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
@@ -21,3 +21,4 @@
 	skill_icon = "swimming-pool"
 	activate_message = "<span class='notice'>You feel like you can take it two rungs at a time!.</span>"
 	deactivate_message = "<span class='notice'>You give up on your dreams of being a fireman.</span>"
+	

--- a/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
@@ -12,3 +12,12 @@
 	desc = "Don't let corporate crooks slip this into your lunch."
 	tastes = list("the jungle" = 1, "acid" = 1)
 	spawned_mob = /mob/living/carbon/alien/humanoid/hunter //This is catatonic.
+
+/obj/item/skillchip/fastclimb
+	name = "Ladder Lover skillchip"
+	auto_traits = list(TRAIT_FASTCLIMB)
+	skill_name = "FastClimbing"
+	skill_description = "Allows you to accend and decend at speeds never known before! Impress your slower friends!."
+	skill_icon = "swimming-pool"
+	activate_message = "<span class='notice'>You feel like you can take it two rungs at a time!.</span>"
+	deactivate_message = "<span class='notice'>You give up on your dreams of being a fireman.</span>"

--- a/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
@@ -7,12 +7,6 @@
 	throwforce = 3
 	w_class = WEIGHT_CLASS_NORMAL
 
-/obj/item/food/monkeycube/beno
-	name = "alien cube"
-	desc = "Don't let corporate crooks slip this into your lunch."
-	tastes = list("the jungle" = 1, "acid" = 1)
-	spawned_mob = /mob/living/carbon/alien/humanoid/hunter //This is catatonic.
-
 /obj/item/skillchip/fastclimb
 	name = "Ladder Lover skillchip"
 	auto_traits = list(TRAIT_FASTCLIMB)

--- a/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
@@ -21,4 +21,3 @@
 	skill_icon = "swimming-pool"
 	activate_message = "<span class='notice'>You feel like you can take it two rungs at a time!.</span>"
 	deactivate_message = "<span class='notice'>You give up on your dreams of being a fireman.</span>"
-	


### PR DESCRIPTION
## About The Pull Request

This adds the ~~unlockable~~ unlocked by default ladder climbing skill-chip to the skill-station tech node. In addition, if you don't have the skill-chip ladders will now take about ~~ten~~ four seconds to climb.

I might have to make some changes and tweaks, but I wanted to get feedback on it now that I have the basic system working.

## Why It's Good For The Game

The skill-station is currently very underused at the moment, so I wanted to add new ways for people to upgrade using it! Given that ladders aren't super common it seemed like a good way to start. I know that having to wait far longer to climb ladders when you could do it right away before might not be fun, but adding more ways to upgrade stuff is good for the game.

## Changelog
:cl:
add: New Ladder-Lover Skill Chip! Climb faster today!
balance: Ladders now take four seconds by default to climb if you don't have it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
