### PR TITLE
[Modular] Spacebox funny tweaks and fixes.

### DIFF
--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -30695,6 +30695,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bZp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "bZr" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
@@ -78374,7 +78381,7 @@ boK
 ofT
 boK
 ofT
-buC
+bZp
 aZE
 xzh
 xzh

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -683,6 +683,7 @@
 /obj/item/instrument/eguitar{
 	pixel_x = 5
 	},
+/obj/item/instrument/violin,
 /turf/open/floor/wood,
 /area/service/theater)
 "adr" = (
@@ -906,9 +907,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/engineering/main)
-"aeE" = (
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
 "aeQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -984,17 +982,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"afr" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
 "afs" = (
 /obj/machinery/shower{
 	dir = 8
@@ -1067,12 +1054,14 @@
 /turf/open/floor/plating,
 /area/security/office)
 "aga" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "agc" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
@@ -1294,11 +1283,9 @@
 /turf/open/floor/iron/white,
 /area/security/brig)
 "ahT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/fore/secondary)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "ahV" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -1387,7 +1374,10 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "aiA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/airlock/maintenance{
+	name = "Recharge Dock";
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aiB" = (
@@ -1802,13 +1792,8 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "akV" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
-	},
-/obj/machinery/bounty_board{
-	dir = 1;
-	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -1858,19 +1843,10 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
 "alu" = (
-/obj/machinery/nuclearbomb/selfdestruct,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/plating/airless,
+/area/space)
 "alz" = (
 /obj/machinery/button/door{
 	id = "briggate";
@@ -2040,13 +2016,7 @@
 /turf/open/floor/plating,
 /area/security/courtroom)
 "ams" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "amt" = (
@@ -2251,10 +2221,14 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "and" = (
-/obj/machinery/light/small{
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "12;24"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "ane" = (
@@ -2347,11 +2321,15 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "anE" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/obj/item/extinguisher,
+/obj/item/clothing/head/hardhat/red,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -2359,9 +2337,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "anG" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "anH" = (
@@ -2413,16 +2395,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"anW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "anX" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -2466,16 +2438,6 @@
 /obj/machinery/computer/secure_data,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
-"aod" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aoe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -2576,12 +2538,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aoL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/mirror{
+	pixel_y = 28
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/dorms)
 "aoM" = (
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
@@ -2686,11 +2653,9 @@
 /turf/closed/wall,
 /area/service/lawoffice)
 "api" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "apl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2736,37 +2701,23 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "apw" = (
-/obj/effect/landmark/blobstart,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump/on/layer4{
-	dir = 8;
-	name = "Air out"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/dorms)
 "apx" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "12;24"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "apy" = (
-/obj/item/wrench,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/toilet{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/dorms)
 "apB" = (
 /obj/machinery/camera{
 	c_tag = "Fore Starboard Solars";
@@ -2951,55 +2902,31 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/item/bedsheet/dorms,
+/obj/effect/landmark/start/hangover,
 /obj/machinery/button/door{
-	id = "Dorm4";
+	id = "Dorm3";
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
 	specialfunctions = 4
 	},
-/obj/item/bedsheet/dorms,
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "aqo" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
+/obj/structure/dresser,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "aqp" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/fire/firefighter,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/obj/item/extinguisher,
-/obj/item/clothing/head/hardhat/red,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/binary/pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/obj/structure/curtain,
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/dorms)
 "aqq" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"aqr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/closed/wall,
-/area/commons/fitness)
 "aqs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -3038,16 +2965,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
-"aqv" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aqw" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Bow Solar Access";
@@ -3225,14 +3142,11 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/wood,
 /area/commons/dorms)
-"arj" = (
-/turf/closed/wall,
-/area/commons/fitness)
 "ark" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -3252,34 +3166,28 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "arn" = (
-/obj/structure/closet/athletic_mixed,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
+/obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/commons/fitness)
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "aro" = (
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
 "arp" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
+"arq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"arq" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance/eight,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/commons/fitness)
 "arr" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -3434,18 +3342,9 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "asb" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "asd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -3515,7 +3414,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "asn" = (
@@ -3524,86 +3422,43 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "aso" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "asp" = (
-/obj/structure/table/wood,
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/commons/dorms)
-"asq" = (
-/obj/machinery/camera{
-	c_tag = "Fitness Room"
-	},
-/obj/structure/closet/masks,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "asr" = (
-/obj/structure/closet/boxinggloves,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/clothing/shoes/jackboots,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
+/obj/structure/fireplace,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "ass" = (
-/obj/structure/closet/lasertag/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "ast" = (
-/obj/structure/closet/lasertag/blue,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/commons/fitness)
-"asu" = (
 /obj/structure/bed,
-/obj/machinery/button/door{
-	id = "Dorm5";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -25;
-	specialfunctions = 4
-	},
 /obj/item/bedsheet/dorms,
-/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/commons/dorms)
+"asu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/commons/dorms)
 "asv" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/fitness)
 "asx" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -3687,15 +3542,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asL" = (
-/obj/structure/bed,
-/obj/machinery/button/door{
-	id = "Dorm6";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -25;
-	specialfunctions = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/item/bedsheet/dorms,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "asN" = (
@@ -3744,11 +3593,6 @@
 /obj/structure/marker_beacon/burgundy,
 /turf/open/floor/plating/airless,
 /area/solars/starboard/fore)
-"asY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/commons/fitness)
 "asZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -3791,15 +3635,15 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "atg" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm4";
-	name = "Dorm 4"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm3";
+	name = "Dorm 3"
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
@@ -3850,6 +3694,9 @@
 /turf/open/floor/plating/airless,
 /area/solars/starboard/fore)
 "atm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "atn" = (
@@ -3895,28 +3742,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ats" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
+/obj/structure/table/glass,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "atu" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall/rust,
 /area/security/prison)
-"atv" = (
-/obj/structure/table,
-/obj/item/shard,
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/obj/item/shard{
-	icon_state = "small"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "atw" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -4049,15 +3881,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"atQ" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm5";
-	name = "Cabin 1"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/commons/dorms)
 "atR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -4079,21 +3902,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "atV" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/fitness)
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "atW" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
@@ -4115,21 +3931,8 @@
 /obj/structure/cable,
 /turf/open/floor/iron/airless/solarpanel,
 /area/solars/port/aft)
-"atZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "aua" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/structure/closet/wardrobe/green,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "auc" = (
@@ -4237,13 +4040,11 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "aup" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm6";
-	name = "Cabin 2"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet,
 /area/commons/dorms)
 "auq" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -4260,14 +4061,14 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/item/bedsheet/dorms,
 /obj/machinery/button/door{
-	id = "Dorm3";
+	id = "Dorm2";
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
 	specialfunctions = 4
 	},
-/obj/item/bedsheet/dorms,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "aux" = (
@@ -4283,12 +4084,8 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "auy" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
+/obj/structure/chair/comfy/black{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
@@ -4298,10 +4095,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"auB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/commons/fitness)
 "auC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -4375,45 +4168,16 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "auS" = (
-/obj/machinery/requests_console{
-	department = "Crew Quarters";
-	pixel_y = 30
-	},
-/obj/machinery/camera{
-	c_tag = "Dormitory North"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/closet/athletic_mixed,
 /turf/open/floor/iron,
-/area/commons/dorms)
+/area/commons/fitness)
 "auU" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/structure/closet/athletic_mixed,
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/commons/dorms)
+/area/commons/fitness)
 "auV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4520,31 +4284,20 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "avm" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/door/airlock/maintenance{
+	name = "Fitness Maintenance";
+	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/bluespace_vendor/north,
-/turf/open/floor/iron,
-/area/commons/dorms)
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "avn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock{
+	id_tag = "Dorm4";
+	name = "Dorm 4"
+	},
+/turf/open/floor/wood,
 /area/commons/dorms)
 "avo" = (
 /obj/structure/sign/warning/electricshock,
@@ -4600,6 +4353,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "avw" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4609,11 +4366,16 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/fitness)
-"avx" = (
-/obj/effect/spawner/structure/window,
+/obj/machinery/door/airlock/maintenance{
+	name = "Fitness Maintenance";
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
+/area/maintenance/fore/secondary)
+"avx" = (
+/obj/effect/turf_decal/siding/yellow/corner,
+/turf/open/floor/iron,
 /area/commons/fitness)
 "avB" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -4726,8 +4488,19 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "avR" = (
-/obj/structure/table/wood,
-/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/bluespace_vendor/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "avS" = (
@@ -4843,22 +4616,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "awo" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm3";
-	name = "Dorm 3"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm2";
+	name = "Dorm 2"
+	},
 /turf/open/floor/wood,
-/area/commons/dorms)
-"awp" = (
-/obj/structure/table/wood,
-/obj/item/storage/pill_bottle/dice,
-/turf/open/floor/iron,
 /area/commons/dorms)
 "awq" = (
 /obj/structure/disposalpipe/segment{
@@ -4871,20 +4639,54 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aws" = (
-/obj/structure/table/wood,
-/obj/item/coin/silver,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "awu" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -5;
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
 "awv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "awx" = (
@@ -4899,27 +4701,32 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/fitness)
-"awz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Fitness"
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
+"awz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/commons/fitness)
-"awB" = (
-/obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
+"awB" = (
+/obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "awD" = (
@@ -5176,18 +4983,9 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "axm" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -32
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/effect/turf_decal/siding/yellow,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "axn" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -5220,6 +5018,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "axs" = (
@@ -5336,46 +5135,53 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "axM" = (
-/obj/structure/table/wood,
-/obj/item/paicard,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"axN" = (
-/obj/structure/table/wood,
-/obj/item/storage/crayons,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"axO" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 8
 	},
-/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/commons/fitness)
+"axN" = (
+/obj/structure/bed,
+/turf/open/floor/iron,
+/area/commons/fitness)
+"axO" = (
+/obj/machinery/requests_console{
+	department = "Crew Quarters";
+	pixel_y = 30
+	},
+/obj/machinery/camera{
+	c_tag = "Dormitory North"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/commons/dorms)
 "axP" = (
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck{
-	pixel_x = 2
-	},
-/obj/item/clothing/mask/balaclava{
-	pixel_x = -8;
-	pixel_y = 8
-	},
+/obj/structure/cable,
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "axQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/dorms)
 "axR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Fitness"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/fitness)
+/turf/closed/wall,
+/area/maintenance/fore/secondary)
 "axV" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -5384,25 +5190,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "axY" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "axZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
@@ -5550,10 +5348,11 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
 "ayB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/fitness)
 "ayC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5707,14 +5506,14 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/item/bedsheet/dorms,
 /obj/machinery/button/door{
-	id = "Dorm2";
+	id = "Dorm1";
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
 	specialfunctions = 4
 	},
-/obj/item/bedsheet/dorms,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "ayW" = (
@@ -5745,19 +5544,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aza" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck{
+	pixel_x = 2
+	},
 /turf/open/floor/iron,
 /area/commons/dorms)
 "azb" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable,
+/obj/structure/table/wood/poker,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "azc" = (
@@ -5770,63 +5566,28 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "azd" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/turf/open/water/overlay{
+	desc = "It's a pool for swimming in!";
+	icon_state = "hotspring_tile";
+	name = "pool"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"aze" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
-"azf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
 /area/commons/fitness)
+"aze" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "azg" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"azh" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "azj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/iron,
-/area/commons/fitness)
-"azo" = (
-/turf/open/floor/iron,
-/area/commons/fitness)
-"azp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/commons/fitness)
+/area/commons/dorms)
 "azq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
@@ -5835,8 +5596,11 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "azr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/commons/fitness)
 "azs" = (
 /obj/structure/disposalpipe/segment{
@@ -5994,16 +5758,11 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "azT" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/commons/dorms)
+/area/commons/fitness)
 "azU" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -6025,12 +5784,11 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "azX" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Showers"
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "azY" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -6050,15 +5808,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aAb" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm2";
-	name = "Dorm 2"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm1";
+	name = "Dorm 1"
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
@@ -6069,15 +5827,17 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aAd" = (
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/commons/dorms)
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "aAe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -6092,145 +5852,77 @@
 /turf/open/floor/iron/showroomfloor,
 /area/hallway/secondary/service)
 "aAf" = (
-/obj/structure/closet/wardrobe/pjs,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/commons/dorms)
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
+	dir = 1;
+	name = "Air out"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "aAg" = (
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/vending/dorms,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
-/area/commons/dorms)
+/area/commons/fitness)
 "aAh" = (
 /turf/closed/wall,
 /area/commons/toilet)
 "aAi" = (
-/obj/structure/closet/wardrobe/pjs,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/cable,
+/obj/structure/chair/comfy/brown{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aAk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "aAl" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/landmark/blobstart,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/fitness)
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "aAm" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/segment{
+/obj/item/wrench,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "aAn" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/camera{
+	c_tag = "Pool West";
 	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
 "aAo" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/commons/dorms)
 "aAp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/dorms)
 "aAq" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -6456,12 +6148,21 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "aAZ" = (
-/obj/structure/cable,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "aBa" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/command/nuke_storage)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/camera{
+	c_tag = "Pool East";
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aBb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -6597,39 +6298,52 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "aBy" = (
-/turf/open/floor/iron/freezer,
+/obj/machinery/door/airlock{
+	id_tag = null;
+	name = "Unit 3"
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/commons/toilet)
 "aBz" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
-"aBA" = (
-/obj/machinery/shower{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
-"aBB" = (
-/obj/machinery/bounty_board{
-	dir = 8;
-	pixel_x = 32
+/turf/open/floor/iron,
+/area/commons/dorms)
+"aBA" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
-"aBC" = (
+/obj/item/paicard,
+/obj/item/storage/crayons,
+/obj/item/clothing/mask/balaclava{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
+"aBB" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Service Hall";
-	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
+"aBC" = (
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 26
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "aBD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6721,51 +6435,29 @@
 /turf/closed/wall/r_wall,
 /area/commons/storage/primary)
 "aBS" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aBT" = (
-/obj/machinery/computer/bank_machine,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/obj/structure/bed,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aBV" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aBW" = (
-/obj/structure/filingcabinet,
-/obj/item/folder/documents,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aBX" = (
 /obj/structure/table,
 /obj/structure/window/reinforced/tinted{
@@ -6813,20 +6505,17 @@
 /turf/open/floor/iron/dark,
 /area/crew_quarters/cryopod)
 "aCe" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/item/bikehorn/rubberducky,
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
-"aCf" = (
-/obj/machinery/camera{
-	c_tag = "Theater Storage"
-	},
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/siding/yellow/corner{
 	dir = 4
 	},
-/area/service/theater)
+/turf/open/floor/iron,
+/area/commons/fitness)
+"aCf" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aCg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -6838,11 +6527,12 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aCh" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/iron/white/side{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
 	},
-/area/service/theater)
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aCi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -6863,24 +6553,17 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aCm" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/obj/machinery/light{
+/obj/effect/turf_decal/siding/yellow/corner{
 	dir = 1
 	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aCn" = (
-/obj/structure/urinal{
-	pixel_y = 32
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
 	},
-/turf/open/floor/iron/freezer,
+/obj/structure/cable,
+/turf/open/floor/mineral/titanium/blue,
 /area/commons/toilet)
 "aCp" = (
 /obj/machinery/camera{
@@ -6894,18 +6577,9 @@
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "aCq" = (
-/obj/structure/table/wood,
-/obj/machinery/requests_console{
-	department = "Theater";
-	name = "Theater RC";
-	pixel_x = -32
-	},
-/obj/item/food/baguette,
-/obj/item/toy/dummy,
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/service/theater)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aCr" = (
 /turf/closed/wall,
 /area/service/theater)
@@ -6915,10 +6589,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/closed/wall,
+/turf/open/floor/iron/dark,
 /area/commons/fitness)
 "aCv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -6950,21 +6621,14 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "aCz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/railing,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCA" = (
 /obj/structure/cable,
 /obj/structure/railing,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
@@ -7129,52 +6793,34 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aDr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aDs" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/table/glass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aDt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Pool Room"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/commons/fitness)
+"aDv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
-"aDv" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/turf/closed/wall,
+/area/commons/fitness)
 "aDx" = (
 /obj/machinery/door/window{
 	name = "Gateway Chamber";
@@ -7275,90 +6921,50 @@
 	},
 /turf/open/floor/iron,
 /area/crew_quarters/cryopod)
-"aDM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
 "aDN" = (
-/obj/machinery/light/small,
-/turf/open/floor/iron/freezer,
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Bathroom";
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/commons/toilet)
 "aDO" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
-"aDP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
-"aDQ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
+/turf/closed/wall,
+/area/commons/fitness)
+"aDQ" = (
+/obj/machinery/door/airlock{
+	id_tag = "Toilet1";
+	name = "Unit 1"
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/mineral/titanium/blue,
 /area/commons/toilet)
 "aDR" = (
 /obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = -28
+/obj/machinery/requests_console{
+	department = "Theater";
+	name = "Theater RC";
+	pixel_x = -32
 	},
-/obj/item/lipstick/random{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/lipstick/random{
-	pixel_x = -2;
-	pixel_y = -2
-	},
+/obj/item/food/baguette,
+/obj/item/toy/dummy,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
 /area/service/theater)
 "aDS" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Showers"
+/obj/machinery/camera{
+	c_tag = "Fitness Room"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
+/obj/structure/closet/wardrobe/black,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aDT" = (
-/obj/machinery/light/small,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
-"aDU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "aDX" = (
@@ -7368,13 +6974,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aDY" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/mime,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Theater Storage"
 	},
 /turf/open/floor/iron/white/side{
 	dir = 4
@@ -7474,10 +7075,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aEA" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 2;
-	sortType = 18
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -7485,6 +7082,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "aEC" = (
@@ -7535,48 +7133,26 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "aEM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
+/obj/structure/chair/sofa/right,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aEN" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/structure/closet/crate/goldcrate,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/obj/structure/chair/sofa/left,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aEO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/camera{
+	c_tag = "Holodeck - Fore";
+	name = "holodeck camera"
 	},
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
+/turf/open/floor/engine{
+	name = "Holodeck Projector Floor"
+	},
+/area/holodeck/rec_center)
 "aEP" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/structure/closet/crate/silvercrate,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/obj/structure/table/wood/fancy,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aEQ" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -7678,27 +7254,18 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aFf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
+/obj/structure/table/wood/fancy,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aFh" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/commons/fitness)
 "aFi" = (
 /obj/machinery/door/airlock/freezer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7706,23 +7273,34 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "aFj" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/mime,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
 /area/service/theater)
 "aFl" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = -28
 	},
-/obj/structure/dresser,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/item/lipstick/random{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/turf/open/floor/iron,
+/obj/item/lipstick/random{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
 /area/service/theater)
 "aFm" = (
 /obj/structure/disposalpipe/segment{
@@ -7925,69 +7503,38 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aGa" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "aGb" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/machinery/ore_silo,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/obj/structure/closet/wardrobe/grey,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aGc" = (
-/obj/machinery/camera/motion{
-	c_tag = "Vault";
-	dir = 1;
-	network = list("vault")
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
-"aGd" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
-"aGe" = (
-/obj/structure/safe,
-/obj/item/clothing/head/bearpelt,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/gun/ballistic/revolver/russian,
-/obj/item/ammo_box/a357,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/chair/sofa/left{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/iron,
+/area/commons/fitness)
+"aGd" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/commons/fitness)
+"aGe" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/engine{
+	name = "Holodeck Projector Floor"
+	},
+/area/holodeck/rec_center)
 "aGf" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -8008,26 +7555,8 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "aGk" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
-"aGl" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
-"aGm" = (
 /obj/structure/toilet{
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/button/door{
 	id = "Toilet1";
@@ -8036,25 +7565,25 @@
 	pixel_y = 25;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/toilet)
+"aGl" = (
+/obj/machinery/door/airlock{
+	id_tag = "Toilet2";
+	name = "Unit 2"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/toilet)
+"aGm" = (
+/obj/structure/table/glass,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/mineral/titanium/blue,
 /area/commons/toilet)
 "aGn" = (
-/obj/structure/toilet{
-	pixel_y = 8
+/obj/machinery/shower{
+	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/landmark/blobstart,
-/obj/machinery/button/door{
-	id = "Toilet2";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_y = 25;
-	specialfunctions = 4
-	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "aGo" = (
@@ -8076,10 +7605,9 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aGp" = (
-/obj/machinery/light/small{
+/obj/machinery/shower{
 	dir = 8
 	},
-/obj/machinery/recharge_station,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "aGq" = (
@@ -8093,21 +7621,12 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aGr" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/clown,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/clown,
 /turf/open/floor/iron,
 /area/service/theater)
 "aGs" = (
@@ -8225,20 +7744,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/hallway/secondary/service)
 "aGD" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = -28
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/item/flashlight/lamp/bananalamp{
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/structure/dresser,
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -8506,10 +8016,8 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "aHw" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "aHx" = (
@@ -8587,31 +8095,22 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aHF" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/command/nuke_storage)
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/commons/dorms)
 "aHG" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/vault{
-	name = "Vault";
-	req_access_txt = "53"
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/button/door{
+	id = "Dorm4";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/navbeacon/wayfinding,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/turf/open/floor/wood,
+/area/commons/dorms)
 "aHH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -8744,37 +8243,41 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aHU" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/obj/machinery/button/door{
+	id = "Dorm5";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
 	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "aHV" = (
-/obj/machinery/door/airlock{
-	id_tag = "Toilet1";
-	name = "Unit 1"
-	},
-/turf/open/floor/iron/freezer,
+/obj/structure/table/glass,
+/turf/open/floor/mineral/titanium/blue,
 /area/commons/toilet)
 "aHW" = (
-/obj/machinery/door/airlock{
-	id_tag = "Toilet2";
-	name = "Unit 2"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aHX" = (
-/obj/machinery/door/airlock{
-	name = "Unit B"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
 	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aHY" = (
 /obj/effect/turf_decal/trimline/white/line,
 /turf/open/floor/iron/showroomfloor,
@@ -9140,27 +8643,16 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"aJd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/hallway/primary/port)
 "aJe" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/hallway/primary/port)
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aJf" = (
 /obj/machinery/camera{
 	c_tag = "EVA South";
@@ -9347,11 +8839,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aJz" = (
-/obj/machinery/camera{
-	c_tag = "Dormitory Toilets";
-	dir = 1
-	},
-/turf/open/floor/iron/freezer,
+/obj/machinery/recharge_station,
+/turf/open/floor/mineral/titanium/blue,
 /area/commons/toilet)
 "aJB" = (
 /obj/structure/disposalpipe/segment,
@@ -9638,21 +9127,8 @@
 /turf/open/floor/plating,
 /area/commons/storage/primary)
 "aKw" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/hallway/primary/port)
 "aKy" = (
 /obj/structure/disposalpipe/segment,
@@ -9928,9 +9404,6 @@
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
 "aLl" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -10037,17 +9510,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aLJ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/commons/fitness)
 "aLK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -10243,17 +9714,23 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aMp" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/service/theater)
+/obj/machinery/computer/holodeck,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aMq" = (
-/obj/structure/musician/piano{
-	icon_state = "piano"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/service/theater)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aMr" = (
 /turf/open/floor/wood,
 /area/service/theater)
@@ -10423,24 +9900,18 @@
 /area/cargo/office)
 "aMQ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aMR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/closet/wardrobe/pink,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/commons/fitness)
 "aMS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -10682,7 +10153,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -10884,22 +10355,19 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"aOy" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
 "aOz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/darkblue,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "aOE" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -11212,11 +10680,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aPJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "aPK" = (
 /turf/closed/wall,
 /area/commons/storage/emergency/port)
@@ -11296,8 +10771,9 @@
 /area/service/bar)
 "aQb" = (
 /obj/structure/window/reinforced,
-/obj/structure/table/wood,
-/obj/item/instrument/violin,
+/obj/structure/musician/piano{
+	icon_state = "piano"
+	},
 /turf/open/floor/wood,
 /area/service/theater)
 "aQc" = (
@@ -16574,6 +16050,9 @@
 	dir = 8;
 	pixel_x = 27
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/command/meeting_room)
 "bfs" = (
@@ -16613,6 +16092,13 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
+	name = "Captain RC";
+	pixel_x = -30
+	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "bfz" = (
@@ -17020,27 +16506,11 @@
 /turf/open/floor/wood,
 /area/command/meeting_room)
 "bgM" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/light{
+/obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/command/meeting_room)
-"bgN" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/turf/open/floor/iron,
+/area/commons/fitness)
 "bgP" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/yellow/end{
@@ -17060,16 +16530,15 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bgS" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Captain's Desk";
-	departmentType = 5;
-	name = "Captain RC";
-	pixel_x = -30
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/structure/filingcabinet,
-/turf/open/floor/wood,
-/area/command/heads_quarters/captain)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "bgT" = (
 /obj/machinery/computer/communications{
 	dir = 8
@@ -17625,37 +17094,14 @@
 /turf/open/floor/wood,
 /area/command/meeting_room)
 "big" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit/green,
-/area/engineering/gravity_generator)
-"bih" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/turf/open/floor/circuit,
+/area/ai_monitored/command/nuke_storage)
 "bii" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/turf/open/floor/circuit,
+/area/ai_monitored/command/nuke_storage)
 "bij" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -18914,11 +18360,12 @@
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "blD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/commons/fitness)
 "blE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -19036,8 +18483,8 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "blU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "blV" = (
@@ -19870,24 +19317,35 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "bnU" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/command/glass{
-	name = "Gravity Generator Chamber";
-	req_access_txt = "19; 61"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/ai_monitored/command/nuke_storage)
 "bnV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/engineering/gravity_generator)
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "bnW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/bot_white/right,
+/obj/machinery/ore_silo,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "bnX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -20343,19 +19801,22 @@
 /turf/open/floor/iron,
 /area/science/lab)
 "bpg" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/darkblue,
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "bph" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/ai_monitored/command/nuke_storage)
 "bpi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -20810,19 +20271,10 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "bqD" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/ai_monitored/command/nuke_storage)
 "bqH" = (
 /turf/closed/wall/r_wall,
 /area/command/teleporter)
@@ -22056,15 +21508,18 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "btG" = (
-/obj/machinery/camera{
-	c_tag = "Public Mining Storage";
-	dir = 4;
-	network = list("minisat");
-	start_active = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "btH" = (
 /obj/structure/chair/stool,
 /obj/structure/cable,
@@ -22579,21 +22034,27 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "buQ" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = -28
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/darkblue,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "buS" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "buT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22986,9 +22447,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bvY" = (
@@ -23090,10 +22548,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
-"bwn" = (
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
 "bwp" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -23429,10 +22883,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
-"bxI" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall,
-/area/engineering/gravity_generator)
 "bxJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -25479,9 +24929,18 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "bEx" = (
-/obj/structure/sign/warning/radiation/rad_area,
-/turf/closed/wall/r_wall,
-/area/engineering/gravity_generator)
+/obj/machinery/camera/motion{
+	c_tag = "Vault";
+	dir = 1;
+	network = list("vault")
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "bEy" = (
 /obj/machinery/computer/turbine_computer{
 	dir = 1;
@@ -28785,15 +28244,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
-"bPW" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bPX" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "bPZ" = (
 /obj/structure/chair{
 	dir = 1
@@ -28915,6 +28372,9 @@
 "bQC" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/effect/turf_decal/vg_decals/atmos/mix{
+	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
@@ -29349,9 +28809,16 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "bSp" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "bSq" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/loot_site_spawner,
@@ -29956,7 +29423,7 @@
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
 "bUU" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bUV" = (
@@ -29966,6 +29433,9 @@
 "bUW" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/effect/turf_decal/vg_decals/atmos/nitrous_oxide{
+	dir = 8
 	},
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
@@ -31132,7 +30602,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bYU" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bYV" = (
@@ -31142,6 +30612,9 @@
 "bYW" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/effect/turf_decal/vg_decals/atmos/plasma{
+	dir = 8
 	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
@@ -31948,11 +31421,6 @@
 /obj/machinery/light,
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"ccd" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cce" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32114,7 +31582,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ccB" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "ccC" = (
@@ -32124,6 +31592,9 @@
 "ccD" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide{
+	dir = 8
 	},
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
@@ -33060,6 +32531,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "chC" = (
@@ -33072,6 +32547,14 @@
 /area/maintenance/starboard/aft)
 "chD" = (
 /obj/effect/turf_decal/loading_area,
+/obj/machinery/camera{
+	c_tag = "Engineering Storage";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "chE" = (
@@ -33440,9 +32923,6 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "cjj" = (
@@ -33946,14 +33426,14 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "clT" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "clU" = (
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "clV" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "clW" = (
@@ -34069,14 +33549,23 @@
 /area/security/office)
 "cmU" = (
 /obj/machinery/light/small,
+/obj/effect/turf_decal/vg_decals/atmos/nitrogen{
+	dir = 1
+	},
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "cmV" = (
 /obj/machinery/light/small,
+/obj/effect/turf_decal/vg_decals/atmos/oxygen{
+	dir = 1
+	},
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "cmW" = (
 /obj/machinery/light/small,
+/obj/effect/turf_decal/vg_decals/atmos/air{
+	dir = 1
+	},
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "cmX" = (
@@ -34181,6 +33670,7 @@
 	pixel_y = 30
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/engineering/main)
 "cnY" = (
@@ -34281,12 +33771,19 @@
 "cpl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "cpq" = (
 /obj/structure/closet/toolcloset,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "cps" = (
@@ -34348,25 +33845,30 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "cpR" = (
-/obj/machinery/door/airlock{
-	name = "Observatory Access"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"cpV" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Storage";
+/obj/structure/chair/office/light{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/main)
-"cpW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/area/engineering/gravity_generator)
+"cpV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
+"cpW" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Holodeck Control";
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/commons/fitness)
 "cpX" = (
 /obj/structure/table,
 /obj/item/stack/rods/fifty,
@@ -34587,17 +34089,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
-"cqK" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cqL" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman,
+/obj/machinery/light,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "cqN" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -34689,17 +34189,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"crl" = (
-/obj/structure/table,
-/obj/item/taperecorder,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"crm" = (
-/obj/structure/table,
-/obj/item/storage/box/matches,
-/obj/item/storage/fancy/cigarettes,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cro" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -36287,13 +35776,23 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "cxW" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "cxY" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Escape Pod 1";
@@ -36780,9 +36279,9 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "cAQ" = (
-/obj/structure/chair,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "cAR" = (
 /obj/machinery/door/window{
 	dir = 1;
@@ -37041,9 +36540,15 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "cBP" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/engine/air,
-/area/engineering/atmos)
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/item/coin,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "cBR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -38271,15 +37776,11 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cJQ" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/chair/comfy/black{
+	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "cKx" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
@@ -38532,16 +38033,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "cRr" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron,
-/area/commons/fitness)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "cRD" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot{
@@ -38586,6 +38082,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
+"cSz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/command/nuke_storage)
 "cSE" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
@@ -39040,6 +38543,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/mixing)
+"dfw" = (
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/command/nuke_storage)
 "dfx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39159,6 +38668,15 @@
 /obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"dlY" = (
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/toilet)
 "dmq" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -39526,20 +39044,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"dJg" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "dJo" = (
 /obj/machinery/button/curtain{
 	id = "prisoncell3";
@@ -39572,13 +39076,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "dMS" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/computer/holodeck,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/dorms)
 "dMZ" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
@@ -39804,16 +39306,7 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "eat" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -39940,13 +39433,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"ejU" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/plasteel/twenty,
-/obj/item/wrench,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
 "ekG" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -40211,11 +39697,11 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "ezU" = (
-/obj/item/clothing/gloves/boxing/green,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/drinks/waterbottle,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/landmark/start/assistant,
+/obj/structure/cable,
+/obj/structure/chair/comfy/black,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "eAT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40337,11 +39823,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"eMD" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
 "eNr" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -40513,10 +39994,14 @@
 /turf/open/floor/plating,
 /area/security/office)
 "faH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "fbT" = (
@@ -40551,6 +40036,19 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"fds" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Gravity Generator Chamber";
+	req_access_txt = "19; 61"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "fep" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -40575,6 +40073,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"feM" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/toilet)
 "feO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -40601,6 +40105,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/locker)
+"fhG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "fie" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	external_pressure_bound = 120;
@@ -40692,6 +40205,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"fkH" = (
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "flc" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
 	dir = 1
@@ -40737,9 +40253,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "fnC" = (
-/obj/effect/decal/cleanable/ash,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/closed/wall,
+/area/commons/fitness)
 "fox" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
@@ -40911,10 +40429,6 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/clothing/gloves/botanic_leather,
 /obj/item/clothing/gloves/color/blue,
-/obj/item/caution,
-/obj/item/caution,
-/obj/item/caution,
-/obj/item/caution,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
@@ -41139,6 +40653,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"fGl" = (
+/obj/machinery/gravity_generator/main/station,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "fGq" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -41233,10 +40766,38 @@
 /obj/item/stack/sheet/iron/twenty,
 /turf/open/floor/plating,
 /area/security/prison)
+"fOl" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "fPh" = (
 /obj/structure/sign/painting/library,
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"fPm" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/gravity_generator)
 "fPO" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -41389,11 +40950,12 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "fXn" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/airlock{
+	id_tag = "Dorm6";
+	name = "Cabin 2"
 	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
+/turf/open/floor/wood,
+/area/commons/dorms)
 "fXF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -41571,12 +41133,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"gel" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/holodeck/rec_center)
 "geD" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
@@ -41633,22 +41189,15 @@
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "giQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Theater Backstage Service Hall";
-	req_access_txt = "46"
-	},
-/turf/open/floor/plastic,
-/area/hallway/secondary/service)
+/turf/open/floor/iron,
+/area/commons/fitness)
 "giT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -41674,13 +41223,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "gjD" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
 	},
-/obj/machinery/camera{
-	c_tag = "Holodeck Control";
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
@@ -41742,6 +41290,11 @@
 	icon_state = "wood-broken"
 	},
 /area/maintenance/port/aft)
+"gnd" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "gnf" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
@@ -41817,17 +41370,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
-"gsz" = (
-/obj/machinery/camera{
-	c_tag = "Fitness Room South";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "guf" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/structure/cable,
@@ -41896,6 +41438,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"gzV" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/command/meeting_room)
 "gAK" = (
 /obj/machinery/button/flasher{
 	id = "IsolationFlash";
@@ -41931,17 +41477,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "gBW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/commons/fitness)
 "gDa" = (
 /obj/effect/turf_decal/stripes/line,
@@ -41969,17 +41512,12 @@
 	},
 /area/security/prison/safe)
 "gDr" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/shower{
+	dir = 4
 	},
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/obj/item/soap,
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/dorms)
 "gEc" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -42007,11 +41545,19 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"gFn" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/iron,
-/area/commons/fitness)
+"gFS" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/darkblue,
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "gGW" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 6
@@ -42349,8 +41895,7 @@
 /turf/open/floor/iron,
 /area/science/misc_lab)
 "hau" = (
-/obj/machinery/gravity_generator/main/station,
-/obj/effect/turf_decal/bot_white,
+/obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -42362,7 +41907,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/ai_monitored/command/nuke_storage)
 "hbb" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 4
@@ -42423,15 +41968,23 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/brig)
+"hgs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/gravity_generator)
 "hgD" = (
 /obj/machinery/suit_storage_unit/security_peacekeeper,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "hgK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/closed/wall,
+/obj/structure/training_machine,
+/obj/item/target,
+/turf/open/floor/iron,
 /area/commons/fitness)
 "hgP" = (
 /obj/structure/disposalpipe/segment{
@@ -42588,6 +42141,18 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"hsx" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator";
+	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "hte" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
@@ -42663,8 +42228,7 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "hwE" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/mineral/titanium/blue,
 /area/commons/toilet)
 "hxq" = (
 /obj/structure/disposalpipe/segment{
@@ -42747,16 +42311,22 @@
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "hAV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/commons/dorms)
 "hBw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall,
+/turf/open/floor/iron,
 /area/commons/fitness)
 "hBY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -42946,6 +42516,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"hGX" = (
+/obj/machinery/computer/bank_machine,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "hHq" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
@@ -42975,12 +42563,18 @@
 /turf/open/floor/iron,
 /area/medical/virology)
 "hJT" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/button/door{
+	id = "Dorm6";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "hKu" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /obj/machinery/posialert{
@@ -43040,12 +42634,22 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "hQC" = (
-/obj/structure/urinal{
-	pixel_y = 32
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/training_toolbox{
+	pixel_y = 5
+	},
+/obj/structure/table,
+/obj/item/training_toolbox{
+	pixel_y = -2
+	},
+/turf/open/floor/iron,
+/area/commons/fitness)
 "hQK" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -43132,18 +42736,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"hVN" = (
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 8;
-	icon_state = "left";
-	name = "Fitness Ring"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "hWj" = (
 /obj/machinery/door/window/southleft{
 	dir = 4;
@@ -43181,15 +42773,11 @@
 	},
 /area/security/prison)
 "hXw" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
+/turf/open/floor/iron,
+/area/commons/dorms)
 "hXL" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -43247,11 +42835,11 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "ibL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/closed/wall,
-/area/commons/fitness)
+/turf/open/floor/iron,
+/area/commons/dorms)
 "icS" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -43691,9 +43279,9 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "izV" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
+/obj/item/clothing/gloves/boxing/green,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/drinks/waterbottle,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "iAM" = (
@@ -43726,6 +43314,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"iCO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/engineering/gravity_generator)
 "iEr" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -43822,6 +43418,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"iLJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "iLK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43864,10 +43466,6 @@
 "iQF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/main)
 "iSr" = (
@@ -44045,20 +43643,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "jcM" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/door/airlock/vault{
+	name = "Vault";
+	req_access_txt = "53"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/ai_monitored/command/nuke_storage)
 "jdF" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "permainner";
@@ -44150,6 +43741,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
+"jhN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "jib" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -44263,6 +43861,10 @@
 	dir = 5
 	},
 /area/security/prison/safe)
+"jms" = (
+/obj/structure/cable,
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/toilet)
 "jmA" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
 /turf/open/floor/iron/dark,
@@ -44306,6 +43908,17 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"jpB" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/gravity_generator)
 "jqo" = (
 /obj/machinery/computer/prisoner/management,
 /turf/open/floor/iron/showroomfloor,
@@ -44373,20 +43986,7 @@
 /turf/open/floor/iron/dark,
 /area/security/processing)
 "jtQ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/training_toolbox{
-	pixel_y = 5
-	},
-/obj/structure/table,
-/obj/item/training_toolbox{
-	pixel_y = -2
-	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "jud" = (
@@ -45018,12 +44618,13 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "kbz" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/vending/games,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
@@ -45216,15 +44817,30 @@
 /obj/item/storage/secure/briefcase,
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
-"khB" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
+"kfE" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
+"kgZ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
+"khB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/area/commons/fitness)
 "khQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -45289,20 +44905,10 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "kmR" = (
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	icon_state = "left";
-	name = "Fitness Ring"
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "kmZ" = (
 /obj/item/radio/intercom{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
@@ -45321,19 +44927,9 @@
 /area/security/prison/safe)
 "knx" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access_txt = "10"
-	},
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/trimline/neutral/filled/warning,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "koN" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -45573,9 +45169,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "kzK" = (
-/obj/structure/cable,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/dorms)
 "kzL" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -45627,6 +45225,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"kAt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/command/nuke_storage)
 "kAE" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -45657,6 +45261,18 @@
 "kBu" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
+"kCz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/command/nuke_storage)
+"kCD" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "kDo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -46075,12 +45691,11 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "leY" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/structure/training_machine,
-/obj/item/target,
+/obj/machinery/vending/dorms,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "lfF" = (
@@ -46116,25 +45731,12 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "lhD" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/west,
-/turf/open/floor/iron,
-/area/commons/fitness)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "lif" = (
 /obj/machinery/modular_computer/console/preset/id,
 /obj/machinery/light{
@@ -46327,11 +45929,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
 "lvJ" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "lwn" = (
 /turf/open/floor/iron/airless,
 /area/space/nearstation)
@@ -46543,6 +46145,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"lIJ" = (
+/obj/machinery/door/airlock{
+	name = "Showers"
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "lIZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -46638,6 +46246,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"lNi" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "lNo" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -46794,12 +46406,9 @@
 /turf/open/floor/iron,
 /area/science/misc_lab)
 "lSU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/tile/blue/darkblue,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "lTj" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Wing"
@@ -47460,13 +47069,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"mKj" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
 "mLn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -47514,15 +47116,16 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
 "mME" = (
-/obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/bounty_board{
+	dir = 1;
+	pixel_y = -32
 	},
-/turf/open/floor/plating,
-/area/engineering/gravity_generator)
+/turf/open/floor/iron,
+/area/commons/dorms)
 "mMH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -47555,6 +47158,10 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet/blue,
 /area/medical/psychology)
+"mNP" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain)
 "mNR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -47650,6 +47257,16 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/security/prison)
+"mRN" = (
+/obj/machinery/door/airlock/command{
+	name = "Conference Room";
+	req_access_txt = "19"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "mSf" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -47683,6 +47300,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"mUy" = (
+/obj/machinery/door/airlock/command{
+	name = "Captain's Office";
+	req_access_txt = "20"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "mUB" = (
 /obj/machinery/button/curtain{
 	id = "prisoncell2";
@@ -47703,12 +47330,6 @@
 /obj/effect/turf_decal/box/blue,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"mVU" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "mWd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -47722,15 +47343,24 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "mWI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/dorms)
 "mXr" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"mXA" = (
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "mXH" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -47856,15 +47486,15 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "ndD" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/item/radio/intercom{
+	pixel_y = -29
 	},
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/dorms)
 "ndR" = (
 /obj/structure/cable,
 /obj/machinery/photocopier,
@@ -47934,12 +47564,11 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "nlo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "nlx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48485,6 +48114,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/locker)
+"nLd" = (
+/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "nLS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -48581,22 +48224,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"nRy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "nRA" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/camera{
@@ -48632,6 +48259,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/art)
+"nTh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/command/nuke_storage)
 "nTD" = (
 /obj/structure/filingcabinet,
 /obj/machinery/power/apc/auto_name/north,
@@ -48781,16 +48417,16 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ofZ" = (
-/obj/machinery/holopad,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/dorms)
 "ogm" = (
 /turf/closed/wall,
 /area/science/storage)
@@ -49176,6 +48812,16 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/engineering/main)
+"oFd" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/darkblue,
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "oFG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted,
@@ -49202,9 +48848,6 @@
 	dir = 1
 	},
 /area/security/prison/safe)
-"oGZ" = (
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
 "oHk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -49255,14 +48898,11 @@
 /turf/open/floor/iron,
 /area/science/nanite)
 "oNd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/commons/dorms)
 "oND" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -49531,11 +49171,10 @@
 	},
 /area/security/prison/safe)
 "pbT" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
+/obj/machinery/light,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "pdW" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -49630,9 +49269,8 @@
 /turf/closed/wall,
 /area/maintenance/port/aft)
 "phX" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/fitness)
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "pii" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -50120,14 +49758,9 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "pFO" = (
-/obj/machinery/camera{
-	c_tag = "Holodeck - Fore";
-	name = "holodeck camera"
-	},
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/holodeck/rec_center)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall,
+/area/commons/fitness)
 "pGf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -50694,20 +50327,11 @@
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "qhl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/commons/dorms)
 "qil" = (
@@ -50907,10 +50531,13 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "quE" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "qvC" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -51099,6 +50726,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"qJG" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/toilet)
 "qJO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk,
@@ -51149,16 +50782,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "qMc" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/structure/table,
-/obj/item/toner/large,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 2;
+	sortType = 18
+	},
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "qNz" = (
@@ -51295,12 +50929,18 @@
 /turf/open/floor/wood,
 /area/security/prison)
 "qVn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/dorms)
 "qVU" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
@@ -51323,6 +50963,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"qWZ" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qXC" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -51940,6 +51585,13 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"rFQ" = (
+/obj/structure/window/reinforced,
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
+/area/service/theater)
 "rGy" = (
 /obj/structure/closet/secure_closet/freezer/meat{
 	req_access = null
@@ -52139,9 +51791,8 @@
 /turf/closed/wall,
 /area/maintenance/port)
 "rQR" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/closed/wall,
+/area/commons/fitness)
 "rRS" = (
 /obj/item/trash/energybar,
 /obj/effect/decal/cleanable/dirt,
@@ -52182,10 +51833,39 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"rUV" = (
-/obj/effect/decal/cleanable/dirt,
+"rTH" = (
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/hallway/primary/central)
+"rUV" = (
+/obj/structure/filingcabinet,
+/obj/item/folder/documents,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
+"rVc" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "Toilet2";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_y = 25;
+	specialfunctions = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/toilet)
 "rVn" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -52250,6 +51930,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"rZm" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "rZD" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
@@ -52322,16 +52008,10 @@
 /area/security/checkpoint/medical)
 "sed" = (
 /obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/dorms)
 "seq" = (
 /obj/structure/table,
 /obj/item/t_scanner,
@@ -52342,15 +52022,9 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "sgh" = (
-/obj/machinery/camera{
-	c_tag = "Holodeck - Aft";
-	dir = 1;
-	name = "holodeck camera"
-	},
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/holodeck/rec_center)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall,
+/area/commons/fitness)
 "sgR" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/green,
@@ -52622,11 +52296,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"swV" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port/aft)
 "swY" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -52906,6 +52575,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"sNV" = (
+/obj/structure/closet/toolcloset,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "sNY" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -53172,6 +52848,17 @@
 /obj/machinery/dna_scannernew,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"tdz" = (
+/obj/structure/cable,
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/toilet)
 "tej" = (
 /obj/machinery/destructive_scanner,
 /obj/effect/turf_decal/stripes/end,
@@ -53198,20 +52885,13 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "teG" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/fitness)
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "teJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53243,21 +52923,27 @@
 /turf/open/floor/iron,
 /area/science/nanite)
 "tgF" = (
-/obj/structure/table,
-/obj/item/wrench,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"thf" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/iron,
+/area/commons/dorms)
+"thf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
 /area/service/theater)
 "thn" = (
 /obj/structure/cable,
@@ -53282,10 +52968,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "tix" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fitness Maintenance";
-	req_access_txt = "12"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53374,24 +53056,13 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "tma" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+/obj/structure/chair/comfy/brown{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "tmz" = (
@@ -53443,7 +53114,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "tqo" = (
@@ -53529,6 +53199,13 @@
 /obj/item/circuitboard/machine/chem_dispenser/drinks,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"tue" = (
+/obj/effect/turf_decal/tile/blue/darkblue,
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "tuj" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -53602,11 +53279,16 @@
 /turf/open/floor/iron/white,
 /area/security/brig)
 "twX" = (
-/obj/structure/chair/plastic{
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/iron,
+/area/commons/dorms)
 "txz" = (
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -53772,10 +53454,34 @@
 	icon_state = "oldsmoothdirt"
 	},
 /area/security/prison)
+"tFu" = (
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "tGE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/vault{
+	name = "Vault";
+	req_access_txt = "53"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/navbeacon/wayfinding,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "tGP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -53813,6 +53519,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/processing)
+"tKh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "tKp" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral,
@@ -53990,6 +53703,21 @@
 	dir = 10
 	},
 /area/security/prison)
+"tSc" = (
+/obj/effect/turf_decal/bot_white/left,
+/obj/structure/closet/crate/silvercrate,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "tSO" = (
 /obj/structure/sink{
 	dir = 8;
@@ -54232,11 +53960,6 @@
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"uhq" = (
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
 "uhA" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -54254,6 +53977,24 @@
 /obj/structure/rack,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"uhQ" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "uio" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -54271,30 +54012,27 @@
 /turf/open/floor/iron/dark,
 /area/security/processing)
 "uiN" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 1
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
+/turf/open/floor/iron,
+/area/commons/dorms)
 "uku" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock{
+	id_tag = "Dorm5";
+	name = "Cabin 1"
+	},
+/turf/open/floor/wood,
 /area/commons/dorms)
 "ukw" = (
 /obj/structure/bed/maint,
@@ -54375,6 +54113,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
+"uoT" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/structure/closet/crate/goldcrate,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "upf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -54405,8 +54158,8 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "urc" = (
-/turf/closed/wall/r_wall,
-/area/engineering/gravity_generator)
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "urm" = (
 /obj/machinery/camera{
 	c_tag = " Prison - Abandoned Yard";
@@ -54415,6 +54168,26 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"uro" = (
+/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "urC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -54431,6 +54204,23 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"usa" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "usl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -54471,6 +54261,13 @@
 	},
 /turf/open/floor/iron,
 /area/science/misc_lab)
+"uvK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "uvZ" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 1";
@@ -54596,6 +54393,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"uzr" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "uzJ" = (
 /turf/open/floor/iron/dark/side{
 	dir = 9
@@ -54793,12 +54594,17 @@
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "uPR" = (
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/commons/fitness)
+/obj/machinery/disposal/bin,
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "uQX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55251,6 +55057,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"vmC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/door/airlock{
+	name = "Theater Backstage Service Hall";
+	req_access_txt = "46"
+	},
+/turf/open/floor/plastic,
+/area/service/theater)
 "vmG" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 1
@@ -55282,21 +55105,22 @@
 /turf/open/floor/plating,
 /area/security/office)
 "voE" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engineering/gravity_generator)
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "voM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/security/prison)
 "vpB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/vending/clothing,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/commons/fitness)
 "vpS" = (
@@ -55585,9 +55409,18 @@
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "vFR" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "vFS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown{
@@ -55839,16 +55672,15 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "vUu" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/camera{
+	c_tag = "Holodeck - Aft";
+	dir = 1;
+	name = "holodeck camera"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/turf/open/floor/engine{
+	name = "Holodeck Projector Floor"
 	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
+/area/holodeck/rec_center)
 "vVc" = (
 /obj/machinery/vending/clothing,
 /obj/machinery/light/small{
@@ -55941,15 +55773,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "wba" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/closed/wall/r_wall,
+/area/engineering/gravity_generator)
 "wbB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56469,6 +56294,27 @@
 /obj/structure/tank_holder/oxygen,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"wES" = (
+/obj/structure/safe,
+/obj/item/clothing/head/bearpelt,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/gun/ballistic/revolver/russian,
+/obj/item/ammo_box/a357,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "wFc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -56560,11 +56406,13 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "wIi" = (
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
 	},
-/area/maintenance/port/aft)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "wIo" = (
 /obj/machinery/deepfryer,
 /obj/machinery/light{
@@ -56934,6 +56782,26 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
+"wZU" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "xac" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 1
@@ -56953,16 +56821,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "xbg" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/engineering/gravity_generator)
+/turf/closed/wall/r_wall,
+/area/ai_monitored/command/nuke_storage)
 "xbF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -57011,14 +56871,11 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "xec" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Fitness Room South";
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/commons/fitness)
 "xeI" = (
 /obj/structure/table,
@@ -57153,6 +57010,20 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"xic" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "xiQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
@@ -57162,6 +57033,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"xiV" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "xjt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -57183,9 +57060,8 @@
 /turf/open/floor/iron,
 /area/science/storage)
 "xkH" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "xkP" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -57560,6 +57436,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/service)
+"xHC" = (
+/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "xHG" = (
 /obj/machinery/shower{
 	dir = 8
@@ -57629,18 +57520,14 @@
 	},
 /area/hallway/secondary/exit)
 "xNR" = (
-/obj/structure/closet/secure_closet/freezer/cream_pie,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/theater)
@@ -57800,8 +57687,9 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "xWd" = (
-/turf/closed/wall,
-/area/engineering/gravity_generator)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "xWn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57832,6 +57720,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"xXd" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/gravity_generator)
 "xXe" = (
 /obj/structure/closet/radiation,
 /obj/machinery/airalarm{
@@ -57892,22 +57787,11 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "xZS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
+	dir = 5
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/dorms)
+/turf/closed/wall,
+/area/commons/fitness)
 "yay" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/iron/grimy,
@@ -77804,7 +77688,7 @@ alU
 ali
 ali
 alU
-axm
+neA
 ayz
 ayz
 ayz
@@ -77815,7 +77699,7 @@ aBR
 aBR
 aBR
 aBR
-aLJ
+aLm
 aNl
 aOl
 aPA
@@ -78062,7 +77946,7 @@ xzh
 xzh
 aqQ
 neA
-ayB
+aqQ
 xzh
 xzh
 xzh
@@ -78071,7 +77955,7 @@ xzh
 xzh
 xzh
 xzh
-aJd
+aKw
 aLM
 joy
 aOs
@@ -78319,16 +78203,16 @@ xzh
 xzh
 aqQ
 axq
-ayB
+aqQ
 xzh
-aBa
-aBa
-aBa
-aBa
-aBa
-aBa
 xzh
-aJd
+xzh
+xzh
+xzh
+xzh
+xzh
+xzh
+aKw
 aLL
 bDe
 aOl
@@ -78576,16 +78460,16 @@ xzh
 xzh
 aqQ
 axq
-ayB
+aqQ
 xzh
-aBa
-aBT
-aDs
-aEN
-aGb
-aBa
 xzh
-aJd
+xzh
+xzh
+xzh
+xzh
+xzh
+xzh
+aKw
 aLN
 aNl
 aOi
@@ -78833,16 +78717,16 @@ aqQ
 aqQ
 arP
 axq
-ayB
+aqQ
 xzh
-aBa
-aBS
-aDr
-aEM
-aGa
-aHF
-aJd
-aJd
+xzh
+xzh
+xzh
+xzh
+xzh
+xzh
+xzh
+aKw
 aLN
 aNl
 aOl
@@ -79090,18 +78974,18 @@ aqR
 aqR
 aqR
 axq
-ayB
+aqQ
 xzh
-aBa
-aBV
-alu
-aso
-aGd
-aHG
-aJe
+xzh
+xzh
+xzh
+xzh
+xzh
+xzh
+xzh
 aKw
-aLP
-aMR
+aLN
+aNl
 aNU
 aPG
 aPG
@@ -79347,16 +79231,16 @@ aqQ
 aqQ
 arP
 axq
-ayB
+aqQ
 xzh
-aBa
-quE
-aDt
-aEO
-aGc
-aHF
-aJd
-aJd
+xzh
+xzh
+xzh
+xzh
+xzh
+xzh
+xzh
+aKw
 aLN
 aMQ
 aNT
@@ -79604,18 +79488,18 @@ xzh
 xzh
 aqQ
 axq
-ayB
+aqQ
 xzh
-aBa
-aBW
-aDv
-aEP
-aGe
-aBa
 xzh
-aJd
+xzh
+xzh
+xzh
+xzh
+xzh
+xzh
+aKw
 aLN
-jTW
+jhN
 aOn
 aPK
 aPK
@@ -79680,7 +79564,7 @@ uRx
 uRx
 xzh
 uRx
-xzh
+sUX
 xzh
 xzh
 xzh
@@ -79861,18 +79745,18 @@ xzh
 xzh
 aqQ
 axq
-ayB
+aqQ
 xzh
-aBa
-aBa
-aBa
-aBa
-aBa
-aBa
 xzh
-aJd
+xzh
+xzh
+xzh
+xzh
+xzh
+xzh
+aKw
 aLN
-jTW
+jhN
 aOl
 tsw
 aPK
@@ -79934,12 +79818,12 @@ bCq
 bUt
 bLv
 xzh
+sUX
 xzh
 xzh
+sUX
 xzh
-xzh
-xzh
-xzh
+sNY
 xzh
 xzh
 xzh
@@ -80118,7 +80002,7 @@ uRx
 uRx
 aqQ
 neA
-ayB
+aqQ
 xzh
 xzh
 xzh
@@ -80127,9 +80011,9 @@ xzh
 xzh
 xzh
 xzh
-aJd
+aKw
 aLN
-jTW
+jhN
 aOi
 aNl
 uAu
@@ -80191,10 +80075,10 @@ bCq
 bUt
 bLv
 xzh
+sUX
 xzh
 xzh
-xzh
-xzh
+sUX
 xzh
 xzh
 xzh
@@ -80374,7 +80258,7 @@ xzh
 arP
 avd
 arP
-axm
+neA
 ayE
 ayE
 ayE
@@ -80447,17 +80331,17 @@ suK
 bCq
 bUt
 bLv
-xzh
-xzh
-xzh
-xzh
-xzh
-sNY
-xzh
-xzh
-xzh
-xzh
-xzh
+sUX
+wba
+wba
+wba
+wba
+wba
+wba
+wba
+wba
+wba
+wba
 xzh
 xzh
 xzh
@@ -80705,16 +80589,16 @@ bCq
 bUt
 bLv
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+wba
+mXA
+rZm
+mXA
+mXA
+wba
+jpB
+fPm
+xXd
+wba
 xzh
 xzh
 xzh
@@ -80962,16 +80846,16 @@ bLv
 bUt
 bLv
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+wba
+xic
+uhQ
+nLd
+mXA
+hgs
+uvK
+fkH
+cAQ
+wba
 xzh
 xzh
 xzh
@@ -81219,16 +81103,16 @@ bLv
 bUt
 bLv
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+wba
+fOl
+iCO
+fGl
+tKh
+fds
+bPX
+bPX
+cAQ
+wba
 xzh
 xzh
 xzh
@@ -81476,17 +81360,17 @@ bLv
 bUt
 bLv
 xzh
+wba
+xHC
+usa
+xic
+mXA
+hgs
+cAQ
+bPX
+cAQ
+wba
 xzh
-xzh
-uRx
-xzh
-xzh
-xzh
-bCq
-bCq
-bLv
-bLv
-bLv
 xzh
 xzh
 xzh
@@ -81732,18 +81616,18 @@ iXm
 bLv
 bUt
 bCq
-bCq
-bLv
-bLv
-bCq
-bLv
-bLv
-bCq
-bCq
+xzh
+wba
+mXA
+kgZ
+mXA
+mXA
+wba
+gnd
 bPX
-cqK
-crl
-bLv
+cAQ
+wba
+xzh
 sUX
 sUX
 bBM
@@ -81988,19 +81872,19 @@ vVc
 vOr
 bCq
 bUt
-bSp
-bHE
-bPW
-bHE
+bCq
+sUX
 wba
-bHE
-swV
-bHE
+wba
+wba
+wba
+wba
+wba
 cpR
-bHE
+bPX
 cAQ
-crm
-bLv
+wba
+xzh
 xzh
 xzh
 bBM
@@ -82246,18 +82130,18 @@ bCq
 bCq
 bUt
 bCq
-bJf
-bHE
-cjI
-bCq
-tgF
-bPZ
-ccd
-bCq
+xzh
+sUX
+xzh
+xzh
+xzh
+xzh
+wba
+lNi
 wIi
 cqL
-bJe
-bLv
+wba
+xzh
 xzh
 xzh
 bBM
@@ -82509,11 +82393,11 @@ bCq
 bCq
 bCq
 ccw
-ccw
-ccw
-ccw
-ccw
-ccw
+wba
+wba
+hsx
+wba
+wba
 ccw
 xzh
 xzh
@@ -82770,7 +82654,7 @@ cnr
 chD
 cpV
 cpq
-cpq
+sNV
 ccw
 ccw
 xzh
@@ -83025,9 +82909,9 @@ ufp
 ccw
 ccw
 chB
+ckH
 cgR
-cpW
-blD
+cgR
 cqN
 cro
 ksk
@@ -83282,7 +83166,7 @@ cfe
 cfD
 ciN
 chE
-ciN
+iQF
 iQF
 cji
 cDZ
@@ -85539,9 +85423,9 @@ aZP
 bbh
 bcc
 bdd
-bbX
+gzV
 bfr
-bgM
+bbX
 bif
 aZM
 aZM
@@ -85798,17 +85682,17 @@ bfv
 bfv
 bfv
 bfv
-aZM
-aZM
-aZM
-urc
+mRN
+xbg
+xbg
 xzh
 xzh
 xzh
+xWd
 xzh
 xzh
 xzh
-xzh
+xWd
 xzh
 aJn
 aXf
@@ -86056,17 +85940,17 @@ bdf
 beb
 bfv
 urc
-urc
-urc
-urc
-urc
-urc
-xWd
-xWd
-xWd
-xWd
+xbg
 xzh
 xzh
+xzh
+xzh
+xWd
+xWd
+aJw
+aJw
+aJw
+xWd
 aJn
 aXf
 jpA
@@ -86313,19 +86197,19 @@ bbm
 beh
 bfv
 urc
-urc
-urc
-urc
-urc
-urc
 xbg
-mME
+xbg
+xbg
+xbg
+xbg
+xbg
+aJw
 voE
-xWd
-xzh
-xzh
-aJn
-aXf
+xiV
+xkH
+aJw
+aJw
+fhG
 ova
 aJq
 bCs
@@ -86570,18 +86454,18 @@ aZR
 aZR
 bft
 urc
-oGZ
-oGZ
-rUV
-rUV
+xbg
+hGX
+wZU
+uoT
 bnW
-aOy
-tGE
+xbg
+tue
 vFR
-xWd
-xWd
-xWd
-xWd
+voE
+xkH
+uzr
+aJw
 byS
 ova
 aJq
@@ -86827,18 +86711,18 @@ bdh
 bee
 bfv
 urc
-bih
-jcM
+xbg
+dfw
 bii
-rUV
+kAt
 bnV
 bph
 lSU
-aOy
+kfE
 btG
 buQ
-eMD
-bxI
+xkH
+knx
 bwa
 raE
 bBq
@@ -87087,14 +86971,14 @@ urc
 jcM
 big
 hau
-rUV
+nTh
 bnU
 tGE
-afr
+xkH
 aOz
 aPJ
 aga
-aga
+xkH
 knx
 bvW
 bAf
@@ -87341,18 +87225,18 @@ aEj
 bef
 bfv
 urc
-bgN
+xbg
 bqD
-bih
-rUV
+cSz
+kCz
 bEx
-tGE
+bph
 nlo
-tGE
+bpg
 bpg
 buS
-bwn
-xWd
+xkH
+knx
 bwh
 hDI
 aXf
@@ -87598,18 +87482,18 @@ aZR
 aZR
 bfw
 urc
-oGZ
+xbg
 rUV
-rUV
-rUV
-bnW
-tGE
-uhq
-aeE
-xWd
-xWd
-xWd
-xWd
+uro
+tSc
+wES
+xbg
+xkH
+xkH
+oFd
+gFS
+rTH
+aJw
 bwb
 ova
 bBr
@@ -87855,18 +87739,18 @@ bbm
 beh
 bfv
 urc
-urc
-urc
-urc
-urc
-urc
-ejU
-tGE
+xbg
+xbg
+xbg
+xbg
+xbg
+xbg
+aJw
 xkH
-xWd
-xzh
-xzh
-aJn
+iLJ
+tFu
+aJw
+aJw
 lfF
 ova
 bBu
@@ -88112,17 +87996,17 @@ aZU
 beg
 bfv
 urc
-urc
-urc
-urc
-urc
-urc
-xWd
-xWd
-xWd
-xWd
+xbg
 xzh
 xzh
+xzh
+xzh
+xWd
+xWd
+aJw
+aJw
+aJw
+xWd
 aJn
 aJq
 ova
@@ -88368,17 +88252,17 @@ bfv
 bfv
 bfv
 bfv
-aZV
-aZV
-aZV
-urc
+mUy
+xbg
+xbg
 xzh
 xzh
 xzh
+xWd
 xzh
 xzh
 xzh
-xzh
+xWd
 xzh
 aJn
 aJq
@@ -88625,7 +88509,7 @@ bch
 bdi
 bei
 bfy
-bgS
+bbw
 bik
 aZV
 aZV
@@ -89628,8 +89512,8 @@ aux
 avt
 axL
 bbl
-azT
-auk
+avt
+lvJ
 auk
 aDG
 aFd
@@ -89881,15 +89765,15 @@ arf
 arf
 arf
 arf
-auU
+arf
+cxW
+dMS
 awr
-awr
-api
 akV
+mME
 aAh
 aAh
 aAh
-aFh
 aAh
 aAh
 aAh
@@ -90137,18 +90021,18 @@ aqh
 arf
 aqo
 asp
+aHF
 arf
-auS
 axO
-awu
 awr
-aAd
+awr
+awr
+mWI
 aAh
-aCm
 aGk
-aFf
-aGk
-aHU
+aAh
+rVc
+aAh
 aJz
 aAh
 aLQ
@@ -90394,18 +90278,18 @@ aqh
 arf
 asm
 blU
-atQ
+blU
 avn
-awp
-axN
+awv
+awr
 kuW
-aAg
+awr
+ndD
 aAh
-aDO
 aDQ
-vUu
+aAh
 aGl
-ats
+aAh
 aBy
 aAh
 aMn
@@ -90425,7 +90309,7 @@ hec
 ben
 bfE
 bgX
-bbw
+mNP
 aGx
 bld
 bmD
@@ -90651,19 +90535,19 @@ aqh
 arf
 ari
 asu
+aHG
 arf
-avm
 avR
-axM
-awu
-aAf
+awr
+hXw
+awr
+aBz
 aAh
-hQC
-aDM
-aAh
-aAh
-aAh
-aBy
+hwE
+hwE
+hwE
+hwE
+hwE
 aAh
 ioJ
 ova
@@ -90909,19 +90793,19 @@ arf
 arf
 arf
 arf
-qhl
+arf
 aws
 axP
 azb
 aAi
-aAh
+qhl
 aCn
-aDM
-aAh
+jms
+tdz
 aGm
 aHV
 hwE
-aAh
+qJG
 aJq
 ova
 aJq
@@ -91165,15 +91049,15 @@ awn
 arf
 ask
 atm
+phX
 arf
-tma
 awu
-axO
+ezU
 aza
+kzK
+quE
 aAh
 aAh
-aAh
-aDS
 aAh
 aAh
 aAh
@@ -91427,14 +91311,14 @@ uku
 awv
 axX
 aze
-aAh
+awr
 aBz
-aBz
-aDU
 aAh
 aGn
-aHW
-aBy
+aGn
+aGn
+aAh
+feM
 aAh
 aJq
 aJq
@@ -91679,19 +91563,19 @@ dDR
 arf
 ark
 asL
+aHU
 arf
-xZS
 hAV
 axV
-azd
-azX
+awr
+awr
 aAZ
-aCe
+aAh
 aDT
-aAh
-aAh
-aAh
-aBy
+aDT
+aDT
+lIJ
+hwE
 aAh
 aCr
 aCr
@@ -91933,24 +91817,24 @@ agZ
 ajo
 apt
 dDR
-arj
-arj
-arj
-arj
-avx
+arf
+arf
+arf
+arf
+arf
 awz
-axR
-avx
-aAh
+axV
+awr
+awr
 aBA
-aBA
-aDP
 aAh
 aGp
-aHX
-hwE
+aGp
+aGp
 aAh
-aMq
+dlY
+qJG
+aMr
 adq
 aQb
 aPZ
@@ -92198,7 +92082,8 @@ avw
 awy
 axQ
 azj
-arj
+awr
+qVn
 aAh
 aAh
 aAh
@@ -92206,10 +92091,9 @@ aAh
 aAh
 aAh
 aAh
-aAh
-aMp
 aMr
-aOH
+aMr
+rFQ
 aPY
 aQc
 aRx
@@ -92447,17 +92331,17 @@ anb
 aoJ
 anZ
 apu
-arj
-asb
-qVn
-kzK
-kzK
+arf
+arf
+arf
+arf
+arf
 ofZ
-vpB
-nRy
-aAl
-arj
-aCq
+awr
+sed
+awr
+tgF
+aCr
 aDR
 aFl
 aGD
@@ -92697,24 +92581,24 @@ anc
 anc
 anc
 anc
-anc
-anc
-anc
+azX
+aAk
+aBB
 bkV
 fXZ
 anD
 qps
-arj
+arf
 arn
 phX
-hVN
+phX
 fXn
-fXn
-hXw
+ofZ
+awr
 sed
-aAk
-arj
-aCf
+awr
+tma
+aCr
 aDY
 aFj
 aGr
@@ -92786,7 +92670,7 @@ bMQ
 caO
 buw
 cla
-cBP
+clZ
 cmW
 bOh
 xzh
@@ -92948,30 +92832,30 @@ abq
 ahn
 ahn
 aiA
-aiA
-aiA
-ahn
-aiA
-aiA
-aiA
-ahn
-and
-anF
-ahn
 ahn
 apx
-ahT
-arj
+ahn
+asb
+anF
+axR
+ahn
+and
+ahn
+ahn
+arf
+arf
+arf
+arf
 asr
-azo
+phX
 hJT
-gBW
-dJg
-uPR
-gFn
-aAn
-arj
-aCh
+arf
+ofZ
+awr
+sed
+awr
+twX
+aCr
 eat
 thf
 xNR
@@ -93203,34 +93087,34 @@ aHs
 uVy
 abq
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
 ahn
+api
 ahn
+aqq
+ahn
+asb
+anF
+axR
+aAd
+aAl
 anE
 ahn
 gDr
 apw
 aqp
-arj
-asq
-azo
+phX
+phX
+aGa
 pbT
-gBW
+arf
 uiN
+awr
+sed
+awr
 uPR
-mVU
-aAm
-arj
 aCr
-giQ
-aCr
+cVb
+vmC
 aCr
 aCr
 aCr
@@ -93460,29 +93344,29 @@ xzh
 xzh
 adR
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
 ahn
+ahn
+ahn
+anF
+ahn
+asb
+anF
+axR
+aAf
+aAm
 anG
 ahn
 aoL
 apy
-aqq
-arj
+arf
+ask
 ast
-azo
+phX
 cJQ
-mKj
-mKj
+arf
+ofZ
 kmR
-azo
+ibL
 aAp
 aBC
 cpl
@@ -93711,38 +93595,38 @@ xzh
 xzh
 xzh
 xzh
+xWd
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+xWd
 xzh
 xzh
 xzh
 ahn
-khB
+arp
+ahn
+ahn
+avm
 ahn
 ahn
 ahn
 ahn
-arj
-ass
-azo
-faH
-mWI
-mWI
+ahn
+arf
+arf
+arf
+arf
+arf
+arf
+arf
+arf
+arf
 oNd
-azf
 aAo
-arj
-aBB
+aAo
+arf
+cVb
 myW
 myW
 aGy
@@ -93968,37 +93852,37 @@ xzh
 xzh
 xzh
 xzh
+xWd
 xzh
 xzh
 xzh
+xWd
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-aCS
-aCS
-aCS
-xzh
-xzh
-xzh
-arj
+bgR
+bgR
+rQR
+aso
+hBw
+axZ
+aAg
+aAn
+aBS
+aBV
+aBW
+aCq
+rQR
+aDS
 aua
-aua
+aGb
 ams
-aua
+aMR
 awB
 axY
-azh
-gsz
-arj
+hBw
+hBw
+azr
 cVb
 fPh
 myW
@@ -94225,36 +94109,36 @@ xzh
 xzh
 xzh
 xzh
-xzh
+aCS
 xzh
 ayw
 xzh
+aCS
 xzh
 xzh
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-aqr
+arq
+aso
+avx
+ayB
+ayB
+ayB
+ayB
+ayB
+aCe
+aCq
+rQR
 hBw
-asY
-asY
-atZ
-auB
-auB
-anW
-azp
-azp
+hBw
+hBw
+hBw
+hBw
+hBw
+axY
+hBw
+hBw
 azr
 aCu
 cVb
@@ -94482,38 +94366,38 @@ xzh
 xzh
 xzh
 xzh
+aCS
+aCS
+xzh
+aCS
+aCS
 xzh
 xzh
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-aqs
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aCv
+arq
+aso
+axm
+azd
+azd
+azd
+azd
+azd
+aCf
+aCq
+aDt
+aCq
+aCq
+aCq
+aCq
+aCq
+aCq
+axY
+jtQ
+hBw
+azr
+aCu
 fPh
 kWH
 dlp
@@ -94739,38 +94623,38 @@ xzh
 xzh
 xzh
 xzh
+ahT
+ahT
+xWd
+ahT
+ahT
 xzh
 xzh
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-aqs
-aro
-aro
-gel
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aCv
+arq
+aso
+axm
+azd
+azd
+azd
+azd
+azd
+aCf
+hBw
+hBw
+hBw
+hBw
+hBw
+hBw
+hBw
+hBw
+axY
+hBw
+hBw
+azr
+aCu
 dJS
 xLr
 xVA
@@ -94997,37 +94881,37 @@ xzh
 xzh
 xzh
 xzh
+xWd
+xzh
+xWd
 xzh
 xzh
 xzh
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-aqs
-aro
-aro
-aro
-aro
-aro
-aro
-gel
-aro
-aro
-aro
-aCv
+rQR
+ass
+axm
+azd
+azd
+azd
+azd
+azd
+aCf
+hBw
+rQR
+aEM
+aEP
+aGc
+hBw
+bgM
+bgM
+axY
+hBw
+hBw
+azr
+aCu
 cVb
 gQz
 aGA
@@ -95254,37 +95138,37 @@ xzh
 xzh
 xzh
 xzh
+alu
+xzh
+alu
 xzh
 xzh
 xzh
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-aqs
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aCv
+arq
+hBw
+axm
+azd
+azd
+azd
+azd
+azd
+aCf
+hBw
+rQR
+aEN
+aFf
+aGd
+aHW
+bgS
+cBP
+faH
+kbz
+leY
+vpB
+xec
 cVb
 rrd
 xVA
@@ -95520,28 +95404,28 @@ xzh
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-aqs
+arq
+hBw
+axm
+azd
+azd
+azd
+azd
+azd
+aCh
+hBw
+aDv
 pFO
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
+aFh
+aFh
+aHX
+arq
+arq
+giQ
+khB
+khB
 sgh
-aCv
+xZS
 cVb
 ijI
 goT
@@ -95777,25 +95661,25 @@ xzh
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+arq
+hBw
+axm
+azd
+azd
+azd
+azd
+azd
+aCf
+hBw
 aqs
 aro
 aro
 aro
 aro
-gel
 aro
 aro
-gel
+aro
+aro
 aro
 aro
 aCv
@@ -96034,20 +95918,20 @@ xzh
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-sNY
-xzh
-xzh
-xzh
-xzh
-xzh
+rQR
+asv
+axm
+azd
+azd
+azd
+azd
+azd
+aCf
+hBw
 aqs
 aro
 aro
-aro
+aGe
 aro
 aro
 aro
@@ -96291,16 +96175,16 @@ xzh
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+arq
+ats
+axm
+azd
+azd
+azd
+azd
+azd
+aCf
+hBw
 aqs
 aro
 aro
@@ -96308,7 +96192,7 @@ aro
 aro
 aro
 aro
-aro
+aGe
 aro
 aro
 aro
@@ -96543,21 +96427,21 @@ xzh
 xzh
 xzh
 xzh
+sNY
 xzh
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+arq
+auy
+axm
+azd
+azd
+azd
+azd
+azd
+aCf
+hBw
 aqs
 aro
 aro
@@ -96805,28 +96689,28 @@ xzh
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-ibL
-hBw
-hBw
-hBw
-auy
-auB
-auB
-axZ
-azr
-azr
-azr
-hgK
+arq
+auS
+axM
+azT
+azT
+azT
+azT
+azT
+aCm
+aDr
+aqs
+aEO
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+vUu
+aCv
 cVb
 cSk
 eAT
@@ -97062,28 +96946,28 @@ xzh
 xzh
 xzh
 xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-auB
-xec
-aua
-aua
-kbz
-arj
-xzh
-xzh
-xzh
+rQR
+auU
+axN
+axN
+axN
+aBa
+aBT
+aBT
+aBT
+aDs
+aqs
+aro
+aro
+aro
+aro
+aGe
+aro
+aro
+aGe
+aro
+aro
+aCv
 cVb
 xWM
 pOR
@@ -97318,29 +97202,29 @@ bBM
 bBM
 bBM
 bBM
-bBM
-bBM
-bBM
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-auB
-dMS
-cRr
-aua
-leY
-arj
-xzh
-alP
-alP
+sUX
+rQR
+rQR
+arq
+arq
+arq
+rQR
+arq
+arq
+arq
+rQR
+aqs
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aCv
 alP
 alP
 aGP
@@ -97577,7 +97461,6 @@ xzh
 xzh
 sUX
 xzh
-bBM
 xzh
 xzh
 xzh
@@ -97587,17 +97470,18 @@ xzh
 xzh
 xzh
 xzh
-xzh
-xzh
-auB
-ndD
-gjD
-aua
-jtQ
-arj
-xzh
-alP
-anf
+aqs
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aCv
 aDX
 alP
 aGH
@@ -97834,27 +97718,27 @@ age
 aee
 age
 xzh
-bBM
 xzh
 xzh
 xzh
 xzh
 xzh
 xzh
-aCS
-alO
-arp
-alO
-alP
-alP
-alP
-alP
-lvJ
-alP
-alP
-alP
-alP
-twX
+xzh
+xzh
+xzh
+aqs
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aCv
 fDD
 alP
 aGQ
@@ -98098,22 +97982,22 @@ xzh
 xzh
 xzh
 xzh
-aCS
-cxW
-anf
-aqv
-anf
-anf
-anf
-anf
-anf
-anf
-anf
-anf
-atB
+xzh
+xzh
+aDO
+pFO
+pFO
+pFO
+aJe
+arq
+arq
+gjD
+sgh
+sgh
+sgh
 fnC
 kPd
-alP
+cRr
 arr
 aGH
 aIp
@@ -98355,19 +98239,19 @@ xzh
 xzh
 xzh
 xzh
-aCS
-alO
-arp
-alO
-aqy
-anf
-anf
-awF
-anf
-anf
-anf
-anf
-alP
+xzh
+xzh
+xzh
+xzh
+xzh
+arq
+aLJ
+blD
+blD
+gBW
+rQR
+xzh
+xzh
 alP
 alP
 alP
@@ -98614,19 +98498,19 @@ xzh
 xzh
 xzh
 xzh
-apC
-apC
-apC
-apC
-apC
-apC
+xzh
+xzh
+xzh
+arq
+aMp
+bSp
+blD
+hgK
+rQR
+xzh
 alP
-anf
-anf
-anf
-anf
-anf
-anf
+alP
+kCD
 wBd
 aFm
 aIl
@@ -98872,16 +98756,16 @@ aof
 aof
 aof
 aof
-arq
-asv
-atv
-auD
-apC
-awF
-anf
+alP
+alP
 rQR
-anf
-anf
+aMq
+cpW
+blD
+hQC
+rQR
+alP
+alP
 aCz
 arI
 lHi
@@ -99131,16 +99015,16 @@ sDq
 aof
 kzL
 anf
-arx
+rQR
+rQR
+rQR
+cRr
+rQR
+rQR
 anf
-apC
-aoQ
-aod
-apl
-apl
 apl
 aCA
-aEl
+qWZ
 awD
 aGW
 aIp
@@ -99390,12 +99274,12 @@ arr
 arr
 arr
 arr
-apC
-awG
+alP
+anf
 aEe
-alP
-atB
-alP
+apl
+apl
+apl
 alP
 alP
 alO
@@ -99647,12 +99531,12 @@ art
 aoP
 atw
 arr
-apC
+alP
 awH
 aEe
-apE
-anf
-ezU
+alP
+atB
+alP
 alO
 xzh
 xzh
@@ -99904,7 +99788,7 @@ atB
 alP
 aty
 arr
-apC
+alP
 aoP
 aEe
 apE
@@ -100161,7 +100045,7 @@ anf
 alP
 aty
 arr
-apC
+alP
 alP
 aEe
 alP
@@ -100418,7 +100302,7 @@ anf
 alP
 atx
 arr
-apC
+alP
 auD
 aEe
 alP
@@ -100675,7 +100559,7 @@ anf
 alP
 apE
 auG
-apC
+alP
 aoP
 aEe
 apE

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -5345,8 +5345,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ayz" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/port/fore)
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "ayB" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -5374,7 +5376,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ayE" = (
-/turf/closed/wall/r_wall,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "ayG" = (
 /turf/closed/wall/r_wall,
@@ -6432,8 +6437,10 @@
 /turf/closed/wall,
 /area/commons/storage/primary)
 "aBR" = (
-/turf/closed/wall/r_wall,
-/area/commons/storage/primary)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "aBS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/west,
@@ -9127,8 +9134,7 @@
 /turf/open/floor/plating,
 /area/commons/storage/primary)
 "aKw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/hallway/primary/port)
 "aKy" = (
 /obj/structure/disposalpipe/segment,
@@ -9404,9 +9410,6 @@
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
 "aLl" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -9528,16 +9531,10 @@
 /obj/machinery/camera{
 	c_tag = "Port Hallway 2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aLM" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aLN" = (
@@ -37779,6 +37776,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "cKx" = (
@@ -38675,6 +38673,9 @@
 /obj/structure/sink{
 	pixel_y = 20
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/commons/toilet)
 "dmq" = (
@@ -39172,6 +39173,11 @@
 	dir = 1
 	},
 /area/security/prison)
+"dTG" = (
+/obj/structure/safe,
+/obj/item/toy/figure/clown,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "dUe" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/door/firedoor,
@@ -39353,6 +39359,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"ecS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/maintenance/fore)
 "eeU" = (
 /obj/structure/noticeboard{
 	dir = 1;
@@ -39394,6 +39406,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"ehM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "eio" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -39731,6 +39747,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
+"eEw" = (
+/obj/item/food/canned/beans,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "eFj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump/layer4{
@@ -39978,6 +39998,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/mixing)
+"eZu" = (
+/turf/open/floor/iron,
+/area/maintenance/fore)
 "eZH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -39987,6 +40010,10 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"eZS" = (
+/obj/effect/loot_site_spawner,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "fak" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -40954,6 +40981,8 @@
 	id_tag = "Dorm6";
 	name = "Cabin 2"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "fXF" = (
@@ -42437,6 +42466,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"hFk" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hFp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42573,6 +42606,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "hKu" = (
@@ -43613,6 +43647,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"jbp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/commons/toilet)
 "jbq" = (
 /obj/structure/cable,
 /obj/structure/tank_holder/extinguisher,
@@ -44907,6 +44947,7 @@
 "kmR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "kmZ" = (
@@ -44974,6 +45015,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"kqE" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/maintenance/fore)
 "krE" = (
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/meter/atmos/layer4,
@@ -45273,6 +45318,10 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kCI" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "kDo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -45489,6 +45538,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"kOn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/maintenance/fore)
 "kOw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	dir = 4
@@ -45682,6 +45737,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
+"lcp" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "leX" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -47343,14 +47404,8 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "mWI" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/carpet,
 /area/commons/dorms)
 "mXr" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
@@ -48248,6 +48303,11 @@
 	dir = 1
 	},
 /area/security/prison)
+"nSd" = (
+/obj/item/disk/holodisk,
+/obj/structure/frame/machine,
+/turf/open/floor/iron,
+/area/maintenance/fore)
 "nSw" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -48901,6 +48961,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/commons/dorms)
 "oND" = (
@@ -49173,6 +49234,7 @@
 "pbT" = (
 /obj/machinery/light,
 /obj/structure/table/wood/fancy/black,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "pdW" = (
@@ -50202,6 +50264,10 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"qcH" = (
+/obj/item/chair,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "qcV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -51516,6 +51582,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"rAC" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "rAF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/built,
@@ -51674,6 +51744,16 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/science/lab)
+"rKD" = (
+/obj/effect/turf_decal/tile/blue/darkblue{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Vault Lobby";
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "rKP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -52442,6 +52522,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
+"sHc" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "sHk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -53280,9 +53367,6 @@
 /area/security/brig)
 "twX" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -53330,6 +53414,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
+"tzr" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "tzz" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -53410,6 +53499,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/misc_lab)
+"tDC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/commons/fitness)
 "tDP" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -54245,6 +54340,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
+"utz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/maintenance/fore)
 "utD" = (
 /obj/structure/closet/bombcloset/security,
 /obj/effect/turf_decal/bot_blue,
@@ -56069,6 +56170,12 @@
 	},
 /turf/open/floor/wood,
 /area/security/prison)
+"wnG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/fore)
 "woJ" = (
 /turf/open/floor/carpet,
 /area/security/prison)
@@ -56229,6 +56336,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"wzU" = (
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "wAb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56928,6 +57041,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"xeQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "xfl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -57474,6 +57591,14 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xIY" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "DOOMSDAY PREPPER ZONE KEEPPP OUT";
+	req_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "xJJ" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -57507,6 +57632,12 @@
 "xKN" = (
 /turf/closed/wall,
 /area/science/genetics)
+"xKS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "xLr" = (
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
@@ -77689,17 +77820,17 @@ ali
 ali
 alU
 neA
-ayz
-ayz
-ayz
-aBR
-aBR
-aBR
-aBR
-aBR
-aBR
-aBR
-aLm
+alU
+alU
+alU
+aBQ
+aBQ
+aBQ
+aBQ
+aBQ
+aBQ
+aBQ
+lcp
 aNl
 aOl
 aPA
@@ -77946,15 +78077,15 @@ xzh
 xzh
 aqQ
 neA
-aqQ
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+ayE
+aqR
+aqR
+aqR
+aqR
+kCI
+aqR
+sHc
+tzr
 aKw
 aLM
 joy
@@ -78203,15 +78334,15 @@ xzh
 xzh
 aqQ
 axq
-aqQ
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+arP
+arP
+arP
+arP
+arP
+arP
+aqR
+arP
+arP
 aKw
 aLL
 bDe
@@ -78460,17 +78591,17 @@ xzh
 xzh
 aqQ
 axq
-aqQ
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+arP
+aqR
+aqR
+aqR
+aqR
+arP
+aqR
+hFk
+aqR
 aKw
-aLN
+aLE
 aNl
 aOi
 cOF
@@ -78717,17 +78848,17 @@ aqQ
 aqQ
 arP
 axq
-aqQ
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+arP
+kOn
+kOn
+utz
+aqR
+arP
+aqR
+rAC
+aqR
 aKw
-aLN
+aLE
 aNl
 aOl
 aPF
@@ -78974,17 +79105,17 @@ aqR
 aqR
 aqR
 axq
-aqQ
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+arP
+eZu
+nSd
+kqE
+aqR
+sHc
+aqR
+arP
+eZS
 aKw
-aLN
+aLE
 aNl
 aNU
 aPG
@@ -79231,17 +79362,17 @@ aqQ
 aqQ
 arP
 axq
-aqQ
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+arP
+wnG
+wnG
+ecS
+aqR
+arP
+aqR
+arP
+arP
 aKw
-aLN
+aLE
 aMQ
 aNT
 aPI
@@ -79488,17 +79619,17 @@ xzh
 xzh
 aqQ
 axq
-aqQ
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+arP
+aqR
+aqR
+aqR
+dTG
+arP
+aqR
+xIY
+eEw
 aKw
-aLN
+aLE
 jhN
 aOn
 aPK
@@ -79745,17 +79876,17 @@ xzh
 xzh
 aqQ
 axq
-aqQ
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+arP
+arP
+arP
+arP
+arP
+arP
+aqR
+arP
+qcH
 aKw
-aLN
+aLE
 jhN
 aOl
 tsw
@@ -80002,17 +80133,17 @@ uRx
 uRx
 aqQ
 neA
-aqQ
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
-xzh
+arP
+eZS
+aqR
+aqR
+aqR
+hFk
+aqR
+arP
+wzU
 aKw
-aLN
+aLE
 jhN
 aOi
 aNl
@@ -80259,16 +80390,16 @@ arP
 avd
 arP
 neA
+arP
+arP
+arP
+arP
+arP
+arP
 ayE
-ayE
-ayE
-ayE
-ayE
-ayE
-ayE
-ayE
-ayE
-ayE
+arP
+arP
+arP
 aLl
 cyT
 aOl
@@ -85688,11 +85819,11 @@ xbg
 xzh
 xzh
 xzh
-xWd
+sUX
 xzh
 xzh
 xzh
-xWd
+sUX
 xzh
 aJn
 aXf
@@ -85945,12 +86076,12 @@ xzh
 xzh
 xzh
 xzh
-xWd
-xWd
+sUX
+sUX
 aJw
 aJw
 aJw
-xWd
+sUX
 aJn
 aXf
 jpA
@@ -86204,7 +86335,7 @@ xbg
 xbg
 xbg
 aJw
-voE
+rKD
 xiV
 xkH
 aJw
@@ -88001,12 +88132,12 @@ xzh
 xzh
 xzh
 xzh
-xWd
-xWd
+sUX
+sUX
 aJw
 aJw
 aJw
-xWd
+sUX
 aJn
 aJq
 ova
@@ -88258,11 +88389,11 @@ xbg
 xzh
 xzh
 xzh
-xWd
+sUX
 xzh
 xzh
 xzh
-xWd
+sUX
 xzh
 aJn
 aJq
@@ -90027,7 +90158,7 @@ axO
 awr
 awr
 awr
-mWI
+aBz
 aAh
 aGk
 aAh
@@ -90546,7 +90677,7 @@ aAh
 hwE
 hwE
 hwE
-hwE
+jbp
 hwE
 aAh
 ioJ
@@ -92337,7 +92468,7 @@ arf
 arf
 arf
 ofZ
-awr
+axV
 sed
 awr
 tgF
@@ -92590,11 +92721,11 @@ anD
 qps
 arf
 arn
-phX
-phX
+mWI
+aHw
 fXn
 ofZ
-awr
+axV
 sed
 awr
 tma
@@ -92851,7 +92982,7 @@ phX
 hJT
 arf
 ofZ
-awr
+axV
 sed
 awr
 twX
@@ -93108,7 +93239,7 @@ aGa
 pbT
 arf
 uiN
-awr
+axV
 sed
 awr
 uPR
@@ -93361,7 +93492,7 @@ apy
 arf
 ask
 ast
-phX
+ehM
 cJQ
 arf
 ofZ
@@ -93879,7 +94010,7 @@ aGb
 ams
 aMR
 awB
-axY
+xKS
 hBw
 hBw
 azr
@@ -94130,13 +94261,13 @@ ayB
 aCe
 aCq
 rQR
+ayz
 hBw
 hBw
 hBw
 hBw
-hBw
-hBw
-axY
+xeQ
+xKS
 hBw
 hBw
 azr
@@ -94387,13 +94518,13 @@ azd
 aCf
 aCq
 aDt
-aCq
-aCq
-aCq
-aCq
-aCq
-aCq
-axY
+aBR
+aBR
+aBR
+aBR
+aBR
+aBR
+xKS
 jtQ
 hBw
 azr
@@ -94908,7 +95039,7 @@ hBw
 bgM
 bgM
 axY
-hBw
+tDC
 hBw
 azr
 aCu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tweaks and fixes for box. No more errors, buttt.
The dorms are now oldbases' version. Honk?
The vault has been moved to the center of the station again. The gravity generator is now on the exterior of the station.
Where the vault USED to be is now maintenance.
![image](https://user-images.githubusercontent.com/50649185/115327505-16b62b80-a15d-11eb-9753-cdbcf1a6adac.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pays homage to the infamous icebox pool by re-adding oldbase's version, and helps prevent gamer loneops (which still can happen occasionally, apparently) a bit by having the vault in the center of the station
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The vault on NSS Journey has been moved to the center of the station.
add: Nanotrasen continues to deny that pools have any affect on bluespace time, and request all personnel stop asking about it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
