### PR TITLE
Balances Space Dragon Gust

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -455,8 +455,7 @@
 			to_chat(L, "<span class='userdanger'>You're knocked back by the gust!</span>")
 			var/dir_to_target = get_dir(get_turf(src), get_turf(L))
 			var/throwtarget = get_edge_target_turf(target, dir_to_target)
-			L.safe_throw_at(throwtarget, 10, 1, src)
-			L.Paralyze(50)
+			L.safe_throw_at(throwtarget, 15, 1, src)
 	addtimer(CALLBACK(src, .proc/reset_status), 4 + ((tiredness * tiredness_mult) / 10))
 	tiredness = tiredness + (gust_tiredness * tiredness_mult)
 

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -455,7 +455,8 @@
 			to_chat(L, "<span class='userdanger'>You're knocked back by the gust!</span>")
 			var/dir_to_target = get_dir(get_turf(src), get_turf(L))
 			var/throwtarget = get_edge_target_turf(target, dir_to_target)
-			L.safe_throw_at(throwtarget, 15, 1, src)
+			L.safe_throw_at(throwtarget, 15, 1, src) // SKYRAT EDIT - ORIGINAL :(throwtarget, 10, 1, src)
+			M.Knockdown(30) // SKYRAT EDIT - ORIGINAL: L.Paralyze(50)
 	addtimer(CALLBACK(src, .proc/reset_status), 4 + ((tiredness * tiredness_mult) / 10))
 	tiredness = tiredness + (gust_tiredness * tiredness_mult)
 


### PR DESCRIPTION
## About The Pull Request

Space Dragon Gust is no longer a 5 second paralyze and is instead only capable of dealing knockback; to compensate, the knockback goes further, which will still allow the dragon to stun, just not broken-levels of stun.

## Why It's Good For The Game

Hardstuns are not fun to play against, especially with such a quick chargeup (1.5 seconds) and how TIDI/lag works on Skyrat. Replaces that hardstun with further knockback and a 3 second knockdown; still a stun, just not a hard one.

## Changelog
:cl:
balance: Space Dragons no longer hardstun when using gust, but knock back further and deal knockdown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
