### PR TITLE
[oh no] Temp-fixes plasmaman SecMed, CDO, and Sgt

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/junior_officer/junior_officer.dm
+++ b/modular_skyrat/modules/sec_haul/code/junior_officer/junior_officer.dm
@@ -11,8 +11,8 @@
 	exp_requirements = 120
 	exp_type = EXP_TYPE_MEDICAL
 
-
 	outfit = /datum/outfit/job/junior_officer
+	plasmaman_outfit = /datum/outfit/plasmaman/security
 
 	paycheck = PAYCHECK_EASY
 	paycheck_department = ACCOUNT_SEC

--- a/modular_skyrat/modules/sec_haul/code/security_medic/security_medic.dm
+++ b/modular_skyrat/modules/sec_haul/code/security_medic/security_medic.dm
@@ -11,8 +11,8 @@
 	exp_requirements = 120
 	exp_type = EXP_TYPE_MEDICAL
 
-
 	outfit = /datum/outfit/job/security_medic
+	plasmaman_outfit = /datum/outfit/plasmaman/security
 
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_SEC

--- a/modular_skyrat/modules/sec_haul/code/security_sergeant/security_sergeant.dm
+++ b/modular_skyrat/modules/sec_haul/code/security_sergeant/security_sergeant.dm
@@ -12,6 +12,7 @@
 	exp_type = EXP_TYPE_SECURITY
 
 	outfit = /datum/outfit/job/security_sergeant
+	plasmaman_outfit = /datum/outfit/plasmaman/security
 
 	paycheck = PAYCHECK_HARD
 	paycheck_department = ACCOUNT_SEC


### PR DESCRIPTION
## About The Pull Request

They currently spawn on fire. This is bad. Ideally new shit will be made for it but I ain't no spriter and it'll take time.

This gives them the regular security plasmaman outfit as a temporary fix until new suits have been made for them

## Why It's Good For The Game

bug fix

## Changelog
:cl:
fix: Plasmamen can now join as Security Medics, CDOs, and Security Sergeants without bursting into flame.
/:cl: