### PR TITLE
[MODULAR] Stamina Damage 'overhaul'

### DIFF
--- a/code/__DEFINES/~skyrat_defines/combat.dm
+++ b/code/__DEFINES/~skyrat_defines/combat.dm
@@ -9,7 +9,7 @@
 #define SIMPLE_MOB_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.7 //Fights with simple mobs are usually more sustained, so apply a bit less
 #define BLUNT_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.8 //Brute that isnt sharp, knocks the wind outta you real good
 #define OTHER_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.5 //Burns, sharp implements
-#define PROJECTILE_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.6
+#define PROJECTILE_TISSUE_DAMAGE_STAMINA_MULTIPLIER 0.9
 
 //Glancing attacks happen when someone uses disarm intent with melee weaponry, aiming to disable a person instead
 #define TISSUE_DAMAGE_GLANCING_DAMAGE_MULTIPLIER 0.5

--- a/code/__DEFINES/~skyrat_defines/combat.dm
+++ b/code/__DEFINES/~skyrat_defines/combat.dm
@@ -9,7 +9,7 @@
 #define SIMPLE_MOB_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.7 //Fights with simple mobs are usually more sustained, so apply a bit less
 #define BLUNT_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.8 //Brute that isnt sharp, knocks the wind outta you real good
 #define OTHER_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.5 //Burns, sharp implements
-#define PROJECTILE_TISSUE_DAMAGE_STAMINA_MULTIPLIER 0.9 // if a gun does 10 damage, this will do 9, so heal-stacking isn't a viable "begone bullets" strat.
+#define PROJECTILE_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1 // if a gun does 10 damage, this will also do 10, but as stamina so heal-stacking isn't a viable "begone bullets" strat.
 
 //Glancing attacks happen when someone uses disarm intent with melee weaponry, aiming to disable a person instead
 #define TISSUE_DAMAGE_GLANCING_DAMAGE_MULTIPLIER 0.5

--- a/code/__DEFINES/~skyrat_defines/combat.dm
+++ b/code/__DEFINES/~skyrat_defines/combat.dm
@@ -9,7 +9,7 @@
 #define SIMPLE_MOB_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.7 //Fights with simple mobs are usually more sustained, so apply a bit less
 #define BLUNT_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.8 //Brute that isnt sharp, knocks the wind outta you real good
 #define OTHER_TISSUE_DAMAGE_STAMINA_MULTIPLIER 1.5 //Burns, sharp implements
-#define PROJECTILE_TISSUE_DAMAGE_STAMINA_MULTIPLIER 0.9
+#define PROJECTILE_TISSUE_DAMAGE_STAMINA_MULTIPLIER 0.9 // if a gun does 10 damage, this will do 9, so heal-stacking isn't a viable "begone bullets" strat.
 
 //Glancing attacks happen when someone uses disarm intent with melee weaponry, aiming to disable a person instead
 #define TISSUE_DAMAGE_GLANCING_DAMAGE_MULTIPLIER 0.5


### PR DESCRIPTION
## About The Pull Request

~~tones back projectile stamina damage, doesn't remove it entirely.~~
Sets forth a simple and proud goal, to touch up our stamina damage for the current state of balance, vs how they've been since we've had base TG items.

## Why It's Good For The Game

oop uh oh stmaina 2 much
## Changelog
:cl:
balance: All bullets and their counterparts are no longer shooting vibranium, and do appropriately weighted 'stamina' damage.
/:cl:
