### PR TITLE
[NONMODULAR] Nanotrasen News Bulletin: SR Sector's success leads to pay raises for crew!

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -4,7 +4,7 @@
 //Current design direction: Higher paying jobs are vastly outnumbered by lower paying jobs, so anything above medium hurts inflation, common jobs help inflation
 #define PAYCHECK_PRISONER 25
 #define PAYCHECK_ASSISTANT 50
-#define PAYCHECK_MINIMAL 65 //SKYRAT EDIT ORIGINAL = (55) - Pay Raise
+#define PAYCHECK_MINIMAL 70 //SKYRAT EDIT ORIGINAL = (55) - Pay Raise
 #define PAYCHECK_EASY 80 //SKYRAT EDIT ORIGINAL = (60) - Pay Raise
 #define PAYCHECK_MEDIUM 100 //SKYRAT EDIT ORIGINAL = (75) - Pay Raise
 #define PAYCHECK_HARD 125 //SKYRAT EDIT ORIGINAL = (100)  - Pay Raise

--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -4,10 +4,10 @@
 //Current design direction: Higher paying jobs are vastly outnumbered by lower paying jobs, so anything above medium hurts inflation, common jobs help inflation
 #define PAYCHECK_PRISONER 25
 #define PAYCHECK_ASSISTANT 50
-#define PAYCHECK_MINIMAL 55
-#define PAYCHECK_EASY 60
-#define PAYCHECK_MEDIUM 75
-#define PAYCHECK_HARD 100
+#define PAYCHECK_MINIMAL 65 //SKYRAT EDIT ORIGINAL = (55) - Pay Raise
+#define PAYCHECK_EASY 80 //SKYRAT EDIT ORIGINAL = (60) - Pay Raise
+#define PAYCHECK_MEDIUM 100 //SKYRAT EDIT ORIGINAL = (75) - Pay Raise
+#define PAYCHECK_HARD 125 //SKYRAT EDIT ORIGINAL = (100)  - Pay Raise
 #define PAYCHECK_COMMAND 200
 
 #define STATION_TARGET_BUFFER 40

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -10,7 +10,7 @@
 	outfit = /datum/outfit/job/paramedic
 	plasmaman_outfit = /datum/outfit/plasmaman/paramedic
 
-	paycheck = PAYCHECK_HARD //SKYRAT EDIT ORIGINAL (PAYCHECK_MEDIUM) - Paramed pay increase
+	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_MED
 
 	liver_traits = list(TRAIT_MEDICAL_METABOLISM)

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -10,7 +10,7 @@
 	outfit = /datum/outfit/job/paramedic
 	plasmaman_outfit = /datum/outfit/plasmaman/paramedic
 
-	paycheck = PAYCHECK_MEDIUM
+	paycheck = PAYCHECK_HARD //SKYRAT EDIT ORIGINAL (PAYCHECK_MEDIUM) - Paramed pay increase
 	paycheck_department = ACCOUNT_MED
 
 	liver_traits = list(TRAIT_MEDICAL_METABOLISM)

--- a/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
@@ -11,6 +11,9 @@
 	exp_requirements = 2400
 	exp_type = EXP_TYPE_SECURITY
 
+	paycheck = PAYCHECK_HARD
+	paycheck_department = ACCOUNT_SEC
+
 	outfit = /datum/outfit/job/blueshield
 
 	display_order = JOB_DISPLAY_ORDER_BLUESHIELD


### PR DESCRIPTION
## About The Pull Request

Due to the low death count and minimal complete station loss recently, Nanotrasen has increased pay for the hard working crew of the SR sector!

- Increases pay for everyone except prisoners, assistants, and heads.

- Also fixes blueshield's pay away from the default minimum to a hard level, in line with a security officer. Also draws from sec budget, just like the captain.

~~Increases pay class for paramedics from medium to hard, so paycheck is changed from 75 to 100 cr, meaning they'll also start with 175 more credits at shift start, allowing them to purchase one expensive item out of the med vendor, and not have to ask the CMO or a doctor for a chip in.~~

## Why It's Good For The Game

- It's better than changing the classes on all the jobs that deserve a raise, and makes sense. In the future I hope to add more things to actually spend the money on, and increase vending stock.

- Blueshield bank accounts go brrrrrrrrrr

~~Almost every shift I play paramed I ask the CMO or a doctor for a bit of money so I can purchase the better crew pinpointer or an advanced kit, and I see other paramedics do the same thing. We might as well give them the ability to purchase it themselves since to get them you just have to wait for your paychecks to roll in and that's no fun.~~

## Changelog
:cl:
qol: The station's success has led to raises for almost all crew!
fix: Blueshields actually get paid a living wage now.
/:cl: