### PR TITLE
[MODULAR] [SM] DS-1 EMERGENCY FIX.

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -2665,6 +2665,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/iron,
 /area/cruiser_dock/research)
 "ahu" = (
@@ -14333,6 +14334,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/research)
 "aLF" = (
@@ -18803,6 +18805,7 @@
 	opacity = 0;
 	req_access_txt = "55"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/research)
 "aXy" = (
@@ -19057,7 +19060,7 @@
 /area/cruiser_dock/commons)
 "aYf" = (
 /obj/structure/railing,
-/obj/machinery/computer/shuttle/syndicate_frigate/recall,
+/obj/machinery/computer/shuttle/syndicate_frigate,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/cargo)
 "aYg" = (
@@ -20171,6 +20174,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"fIM" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/turf/open/floor/iron,
+/area/cruiser_dock/research)
 "fUk" = (
 /obj/machinery/button/door{
 	id = "dorm23";
@@ -20424,6 +20432,10 @@
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron/cafeteria,
 /area/centcom/interlink)
+"imX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/turf/open/floor/circuit/telecomms,
+/area/cruiser_dock/research)
 "ixt" = (
 /turf/open/floor/carpet,
 /area/centcom/interlink)
@@ -20696,6 +20708,10 @@
 /obj/structure/window/spawner/north,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"kIt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock/research)
 "kLP" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light{
@@ -21058,6 +21074,13 @@
 /obj/structure/dresser,
 /turf/open/floor/iron/grimy,
 /area/centcom/interlink)
+"olG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock/research)
 "ooR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -21355,6 +21378,11 @@
 /obj/structure/curtain,
 /turf/open/floor/plastic,
 /area/centcom/interlink)
+"qDD" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/turf/open/floor/plating,
+/area/cruiser_dock/research)
 "qJT" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorm21";
@@ -21493,6 +21521,11 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/eighties,
 /area/centcom/interlink)
+"skD" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock/research)
 "snU" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -21782,6 +21815,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"uyy" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock/research)
 "uCW" = (
 /obj/machinery/light{
 	dir = 8
@@ -22058,6 +22098,10 @@
 /obj/structure/sign/departments/evac,
 /turf/closed/indestructible/riveted,
 /area/centcom/interlink)
+"xbw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/turf/open/floor/engine,
+/area/cruiser_dock/research)
 "xga" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -22068,6 +22112,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"xpr" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/turf/open/floor/iron/dark,
+/area/cruiser_dock/research)
 "xuN" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -60127,7 +60178,7 @@ afU
 aEJ
 aum
 afU
-aNt
+skD
 aOE
 atG
 aSW
@@ -60142,11 +60193,11 @@ afX
 akV
 akM
 aYW
-aHB
-aNt
+xpr
+skD
 aht
-agD
-axf
+qDD
+xbw
 aTa
 axf
 axf
@@ -60384,7 +60435,7 @@ afU
 aUc
 aNt
 afU
-aNt
+skD
 aok
 aYV
 afU
@@ -60399,7 +60450,7 @@ afU
 afU
 afU
 afU
-afU
+kIt
 aNt
 ajI
 aNs
@@ -60641,8 +60692,8 @@ afU
 azG
 agn
 afU
-aNt
-aok
+skD
+fIM
 aLE
 aLJ
 aLB
@@ -60656,7 +60707,7 @@ aqa
 aLi
 ahS
 agh
-avo
+uyy
 aNt
 aKK
 afh
@@ -60913,7 +60964,7 @@ aBU
 aMb
 aZi
 aFF
-aYV
+olG
 aNt
 akn
 agD
@@ -61157,7 +61208,7 @@ afU
 afU
 aBg
 aFF
-aqH
+imX
 avs
 aFF
 agD
@@ -61414,7 +61465,7 @@ aPS
 afU
 aiF
 aFF
-aqH
+imX
 avs
 aFF
 axf
@@ -61671,7 +61722,7 @@ afU
 axS
 axI
 aFF
-aqH
+imX
 aqH
 aFF
 axf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Haha, okay! So! Apparently there's an issue with the uhh. DS-1 recall terminal that gives you the NUKIE SHUTTLE CONSOLE if you deconstruct it! So I've quickly decided to fix that!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
DS-1 shouldn't be able to launch the fucking nukie shuttle at the station. It fucks over the round in multiple ways, not limited to syndiecomms being possible to DESTROY there.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: DS-1 now has proper piping in xenobio.
fix: Following a lawsuit from the Gorlex Marauders citing DS-1 as liable for one of their nuclear cruisers going missing, some changes have gone underway to rectify the problem.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
