### PR TITLE
Roundstart Xenos Begone

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -330,10 +330,17 @@
 	lootcount = 5
 
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner
+	/* SKYRAT EDIT STARTS - Original
 	name = "2% chance xeno egg spawner"
 	loot = list(
 		/obj/effect/decal/remains/xeno = 49,
 		/obj/effect/spawner/xeno_egg_delivery = 1)
+	*/
+	// The reason is simple: Mechanical round-ending antag at round-start is bad for a roleplay server
+	name = "0% chance xeno egg spawner"
+	loot = list(
+		/obj/effect/decal/remains/xeno = 50)
+	// SKYRAT EDIT ENDS
 
 /obj/effect/spawner/lootdrop/costume
 	name = "random costume spawner"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The 2% chance xenomorph egg spawner is now a 0% chance xenomorph egg spawner, which means that mappers won't have to change anything, it just won't happen anymore.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's always one-sided and doesn't create any interesting roleplay, it's purely mechanical and belongs to admin events, not regular roundstart rotation.

Permanent mechanical state isn't really fun for anyone but security, and even then, with Xenomorphs you typically can't win unless you powergame or CentCom sends ERTs after ERTs, and even then, it's not guaranteed.

Maybe it'll make a return once Xenomorphs are more balanced, but for now, this is probably the best solution.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex
del: Central Command realized that Xenomorph research was only losing in a complete loss of the station assets, and thus gave up on it pending further research in containment technologies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
