### PR TITLE
[Modular] Makes it so you can attack without being on combat mode.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -170,11 +170,6 @@
 	if(force && HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
 		return
-	//SKYRAT EDIT ADDITION BEGIN
-	if(force && !user.combat_mode)
-		to_chat(user, "<span class='notice'>You go to attack [M] with [src], but refrain from doing so.</span>")
-		return
-	//SKRYAT EDIT END
 	if(!force)
 		playsound(loc, 'sound/weapons/tap.ogg', get_clamped_volume(), TRUE, -1)
 	else if(hitsound)


### PR DESCRIPTION
## About The Pull Request

Makes it so you don't need to be on combat mode to attack.
This is the normal state on TG, we changed it for some reason.

## Why It's Good For The Game

Combat mode is linked with other stuff, so with this change you have to be blocking people in order to attack anything, for example. Its really annoying because if I am clicking something with a weapon its because I want to attack it, and it is has created a couple of issues with the secondary effect of attack-based weapons can trigger without the actual attack. This change really just makes group fights annoying, while leading to cases where I am clearly trying to attack something, but can't, because I am on the wrong mode without noticing in the heat of battle. Oh, and it makes the Grasp of Rust fail to connect all the time, because that has a check to make it not target the floor when combat mode is off, but you need it on to use your actual weapon.

## Changelog
:cl:
qol: Made it easier to attack stuff.
fix: Fixed some issues related to weird attack checks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
