### PR TITLE
Misc. map fixes (typepaths etcetera) and prison updates.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -94886,6 +94886,9 @@
 /area/security/warden)
 "eHr" = (
 /obj/machinery/biogenerator,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/security/prison/safe)
 "eHJ" = (
@@ -95401,21 +95404,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"fmK" = (
-/obj/machinery/hydroponics/soil{
-	desc = "A patch of fertile soil that you can plant stuff in.";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "dirt";
-	layer = 2.0001;
-	plane = -2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/plating/dirt/planet{
-	icon_state = "oldsmoothdirt"
-	},
-/area/security/prison/safe)
 "fno" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -97683,15 +97671,15 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "hQA" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/machinery/hydroponics/soil{
 	desc = "A patch of fertile soil that you can plant stuff in.";
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "dirt";
 	layer = 2.0001;
-	plane = -2
-	},
-/obj/machinery/light{
-	dir = 4
+	plane = -7
 	},
 /turf/open/floor/plating/dirt/planet{
 	icon_state = "oldsmoothdirt"
@@ -98076,13 +98064,6 @@
 /area/security/brig)
 "ihX" = (
 /obj/structure/window,
-/obj/machinery/hydroponics/soil{
-	desc = "A patch of fertile soil that you can plant stuff in.";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "dirt";
-	layer = 2.0001;
-	plane = -2
-	},
 /obj/machinery/camera{
 	c_tag = "Permabrig - Garden";
 	dir = 8;
@@ -98095,6 +98076,13 @@
 	prison_radio = 1
 	},
 /obj/effect/turf_decal/weather/dirt,
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7
+	},
 /turf/open/floor/plating/dirt/planet{
 	icon_state = "oldsmoothdirt"
 	},
@@ -100730,15 +100718,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lce" = (
+/obj/machinery/door/window/southright,
+/obj/effect/turf_decal/weather/dirt,
 /obj/machinery/hydroponics/soil{
 	desc = "A patch of fertile soil that you can plant stuff in.";
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "dirt";
 	layer = 2.0001;
-	plane = -2
+	plane = -7
 	},
-/obj/machinery/door/window/southright,
-/obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plating/dirt/planet{
 	icon_state = "oldsmoothdirt"
 	},
@@ -101945,6 +101933,9 @@
 "mio" = (
 /obj/structure/window,
 /obj/machinery/seed_extractor,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/security/prison/safe)
 "miy" = (
@@ -102324,6 +102315,9 @@
 /area/security/execution/education)
 "mNS" = (
 /obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "mOe" = (
@@ -102743,6 +102737,9 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/crowbar,
 /obj/item/plant_analyzer,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/security/prison/safe)
 "neh" = (
@@ -103362,6 +103359,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"nNY" = (
+/obj/structure/weightmachine/weightlifter,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "nOg" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -108221,6 +108225,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos/upper)
+"sYz" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "sZa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -110048,7 +110058,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "dirt";
 	layer = 2.0001;
-	plane = -2
+	plane = -7
 	},
 /turf/open/floor/plating/dirt/planet{
 	icon_state = "oldsmoothdirt"
@@ -110390,17 +110400,14 @@
 /area/security/office)
 "vjn" = (
 /obj/structure/window,
+/obj/effect/turf_decal/weather/dirt,
 /obj/machinery/hydroponics/soil{
 	desc = "A patch of fertile soil that you can plant stuff in.";
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "dirt";
 	layer = 2.0001;
-	plane = -2
+	plane = -7
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plating/dirt/planet{
 	icon_state = "oldsmoothdirt"
 	},
@@ -110480,18 +110487,18 @@
 /turf/open/floor/iron/white,
 /area/maintenance/department/science)
 "vmv" = (
-/obj/machinery/hydroponics/soil{
-	desc = "A patch of fertile soil that you can plant stuff in.";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "dirt";
-	layer = 2.0001;
-	plane = -2
-	},
 /obj/structure/water_source{
 	dir = 8;
 	name = "sink";
 	pixel_x = 12;
 	pixel_y = -6
+	},
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7
 	},
 /turf/open/floor/plating/dirt/planet{
 	icon_state = "oldsmoothdirt"
@@ -167271,8 +167278,8 @@ uHd
 aaa
 vVc
 kQT
-fmK
-fmK
+uRZ
+uRZ
 vjn
 mNS
 xjZ
@@ -167531,7 +167538,7 @@ kQT
 uRZ
 uRZ
 lce
-yfl
+sYz
 mzo
 jrh
 wQu
@@ -167788,7 +167795,7 @@ kQT
 hQA
 vmv
 ihX
-uKf
+nNY
 hew
 yfl
 yfl

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -45196,7 +45196,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "dirt";
 	layer = 2.0001;
-	plane = -2
+	plane = -7
 	},
 /turf/open/floor/plating/dirt/planet{
 	icon_state = "oldsmoothdirt"
@@ -45823,6 +45823,7 @@
 "krE" = (
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/meter/atmos/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/prison)
 "krJ" = (
@@ -47078,10 +47079,8 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "lJt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/light/small,
-/turf/open/floor/plating,
+/obj/machinery/light,
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "lJw" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
@@ -48341,7 +48340,7 @@
 /obj/item/clothing/head/beanie/orange{
 	pixel_y = 8
 	},
-/obj/item/clothing/shoes/wheelys/skishoes{
+/obj/item/clothing/shoes/sneakers/wheelys/skishoes{
 	pixel_y = -8
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -50263,14 +50262,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
-"oZI" = (
-/obj/item/soap/nanotrasen,
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/obj/structure/curtain/cloth,
-/turf/open/floor/iron/freezer,
-/area/security/prison)
 "oZV" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 9
@@ -50502,6 +50493,7 @@
 "pmK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/prison)
 "pmL" = (
@@ -50970,11 +50962,6 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
-"pGf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "pGO" = (
 /obj/machinery/light{
 	dir = 4
@@ -51001,6 +50988,7 @@
 	},
 /area/security/prison/safe)
 "pIM" = (
+/obj/item/soap/nanotrasen,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "pIS" = (
@@ -52469,12 +52457,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"rhU" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/iron/freezer,
-/area/security/prison)
 "rid" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -53651,10 +53633,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "sxf" = (
-/obj/machinery/shower{
-	pixel_y = 16
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/structure/curtain/cloth,
+/obj/structure/sink{
+	pixel_y = 22
+	},
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "sxQ" = (
@@ -53809,6 +53793,7 @@
 "sHl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/glowstick,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/prison)
 "sHm" = (
@@ -53862,11 +53847,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "sKc" = (
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	pixel_y = -28
+/obj/machinery/shower{
+	dir = 4
 	},
 /turf/open/floor/iron/freezer,
 /area/security/prison)
@@ -54500,6 +54482,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/prison)
 "tqd" = (
@@ -57693,8 +57676,8 @@
 /turf/open/floor/carpet/green,
 /area/maintenance/space_hut/cabin)
 "wFu" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/shower{
+	dir = 8
 	},
 /turf/open/floor/iron/freezer,
 /area/security/prison)
@@ -81086,8 +81069,8 @@ boP
 boP
 boP
 aai
-oZI
-rhU
+sKc
+sKc
 sKc
 abz
 wfd
@@ -81345,7 +81328,7 @@ boP
 aai
 sxf
 pIM
-sKc
+lJt
 abz
 rOV
 giF
@@ -81599,10 +81582,10 @@ bBM
 boP
 boP
 boP
-acd
-sxf
+aai
 wFu
-pIM
+wFu
+wFu
 lzO
 gBy
 aGK
@@ -84429,7 +84412,7 @@ boP
 aai
 lJN
 xZn
-lJt
+wxl
 acd
 vOR
 oBk
@@ -84686,7 +84669,7 @@ boP
 aai
 fNM
 xZn
-pGf
+uAQ
 acd
 wIo
 oBk

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -6871,9 +6871,11 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aCd" = (
-/obj/machinery/cryopod,
 /obj/machinery/airalarm{
 	pixel_y = 18
+	},
+/obj/machinery/cryopod{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/crew_quarters/cryopod)
@@ -7731,18 +7733,9 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aFe" = (
-/obj/machinery/camera{
-	c_tag = "Dormitory South";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
+/obj/machinery/light,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "aFf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -40770,14 +40763,14 @@
 /turf/open/openspace,
 /area/science/xenobiology)
 "few" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/machinery/light_switch{
 	pixel_y = -22
+	},
+/obj/machinery/cryopod{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/crew_quarters/cryopod)
@@ -47079,9 +47072,18 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "lJt" = (
-/obj/machinery/light,
-/turf/open/floor/iron/freezer,
-/area/security/prison)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Dormitory South";
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "lJw" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /obj/machinery/airalarm/all_access{
@@ -50799,9 +50801,11 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "pAr" = (
-/obj/machinery/cryopod,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/cryopod{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/crew_quarters/cryopod)
@@ -54493,11 +54497,11 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "tqo" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/machinery/cryopod{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/crew_quarters/cryopod)
@@ -81328,7 +81332,7 @@ boP
 aai
 sxf
 pIM
-lJt
+aFe
 abz
 rOV
 giF
@@ -90638,8 +90642,8 @@ atj
 aAX
 azc
 qgF
-aFe
 azc
+lJt
 aHT
 aJy
 aJy

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -37730,6 +37730,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "gCa" = (
@@ -47963,10 +47964,10 @@
 "kHA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/item/clothing/shoes/wheelys/rollerskates{
+/obj/item/clothing/shoes/sneakers/wheelys/rollerskates{
 	pixel_y = 5
 	},
-/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/sneakers/wheelys/rollerskates,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
@@ -57454,6 +57455,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "orS" = (
@@ -72891,11 +72893,11 @@
 	pixel_y = -32
 	},
 /obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "dirt";
 	layer = 2.0001;
-	plane = -2;
-	self_sustaining = 1
+	plane = -7
 	},
 /turf/open/floor/grass,
 /area/security/prison)
@@ -83032,11 +83034,11 @@
 	dir = 8
 	},
 /obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "dirt";
 	layer = 2.0001;
-	plane = -2;
-	self_sustaining = 1
+	plane = -7
 	},
 /turf/open/floor/grass,
 /area/security/prison)
@@ -83281,13 +83283,12 @@
 /area/maintenance/port/aft)
 "ybE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "dirt";
 	layer = 2.0001;
-	plane = -2;
-	self_sustaining = 1
+	plane = -7
 	},
 /turf/open/floor/grass,
 /area/security/prison)

--- a/_maps/map_files/MetaStation/MetaStation_skyrat_old.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat_old.dmm
@@ -48767,10 +48767,10 @@
 "kHA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/item/clothing/shoes/wheelys/rollerskates{
+/obj/item/clothing/shoes/sneakers/wheelys/rollerskates{
 	pixel_y = 5
 	},
-/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/sneakers/wheelys/rollerskates,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -33196,6 +33196,7 @@
 "ckh" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 10
 	},
@@ -40599,6 +40600,7 @@
 	id = "prisoncell10";
 	name = "curtain"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "fBf" = (
@@ -42143,6 +42145,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 6
 	},
@@ -44429,7 +44432,7 @@
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "dirt";
 	layer = 2.0001;
-	plane = -2;
+	plane = -7;
 	self_sustaining = 1
 	},
 /turf/open/floor/plating/dirt/planet{
@@ -44542,6 +44545,7 @@
 	id = "prisoncell9";
 	name = "curtain"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "jUA" = (
@@ -45024,6 +45028,7 @@
 "krE" = (
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/meter/atmos/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/prison)
 "krJ" = (
@@ -46202,10 +46207,8 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "lJt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/light/small,
-/turf/open/floor/plating,
+/obj/machinery/light,
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "lJA" = (
 /obj/structure/closet/bombcloset,
@@ -46502,6 +46505,7 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 10
 	},
@@ -46603,6 +46607,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/brown/side,
 /area/security/prison/safe)
 "mbf" = (
@@ -48667,6 +48672,17 @@
 /obj/effect/turf_decal/tile/blue/darkblue,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"otA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell10";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "otB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -49170,14 +49186,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
-"oZI" = (
-/obj/item/soap/nanotrasen,
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/obj/structure/curtain/cloth,
-/turf/open/floor/iron/freezer,
-/area/security/prison)
 "oZV" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 9
@@ -49390,6 +49398,7 @@
 "pmK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/prison)
 "pmL" = (
@@ -49470,6 +49479,7 @@
 	id = "prisoncell11";
 	name = "curtain"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "prA" = (
@@ -49798,10 +49808,16 @@
 /turf/closed/wall,
 /area/commons/fitness)
 "pGf" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell11";
+	name = "curtain"
+	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/security/prison/safe)
 "pGO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49826,6 +49842,7 @@
 	},
 /area/security/prison/safe)
 "pIM" = (
+/obj/item/soap/nanotrasen,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "pIS" = (
@@ -50081,6 +50098,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"pUm" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell9";
+	name = "curtain"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "pUr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -51226,12 +51254,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"rhU" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/iron/freezer,
-/area/security/prison)
 "rid" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -52373,10 +52395,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "sxf" = (
-/obj/machinery/shower{
-	pixel_y = 16
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/structure/curtain/cloth,
+/obj/structure/sink{
+	pixel_y = 22
+	},
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "sxQ" = (
@@ -52522,6 +52546,7 @@
 "sHl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/glowstick,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/prison)
 "sHE" = (
@@ -52571,11 +52596,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "sKc" = (
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	pixel_y = -28
+/obj/machinery/shower{
+	dir = 4
 	},
 /turf/open/floor/iron/freezer,
 /area/security/prison)
@@ -52985,6 +53007,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 6
 	},
@@ -53188,6 +53211,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/prison)
 "tqd" = (
@@ -56506,8 +56530,8 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "wFu" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/shower{
+	dir = 8
 	},
 /turf/open/floor/iron/freezer,
 /area/security/prison)
@@ -79872,8 +79896,8 @@ sUX
 sUX
 sUX
 aai
-oZI
-rhU
+sKc
+sKc
 sKc
 abz
 wfd
@@ -80131,7 +80155,7 @@ xzh
 aai
 sxf
 pIM
-sKc
+lJt
 abz
 rOV
 giF
@@ -80385,10 +80409,10 @@ bBM
 xzh
 xzh
 xzh
-acd
-sxf
+aai
 wFu
-pIM
+wFu
+wFu
 lzO
 gBy
 aGK
@@ -83215,7 +83239,7 @@ xzh
 aai
 lJN
 xZn
-lJt
+wxl
 acd
 vOR
 oBk
@@ -83472,7 +83496,7 @@ xzh
 aai
 fNM
 xZn
-pGf
+uAQ
 acd
 wIo
 oBk
@@ -86825,13 +86849,13 @@ aai
 aai
 aaJ
 aaJ
+pGf
 aaJ
 aaJ
+otA
 aaJ
 aaJ
-aaJ
-aaJ
-aaJ
+pUm
 aaJ
 xzh
 xzh


### PR DESCRIPTION
## About The Pull Request
• Unjanks the sinks in the prison showers and shifts them around to be like a real shower, no privacy.
• Spacebox prison has more windows. The only reason Icebox didn't was because I didn't want the prisoners to be able to just walk out of the prison and walk onto the station with no risk. It's already stupidly easy to escape on Icebox, but, if you're going out of a window to escape into space.
• Fixes incorrect wall in prison showers.
• Prison soil has the correct plane.

## Why It's Good For The Game
funs the stuff make work compile

## Changelog
:cl:
fix: fixes prison gardening patches from aggressively power-topping items.
/:cl:
