### PR TITLE
Patched the Wet floor signs and Added VG decals

### DIFF
--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -29956,7 +29956,9 @@
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
 "bUU" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/effect/turf_decal/vg_decals/atmos/nitrous_oxide{
+	dir = 8
+	},
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bUV" = (
@@ -31132,7 +31134,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bYU" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/vg_decals/atmos/plasma{
+	dir = 8
+	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bYV" = (
@@ -32114,7 +32118,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ccB" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide{
+	dir = 8
+	},
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "ccC" = (
@@ -33946,14 +33952,18 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "clT" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/vg_decals/atmos/nitrogen{
+	dir = 1
+	},
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "clU" = (
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "clV" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/vg_decals/atmos/oxygen{
+	dir = 1
+	},
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "clW" = (
@@ -37041,7 +37051,9 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "cBP" = (
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/vg_decals/atmos/air{
+	dir = 1
+	},
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "cBR" = (
@@ -38945,6 +38957,12 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/security/prison)
+"cYG" = (
+/obj/effect/turf_decal/vg_decals/atmos/mix{
+	dir = 8
+	},
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "cYY" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -40911,10 +40929,10 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/clothing/gloves/botanic_leather,
 /obj/item/clothing/gloves/color/blue,
-/obj/item/caution,
-/obj/item/caution,
-/obj/item/caution,
-/obj/item/caution,
+/obj/item/clothing/suit/caution,
+/obj/item/clothing/suit/caution,
+/obj/item/clothing/suit/caution,
+/obj/item/clothing/suit/caution,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
@@ -42523,6 +42541,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/locker)
+"hlA" = (
+/obj/effect/turf_decal/vg_decals/numbers/two{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "hmF" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -42981,6 +43005,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/commons/fitness)
+"hKd" = (
+/obj/effect/turf_decal/vg_decals/numbers/five{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "hKu" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /obj/machinery/posialert{
@@ -46309,6 +46339,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"lvo" = (
+/mob/living/simple_animal/slime,
+/obj/effect/turf_decal/vg_decals/numbers/four{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "lvw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -48697,6 +48734,12 @@
 	},
 /turf/closed/wall,
 /area/commons/vacant_room/commissary)
+"nXj" = (
+/obj/effect/turf_decal/vg_decals/numbers/three{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "nXH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/start/hangover,
@@ -50774,6 +50817,12 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/cargo/qm)
+"qmx" = (
+/obj/effect/turf_decal/vg_decals/numbers/six{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "qmO" = (
 /obj/machinery/griddle,
 /obj/machinery/power/apc/auto_name/north,
@@ -56929,6 +56978,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"wZe" = (
+/mob/living/simple_animal/slime,
+/obj/effect/turf_decal/vg_decals/numbers/one{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "wZy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -94306,7 +94362,7 @@ bzs
 buf
 bOh
 bPk
-bPm
+cYG
 bPm
 bOh
 bTW
@@ -100733,15 +100789,15 @@ bID
 bIR
 bJN
 xzr
-cKZ
+wZe
 xAv
 bJN
 xzr
-xAv
+nXj
 xAv
 bJN
 xzr
-xAv
+hKd
 xAv
 bDb
 fqg
@@ -103303,15 +103359,15 @@ bMi
 bZb
 bJN
 xAv
-xAv
+hlA
 xzr
 bJN
 xAv
-cKZ
+lvo
 xzr
 bJN
 xAv
-xAv
+qmx
 xzr
 bDb
 sUX


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Revamped box station map got merged into master after the janitor signs update. This fixes the invalid item references to those wet floor signs. Also the VG decals were integrated months ago. I deleted the cans from the gas chambers in atmos and added in the vg decals. also i numbered the xeno pens

## Why It's Good For The Game

fixes map compile errors. Clarifies atmos gas supplies and xeno pen assignments

## Changelog
:cl:
add: VG atrmos decals to map
add: VG decals to the xeno pens
del: Old Wet Floor Signs
fix: compile error and CI checks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
