### PR TITLE
[Modular] Rebalance: Cybersun now gets a pair of Chameleon Thermal Goggles instead of a Mutator.

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/forgottenship_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/forgottenship_skyrat.dmm
@@ -441,13 +441,7 @@
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bt" = (
 /obj/structure/table/reinforced,
-/obj/item/dnainjector{
-	add_mutations = list(/datum/mutation/human/space_adaptation);
-	name = "\improper DNA injector (Space Adaptation)"
-	},
-/obj/item/clothing/glasses/night{
-	pixel_y = 6
-	},
+/obj/item/clothing/glasses/thermal/syndi,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bu" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/forgottenship_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/forgottenship_skyrat.dmm
@@ -441,7 +441,13 @@
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bt" = (
 /obj/structure/table/reinforced,
-/obj/item/dnainjector/thermal,
+/obj/item/dnainjector{
+	add_mutations = list(/datum/mutation/human/space_adaptation);
+	name = "\improper DNA injector (Space Adaptation)"
+	},
+/obj/item/clothing/glasses/night{
+	pixel_y = 6
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bu" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives Cybersun thermal goggles instead of a mutator, to prevent jackasses from copying it over and over across the security force because the captain died in space.
This is somehow a legitimate concern despite ghostrole policy. Seriously. Says a lot.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Same reasons we nuked thermals from genetics in the first place, with the addition of shittery done to ghostroles.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The Cybersun captain now gets thermal vision goggles instead of a mutator.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
