### PR TITLE
[Modular] Cybersun, The Builder's Paradise Upgrade

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/forgottenship_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/forgottenship_skyrat.dmm
@@ -1200,8 +1200,8 @@
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "dz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/cybersun/atmospherics)
 "dA" = (
@@ -1299,9 +1299,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/cybersun/atmospherics)
 "iM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/cybersun/atmospherics)
 "iV" = (
@@ -1422,7 +1422,7 @@
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
 "nt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/cybersun/atmospherics)
 "nL" = (
@@ -1605,12 +1605,11 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "sP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/structure/lattice,
 /turf/template_noop,
 /area/ruin/space/has_grav/cybersun/atmospherics)
 "sU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/cybersun/atmospherics)
 "tc" = (
@@ -1678,15 +1677,15 @@
 /area/ruin/space/has_grav/cybersun/atmospherics)
 "vF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/cybersun/atmospherics)
 "vP" = (
 /obj/machinery/door/airlock/atmos,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/cybersun/atmospherics)
 "wf" = (
@@ -1744,9 +1743,9 @@
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "yp" = (
 /obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/cybersun/atmospherics)
 "yq" = (
@@ -1801,6 +1800,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"zE" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/template_noop,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "zQ" = (
 /obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
@@ -2052,8 +2056,8 @@
 /area/ruin/space/has_grav/cybersun/atmospherics)
 "LF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/cybersun/atmospherics)
 "LH" = (
@@ -4179,7 +4183,7 @@ aa
 aa
 aa
 aa
-sP
+zE
 Vr
 XJ
 IY

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/forgottenship_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/forgottenship_skyrat.dmm
@@ -1316,7 +1316,9 @@
 /turf/template_noop,
 /area/template_noop)
 "jx" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	start_charge = 0
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/cybersun/atmospherics)

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/forgottenship_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/forgottenship_skyrat.dmm
@@ -325,8 +325,8 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "aY" = (
-/turf/template_noop,
-/area/ruin/unpowered/no_grav)
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "aZ" = (
 /turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
@@ -451,6 +451,10 @@
 /obj/item/pen,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"bv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "bx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen/interrogation{
@@ -473,11 +477,6 @@
 	req_one_access_txt = "150"
 	},
 /obj/item/language_manual/codespeak_manual/unlimited,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
-/obj/item/modular_computer/laptop/preset/syndicate,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
 "bB" = (
@@ -1200,10 +1199,11 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "dz" = (
-/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/structure/cable,
-/turf/template_noop,
-/area/ruin/unpowered/no_grav)
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "dA" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/dark,
@@ -1216,6 +1216,13 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"er" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "eu" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -1240,6 +1247,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"gc" = (
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"go" = (
+/obj/effect/turf_decal/vg_decals/atmos/air{
+	dir = 4
+	},
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"gs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "gy" = (
 /turf/closed/mineral,
 /area/ruin/unpowered/no_grav)
@@ -1274,6 +1294,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"is" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"iM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "iV" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -1281,6 +1311,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"iY" = (
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"jx" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"kl" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "ky" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
@@ -1288,6 +1333,13 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"kG" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/crate/solarpanel_small,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "kH" = (
 /obj/machinery/door/window{
 	dir = 1;
@@ -1331,6 +1383,14 @@
 /obj/item/crowbar/red,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"lI" = (
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"lM" = (
+/obj/machinery/door/airlock/external,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "lV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -1361,6 +1421,10 @@
 /obj/item/clothing/mask/chameleon,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
+"nt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "nL" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -1377,6 +1441,10 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"ok" = (
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "oE" = (
 /obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
@@ -1393,6 +1461,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"pa" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"pv" = (
+/obj/item/stack/circuit_stack/full,
+/obj/structure/closet/crate/secure/gear{
+	req_one_access_txt = "150"
+	},
+/obj/item/stack/circuit_stack/full,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "pB" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -1494,6 +1577,17 @@
 /obj/item/card/id/advanced/chameleon,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
+"rZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"sl" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/general/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "ss" = (
 /obj/structure/frame/machine,
 /obj/structure/window/reinforced/spawner,
@@ -1510,6 +1604,15 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"sP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"sU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "tc" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -1559,6 +1662,33 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
+"vj" = (
+/obj/structure/closet/crate/secure/gear{
+	req_one_access_txt = "150"
+	},
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/obj/item/modular_computer/laptop/preset/syndicate,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_forgotten_cargopod)
+"vE" = (
+/turf/open/floor/engine/n2,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"vF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"vP" = (
+/obj/machinery/door/airlock/atmos,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "wf" = (
 /turf/open/floor/mineral/plastitanium{
 	icon_state = "plastitanium_dam1"
@@ -1580,8 +1710,20 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "xz" = (
+/obj/item/circuitboard/machine/spaceship_navigation_beacon,
+/obj/item/circuitboard/machine/spaceship_navigation_beacon,
+/obj/item/circuitboard/machine/spaceship_navigation_beacon,
+/obj/item/circuitboard/machine/spaceship_navigation_beacon,
+/obj/item/circuitboard/machine/spaceship_navigation_beacon,
+/obj/item/circuitboard/machine/spaceship_navigation_beacon,
+/obj/item/circuitboard/machine/spaceship_navigation_beacon,
+/obj/item/circuitboard/machine/spaceship_navigation_beacon,
+/obj/item/circuitboard/machine/spaceship_navigation_beacon,
+/obj/item/circuitboard/machine/spaceship_navigation_beacon,
+/obj/structure/closet/crate/secure/gear{
+	req_one_access_txt = "150"
+	},
 /obj/machinery/light,
-/obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "xF" = (
@@ -1600,6 +1742,16 @@
 /obj/item/storage/bag/tray,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"yp" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"yq" = (
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "yy" = (
 /obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
@@ -1614,6 +1766,12 @@
 /obj/item/skillchip/job/roboticist,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
+"yA" = (
+/obj/effect/turf_decal/vg_decals/atmos/oxygen{
+	dir = 4
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "yK" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -1643,6 +1801,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"zQ" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/n2,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"Ag" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/open/floor/engine/n2,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "Aq" = (
 /turf/open/floor/mineral/plastitanium{
 	icon_state = "plastitanium_dam4"
@@ -1673,6 +1841,10 @@
 /obj/machinery/griddle,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"Cq" = (
+/obj/structure/rack,
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "Df" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -1687,8 +1859,8 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "Dr" = (
-/turf/closed/mineral/random/high_chance,
-/area/template_noop)
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "DA" = (
 /obj/machinery/mineral/ore_redemption{
 	name = "Syndicate ore redemption machine";
@@ -1697,10 +1869,28 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
+"DL" = (
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "DN" = (
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
+"Ed" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"Eh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"EE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4
+	},
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "Fu" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -1725,6 +1915,13 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"GN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "Ha" = (
 /obj/structure/closet/syndicate{
 	anchored = 1;
@@ -1749,6 +1946,9 @@
 "Hp" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"Hr" = (
+/turf/closed/mineral/random,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "Ih" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -1788,6 +1988,14 @@
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"IY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"Jf" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "JC" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/iron/dark,
@@ -1819,15 +2027,42 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"KB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"KD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "Lr" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"Lv" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"LF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "LH" = (
 /obj/effect/decal/cleanable/robot_debris/limb,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"MB" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "MD" = (
 /obj/machinery/door/password/voice/sfc{
 	password = null
@@ -1901,6 +2136,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"OM" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"OS" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/template_noop,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "Ps" = (
 /obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
@@ -1959,6 +2205,11 @@
 /obj/machinery/microwave,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"RN" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/template_noop,
+/area/template_noop)
 "RP" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -1975,6 +2226,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"SI" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "Tj" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -2021,6 +2277,12 @@
 /obj/machinery/computer/bookmanagement,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"UN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4
+	},
+/turf/open/floor/engine/n2,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "UV" = (
 /obj/structure/window/reinforced/spawner,
 /obj/machinery/hydroponics/constructable,
@@ -2029,6 +2291,27 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"Vr" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"Vs" = (
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"Vv" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"Vw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
+"VF" = (
+/obj/effect/turf_decal/vg_decals/atmos/nitrogen{
+	dir = 4
+	},
+/turf/open/floor/engine/n2,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "VG" = (
 /obj/structure/cable,
 /obj/machinery/door/window{
@@ -2066,6 +2349,10 @@
 /obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"XJ" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 "XM" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner,
@@ -2115,6 +2402,7 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
 "Zc" = (
@@ -2127,6 +2415,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
+"Zm" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/cybersun/atmospherics)
 
 (1,1,1) = {"
 aa
@@ -2153,8 +2445,33 @@ aa
 aa
 aa
 aa
-Dr
-Dr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bU
+bU
 aa
 aa
 aa
@@ -2193,9 +2510,34 @@ aa
 aa
 aa
 aa
-Dr
-Dr
-Dr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bU
+bU
+bU
 aa
 aa
 aa
@@ -2234,8 +2576,33 @@ aa
 aa
 aa
 aa
-Dr
-Dr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bU
+bU
 aa
 aa
 aa
@@ -2249,6 +2616,31 @@ aa
 aa
 "}
 (4,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aq
@@ -2291,6 +2683,31 @@ aa
 (5,1,1) = {"
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aq
 aq
 aq
@@ -2330,6 +2747,31 @@ aa
 "}
 (6,1,1) = {"
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ad
 aq
 aq
@@ -2363,13 +2805,38 @@ aa
 aa
 aa
 aa
-Dr
-Dr
-Dr
+bU
+bU
+bU
 aa
 "}
 (7,1,1) = {"
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 bZ
 bZ
 bZ
@@ -2404,11 +2871,36 @@ aa
 aa
 aa
 aa
-Dr
-Dr
-Dr
+bU
+bU
+bU
 "}
 (8,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 bZ
 as
@@ -2449,6 +2941,31 @@ aa
 aa
 "}
 (9,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 af
 ap
 dm
@@ -2489,6 +3006,31 @@ aa
 aa
 "}
 (10,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 af
 dm
 au
@@ -2514,11 +3056,11 @@ aa
 aa
 aa
 aa
-aY
-aY
-aY
-aY
-aY
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -2529,6 +3071,31 @@ aa
 aa
 "}
 (11,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 af
 dk
 dt
@@ -2552,14 +3119,14 @@ aa
 aa
 aa
 aa
-aY
-aY
-aY
+aa
+aa
+aa
 ba
 bU
 ba
-aY
-aY
+aa
+aa
 aa
 aa
 aa
@@ -2569,6 +3136,31 @@ aa
 aa
 "}
 (12,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 bZ
 bZ
 bZ
@@ -2591,16 +3183,16 @@ aa
 aa
 aa
 aa
-aY
-aY
+aa
+aa
 ba
 ba
 ba
 ba
 ba
 ba
-aY
-aY
+aa
+aa
 aa
 aa
 aa
@@ -2609,6 +3201,31 @@ aa
 aa
 "}
 (13,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 bZ
 ae
 dm
@@ -2630,8 +3247,8 @@ aa
 aa
 aa
 aa
-aY
-aY
+aa
+aa
 ba
 ba
 aZ
@@ -2640,7 +3257,7 @@ aZ
 aZ
 ba
 ba
-aY
+aa
 aa
 aa
 aa
@@ -2649,6 +3266,31 @@ aa
 aa
 "}
 (14,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 bZ
 bV
 dm
@@ -2669,8 +3311,8 @@ bZ
 aa
 aa
 aa
-aY
-aY
+aa
+aa
 ba
 ba
 aZ
@@ -2680,7 +3322,7 @@ my
 aZ
 aZ
 ba
-aY
+aa
 aa
 aa
 aa
@@ -2689,6 +3331,31 @@ aa
 aa
 "}
 (15,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 bZ
 ag
 dm
@@ -2709,7 +3376,7 @@ bZ
 aa
 aa
 aa
-aY
+aa
 ba
 ba
 ba
@@ -2720,8 +3387,8 @@ hU
 rU
 aZ
 ba
-aY
-aY
+aa
+aa
 aa
 aa
 aa
@@ -2729,6 +3396,31 @@ aa
 aa
 "}
 (16,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 dg
 bZ
 ch
@@ -2749,7 +3441,7 @@ dg
 aa
 aa
 aa
-aY
+aa
 ba
 bU
 ba
@@ -2761,7 +3453,7 @@ mZ
 aZ
 ba
 bU
-aY
+aa
 aa
 aa
 aa
@@ -2769,6 +3461,31 @@ aa
 aa
 "}
 (17,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 bZ
 bZ
@@ -2789,8 +3506,8 @@ aa
 aa
 aa
 aa
-aY
-aY
+aa
+aa
 ba
 ba
 aZ
@@ -2801,14 +3518,39 @@ YT
 aZ
 ba
 ba
-aY
-aY
+aa
+aa
 aa
 aa
 aa
 aa
 "}
 (18,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 bZ
 av
@@ -2829,7 +3571,7 @@ aa
 aa
 aa
 aa
-aY
+aa
 ba
 ba
 ba
@@ -2842,13 +3584,38 @@ aZ
 ba
 ba
 ba
-aY
-aY
+aa
+aa
 aa
 aa
 aa
 "}
 (19,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 bZ
 ay
@@ -2869,7 +3636,7 @@ aa
 aa
 aa
 aa
-aY
+aa
 ba
 ba
 bU
@@ -2883,12 +3650,37 @@ ba
 ba
 ba
 ba
-aY
+aa
 aa
 aa
 aa
 "}
 (20,1,1) = {"
+aa
+aa
+aa
+aa
+Vs
+Vs
+Vs
+Vs
+Vs
+Vs
+Vs
+Vs
+Vs
+Vs
+Vs
+Vs
+Vs
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 bZ
 aA
@@ -2909,8 +3701,8 @@ aa
 aa
 aa
 aa
-aY
-aY
+aa
+aa
 ba
 ba
 dd
@@ -2921,14 +3713,39 @@ vh
 bb
 ba
 ba
-aY
-aY
-aY
+aa
+aa
+aa
 aa
 aa
 aa
 "}
 (21,1,1) = {"
+aa
+aa
+aa
+aa
+Vs
+gc
+yA
+gc
+Vs
+vE
+VF
+vE
+Vs
+yq
+go
+yq
+Vs
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 bZ
 am
@@ -2950,7 +3767,7 @@ aa
 aa
 aa
 aa
-aY
+aa
 ba
 ba
 bb
@@ -2960,15 +3777,40 @@ DA
 bj
 bb
 ba
-aY
-aY
-aY
-aY
+aa
+aa
+aa
+aa
 aa
 aa
 aa
 "}
 (22,1,1) = {"
+aa
+aa
+aa
+aa
+Vs
+gc
+Jf
+gc
+Vs
+vE
+zQ
+vE
+Vs
+yq
+yq
+yq
+Vs
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 bZ
 aj
 al
@@ -2990,8 +3832,8 @@ aa
 aa
 aa
 aa
-aY
-aY
+aa
+aa
 ba
 bb
 xF
@@ -3003,12 +3845,37 @@ gy
 ba
 ba
 ba
-aY
+aa
 aa
 aa
 aa
 "}
 (23,1,1) = {"
+aa
+aa
+aa
+aa
+Vs
+kl
+gc
+KB
+Vs
+Ag
+vE
+UN
+Vs
+Lv
+yq
+EE
+Vs
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 bZ
 bZ
 ar
@@ -3031,24 +3898,49 @@ aa
 aa
 aa
 aa
-aY
-aY
+aa
+aa
 aX
 DN
 bj
 bj
-bj
+pv
 bb
 bU
 ba
 ba
-aY
-aY
+aa
+aa
 aa
 aa
 aa
 "}
 (24,1,1) = {"
+aa
+aa
+aa
+aa
+Vs
+SI
+Ed
+SI
+Vs
+SI
+Ed
+SI
+Vs
+SI
+Ed
+SI
+Vs
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ac
 bd
 bh
@@ -3071,24 +3963,49 @@ eK
 eK
 eK
 eK
-dz
-dz
+eK
+eK
 dh
 DN
 bj
 bj
-bj
+vj
 bb
 ba
 ba
-aY
-aY
+aa
+aa
 aa
 aa
 aa
 aa
 "}
 (25,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+OS
+lI
+OS
+aa
+OS
+lI
+OS
+aa
+OS
+lI
+OS
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 bZ
 bS
 bT
@@ -3111,17 +4028,17 @@ aa
 aa
 aa
 aa
-aY
-aY
+aa
+aa
 bf
-de
+kG
 bj
 bj
 xz
 bb
 ba
 ba
-aY
+aa
 aa
 aa
 aa
@@ -3129,6 +4046,31 @@ aa
 aa
 "}
 (26,1,1) = {"
+aa
+aa
+aa
+aa
+MB
+Eh
+Vw
+Eh
+MB
+Eh
+Vw
+Eh
+MB
+Eh
+Vw
+Eh
+MB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 bZ
 ai
 cr
@@ -3150,8 +4092,8 @@ aa
 aa
 aa
 aa
-aY
-aY
+aa
+aa
 ba
 bb
 bb
@@ -3161,7 +4103,7 @@ bb
 bb
 ba
 ba
-aY
+aa
 aa
 aa
 aa
@@ -3169,6 +4111,31 @@ aa
 aa
 "}
 (27,1,1) = {"
+aa
+aa
+aa
+sP
+MB
+is
+Vv
+rZ
+rZ
+sl
+rZ
+ok
+rZ
+rZ
+Vv
+rZ
+MB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 dg
 Hp
 aU
@@ -3190,7 +4157,7 @@ aa
 aa
 aa
 aa
-aY
+aa
 ba
 ba
 ba
@@ -3201,7 +4168,7 @@ bb
 ba
 ba
 bU
-aY
+aa
 aa
 aa
 aa
@@ -3209,6 +4176,31 @@ aa
 aa
 "}
 (28,1,1) = {"
+aa
+aa
+aa
+sP
+Vr
+XJ
+IY
+IY
+IY
+Zm
+IY
+IY
+IY
+IY
+IY
+pa
+gs
+OM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 bZ
 bZ
@@ -3230,8 +4222,8 @@ aa
 aa
 aa
 aa
-aY
-aY
+aa
+aa
 ba
 ba
 ba
@@ -3240,8 +4232,8 @@ bU
 ba
 ba
 ba
-aY
-aY
+aa
+aa
 aa
 aa
 aa
@@ -3249,6 +4241,31 @@ aa
 aa
 "}
 (29,1,1) = {"
+aa
+aa
+aa
+sU
+MB
+er
+KD
+KD
+KD
+KD
+KD
+KD
+KD
+KD
+KD
+GN
+MB
+MB
+MB
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -3271,16 +4288,16 @@ aa
 aa
 aa
 aa
-aY
-aY
+aa
+aa
 bU
 ba
 ba
 ba
 ba
 ba
-aY
-aY
+aa
+aa
 aa
 aa
 aa
@@ -3289,6 +4306,31 @@ aa
 aa
 "}
 (30,1,1) = {"
+aa
+aa
+aY
+nt
+MB
+DL
+DL
+DL
+DL
+DL
+DL
+DL
+DL
+DL
+DL
+bv
+MB
+Vv
+MB
+RN
+aa
+aa
+aa
+aa
+aa
 bZ
 bZ
 bZ
@@ -3312,14 +4354,14 @@ aa
 aa
 aa
 aa
-aY
-aY
-aY
-aY
-aY
-aY
-aY
-aY
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -3329,6 +4371,31 @@ aa
 aa
 "}
 (31,1,1) = {"
+aa
+aa
+dz
+LF
+vP
+vF
+vF
+vF
+vF
+vF
+vF
+vF
+vF
+vF
+vF
+vF
+yp
+iM
+lM
+iY
+aa
+aa
+aa
+aa
+aa
 bZ
 ak
 aP
@@ -3369,6 +4436,31 @@ aa
 aa
 "}
 (32,1,1) = {"
+aa
+aY
+Dr
+Cq
+MB
+Hr
+Hr
+DL
+DL
+Hr
+Hr
+DL
+jx
+Hr
+DL
+DL
+MB
+Vv
+MB
+RN
+aa
+aa
+aa
+aa
+aa
 bZ
 an
 bH
@@ -3409,6 +4501,31 @@ aa
 aa
 "}
 (33,1,1) = {"
+aa
+ba
+aY
+MB
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
+MB
+Hr
+Hr
+MB
+MB
+MB
+MB
+aa
+aa
+aa
+aa
+aa
+aa
 dg
 Hp
 bQ
@@ -3449,6 +4566,31 @@ aa
 aa
 "}
 (34,1,1) = {"
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 bZ
 bZ
@@ -3489,6 +4631,31 @@ aa
 aa
 "}
 (35,1,1) = {"
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 bZ
@@ -3520,7 +4687,7 @@ aa
 aa
 aa
 aa
-Dr
+bU
 aa
 aa
 aa
@@ -3530,6 +4697,31 @@ aa
 "}
 (36,1,1) = {"
 aa
+ba
+ba
+ba
+bU
+bU
+bU
+bU
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 dg
@@ -3558,10 +4750,10 @@ aa
 aa
 aa
 aa
-Dr
-Dr
-Dr
-Dr
+bU
+bU
+bU
+bU
 aa
 aa
 aa
@@ -3571,6 +4763,20 @@ aa
 (37,1,1) = {"
 aa
 aa
+ba
+ba
+ba
+bU
+bU
+bU
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
 aa
 aa
 aa
@@ -3598,9 +4804,20 @@ aa
 aa
 aa
 aa
-Dr
-Dr
-Dr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bU
+bU
+bU
 aa
 aa
 aa
@@ -3610,6 +4827,19 @@ aa
 "}
 (38,1,1) = {"
 aa
+ba
+ba
+ba
+ba
+bU
+bU
+ba
+ba
+ba
+ba
+ba
+ba
+ba
 aa
 aa
 aa
@@ -3629,7 +4859,19 @@ aa
 aa
 aa
 aa
-Dr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bU
 aa
 aa
 aa
@@ -3650,6 +4892,17 @@ aa
 "}
 (39,1,1) = {"
 aa
+ba
+ba
+ba
+ba
+bU
+bU
+ba
+ba
+ba
+ba
+ba
 aa
 aa
 aa
@@ -3668,9 +4921,23 @@ aa
 aa
 aa
 aa
-Dr
-Dr
-Dr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bU
+bU
+bU
 aa
 aa
 aa
@@ -3689,6 +4956,17 @@ aa
 aa
 "}
 (40,1,1) = {"
+ba
+ba
+ba
+ba
+ba
+bU
+ba
+ba
+ba
+ba
+ba
 aa
 aa
 aa
@@ -3708,10 +4986,24 @@ aa
 aa
 aa
 aa
-Dr
-Dr
-Dr
-Dr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bU
+bU
+bU
+bU
 aa
 aa
 aa
@@ -3729,6 +5021,17 @@ aa
 aa
 "}
 (41,1,1) = {"
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
 aa
 aa
 aa
@@ -3749,7 +5052,216 @@ aa
 aa
 aa
 aa
-Dr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bU
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(42,1,1) = {"
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(43,1,1) = {"
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(44,1,1) = {"
+aa
+ba
+ba
+ba
+ba
+ba
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa

--- a/modular_skyrat/modules/mapping/code/game/area/areas/ruins/space.dm
+++ b/modular_skyrat/modules/mapping/code/game/area/areas/ruins/space.dm
@@ -1,0 +1,8 @@
+//Cybersun, Forgotten Ship
+/area/ruin/space/has_grav/cybersun
+	name = "Cybersun"
+	icon_state = "spacecontent1"
+
+/area/ruin/space/has_grav/cybersun/atmospherics
+	name = "Abandoned Atmospherics Wing"
+	icon_state = "atmos"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4103,6 +4103,7 @@
 #include "modular_skyrat\modules\mapping\code\datums\ruins\lavaland.dm"
 #include "modular_skyrat\modules\mapping\code\datums\ruins\space.dm"
 #include "modular_skyrat\modules\mapping\code\game\area\areas\shuttles.dm"
+#include "modular_skyrat\modules\mapping\code\game\area\areas\ruins\space.dm"
 #include "modular_skyrat\modules\mapping\code\game\gamemodes\brother\traitor_bro.dm"
 #include "modular_skyrat\modules\mapping\code\game\gamemodes\changeling\changeling.dm"
 #include "modular_skyrat\modules\mapping\code\game\gamemodes\changeling\traitor_chan.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives Cybersun the Ability to flex on free golems a bit - they now spawn next to a derelict atmospherics wing, ready for use in any construction projects.
This is, admittedly, a very personal-need based PR. I've built several ministations as cybersun only to run into the issue of "No atmospherics" time and time again. ~~Not to mention you're expected to build the prison yourself if you want to shit on space explorers.~~ This addresses that problem handily, and also cleans up some.. icky area distribution.
Also adds 10 bluespace navigation gigabeacon boards to Cybersun, and two stacks of polycircuit aggregates. Honk.
![image](https://user-images.githubusercontent.com/50649185/115895683-b0fdc400-a428-11eb-8f39-32b34dfb1e41.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Free golems are the science ghostrole, Interdyne is the mining ghostrole, and Cybersun's meant to be the engineering ghostrole. It's damn well time I got other people into building stuff in-game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Cybersun now has a derelict atmospherics wing to appropriate for their own ends. Get out there and build cool stuff.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
