### PR TITLE
Disguises the EMP Syndibomb

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -226,8 +226,8 @@
 	payload = /obj/item/bombcore/training
 
 /obj/machinery/syndicatebomb/emp
-	name = "EMP Bomb"
-	desc = "A modified bomb designed to release a crippling electromagnetic pulse instead of explode"
+	//name = "EMP bomb" //SKYRAT EDIT: Makes the bomb look identical to its deadlier cousin
+	//desc = "A modified bomb designed to release a crippling electromagnetic pulse instead of explode" //SKYRAT EDIT: see above
 	payload = /obj/item/bombcore/emp
 
 /obj/machinery/syndicatebomb/badmin


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Takes away the identifying factors of the EMP syndicate bomb so it looks identical to the more physically explosive cousin
## Why It's Good For The Game
Buff's the bomb's scary factor. 7 TC for a bomb that does no real lasting damage is kind of lame, but knowing you're dealing with one just isn't nearly as intimidating for security / the station. 
I'd love to add description checks for syndicate but that's not implemented on machines.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The EMP Syndicate Bomb has had its name scrubbed off. Better hope that bomb you're defusing is one of those instead!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
