### PR TITLE
[NONMODULAR] [TM FIRST] Shooting a gun while prone temporarily imobilises you, and reverts PR #5083 (laying down makes you drop stuff)

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1279,7 +1279,6 @@
 	if(!buckled || buckled.buckle_lying != 0)
 		lying_angle_on_lying_down(new_lying_angle)
 
-	drop_all_held_items() //SKYRAT EDIT ADDITION
 
 /// Special carbon interaction on lying down, to transform its sprite by a rotation.
 /mob/living/carbon/proc/lying_angle_on_lying_down(new_lying_angle)

--- a/modular_skyrat/master_files/code/modules/projectiles/guns/gun.dm
+++ b/modular_skyrat/master_files/code/modules/projectiles/guns/gun.dm
@@ -279,7 +279,7 @@
 								"<span class='danger'>You fire [src]!</span>", \
 								"<span class='hear'>You hear a gunshot!</span>", COMBAT_MESSAGE_RANGE)
 	if(user.resting) // SKYRAT EDIT ADD - no crawlshooting
-		user.Immobilize(10, TRUE) // SKYRAT EDIT END
+		user.Immobilize(20, TRUE) // SKYRAT EDIT END
 
 /obj/item/gun/emp_act(severity)
 	. = ..()

--- a/modular_skyrat/master_files/code/modules/projectiles/guns/gun.dm
+++ b/modular_skyrat/master_files/code/modules/projectiles/guns/gun.dm
@@ -278,6 +278,8 @@
 				user.visible_message("<span class='danger'>[user] fires [src]!</span>", \
 								"<span class='danger'>You fire [src]!</span>", \
 								"<span class='hear'>You hear a gunshot!</span>", COMBAT_MESSAGE_RANGE)
+	if(user.resting) // SKYRAT EDIT ADD - no crawlshooting
+		user.Immobilize(10, TRUE) // SKYRAT EDIT END
 
 /obj/item/gun/emp_act(severity)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what the title says. A TM would be appreciated to make sure the balance is, well, balanced. I tested it on a private hosting, but, that's without 120 players and like 50 or so tidi so, yeah.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stuns are OP if they make you drop things. A single baton hit/wall shove and you've lost the fight.

This way counters OP laying down combat (You're easier to hit while immobile), without INSANELY buffing stun combat, and makes sense from an IC perspective.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Combat has been changed again. Crawlshooting (as opposed from prone shooting) is no longer possible, while soft stuns (such as baton hits, or just laying down) no longer make you drop things.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
