### PR TITLE
[Modular] Prevents Shrink Module Usage on Small Borgs

### DIFF
--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,5 +1,4 @@
-mob/living/silicon/robot //For restricting shrink module usage on small borgs
-	var/has_small_sprite = FALSE
+var/has_small_sprite = FALSE
 
 /obj/item/robot_model/proc/dogborg_equip()
 	has_snowflake_deadsprite = TRUE
@@ -29,8 +28,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 //ROBOT ADDITIONAL MODULES
 
 //STANDARD
-/obj/item/robot_model/standard/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
-	. = ..()
+/obj/item/robot_model/standard/be_transformed_to(obj/item/robot_model/old_model)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/standard_icons = list(
 		"Default" = image(icon = 'icons/mob/robots.dmi', icon_state = "robot"),
@@ -65,7 +63,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			cyborg_base_icon = "eyebotsd"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
 			has_snowflake_deadsprite = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		if("Robot")
 			cyborg_base_icon = "robot_old"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
@@ -93,8 +91,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //MEDICAL
-/obj/item/robot_model/medical/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
-	. = ..()
+/obj/item/robot_model/medical/be_transformed_to(obj/item/robot_model/old_model)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/med_icons
 	if(!med_icons)
@@ -130,7 +127,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			cyborg_base_icon = "zoomba_med"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
 			has_snowflake_deadsprite = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		if("Droid")
 			cyborg_base_icon = "medical"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
@@ -145,7 +142,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			cyborg_base_icon = "eyebotmed"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
 			has_snowflake_deadsprite = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		if("Heavy")
 			cyborg_base_icon = "heavymed"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
@@ -217,14 +214,13 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			model_select_icon = "medihound"
 			model_select_alternate_icon = 'modular_skyrat/modules/altborgs/icons/ui/screen_cyborg.dmi'
 			dogborg = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		else
 			return FALSE
 	return ..()
 
 //ENGINEERING
-/obj/item/robot_model/engineering/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
-	. = ..()
+/obj/item/robot_model/engineering/be_transformed_to(obj/item/robot_model/old_model)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/engi_icons
 	if(!engi_icons)
@@ -262,7 +258,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			cyborg_base_icon = "zoomba_engi"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_eng.dmi'
 			has_snowflake_deadsprite = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		if("Default - Treads")
 			cyborg_base_icon = "engi-tread"
 			special_light_key = "engineer"
@@ -311,7 +307,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			cyborg_base_icon = "eyeboteng"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_eng.dmi'
 			has_snowflake_deadsprite = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		//Dogborgs
 		if("Pup Dozer")
 			cyborg_base_icon = "pupdozer"
@@ -349,7 +345,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 			sleeper_overlay = "borgi-eng-sleeper"
 			dogborg = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		if("Otie")
 			cyborg_base_icon = "otiee"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
@@ -360,8 +356,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //SECURITY
-/obj/item/robot_model/security/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
-	. = ..()
+/obj/item/robot_model/security/be_transformed_to(obj/item/robot_model/old_model)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/sec_icons
 	if(!sec_icons)
@@ -397,7 +392,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			cyborg_base_icon = "zoomba_sec"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_sec.dmi'
 			has_snowflake_deadsprite = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		if("Default - Treads")
 			cyborg_base_icon = "sec-tread"
 			special_light_key = "sec"
@@ -433,7 +428,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			cyborg_base_icon = "eyebotsec"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_sec.dmi'
 			has_snowflake_deadsprite = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		if("Insekt")
 			cyborg_base_icon = "insekt-Sec"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_sec.dmi'
@@ -477,14 +472,13 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			sleeper_overlay = "borgi-sec-sleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
 			dogborg = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		else
 			return FALSE
 	return ..()
 
 //PEACEKEEPER
-/obj/item/robot_model/peacekeeper/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
-	. = ..()
+/obj/item/robot_model/peacekeeper/be_transformed_to(obj/item/robot_model/old_model)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/peace_icons
 	if(!peace_icons)
@@ -517,7 +511,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 		if("Spider")
 			cyborg_base_icon = "whitespider"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		if("Marina")
 			cyborg_base_icon = "marinapeace"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
@@ -537,7 +531,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 		if("Omni")
 			cyborg_base_icon = "omoikane"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		//Dogborgs
 		if("Drake")
 			cyborg_base_icon = "drakepeace"
@@ -549,7 +543,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			sleeper_overlay = "borgi-sleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_pk.dmi'
 			dogborg = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		if("Vale")
 			cyborg_base_icon = "valepeace"
 			sleeper_overlay = "valepeace-sleeper"
@@ -560,8 +554,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //JANITOR
-/obj/item/robot_model/janitor/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
-	. = ..()
+/obj/item/robot_model/janitor/be_transformed_to(obj/item/robot_model/old_model)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/janitor_icons
 	if(!janitor_icons)
@@ -597,7 +590,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			cyborg_base_icon = "zoomba_jani"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_jani.dmi'
 			has_snowflake_deadsprite = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		if("Marina")
 			cyborg_base_icon = "marinajan"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_jani.dmi'
@@ -629,7 +622,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			cyborg_base_icon = "eyebotjani"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_jani.dmi'
 			has_snowflake_deadsprite = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		if("Insekt")
 			cyborg_base_icon = "insekt-Sci"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_jani.dmi'
@@ -665,7 +658,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_jani.dmi'
 			sleeper_overlay = "borgi-jani-sleeper"
 			dogborg = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		else
 			return FALSE
 	return ..()
@@ -711,8 +704,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //SERVICE
-/obj/item/robot_model/service/skyrat/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
-	. = ..()
+/obj/item/robot_model/service/skyrat/be_transformed_to(obj/item/robot_model/old_model)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/service_icons
 	if(!service_icons)
@@ -779,7 +771,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			cyborg_base_icon = "zoomba_green"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_serv.dmi'
 			has_snowflake_deadsprite = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		if("Mech")
 			cyborg_base_icon = "lloyd"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_serv.dmi'
@@ -812,14 +804,13 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 			sleeper_overlay = "borgi-sleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
 			dogborg = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		else
 			return FALSE
 	return TRUE
 
 //MINING
-/obj/item/robot_model/miner/skyrat/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
-	. = ..()
+/obj/item/robot_model/miner/skyrat/be_transformed_to(obj/item/robot_model/old_model)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/mining_icons
 	if(!mining_icons)
@@ -890,12 +881,12 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 		if("Drone")
 			cyborg_base_icon = "miningdrone"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_mine.dmi'
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		if("Zoomba")
 			cyborg_base_icon = "zoomba_miner"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_mine.dmi'
 			has_snowflake_deadsprite = TRUE
-			R.has_small_sprite = TRUE
+			has_small_sprite = TRUE
 		//Dogborgs
 		if("Blade")
 			cyborg_base_icon = "blade"

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,4 +1,4 @@
-/obj/item/robot_model/var/has_small_sprite = TRUE
+var/has_small_sprite = TRUE
 
 /obj/item/robot_model/proc/dogborg_equip()
 	has_snowflake_deadsprite = TRUE

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -47,6 +47,7 @@ var/has_small_sprite = FALSE
 		wide.pixel_x = -16
 		standard_icons[a] = wide
 	standard_icons = sortList(standard_icons)
+	has_small_sprite = FALSE
 	var/standard_borg_icon = show_radial_menu(cyborg, cyborg , standard_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(standard_borg_icon)
 		if("Default")
@@ -119,6 +120,7 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			med_icons[a] = wide
 		med_icons = sortList(med_icons)
+	has_small_sprite = FALSE
 	var/med_borg_icon = show_radial_menu(cyborg, cyborg , med_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(med_borg_icon)
 		if("Default")
@@ -250,6 +252,7 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			engi_icons[a] = wide
 		engi_icons = sortList(engi_icons)
+	has_small_sprite = FALSE
 	var/engi_borg_icon = show_radial_menu(cyborg, cyborg , engi_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(engi_borg_icon)
 		if("Default")
@@ -384,6 +387,7 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			sec_icons[a] = wide
 		sec_icons = sortList(sec_icons)
+	has_small_sprite = FALSE
 	var/sec_borg_icon = show_radial_menu(cyborg, cyborg , sec_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(sec_borg_icon)
 		if("Default")
@@ -500,6 +504,7 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			peace_icons[a] = wide
 		peace_icons = sortList(peace_icons)
+	has_small_sprite = FALSE
 	var/peace_borg_icon = show_radial_menu(cyborg, cyborg , peace_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(peace_borg_icon)
 		if("Default")
@@ -582,6 +587,7 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			janitor_icons[a] = wide
 		janitor_icons = sortList(janitor_icons)
+	has_small_sprite = FALSE
 	var/janitor_robot_icon = show_radial_menu(cyborg, cyborg , janitor_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(janitor_robot_icon)
 		if("Default")
@@ -675,6 +681,7 @@ var/has_small_sprite = FALSE
 		"Robot" = image(icon = 'modular_skyrat/modules/altborgs/icons/mob/robots_clown.dmi', icon_state = "clownbot"),
 		"Sleek" = image(icon = 'modular_skyrat/modules/altborgs/icons/mob/robots_clown.dmi', icon_state = "clownman")
 		))
+	has_small_sprite = FALSE
 	var/clown_borg_icon = show_radial_menu(cyborg, cyborg , clown_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(clown_borg_icon)
 		if("Default")
@@ -730,6 +737,7 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			service_icons[a] = wide
 		service_icons = sortList(service_icons)
+	has_small_sprite = FALSE
 	var/service_robot_icon = show_radial_menu(cyborg, cyborg , service_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(service_robot_icon)
 		if("Waitress")
@@ -837,6 +845,7 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			mining_icons[a] = wide
 		mining_icons = sortList(mining_icons)
+	has_small_sprite = FALSE
 	var/mining_borg_icon = show_radial_menu(cyborg, cyborg , mining_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(mining_borg_icon)
 		if("Lavaland")
@@ -978,6 +987,7 @@ var/has_small_sprite = FALSE
 		"Male Booty Syndicate" = image(icon = 'modular_skyrat/modules/altborgs/icons/mob/robots_syndi.dmi', icon_state = "male_bootysyndie"),
 		"Mech" = image(icon = 'modular_skyrat/modules/altborgs/icons/mob/robots_syndi.dmi', icon_state = "chesty")
 		))
+	has_small_sprite = FALSE
 	var/syndiejack_icon = show_radial_menu(cyborg, cyborg , syndicatejack_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(syndiejack_icon)
 		if("Saboteur")

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,4 +1,4 @@
-var/has_small_sprite = TRUE
+/obj/item/robot_model/var/has_small_sprite = TRUE
 
 /obj/item/robot_model/proc/dogborg_equip()
 	has_snowflake_deadsprite = TRUE

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,4 +1,4 @@
-mob/living/silicon/robot/var/has_small_sprite = TRUE
+/obj/item/robot_model/var/has_small_sprite = TRUE
 
 /obj/item/robot_model/proc/dogborg_equip()
 	has_snowflake_deadsprite = TRUE

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,4 +1,4 @@
-var/has_small_sprite = TRUE
+var/has_small_sprite = TRUE //For Shrink Module Blacklist
 
 /obj/item/robot_model/proc/dogborg_equip()
 	has_snowflake_deadsprite = TRUE
@@ -121,7 +121,7 @@ var/has_small_sprite = TRUE
 			wide.pixel_x = -16
 			med_icons[a] = wide
 		med_icons = sortList(med_icons)
-	has_small_sprite = FALSE
+	has_small_sprite = FALSE //Removes borgs from the shrink module blacklist when they select a chassis
 	var/med_borg_icon = show_radial_menu(cyborg, cyborg , med_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(med_borg_icon)
 		if("Default")
@@ -131,7 +131,7 @@ var/has_small_sprite = TRUE
 			cyborg_base_icon = "zoomba_med"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
 			has_snowflake_deadsprite = TRUE
-			has_small_sprite = TRUE
+			has_small_sprite = TRUE //If this chassis is selected, the borg is added to the shrink module blacklist
 		if("Droid")
 			cyborg_base_icon = "medical"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -30,6 +30,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 
 //STANDARD
 /obj/item/robot_model/standard/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/standard_icons = list(
 		"Default" = image(icon = 'icons/mob/robots.dmi', icon_state = "robot"),
@@ -93,6 +94,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 
 //MEDICAL
 /obj/item/robot_model/medical/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/med_icons
 	if(!med_icons)
@@ -222,6 +224,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 
 //ENGINEERING
 /obj/item/robot_model/engineering/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/engi_icons
 	if(!engi_icons)
@@ -358,6 +361,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 
 //SECURITY
 /obj/item/robot_model/security/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/sec_icons
 	if(!sec_icons)
@@ -480,6 +484,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 
 //PEACEKEEPER
 /obj/item/robot_model/peacekeeper/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/peace_icons
 	if(!peace_icons)
@@ -556,6 +561,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 
 //JANITOR
 /obj/item/robot_model/janitor/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/janitor_icons
 	if(!janitor_icons)
@@ -706,6 +712,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 
 //SERVICE
 /obj/item/robot_model/service/skyrat/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/service_icons
 	if(!service_icons)
@@ -812,6 +819,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 
 //MINING
 /obj/item/robot_model/miner/skyrat/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/mining_icons
 	if(!mining_icons)

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,4 +1,4 @@
-/obj/item/robot_model/var/has_small_sprite = TRUE
+mob/living/silicon/robot/var/has_small_sprite = TRUE
 
 /obj/item/robot_model/proc/dogborg_equip()
 	has_snowflake_deadsprite = TRUE

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,4 +1,4 @@
-var/mob/living/silicon/robot //For restricting shrink module usage on small borgs
+mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	var/has_small_sprite = FALSE
 
 /obj/item/robot_model/proc/dogborg_equip()

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -92,7 +92,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //MEDICAL
-/obj/item/robot_model/medical/be_transformed_to(obj/item/robot_model/old_model)
+/obj/item/robot_model/medical/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/med_icons
 	if(!med_icons)
@@ -221,7 +221,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //ENGINEERING
-/obj/item/robot_model/engineering/be_transformed_to(obj/item/robot_model/old_model)
+/obj/item/robot_model/engineering/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/engi_icons
 	if(!engi_icons)
@@ -357,7 +357,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //SECURITY
-/obj/item/robot_model/security/be_transformed_to(obj/item/robot_model/old_model)
+/obj/item/robot_model/security/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/sec_icons
 	if(!sec_icons)
@@ -479,7 +479,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //PEACEKEEPER
-/obj/item/robot_model/peacekeeper/be_transformed_to(obj/item/robot_model/old_model)
+/obj/item/robot_model/peacekeeper/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/peace_icons
 	if(!peace_icons)
@@ -555,7 +555,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //JANITOR
-/obj/item/robot_model/janitor/be_transformed_to(obj/item/robot_model/old_model)
+/obj/item/robot_model/janitor/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/janitor_icons
 	if(!janitor_icons)
@@ -665,7 +665,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //CLOWN
-/obj/item/robot_model/clown/be_transformed_to(obj/item/robot_model/old_model)
+/obj/item/robot_model/clown/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/clown_icons = sortList(list(
 		"Default" = image(icon = 'icons/mob/robots.dmi', icon_state = "clown"),
@@ -705,7 +705,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //SERVICE
-/obj/item/robot_model/service/skyrat/be_transformed_to(obj/item/robot_model/old_model)
+/obj/item/robot_model/service/skyrat/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/service_icons
 	if(!service_icons)
@@ -811,7 +811,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return TRUE
 
 //MINING
-/obj/item/robot_model/miner/skyrat/be_transformed_to(obj/item/robot_model/old_model)
+/obj/item/robot_model/miner/skyrat/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/mining_icons
 	if(!mining_icons)

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,3 +1,6 @@
+var/mob/living/silicon/robot
+	var/R.has_small_sprite = FALSE
+
 /obj/item/robot_model/proc/dogborg_equip()
 	has_snowflake_deadsprite = TRUE
 	cyborg_pixel_offset = -16
@@ -26,7 +29,7 @@
 //ROBOT ADDITIONAL MODULES
 
 //STANDARD
-/obj/item/robot_model/standard/be_transformed_to(obj/item/robot_model/old_model)
+/obj/item/robot_model/standard/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/standard_icons = list(
 		"Default" = image(icon = 'icons/mob/robots.dmi', icon_state = "robot"),
@@ -61,6 +64,7 @@
 			cyborg_base_icon = "eyebotsd"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
 			has_snowflake_deadsprite = TRUE
+			R.has_small_sprite = TRUE
 		if("Robot")
 			cyborg_base_icon = "robot_old"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
@@ -124,6 +128,7 @@
 			cyborg_base_icon = "zoomba_med"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
 			has_snowflake_deadsprite = TRUE
+			R.has_small_sprite = TRUE
 		if("Droid")
 			cyborg_base_icon = "medical"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
@@ -138,6 +143,7 @@
 			cyborg_base_icon = "eyebotmed"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
 			has_snowflake_deadsprite = TRUE
+			R.has_small_sprite = TRUE
 		if("Heavy")
 			cyborg_base_icon = "heavymed"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
@@ -209,6 +215,7 @@
 			model_select_icon = "medihound"
 			model_select_alternate_icon = 'modular_skyrat/modules/altborgs/icons/ui/screen_cyborg.dmi'
 			dogborg = TRUE
+			R.has_small_sprite = TRUE
 		else
 			return FALSE
 	return ..()
@@ -252,6 +259,7 @@
 			cyborg_base_icon = "zoomba_engi"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_eng.dmi'
 			has_snowflake_deadsprite = TRUE
+			R.has_small_sprite = TRUE
 		if("Default - Treads")
 			cyborg_base_icon = "engi-tread"
 			special_light_key = "engineer"
@@ -300,6 +308,7 @@
 			cyborg_base_icon = "eyeboteng"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_eng.dmi'
 			has_snowflake_deadsprite = TRUE
+			R.has_small_sprite = TRUE
 		//Dogborgs
 		if("Pup Dozer")
 			cyborg_base_icon = "pupdozer"
@@ -337,6 +346,7 @@
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 			sleeper_overlay = "borgi-eng-sleeper"
 			dogborg = TRUE
+			R.has_small_sprite = TRUE
 		if("Otie")
 			cyborg_base_icon = "otiee"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
@@ -383,6 +393,7 @@
 			cyborg_base_icon = "zoomba_sec"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_sec.dmi'
 			has_snowflake_deadsprite = TRUE
+			R.has_small_sprite = TRUE
 		if("Default - Treads")
 			cyborg_base_icon = "sec-tread"
 			special_light_key = "sec"
@@ -418,6 +429,7 @@
 			cyborg_base_icon = "eyebotsec"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_sec.dmi'
 			has_snowflake_deadsprite = TRUE
+			R.has_small_sprite = TRUE
 		if("Insekt")
 			cyborg_base_icon = "insekt-Sec"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_sec.dmi'
@@ -461,6 +473,7 @@
 			sleeper_overlay = "borgi-sec-sleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
 			dogborg = TRUE
+			R.has_small_sprite = TRUE
 		else
 			return FALSE
 	return ..()
@@ -499,6 +512,7 @@
 		if("Spider")
 			cyborg_base_icon = "whitespider"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
+			R.has_small_sprite = TRUE
 		if("Marina")
 			cyborg_base_icon = "marinapeace"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
@@ -518,6 +532,7 @@
 		if("Omni")
 			cyborg_base_icon = "omoikane"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
+			R.has_small_sprite = TRUE
 		//Dogborgs
 		if("Drake")
 			cyborg_base_icon = "drakepeace"
@@ -529,6 +544,7 @@
 			sleeper_overlay = "borgi-sleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_pk.dmi'
 			dogborg = TRUE
+			R.has_small_sprite = TRUE
 		if("Vale")
 			cyborg_base_icon = "valepeace"
 			sleeper_overlay = "valepeace-sleeper"
@@ -575,6 +591,7 @@
 			cyborg_base_icon = "zoomba_jani"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_jani.dmi'
 			has_snowflake_deadsprite = TRUE
+			R.has_small_sprite = TRUE
 		if("Marina")
 			cyborg_base_icon = "marinajan"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_jani.dmi'
@@ -606,6 +623,7 @@
 			cyborg_base_icon = "eyebotjani"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_jani.dmi'
 			has_snowflake_deadsprite = TRUE
+			R.has_small_sprite = TRUE
 		if("Insekt")
 			cyborg_base_icon = "insekt-Sci"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_jani.dmi'
@@ -641,6 +659,7 @@
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_jani.dmi'
 			sleeper_overlay = "borgi-jani-sleeper"
 			dogborg = TRUE
+			R.has_small_sprite = TRUE
 		else
 			return FALSE
 	return ..()
@@ -753,6 +772,7 @@
 			cyborg_base_icon = "zoomba_green"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_serv.dmi'
 			has_snowflake_deadsprite = TRUE
+			R.has_small_sprite = TRUE
 		if("Mech")
 			cyborg_base_icon = "lloyd"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_serv.dmi'
@@ -785,6 +805,7 @@
 			sleeper_overlay = "borgi-sleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
 			dogborg = TRUE
+			R.has_small_sprite = TRUE
 		else
 			return FALSE
 	return TRUE
@@ -861,10 +882,12 @@
 		if("Drone")
 			cyborg_base_icon = "miningdrone"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_mine.dmi'
+			R.has_small_sprite = TRUE
 		if("Zoomba")
 			cyborg_base_icon = "zoomba_miner"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_mine.dmi'
 			has_snowflake_deadsprite = TRUE
+			R.has_small_sprite = TRUE
 		//Dogborgs
 		if("Blade")
 			cyborg_base_icon = "blade"

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -29,7 +29,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 //ROBOT ADDITIONAL MODULES
 
 //STANDARD
-/obj/item/robot_model/standard/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+/obj/item/robot_model/standard/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
 	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/standard_icons = list(
@@ -93,7 +93,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //MEDICAL
-/obj/item/robot_model/medical/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+/obj/item/robot_model/medical/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
 	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/med_icons
@@ -223,7 +223,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //ENGINEERING
-/obj/item/robot_model/engineering/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+/obj/item/robot_model/engineering/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
 	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/engi_icons
@@ -360,7 +360,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //SECURITY
-/obj/item/robot_model/security/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+/obj/item/robot_model/security/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
 	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/sec_icons
@@ -483,7 +483,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //PEACEKEEPER
-/obj/item/robot_model/peacekeeper/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+/obj/item/robot_model/peacekeeper/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
 	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/peace_icons
@@ -560,7 +560,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //JANITOR
-/obj/item/robot_model/janitor/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+/obj/item/robot_model/janitor/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
 	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/janitor_icons
@@ -671,7 +671,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //CLOWN
-/obj/item/robot_model/clown/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+/obj/item/robot_model/clown/be_transformed_to(obj/item/robot_model/old_model)
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/clown_icons = sortList(list(
 		"Default" = image(icon = 'icons/mob/robots.dmi', icon_state = "clown"),
@@ -711,7 +711,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return ..()
 
 //SERVICE
-/obj/item/robot_model/service/skyrat/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+/obj/item/robot_model/service/skyrat/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
 	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/service_icons
@@ -818,7 +818,7 @@ mob/living/silicon/robot //For restricting shrink module usage on small borgs
 	return TRUE
 
 //MINING
-/obj/item/robot_model/miner/skyrat/be_transformed_to(obj/item/robot_model/old_model, mob/living/silicon/robot/R)
+/obj/item/robot_model/miner/skyrat/be_transformed_to(mob/living/silicon/robot/R, obj/item/robot_model/old_model)
 	. = ..()
 	var/mob/living/silicon/robot/cyborg = loc
 	var/static/list/mining_icons

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -47,11 +47,13 @@ var/has_small_sprite = FALSE
 		wide.pixel_x = -16
 		standard_icons[a] = wide
 	standard_icons = sortList(standard_icons)
-	has_small_sprite = FALSE
 	var/standard_borg_icon = show_radial_menu(cyborg, cyborg , standard_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(standard_borg_icon)
+		if (1 == 1)
+			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "robot"
+			has_small_sprite = TRUE
 		if("Marina")
 			cyborg_base_icon = "marinasd"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
@@ -120,11 +122,13 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			med_icons[a] = wide
 		med_icons = sortList(med_icons)
-	has_small_sprite = FALSE
 	var/med_borg_icon = show_radial_menu(cyborg, cyborg , med_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(med_borg_icon)
+		if (1 == 1)
+			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "medical"
+			has_small_sprite = TRUE
 		if("Zoomba")
 			cyborg_base_icon = "zoomba_med"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
@@ -252,9 +256,10 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			engi_icons[a] = wide
 		engi_icons = sortList(engi_icons)
-	has_small_sprite = FALSE
 	var/engi_borg_icon = show_radial_menu(cyborg, cyborg , engi_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(engi_borg_icon)
+		if (1 == 1)
+			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "engineer"
 		if("Zoomba")
@@ -387,9 +392,10 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			sec_icons[a] = wide
 		sec_icons = sortList(sec_icons)
-	has_small_sprite = FALSE
 	var/sec_borg_icon = show_radial_menu(cyborg, cyborg , sec_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(sec_borg_icon)
+		if (1 == 1)
+			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "sec"
 		if("Zoomba")
@@ -504,9 +510,10 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			peace_icons[a] = wide
 		peace_icons = sortList(peace_icons)
-	has_small_sprite = FALSE
 	var/peace_borg_icon = show_radial_menu(cyborg, cyborg , peace_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(peace_borg_icon)
+		if (1 == 1)
+			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "peace"
 		if("Sleek")
@@ -587,9 +594,10 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			janitor_icons[a] = wide
 		janitor_icons = sortList(janitor_icons)
-	has_small_sprite = FALSE
 	var/janitor_robot_icon = show_radial_menu(cyborg, cyborg , janitor_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(janitor_robot_icon)
+		if (1 == 1)
+			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "janitor"
 		if("Zoomba")
@@ -681,9 +689,10 @@ var/has_small_sprite = FALSE
 		"Robot" = image(icon = 'modular_skyrat/modules/altborgs/icons/mob/robots_clown.dmi', icon_state = "clownbot"),
 		"Sleek" = image(icon = 'modular_skyrat/modules/altborgs/icons/mob/robots_clown.dmi', icon_state = "clownman")
 		))
-	has_small_sprite = FALSE
 	var/clown_borg_icon = show_radial_menu(cyborg, cyborg , clown_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(clown_borg_icon)
+		if (1 == 1)
+			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "clown"
 		if("Bootyborg")
@@ -737,9 +746,10 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			service_icons[a] = wide
 		service_icons = sortList(service_icons)
-	has_small_sprite = FALSE
 	var/service_robot_icon = show_radial_menu(cyborg, cyborg , service_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(service_robot_icon)
+		if (1 == 1)
+			has_small_sprite = FALSE
 		if("Waitress")
 			cyborg_base_icon = "service_f"
 			special_light_key = "service"
@@ -845,9 +855,10 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			mining_icons[a] = wide
 		mining_icons = sortList(mining_icons)
-	has_small_sprite = FALSE
 	var/mining_borg_icon = show_radial_menu(cyborg, cyborg , mining_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(mining_borg_icon)
+		if (1 == 1)
+			has_small_sprite = FALSE
 		if("Lavaland")
 			cyborg_base_icon = "miner"
 		if("Asteroid")
@@ -987,9 +998,10 @@ var/has_small_sprite = FALSE
 		"Male Booty Syndicate" = image(icon = 'modular_skyrat/modules/altborgs/icons/mob/robots_syndi.dmi', icon_state = "male_bootysyndie"),
 		"Mech" = image(icon = 'modular_skyrat/modules/altborgs/icons/mob/robots_syndi.dmi', icon_state = "chesty")
 		))
-	has_small_sprite = FALSE
 	var/syndiejack_icon = show_radial_menu(cyborg, cyborg , syndicatejack_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(syndiejack_icon)
+		if (1 == 1) //Remove this to disallow shrink module usage on syndie borgs
+			has_small_sprite = FALSE
 		if("Saboteur")
 			cyborg_base_icon = "synd_engi"
 			cyborg_icon_override = 'icons/mob/robots.dmi'

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,5 +1,5 @@
-var/mob/living/silicon/robot
-	var/R.has_small_sprite = FALSE
+var/mob/living/silicon/robot //For restricting shrink module usage on small borgs
+	var/has_small_sprite = FALSE
 
 /obj/item/robot_model/proc/dogborg_equip()
 	has_snowflake_deadsprite = TRUE

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,4 +1,4 @@
-var/has_small_sprite = FALSE
+var/has_small_sprite = TRUE
 
 /obj/item/robot_model/proc/dogborg_equip()
 	has_snowflake_deadsprite = TRUE
@@ -47,10 +47,9 @@ var/has_small_sprite = FALSE
 		wide.pixel_x = -16
 		standard_icons[a] = wide
 	standard_icons = sortList(standard_icons)
+	has_small_sprite = FALSE
 	var/standard_borg_icon = show_radial_menu(cyborg, cyborg , standard_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(standard_borg_icon)
-		if (1 == 1)
-			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "robot"
 			has_small_sprite = TRUE
@@ -122,10 +121,9 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			med_icons[a] = wide
 		med_icons = sortList(med_icons)
+	has_small_sprite = FALSE
 	var/med_borg_icon = show_radial_menu(cyborg, cyborg , med_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(med_borg_icon)
-		if (1 == 1)
-			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "medical"
 			has_small_sprite = TRUE
@@ -256,10 +254,9 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			engi_icons[a] = wide
 		engi_icons = sortList(engi_icons)
+	has_small_sprite = FALSE
 	var/engi_borg_icon = show_radial_menu(cyborg, cyborg , engi_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(engi_borg_icon)
-		if (1 == 1)
-			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "engineer"
 		if("Zoomba")
@@ -392,10 +389,9 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			sec_icons[a] = wide
 		sec_icons = sortList(sec_icons)
+	has_small_sprite = FALSE
 	var/sec_borg_icon = show_radial_menu(cyborg, cyborg , sec_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(sec_borg_icon)
-		if (1 == 1)
-			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "sec"
 		if("Zoomba")
@@ -510,10 +506,9 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			peace_icons[a] = wide
 		peace_icons = sortList(peace_icons)
+	has_small_sprite = FALSE
 	var/peace_borg_icon = show_radial_menu(cyborg, cyborg , peace_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(peace_borg_icon)
-		if (1 == 1)
-			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "peace"
 		if("Sleek")
@@ -594,10 +589,9 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			janitor_icons[a] = wide
 		janitor_icons = sortList(janitor_icons)
+	has_small_sprite = FALSE
 	var/janitor_robot_icon = show_radial_menu(cyborg, cyborg , janitor_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(janitor_robot_icon)
-		if (1 == 1)
-			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "janitor"
 		if("Zoomba")
@@ -689,10 +683,9 @@ var/has_small_sprite = FALSE
 		"Robot" = image(icon = 'modular_skyrat/modules/altborgs/icons/mob/robots_clown.dmi', icon_state = "clownbot"),
 		"Sleek" = image(icon = 'modular_skyrat/modules/altborgs/icons/mob/robots_clown.dmi', icon_state = "clownman")
 		))
+	has_small_sprite = FALSE
 	var/clown_borg_icon = show_radial_menu(cyborg, cyborg , clown_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(clown_borg_icon)
-		if (1 == 1)
-			has_small_sprite = FALSE
 		if("Default")
 			cyborg_base_icon = "clown"
 		if("Bootyborg")
@@ -746,10 +739,9 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			service_icons[a] = wide
 		service_icons = sortList(service_icons)
+	has_small_sprite = FALSE
 	var/service_robot_icon = show_radial_menu(cyborg, cyborg , service_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(service_robot_icon)
-		if (1 == 1)
-			has_small_sprite = FALSE
 		if("Waitress")
 			cyborg_base_icon = "service_f"
 			special_light_key = "service"
@@ -855,10 +847,9 @@ var/has_small_sprite = FALSE
 			wide.pixel_x = -16
 			mining_icons[a] = wide
 		mining_icons = sortList(mining_icons)
+	has_small_sprite = FALSE
 	var/mining_borg_icon = show_radial_menu(cyborg, cyborg , mining_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(mining_borg_icon)
-		if (1 == 1)
-			has_small_sprite = FALSE
 		if("Lavaland")
 			cyborg_base_icon = "miner"
 		if("Asteroid")
@@ -998,10 +989,9 @@ var/has_small_sprite = FALSE
 		"Male Booty Syndicate" = image(icon = 'modular_skyrat/modules/altborgs/icons/mob/robots_syndi.dmi', icon_state = "male_bootysyndie"),
 		"Mech" = image(icon = 'modular_skyrat/modules/altborgs/icons/mob/robots_syndi.dmi', icon_state = "chesty")
 		))
+	has_small_sprite = FALSE //Remove this line to prevent the shrink module from being used on any syndie borgs
 	var/syndiejack_icon = show_radial_menu(cyborg, cyborg , syndicatejack_icons, custom_check = CALLBACK(src, .proc/check_menu, cyborg, old_model), radius = 42, require_near = TRUE)
 	switch(syndiejack_icon)
-		if (1 == 1) //Remove this to disallow shrink module usage on syndie borgs
-			has_small_sprite = FALSE
 		if("Saboteur")
 			cyborg_base_icon = "synd_engi"
 			cyborg_icon_override = 'icons/mob/robots.dmi'

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -1,3 +1,4 @@
+var/mob/living/silicon/robot = new
 /mob/living/silicon/robot
 	var/hasShrunk = FALSE
 
@@ -14,7 +15,7 @@
 			to_chat(usr, "<span class='warning'>This unit already has a shrink module installed!</span>")
 			return FALSE
 
-		if(R.has_small_sprite && !R.hasExpanded)
+		if(has_small_sprite && !R.hasExpanded)
 			to_chat(usr, "<span class='warning'>This unit is too compact. It wouldn't be feasible make it any smaller!</span>")
 			return FALSE
 

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -40,6 +40,7 @@
 /obj/item/borg/upgrade/shrink/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (.)
+	R.has_small_sprite = FALSE
 		if (R.hasShrunk)
 			R.hasShrunk = FALSE
 			R.resize = (4/3)

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -11,7 +11,7 @@ var/mob/living/silicon/robot = new
 	. = ..()
 	if(.)
 
-		to_chat(usr, "<span class='warning'>DEBUG"+has_small_sprite+"</span>")
+		to_chat(usr, "<span class='warning'>DEBUG".has_small_sprite."</span>")
 
 		if(R.hasShrunk)
 			to_chat(usr, "<span class='warning'>This unit already has a shrink module installed!</span>")

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -15,8 +15,8 @@
 			return FALSE
 
 		if(R.has_small_sprite && !R.hasExpanded)
-				to_chat(usr, "<span class='warning'>This unit is too compact. It wouldn't be feasible make it any smaller!</span>")
-				return FALSE
+			to_chat(usr, "<span class='warning'>This unit is too compact. It wouldn't be feasible make it any smaller!</span>")
+			return FALSE
 
 		R.notransform = TRUE
 		var/prev_lockcharge = R.lockcharge

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -1,4 +1,4 @@
-var/mob/living/silicon/robot(obj/item/robot_model) = new
+var/mob/living/silicon/robot = new
 /mob/living/silicon/robot
 	var/hasShrunk = FALSE
 

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -1,4 +1,4 @@
-var/obj/item/robot_model = new
+var/mob/living/silicon/robot = new
 /mob/living/silicon/robot
 	var/hasShrunk = FALSE
 

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -43,7 +43,6 @@ var/mob/living/silicon/robot = new
 /obj/item/borg/upgrade/shrink/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (.)
-		has_small_sprite = FALSE
 		if (R.hasShrunk)
 			R.hasShrunk = FALSE
 			R.resize = (4/3)

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -43,6 +43,7 @@ var/mob/living/silicon/robot = new
 /obj/item/borg/upgrade/shrink/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (.)
+		has_small_sprite = TRUE
 		if (R.hasShrunk)
 			R.hasShrunk = FALSE
 			R.resize = (4/3)

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -41,7 +41,7 @@ var/mob/living/silicon/robot = new
 /obj/item/borg/upgrade/shrink/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (.)
-		R.has_small_sprite = FALSE
+		has_small_sprite = FALSE
 		if (R.hasShrunk)
 			R.hasShrunk = FALSE
 			R.resize = (4/3)

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -1,4 +1,4 @@
-var/mob/living/silicon/robot = new
+var/mob/living/silicon/robot = new //Imports variables for shrink module blacklist
 /mob/living/silicon/robot
 	var/hasShrunk = FALSE
 

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -1,4 +1,4 @@
-var/mob/living/silicon/robot = new
+var/obj/item/robot_model = new
 /mob/living/silicon/robot
 	var/hasShrunk = FALSE
 

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -1,4 +1,4 @@
-var/mob/living/silicon/robot = new
+var/mob/living/silicon/robot(obj/item/robot_model) = new
 /mob/living/silicon/robot
 	var/hasShrunk = FALSE
 

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -11,8 +11,6 @@ var/mob/living/silicon/robot = new
 	. = ..()
 	if(.)
 
-		to_chat(usr, "<span class='warning'>DEBUG: [has_small_sprite]</span>")
-
 		if(R.hasShrunk)
 			to_chat(usr, "<span class='warning'>This unit already has a shrink module installed!</span>")
 			return FALSE

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -11,11 +11,13 @@ var/mob/living/silicon/robot = new
 	. = ..()
 	if(.)
 
+		to_chat(usr, "<span class='warning'>DEBUG"+has_small_sprite+"</span>")
+
 		if(R.hasShrunk)
 			to_chat(usr, "<span class='warning'>This unit already has a shrink module installed!</span>")
 			return FALSE
 
-		if(has_small_sprite && !R.hasExpanded)
+		if(has_small_sprite == TRUE && !R.hasExpanded)
 			to_chat(usr, "<span class='warning'>This unit is too compact. It wouldn't be feasible make it any smaller!</span>")
 			return FALSE
 

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -11,7 +11,7 @@ var/mob/living/silicon/robot = new
 	. = ..()
 	if(.)
 
-		to_chat(usr, "<span class='warning'>DEBUG".has_small_sprite."</span>")
+		to_chat(usr, "<span class='warning'>DEBUG: [has_small_sprite]</span>")
 
 		if(R.hasShrunk)
 			to_chat(usr, "<span class='warning'>This unit already has a shrink module installed!</span>")

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -14,6 +14,10 @@
 			to_chat(usr, "<span class='warning'>This unit already has a shrink module installed!</span>")
 			return FALSE
 
+		if(R.has_small_sprite && !R.hasExpanded)
+				to_chat(usr, "<span class='warning'>This unit is too compact. It wouldn't be feasible make it any smaller!</span>")
+				return FALSE
+
 		R.notransform = TRUE
 		var/prev_lockcharge = R.lockcharge
 		R.SetLockdown(1)

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -1,5 +1,6 @@
 /mob/living/silicon/robot
 	var/hasShrunk = FALSE
+	var/has_small_sprite = FALSE
 
 /obj/item/borg/upgrade/shrink
 	name = "borg shrinker"

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -40,7 +40,7 @@
 /obj/item/borg/upgrade/shrink/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (.)
-	R.has_small_sprite = FALSE
+		R.has_small_sprite = FALSE
 		if (R.hasShrunk)
 			R.hasShrunk = FALSE
 			R.resize = (4/3)

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -1,6 +1,5 @@
 /mob/living/silicon/robot
 	var/hasShrunk = FALSE
-	var/has_small_sprite = FALSE
 
 /obj/item/borg/upgrade/shrink
 	name = "borg shrinker"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Borgs with small sprites are selectively disallowed from accepting the shrink module. This currently applies to the **default** borg, **Borgis**, **Zoombas**, **Eyebots**, that one **drone** borg, **certain** spider borgs (the weird small ones), and **Omoikane**. If you think there are any small borg types that I missed, please let me know in the comments. This PR is proposed alternative that closes #5186.

**Note: Borgs will not be able to accept the shrink upgrade until after they've selected their base borg module/type.**

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Borgs that are <5 pixels in height make some people angery. This is a better alternative to completely removing the shrink module from the game, which Xyel planned to do if no alternative was provided.

## Changelog
:cl:
balance: Prevents already-small borgs from becoming even smaller with the shrink module.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
