### PR TITLE
[NON-MODULAR] Fixes an inconsistency where the nanite chamber couldn't interact on MOB_HUMANOID

### DIFF
--- a/code/modules/research/nanites/nanite_chamber_computer.dm
+++ b/code/modules/research/nanites/nanite_chamber_computer.dm
@@ -41,8 +41,9 @@
 		return data
 
 	var/mob/living/L = chamber.occupant
-
-	if(!(L.mob_biotypes & (MOB_ORGANIC|MOB_UNDEAD)))
+//SKYRAT ADDITION START - ALLOWS MOB_HUMANOID ENTITIES TO USE NANITES
+	if(!(L.mob_biotypes & (MOB_ORGANIC | MOB_UNDEAD | MOB_HUMANOID)))
+//SKYRAT ADDITION END
 		data["status_msg"] = "Occupant not compatible with nanites."
 		return data
 

--- a/code/modules/research/nanites/nanite_chamber_computer.dm
+++ b/code/modules/research/nanites/nanite_chamber_computer.dm
@@ -42,6 +42,7 @@
 
 	var/mob/living/L = chamber.occupant
 //SKYRAT ADDITION START - ALLOWS MOB_HUMANOID ENTITIES TO USE NANITES
+//ORIGINAL: (MOB_ORGANIC | MOB_UNDEAD) -> NEW: (MOB_ORGANIC | MOB_UNDEAD | MOB_HUMANOID)
 	if(!(L.mob_biotypes & (MOB_ORGANIC | MOB_UNDEAD | MOB_HUMANOID)))
 //SKYRAT ADDITION END
 		data["status_msg"] = "Occupant not compatible with nanites."


### PR DESCRIPTION
## About The Pull Request

A while back the public nanite chamber was modified to allow it to operate on MOB_HUMANOID; however, it seems that whoever did that forgot to also make the controlled chamber able to operate on them aswell.

## Why It's Good For The Game

Because it is.

## Changelog
:cl: ZephyrTFA
fix: Nanite Chambers can now operate on synths! (any MOB_HUMANOID)
/:cl:

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/4848