### PR TITLE
[SEMI-MODULAR] Replaces Oztek boomerangs with peacekeeper boomerangs

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -329,13 +329,28 @@
 	build_path = /obj/item/melee/cleric_mace
 	category = list("Imported")
 
+//SKYRAT EDIT REMOVAL BEGIN - boomerang nerf
+/*
 /datum/design/stun_boomerang
 	name = "OZtek Boomerang"
-	desc = "Uses reverse flow gravitodynamics to flip its personal gravity back to the thrower mid-flight. Also functions similar to a baton." //SKYRAT EDIT - boomerang nerf Original: "similar to a stun baton"
+	desc = "Uses reverse flow gravitodynamics to flip its personal gravity back to the thrower mid-flight. Also functions similar to a stun baton."
 	id = "stun_boomerang"
 	build_type = PROTOLATHE | AWAY_LATHE
-	//materials = list(/datum/material/iron = 10000, /datum/material/glass = 4000, /datum/material/silver = 10000, /datum/material/gold = 2000) //SKYRAT EDIT REMOVAL - boomerang nerf
-	materials = list(/datum/material/iron = 4000, /datum/material/glass = 2000, /datum/material/silver = 1000, /datum/material/gold = 500) //SKYRAT EDIT ADDITION - boomerang nerf
+	materials = list(/datum/material/iron = 10000, /datum/material/glass = 4000, /datum/material/silver = 10000, /datum/material/gold = 2000)
 	build_path = /obj/item/melee/baton/boomerang
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+*/
+//SKYRAT EDIT REMOVAL END - boomerang nerf
+
+//SKYRAT EDIT ADDITION BEGIN - boomerang nerf
+/datum/design/stun_boomerang
+	name = "Peacekeeper Boomerang"
+	desc = "Uses reverse flow gravitodynamics to flip its personal gravity back to the thrower mid-flight. Also functions similar to a baton."
+	id = "stun_boomerang"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 5000, /datum/material/glass = 2000, /datum/material/silver = 1000, /datum/material/gold = 500)
+	build_path = /obj/item/melee/classic_baton/peacekeeper/boomerang
+	category = list("Weapons")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+//SKYRAT EDIT ADDITION END - boomerang nerf

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -331,10 +331,11 @@
 
 /datum/design/stun_boomerang
 	name = "OZtek Boomerang"
-	desc = "Uses reverse flow gravitodynamics to flip its personal gravity back to the thrower mid-flight. Also functions similar to a stun baton."
+	desc = "Uses reverse flow gravitodynamics to flip its personal gravity back to the thrower mid-flight. Also functions similar to a baton." //SKYRAT EDIT - boomerang nerf Original: "similar to a stun baton"
 	id = "stun_boomerang"
 	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 10000, /datum/material/glass = 4000, /datum/material/silver = 10000, /datum/material/gold = 2000)
+	//materials = list(/datum/material/iron = 10000, /datum/material/glass = 4000, /datum/material/silver = 10000, /datum/material/gold = 2000) //SKYRAT EDIT REMOVAL - boomerang nerf
+	materials = list(/datum/material/iron = 4000, /datum/material/glass = 2000, /datum/material/silver = 1000, /datum/material/gold = 500) //SKYRAT EDIT ADDITION - boomerang nerf
 	build_path = /obj/item/melee/baton/boomerang
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_baton.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_baton.dm
@@ -72,7 +72,7 @@
 	icon_state = "boomerang"
 	inhand_icon_state = "boomerang"
 	force = 5
-	throwforce = 5
+	throwforce = 0
 	throw_range = 5
 	var/throw_stun_chance = 99  //Have you prayed today?
 	custom_materials = list(/datum/material/iron = 5000, /datum/material/glass = 2000, /datum/material/silver = 1000, /datum/material/gold = 500)
@@ -81,10 +81,14 @@
 	if(ishuman(thrower))
 		var/mob/living/carbon/human/I = thrower
 		I.throw_mode_off(THROW_MODE_TOGGLE) //so they can catch it on the return.
+	return ..()
 
 /obj/item/melee/classic_baton/peacekeeper/boomerang/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	var/caught = hit_atom.hitby(src, FALSE, FALSE, throwingdatum=throwingdatum)
 	if(isliving(hit_atom) && !iscyborg(hit_atom) && !caught && prob(throw_stun_chance))//if they are a living creature and they didn't catch it
-		attack(hit_atom)
+		if(ishuman(hit_atom))
+			var/mob/living/carbon/human/target = hit_atom
+			target.StaminaKnockdown(1.5)
 	if(thrownby && !caught)
 		addtimer(CALLBACK(src, /atom/movable.proc/throw_at, thrownby, throw_range+2, throw_speed, null, TRUE), 1)
+	return ..()

--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_baton.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_baton.dm
@@ -63,3 +63,28 @@
 	build_path = /obj/item/conversion_kit/nightstick
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/obj/item/melee/classic_baton/peacekeeper/boomerang
+	name = "peacekeeper boomerang"
+	desc = "A device invented thousands of years ago for hunting. These also work exceptionally well for knocking down crew members. Just be careful to catch it when thrown!"
+	throw_speed = 1
+	icon = 'icons/obj/items_and_weapons.dmi'
+	icon_state = "boomerang"
+	inhand_icon_state = "boomerang"
+	force = 5
+	throwforce = 5
+	throw_range = 5
+	var/throw_stun_chance = 99  //Have you prayed today?
+	custom_materials = list(/datum/material/iron = 5000, /datum/material/glass = 2000, /datum/material/silver = 1000, /datum/material/gold = 500)
+
+/obj/item/melee/classic_baton/peacekeeper/boomerang/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, gentle = FALSE, quickstart = TRUE)
+	if(ishuman(thrower))
+		var/mob/living/carbon/human/I = thrower
+		I.throw_mode_off(THROW_MODE_TOGGLE) //so they can catch it on the return.
+
+/obj/item/melee/classic_baton/peacekeeper/boomerang/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	var/caught = hit_atom.hitby(src, FALSE, FALSE, throwingdatum=throwingdatum)
+	if(isliving(hit_atom) && !iscyborg(hit_atom) && !caught && prob(throw_stun_chance))//if they are a living creature and they didn't catch it
+		attack(hit_atom)
+	if(thrownby && !caught)
+		addtimer(CALLBACK(src, /atom/movable.proc/throw_at, thrownby, throw_range+2, throw_speed, null, TRUE), 1)


### PR DESCRIPTION
## About The Pull Request

Title. This was probably overlooked.

SO, The summary of this PR: Replaces the technode build path for the boomerang from the stun baton variant to a new variant that I made that does a knockdown and acts as a normal peacekeeper baton when hitting people.

## Why It's Good For The Game

Stun batons have no place on this station. Security literally print these fuckers out and use them as stun batons. This was overlooked. If you design a system players will surely find a way to abuse it, and not removing the boomerangs was one of those things. oopsies.

## Changelog
:cl:
fix: Replaces Oz'tek boomerangs with ones that don't act as stun batons.
/:cl:

