### PR TITLE
Revert "[NonModular] Sepia/lightpink rebalance"

### DIFF
--- a/code/modules/movespeed/modifiers/status_effects.dm
+++ b/code/modules/movespeed/modifiers/status_effects.dm
@@ -5,7 +5,7 @@
 	multiplicative_slowdown = 3
 
 /datum/movespeed_modifier/status_effect/lightpink
-	multiplicative_slowdown = -0.25 //SKYRAT EDIT: Oiriginal value (-0.5)
+	multiplicative_slowdown = -0.5
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/status_effect/tarfoot

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -684,11 +684,11 @@
 /datum/status_effect/stabilized/sepia/tick()
 	if(prob(50) && mod > -1)
 		mod--
-		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, multiplicative_slowdown = -0.2) //SKYRAT EDIT: Original value (-0.5)
+		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, multiplicative_slowdown = -0.5)
 	else if(mod < 1)
 		mod++
 		// yeah a value of 0 does nothing but replacing the trait in place is cheaper than removing and adding repeatedly
-		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, multiplicative_slowdown = -0.1) //SKYRAT EDIT: Original value (0)
+		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, multiplicative_slowdown = 0)
 	return ..()
 
 /datum/status_effect/stabilized/sepia/on_remove()


### PR DESCRIPTION
With this new upstream PR: https://github.com/Skyrat-SS13/Skyrat-tg/pull/5117 We have a better balance for them.
Thus this one isn't gonna be needed anymore if we merge it.
Fun fact, clicking Revert doesn't given you the usual format.
So I am doing this one free-form baby.
So you can pick pink and be a pacifist, or pick Sepia and have it randomly not work.
Boom, balance.