### PR TITLE
[MODULAR] Fixes icebox's distro not being connected roundstart to the air tank (speedmerge prob lmao)

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -23544,6 +23544,7 @@
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "bxG" = (
@@ -44173,6 +44174,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"iMz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "iNn" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room"
@@ -94313,7 +94318,7 @@ ceB
 bOd
 bOd
 chf
-bLK
+iMz
 bIZ
 ckd
 clc
@@ -94567,10 +94572,10 @@ bPh
 bQy
 bRI
 bQy
-bLK
-bLK
+iMz
+iMz
 bxF
-bLK
+iMz
 caO
 bOh
 bOh


### PR DESCRIPTION
## About The Pull Request
How
![lmao how](https://i.imgur.com/maA7vGR.png)

## Why It's Good For The Game

Because having air tends to be a good thing

## Changelog
:cl:
fix: Reattached Icebox distro to the air tank, supplying the station with much needed air
/:cl:

