### PR TITLE
Disables the electrical welder and brings back OG e-welder, pending fixes.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -72,6 +72,7 @@
 		/obj/item/airlock_painter,
 		/obj/item/pipe_painter,
 		/obj/item/weldingtool/experimental
+		))
 
 /obj/item/storage/belt/utility/chief
 	name = "\improper Chief Engineer's toolbelt" //"the Chief Engineer's toolbelt", because "Chief Engineer's toolbelt" is not a proper noun

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -71,8 +71,7 @@
 		/obj/item/plunger,
 		/obj/item/airlock_painter,
 		/obj/item/pipe_painter,
-		/obj/item/weldingtool_electric //SKYRAT EDIT ADDITION
-		))
+		/obj/item/weldingtool/experimental
 
 /obj/item/storage/belt/utility/chief
 	name = "\improper Chief Engineer's toolbelt" //"the Chief Engineer's toolbelt", because "Chief Engineer's toolbelt" is not a proper noun
@@ -84,7 +83,7 @@
 /obj/item/storage/belt/utility/chief/full/PopulateContents()
 	new /obj/item/screwdriver/power(src)
 	new /obj/item/crowbar/power(src)
-	new /obj/item/weldingtool_electric(src) //SKYRAT EDIT CHANGE //This can be changed if this is too much
+	new /obj/item/weldingtool/experimental
 	new /obj/item/multitool(src)
 	new /obj/item/stack/cable_coil(src)
 	new /obj/item/extinguisher/mini(src)
@@ -103,7 +102,7 @@
 /obj/item/storage/belt/utility/full/powertools/PopulateContents()
 	new /obj/item/screwdriver/power(src)
 	new /obj/item/crowbar/power(src)
-	new /obj/item/weldingtool_electric(src) //SKYRAT EDIT CHANGE
+	new /obj/item/weldingtool/experimental
 	new /obj/item/multitool(src)
 	new /obj/item/holosign_creator/atmos(src)
 	new /obj/item/extinguisher/mini(src)

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -23,7 +23,6 @@
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
-/* SKYRAT EDIT MOVAL - MOVED TO MODULAR
 /datum/design/exwelder
 	name = "Experimental Welding Tool"
 	desc = "An experimental welder capable of self-fuel generation."
@@ -33,7 +32,6 @@
 	build_path = /obj/item/weldingtool/experimental
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
-*/
 
 /datum/design/rpd
 	name = "Rapid Pipe Dispenser (RPD)"

--- a/modular_skyrat/modules/electric_welder/code/electric_welder.dm
+++ b/modular_skyrat/modules/electric_welder/code/electric_welder.dm
@@ -95,7 +95,8 @@
 		inhand_icon_state = "[initial(inhand_icon_state)]"
 	return ..()
 
-/datum/design/exwelder
+// Disabled cause it's broke as shit
+/* /datum/design/exwelder
 	name = "Electrical Welding Tool"
 	desc = "An experimental welding tool capable of creating a flame using electricity."
 	id = "exwelder"
@@ -103,4 +104,4 @@
 	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500, /datum/material/plasma = 1500, /datum/material/uranium = 200)
 	build_path = /obj/item/weldingtool_electric
 	category = list("Tool Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's incredibly broken, to the point where people (or at least, myself) would rather forgo it for a standard welder. Making it the only option at this stage is... a bad idea.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: brings back the classic experiemental welder, pending fixes to the electrical welder
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
