### PR TITLE
[MOSTLY MODULAR]  Suits have 2 storage for small or smaller items.

### DIFF
--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -10,6 +10,9 @@
 	var/blood_overlay_type = "suit"
 	var/togglename = null
 	var/suittoggled = FALSE
+	//Skyrat Edit Pocket Edition
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/exo
+	//Skyrat Edit end
 	limb_integrity = 0 // disabled for most exo-suits
 
 

--- a/modular_skyrat/modules/customization/pockets/pockets.dm
+++ b/modular_skyrat/modules/customization/pockets/pockets.dm
@@ -1,5 +1,5 @@
 /datum/component/storage/concrete/pockets/exo
-	max_items = 3
+	max_items = 2
 	max_w_class = WEIGHT_CLASS_SMALL
 	attack_hand_interact = TRUE
 	quickdraw = FALSE

--- a/modular_skyrat/modules/customization/pockets/pockets.dm
+++ b/modular_skyrat/modules/customization/pockets/pockets.dm
@@ -1,0 +1,13 @@
+/datum/component/storage/concrete/pockets/exo
+	max_items = 3
+	max_w_class = WEIGHT_CLASS_SMALL
+	attack_hand_interact = TRUE
+	quickdraw = FALSE
+	silent = FALSE
+
+/datum/component/storage/concrete/pockets/exo/cloak
+	max_items = 1
+	quickdraw = TRUE
+
+/datum/component/storage/concrete/pockets/exo/large
+	max_items = 3

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3953,6 +3953,7 @@
 #include "modular_skyrat\modules\customization\modules\surgery\organs\tails.dm"
 #include "modular_skyrat\modules\customization\modules\surgery\organs\vox.dm"
 #include "modular_skyrat\modules\customization\modules\surgery\organs\wings.dm"
+#include "modular_skyrat\modules\customization\pockets\pockets.dm"
 #include "modular_skyrat\modules\cyborg\code\borgpowertools.dm"
 #include "modular_skyrat\modules\cyborg\code\mechafabricator_designs.dm"
 #include "modular_skyrat\modules\cyborg\code\robot_upgrades.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Honestly, this is more QOL than a tweak.
To my incoming PR this will be kinda handy
You can attach 3 smolls items to coats and stuff.
Since its behave like an mini-backpack you need to drag your suit to your hands
There's 3 storage on the photos but now its two.
![image](https://user-images.githubusercontent.com/67030229/115940928-b20b1180-a479-11eb-993c-1e205a528e22.png)
![image](https://user-images.githubusercontent.com/67030229/115940937-b9321f80-a479-11eb-9901-2d8508f71884.png)
Since its behave like an mini-backpack you need to drag your suit to your hands

## Changelog
:cl: Guidesu
add: Exo-suit like coats/winter coats/lab coats in general any exo suit can store two small itmes

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
