### PR TITLE
[MODULAR] (< sadly) Return of guns to the people, episode II, Revenge of the Shotguns.

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1221,7 +1221,8 @@
 	build_path = /obj/item/assembly/control
 	category = list("initial","Misc")
 
-/datum/design/shotgun_slug //SKYRAT EDIT START - SHOTGUN AMMO
+//SKYRAT EDIT START - SHOTGUN AMMO
+/datum/design/shotgun_slug
 	name = "Shotgun Slug"
 	id = "shotgun_slug"
 	build_type = AUTOLATHE
@@ -1235,4 +1236,5 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/buckshot
-	category = list("hacked", "Security") //SKYRAT EDIT END - SHOTGUN AMMO
+	category = list("hacked", "Security") 
+//SKYRAT EDIT END - SHOTGUN AMMO

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1221,7 +1221,7 @@
 	build_path = /obj/item/assembly/control
 	category = list("initial","Misc")
 
-/datum/design/shotgun_slug
+/datum/design/shotgun_slug //SKYRAT EDIT START - SHOTGUN AMMO
 	name = "Shotgun Slug"
 	id = "shotgun_slug"
 	build_type = AUTOLATHE
@@ -1235,4 +1235,4 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/buckshot
-	category = list("hacked", "Security")
+	category = list("hacked", "Security") //SKYRAT EDIT END - SHOTGUN AMMO

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1220,21 +1220,3 @@
 	materials = list(/datum/material/iron = 100, /datum/material/glass = 50)
 	build_path = /obj/item/assembly/control
 	category = list("initial","Misc")
-
-//SKYRAT EDIT START - SHOTGUN AMMO
-/datum/design/shotgun_slug
-	name = "Shotgun Slug"
-	id = "shotgun_slug"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 6000)
-	build_path = /obj/item/ammo_casing/shotgun
-	category = list("hacked", "Security")
-
-/datum/design/buckshot_shell
-	name = "Buckshot Shell"
-	id = "buckshot_shell"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/buckshot
-	category = list("hacked", "Security") 
-//SKYRAT EDIT END - SHOTGUN AMMO

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1220,3 +1220,19 @@
 	materials = list(/datum/material/iron = 100, /datum/material/glass = 50)
 	build_path = /obj/item/assembly/control
 	category = list("initial","Misc")
+
+/datum/design/shotgun_slug
+	name = "Shotgun Slug"
+	id = "shotgun_slug"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 6000)
+	build_path = /obj/item/ammo_casing/shotgun
+	category = list("hacked", "Security")
+
+/datum/design/buckshot_shell
+	name = "Buckshot Shell"
+	id = "buckshot_shell"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/buckshot
+	category = list("hacked", "Security")

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -133,6 +133,24 @@
 	crate_name = "unmarked weapons crate"
 	dangerous = TRUE
 	
+/datum/supply_pack/security/randomised/improvised
+	name = "Improvised Weapons Crate"
+	desc = "Really hit rock bottom? Well, we've got a few things laying around from a sting-op on pirates we could lend you. (We'll expect these back.)" //they don't, actually.
+	contraband = TRUE
+	cost = CARGO_CRATE_VALUE * 7
+	num_contained = 3
+	contains = list(/obj/item/gun/ballistic/revolver/rifle/improvised,
+					/obj/item/gun/ballistic/revolver/rifle, //Above, but better.
+					/obj/item/gun/ballistic/rifle/irifle, //just a shittier mosin, in a much less statistically valuable crate.
+					/obj/item/gun/ballistic/rifle/ishotgun,
+					/obj/item/gun/ballistic/rifle/ishotgun/sawn, //Why not, helps pad the list.
+					/obj/item/storage/box/beanbag,
+					/obj/item/storage/box/lethalshot,
+					/obj/item/ammo_box/c38, //Revolver rifle ammo.
+					/obj/item/ammo_box/a762, //rifle ammo.
+					/obj/item/gun/ballistic/automatic/pistol/toy) //they just hate you.
+	crate_name = "dusty crate"
+
 //////////////////////////////////////////////////////////////////////////////
 ///////////////////////////// Engineering ////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -133,7 +133,7 @@
 	crate_name = "unmarked weapons crate"
 	dangerous = TRUE
 	
-/datum/supply_pack/security/randomised/improvised
+/datum/supply_pack/costumes_toys/randomised/improvised
 	name = "Improvised Weapons Crate"
 	desc = "Really hit rock bottom? Well, we've got a few things laying around from a sting-op on pirates we could lend you. (We'll expect these back.)" //they don't, actually.
 	contraband = TRUE

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -148,6 +148,8 @@
 					/obj/item/storage/box/lethalshot,
 					/obj/item/ammo_box/c38, //Revolver rifle ammo.
 					/obj/item/ammo_box/a762, //rifle ammo.
+					/obj/item/gun/ballistic/automatic/surplus, //It's bad
+					/obj/item/ammo_box/magazine/m10mm/rifle,
 					/obj/item/gun/ballistic/automatic/pistol/toy) //they just hate you.
 	crate_name = "dusty crate"
 

--- a/modular_skyrat/modules/modular_weapons/code/modules/research/designs/autolathe_designs.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/research/designs/autolathe_designs.dm
@@ -132,3 +132,19 @@
 	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/ammo_casing/c10mm/rubber
 	category = list("initial", "Security")
+
+/datum/design/shotgun_slug
+	name = "Shotgun Slug"
+	id = "shotgun_slug"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 6000)
+	build_path = /obj/item/ammo_casing/shotgun
+	category = list("hacked", "Security")
+
+/datum/design/buckshot_shell
+	name = "Buckshot Shell"
+	id = "buckshot_shell"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/buckshot
+	category = list("hacked", "Security") 


### PR DESCRIPTION

## About The Pull Request

re-adds shomtgun shells to the autolathe (they're much weaker then, yet again, mosins, in all regards, especially after upstream nerfed them.), and an improvised weapons crate I skipped adding in episode one.
(this crate is yet again, worse then cargos other alternatives, and just slightly cheaper)

## Why It's Good For The Game

Security has a nice surplus of lethals for everything but their shotguns, this brings them back into "availability" without slapping them into the techfab (So they're not the priority, and also so 'regular crew' (antags) have access to them once more.).

the improv crate is just there to increase availability of really shitty guns for standoffs against 'antags' (zombies) and other threats (xenos).
## This is part of my secret anti cargo agenda(return of guns to the people) to justify reworking the mosin crates by providing a surplus of alternatives
## Changelog
:cl:
add: Shotgun shells return to autolathes, now ft'ing an improv weapons crate (its not worth it)
/:cl: