### PR TITLE
[Modular] No more double Interdyne

### DIFF
--- a/modular_skyrat/modules/mapping/code/datums/ruins/icemoon.dm
+++ b/modular_skyrat/modules/mapping/code/datums/ruins/icemoon.dm
@@ -6,6 +6,7 @@
 	suffix = "icemoon_underground_syndicate_base1_skyrat.dmm"
 	cost = 20
 	allow_duplicates = FALSE
+	never_spawn_with = list(/datum/map_template/ruin/lavaland/syndicate_base)
 
 /datum/map_template/ruin/icemoon/underground/mining_site_below
 	name = "Mining Site Underground"

--- a/modular_skyrat/modules/mapping/code/datums/ruins/lavaland.dm
+++ b/modular_skyrat/modules/mapping/code/datums/ruins/lavaland.dm
@@ -6,3 +6,4 @@
 	suffix = "lavaland_surface_syndicate_base1_skyrat.dmm"
 	cost = 20
 	allow_duplicates = FALSE
+	never_spawn_with = list(/datum/map_template/ruin/icemoon/underground/syndicate_base)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so that only one of the Interdyne bases can spawn at a time.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Only one Interdyne outpost can exist at a time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
