### PR TITLE
[Modular] Nullrod Reskins (Sickle Edition)

### DIFF
--- a/modular_skyrat/master_files/code/game/objects/items/holy_weapons.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/holy_weapons.dm
@@ -1,0 +1,21 @@
+/obj/item/nullrod/scythe/sickle
+	name = "Damned Sickle"
+	desc = "A green crescent blade, decorated with an ornamental eye. The pupil has faded..."
+	icon = 'icons/obj/eldritch.dmi'
+	icon_state = "eldritch_blade"
+	inhand_icon_state = "eldritch_blade"
+	lefthand_file = 'icons/mob/inhands/64x64_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
+	inhand_x_dimension = 64
+	inhand_y_dimension = 64
+	slot_flags = ITEM_SLOT_BELT
+	w_class = WEIGHT_CLASS_NORMAL
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")
+	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "rend")
+
+/obj/item/nullrod/scythe/sickle/void
+	name = "Crystal Sickle"
+	desc = "Made of clear crystal, the blade refracts the light slightly. Purity, so close yet unattainable in this form."
+	icon_state = "void_blade"
+	inhand_icon_state = "void_blade"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3559,6 +3559,7 @@
 #include "modular_skyrat\master_files\code\game\machinery\doors\firedoor.dm"
 #include "modular_skyrat\master_files\code\game\objects\ghost_role_spawners.dm"
 #include "modular_skyrat\master_files\code\game\objects\items\hhmirror.dm"
+#include "modular_skyrat\master_files\code\game\objects\items\holy_weapons.dm"
 #include "modular_skyrat\master_files\code\game\objects\items\oxygen_candle.dm"
 #include "modular_skyrat\master_files\code\game\objects\items\devices\radio\encryption_key.dm"
 #include "modular_skyrat\master_files\code\game\objects\items\devices\radio\headset.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds two new reskins for the null rod.
They take the Heretic assets, and adjusts the name and description to be sufficiently neutered.
![image](https://user-images.githubusercontent.com/14105827/114546375-2d6a0780-9cb1-11eb-866c-692d517cfe8c.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fluff, and also requested so that we don't have to keep reskinning the high frequency blade.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Foxtrot (Funce)
add: Two new reskins for the Nullrod! Damned Sickle and the Crystal Sickle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
