### PR TITLE
[MODULAR] Fixes the name on the windoor inside of research's security checkpoint.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -68318,7 +68318,7 @@
 "cZf" = (
 /obj/machinery/door/window/brigdoor{
 	id = "scicell";
-	name = "Medical Cell";
+	name = "Research Cell";
 	req_access_txt = "63"
 	},
 /obj/effect/turf_decal/tile/red{


### PR DESCRIPTION
## About The Pull Request

Corrects the name on the science division's security cell.
It was 'medical cell' it is now 'research cell'
This is why we don't copy/paste people.

## Why It's Good For The Game

I saw a complaint about it so I fixed it.

## Changelog
:cl: ZephyrTFA
spellcheck: There is no longer a 'medical cell' inside of Research.
/:cl:
