### PR TITLE
Reverts "Putting your hand in the food processor without due care is bad #3718"

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -113,19 +113,6 @@
 	else
 		return ..()
 
-//SKYRAT EDIT ADDITION
-/obj/machinery/processor/attack_hand(mob/living/user, list/modifiers)
-	. = ..()
-	if(ishuman(user) && user.Adjacent(src))
-		var/mob/living/carbon/human/H = user
-		if(H.combat_mode)
-			var/obj/item/bodypart/limb = H.get_active_hand()
-			H.visible_message("<span class='danger'>[H] puts their hand in the [src] causing it to be brutally dismembered!</span>", \
-			"<span class='userdanger'>You put your hand in [src] causing it to be torn off, ouch!</span>")
-			playsound(src.loc, 'sound/machines/blender.ogg', 50, TRUE)
-			limb.dismember()
-//SKYRAT EDIT ADDITION END
-
 /obj/machinery/processor/interact(mob/user)
 	if(processing)
 		to_chat(user, "<span class='warning'>[src] is in the process of processing!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

reverts https://github.com/Skyrat-SS13/Skyrat-tg/pull/3718 from the code

## Why It's Good For The Game

the pr that added this was merged in under  25 minutes, it was untested and now clicking on the slime or food prosses at all in combat mode (technically a 50% chance) will 100% instantly delimb your arm, even if you walk away, waitout any warning, and without a delay before it happens. you cant use this to delimb other people's arms so all this does is lead to scientists and chefs has a clean bleedless delimb and confusion on why it happened

## Changelog
:cl:
balance: clicking on the slime grinder or food processes on combat mode no longer instantly delimbs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
