### PR TITLE
[NONMODULAR] Why does Heretic have so much RR

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -239,14 +239,15 @@
 	var/obj/item/bodypart/head/head = locate() in human_user.bodyparts
 	if(head)
 		head.dismember()
-		qdel(head)
+	//	qdel(head) //SKYRAT REMOVAL - RR bad, but funny head goes pop is funny, so let's leave that
 	else
 		human_user.gib()
 
-	var/datum/effect_system/reagents_explosion/explosion = new()
+//SKYRAT REMOVAL START - Probably don't need this if we're just decapping now
+	/*var/datum/effect_system/reagents_explosion/explosion = new()
 	explosion.set_up(1, get_turf(human_user), TRUE, 0)
-	explosion.start()
-
+	explosion.start()*/ 
+//SKYRAT REMOVAL END 
 
 /obj/effect/broken_illusion/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If you used telekinesis on a pierced reality, it would straight up qdel your head. Now it just decaps you. Still funny, but less round removal
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

RR Bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:c:
del: Heretic's round removal edge case has been removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
