### PR TITLE
[MODULAR] Revolution Ammo Gunset Fix

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
@@ -178,7 +178,7 @@
 	new /obj/item/ammo_box/revolver/revolution(src)
 	new /obj/item/ammo_box/revolver/revolution(src)
 	new /obj/item/ammo_box/revolver/revolution(src)
-	new /obj/item/ammo_box/advanced/b12mm/rubber(src)
+	new /obj/item/ammo_box/advanced/b9mm/rubber(src)
 
 
 /////////////////


### PR DESCRIPTION


## About The Pull Request

Corrects the revolution to actually spawn with its ammo

## Why It's Good For The Game
The revolution spawns with the wrong ammo, this fixes that.

## Changelog
:cl:
fix: The revolution gunset now holds the guns appropriate rubber ammo.
/:cl:
