### PR TITLE
[NONMODULAR] Makes examining a 'soulless' body more RP friendly.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -223,13 +223,13 @@
 /mob/living/carbon/human/proc/generate_death_examine_text()
 	var/mob/dead/observer/ghost = get_ghost(TRUE, TRUE)
 	var/t_He = p_they(TRUE)
-	var/t_his = p_their()
+	// var/t_his = p_their() - SKYRAT EDIT - UNUSED VAR
 	var/t_is = p_are()
 	//This checks to see if the body is revivable
 	if(key || !getorgan(/obj/item/organ/brain) || ghost?.can_reenter_corpse)
 		return "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life...</span>"
 	else
-		return "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has departed...</span>"
+		return "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and rigor mortis is starting to set in. Revival is unlikely...</span>" // SKYRAT EDIT - ORIGINAL  ...signs of life and [t_his] soul has departed...
 
 ///copies over clothing preferences like underwear to another human
 /mob/living/carbon/human/proc/copy_clothing_prefs(mob/living/carbon/human/destination)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -229,7 +229,7 @@
 	if(key || !getorgan(/obj/item/organ/brain) || ghost?.can_reenter_corpse)
 		return "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life...</span>"
 	else
-		return "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and rigor mortis is starting to set in. Revival is unlikely...</span>" // SKYRAT EDIT - ORIGINAL  ...signs of life and [t_his] soul has departed...
+		return "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life and rigor mortis is starting to set in...</span>" // SKYRAT EDIT - ORIGINAL  ...signs of life and [t_his] soul has departed...
 
 ///copies over clothing preferences like underwear to another human
 /mob/living/carbon/human/proc/copy_clothing_prefs(mob/living/carbon/human/destination)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bodies will now enter rigor mortis when the soul leaves them, leaving it easily identifiable on examine that they're unrevivable, but not somewhat breaking RP.

"In my medical opinion, this body has no soul anymore."
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
RP good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: Made unrevivable corpses' flavour text more RP friendly. Doctors no longer diagnose based on the soul of a person, it's now Rigor Mortis.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
