### PR TITLE
[MODULAR] Brings Racial Languages Back To Felinids, Plasmamen and Primal Podpeople

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -285,6 +285,7 @@ GLOBAL_LIST_EMPTY(customizable_races)
 /datum/species/human/felinid
 	mutant_bodyparts = list()
 	default_mutant_bodyparts = list("tail" = "Cat", "ears" = "Cat")
+	learnable_languages = list(/datum/language/common, /datum/language/nekomimetic)
 
 /datum/species/human/monkey
 	mutant_bodyparts = list()
@@ -304,6 +305,7 @@ GLOBAL_LIST_EMPTY(customizable_races)
 	mutant_bodyparts = list()
 	can_have_genitals = FALSE
 	can_augment = FALSE
+	learnable_languages = list(/datum/language/common, /datum/language/calcic)
 
 /datum/species/ethereal
 	mutant_bodyparts = list()
@@ -314,6 +316,7 @@ GLOBAL_LIST_EMPTY(customizable_races)
 /datum/species/pod
 	name = "Primal Podperson"
 	always_customizable = TRUE
+	learnable_languages = list(/datum/language/common, /datum/language/sylvan)
 
 /datum/species/proc/get_random_features()
 	var/list/returned = MANDATORY_FEATURE_LIST


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what it says in the title. Felinids can now choose to speak Nekomimetic, Plasmamen can now choose to speak Calcic and Primal Podpeople (the ones from Lavaland) now speak Sylvan.
No, it doesn't give it to them straight away, you gotta spend your points in them to get them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Brings back languages that should've been included in the original PR for cultural changes. Can't use "they don't have a culture" as an argument when we don't have lore yet, so let's give people a chance to make up their own reasons for their characters speaking those languages.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex
fix: Felinids can now speak Nekomimetic again, the sudden widespread amnesia related to how to speak it is now over.
fix: Plasmamen can now speak Calcic again, like the skeletons they were always meant to be.
fix: Primal Podpeople momentarily forgot how to speak Sylvan, while their station equivalent could. Now they can all understand each other.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
