### PR TITLE
[Bug Fix] Multi-Cell chargers no longer only care about the last capacitor

### DIFF
--- a/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
@@ -12,6 +12,8 @@
 	var/list/charging_batteries = list() //The list of batteries we are gonna charge!
 	var/max_batteries = 4
 	var/charge_rate = 250
+	var/charge_rate_base = 250 // Amount of charge we gain from a level one capacitor
+	var/charge_rate_max = 2000 // The highest we allow the charge rate to go
 
 /obj/machinery/cell_charger_multi/update_overlays()
 	. = ..()
@@ -97,9 +99,14 @@
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/cell_charger_multi/RefreshParts()
-	charge_rate = 250
+	charge_rate = 0 // No, you cant get free charging speed!
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
-		charge_rate = clamp((charge_rate *= C.rating), 0, 1500)
+		charge_rate += charge_rate_base * C.rating
+		if(charge_rate >= charge_rate_max) // We've hit the charge speed cap, stop iterating.
+			charge_rate = charge_rate_max
+			break
+	if(charge_rate < charge_rate_base) // This should never happen; but we need to pretend it can.
+		charge_rate = charge_rate_base
 
 /obj/machinery/cell_charger_multi/emp_act(severity)
 	. = ..()

--- a/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
@@ -13,7 +13,7 @@
 	var/max_batteries = 4
 	var/charge_rate = 250
 	var/charge_rate_base = 250 // Amount of charge we gain from a level one capacitor
-	var/charge_rate_max = 2000 // The highest we allow the charge rate to go
+	var/charge_rate_max = 4000 // The highest we allow the charge rate to go
 
 /obj/machinery/cell_charger_multi/update_overlays()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Fixes an issue where multi-cell chargers only cared about the last capacitor.
Also modifies the code a bit to support easier tweaking.

## Why It's Good For The Game

Multi-Cell Chargers should respect the total level of capacitors, not only the best one there is.
This also increases the max charge speed to 4000, making it actually worthwhile to use all T4 capacitors.

This will resolve https://github.com/Skyrat-SS13/Skyrat-tg/issues/4906

## Changelog
:cl: ZephyrTFA
fix: NanoTrasen engineers found an issue where Multi-Cell Chargers could only use one of their capacitors, this has been fixed!
/:cl:
