### PR TITLE
[MODULAR] Tweaks projectiles bonus stamina damage.

### DIFF
--- a/code/__DEFINES/~skyrat_defines/combat.dm
+++ b/code/__DEFINES/~skyrat_defines/combat.dm
@@ -9,7 +9,7 @@
 #define SIMPLE_MOB_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.7 //Fights with simple mobs are usually more sustained, so apply a bit less
 #define BLUNT_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.8 //Brute that isnt sharp, knocks the wind outta you real good
 #define OTHER_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.5 //Burns, sharp implements
-#define PROJECTILE_TISSUE_DAMAGE_STAMINA_MULTIPLIER 0
+#define PROJECTILE_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1
 
 //Glancing attacks happen when someone uses disarm intent with melee weaponry, aiming to disable a person instead
 #define TISSUE_DAMAGE_GLANCING_DAMAGE_MULTIPLIER 0.5

--- a/code/__DEFINES/~skyrat_defines/combat.dm
+++ b/code/__DEFINES/~skyrat_defines/combat.dm
@@ -9,7 +9,7 @@
 #define SIMPLE_MOB_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.7 //Fights with simple mobs are usually more sustained, so apply a bit less
 #define BLUNT_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.8 //Brute that isnt sharp, knocks the wind outta you real good
 #define OTHER_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.5 //Burns, sharp implements
-#define PROJECTILE_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.6
+#define PROJECTILE_TISSUE_DAMAGE_STAMINA_MULTIPLIER 0
 
 //Glancing attacks happen when someone uses disarm intent with melee weaponry, aiming to disable a person instead
 #define TISSUE_DAMAGE_GLANCING_DAMAGE_MULTIPLIER 0.5


### PR DESCRIPTION
## About The Pull Request

Changes the PROJECTILE_TISSUE_DAMAGE_STAMINA_MULTIPLIER from 1.6 to 1. Subject to change of course.

## Why It's Good For The Game

I think its clear at this point that our Combat Rework came with a couple of issues. But this has made it almost impossible to balance the damage of guns correctly, when all of the attacks do extra damage. You want to knock someone into stam-crit with your weapon? Well now you have to actually use the bullets made for it, and we can maybe start to balance stuff correctly. Honestly, I think that there need to be a number of changes made to it outside of this, but I am starting small. If we actually want to have drawn out ranged combat, then this helps allow it, but not making every bullet in the game knock you to the ground super early. I uh, will look into changing other stuff later, after we see how this feels. Rubber bullets are still really strong for doing this, and now they have more of an actual use.

## Changelog
:cl:
fix: Every bullet in the game dealing too much stamina damage. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
