### PR TITLE
[NONMODULAR] Heretic buffs, the slow-start. (all done, time 4 episode II 😈 )

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_book.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_book.dm
@@ -8,7 +8,7 @@
 	///Last person that touched this
 	var/mob/living/last_user
 	///how many charges do we have?
-	var/charge = 1
+	var/charge = 2 //SKYRAT EDIT - ORIGINAL: 1
 	///Where we cannot create the rune?
 	var/static/list/blacklisted_turfs = typecacheof(list(/turf/closed,/turf/open/space,/turf/open/lava))
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -285,7 +285,7 @@
 
 		if(DT_PROB(30,delta_time))
 			human_in_range.emote(pick("giggle","laugh"))
-			human_in_range.adjustStaminaLoss(20) //SKYRAT EDIT - Original: 10
+			human_in_range.adjustStaminaLoss(15) //SKYRAT EDIT - Original: 10
 
 		if(DT_PROB(25,delta_time))
 			human_in_range.Dizzy(5)

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -184,7 +184,7 @@
 	allowed = list(/obj/item/melee/sickly_blade, /obj/item/forbidden_book, /obj/item/living_heart)
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/eldritch
 	// slightly better than normal cult robes
-	armor = list(MELEE = 50, BULLET = 65, LASER = 35,ENERGY = 45, BOMB = 35, BIO = 20, RAD = 0, FIRE = 20, ACID = 20)
+	armor = list(MELEE = 50, BULLET = 65, LASER = 35,ENERGY = 45, BOMB = 35, BIO = 20, RAD = 0, FIRE = 20, ACID = 20) //SKYRAT EDIT - ORIGINAL: armor = list(MELEE = 50, BULLET = 50, LASER = 50,ENERGY = 50, BOMB = 35, BIO = 20, RAD = 0, FIRE = 20, ACID = 20)
 
 /obj/item/reagent_containers/glass/beaker/eldritch
 	name = "flask of eldritch essence"

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -285,7 +285,7 @@
 
 		if(DT_PROB(30,delta_time))
 			human_in_range.emote(pick("giggle","laugh"))
-			human_in_range.adjustStaminaLoss(20)
+			human_in_range.adjustStaminaLoss(20) //SKYRAT EDIT - Original: 10
 
 		if(DT_PROB(25,delta_time))
 			human_in_range.Dizzy(5)

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -74,7 +74,8 @@
 	flags_1 = CONDUCT_1
 	sharpness = SHARP_EDGED
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 17
+	force = 24 //SKYRAT EDIT - ORIGINAL: 17
+	armour_penetration = 15 // SKYRAT EDIT - ADDITION
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -285,7 +285,7 @@
 
 		if(DT_PROB(30,delta_time))
 			human_in_range.emote(pick("giggle","laugh"))
-			human_in_range.adjustStaminaLoss(10)
+			human_in_range.adjustStaminaLoss(20)
 
 		if(DT_PROB(25,delta_time))
 			human_in_range.Dizzy(5)

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -184,7 +184,7 @@
 	allowed = list(/obj/item/melee/sickly_blade, /obj/item/forbidden_book, /obj/item/living_heart)
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/eldritch
 	// slightly better than normal cult robes
-	armor = list(MELEE = 50, BULLET = 50, LASER = 50,ENERGY = 50, BOMB = 35, BIO = 20, RAD = 0, FIRE = 20, ACID = 20)
+	armor = list(MELEE = 50, BULLET = 65, LASER = 35,ENERGY = 45, BOMB = 35, BIO = 20, RAD = 0, FIRE = 20, ACID = 20)
 
 /obj/item/reagent_containers/glass/beaker/eldritch
 	name = "flask of eldritch essence"


### PR DESCRIPTION
## About The Pull Request
This is a start to giving heretics some "much-needed" steroids, as they are comparatively lacking in a fight with even common crewmembers (or just people walking away) using their given items, (partly due to our health buff, and them not having the raw DPS to make up for it, along with not having enough stamina damage to outduel toolboxes, as objectively funny as it is.)

## Why It's Good For The Game
Heretics are lacking in the combat game, even when having an advantage, even more so against security, even at the 'highest' tiers of their levels, bar ascension.

## Feedback is almost a requirement, with all "upcoming" changes.

**more 2 come after some further testing**
## Changelog
:cl:
balance: Heretic sickle-sword now does 7 more damage, and has slight armor pen.
balance: Doubled the stamina damage of the abyssal mask.
balance: Gives another starting point to their book.
/:cl:
