### PR TITLE
[NON-MODULAR] Heretics, Episode II, We went to far😈 

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -504,7 +504,7 @@
 
 /obj/effect/proc_holder/spell/targeted/fiery_rebirth
 	name = "Nightwatcher's Rebirth"
-	desc = "Drains nearby alive people that are engulfed in flames. It heals 10 of each damage type per person. If a target is in critical condition it drains the last of their vitality, killing them."
+	desc = "Drains nearby alive people that are engulfed in flames. It heals a low amount of each damage type per person, favoring burn. If a target is in critical condition it drains the last of their vitality, killing them."
 	invocation = "GL'RY T' TH' N'GHT'W'TCH'ER"
 	invocation_type = INVOCATION_WHISPER
 	school = SCHOOL_FORBIDDEN
@@ -529,11 +529,11 @@
 		target.adjustFireLoss(20)
 		new /obj/effect/temp_visual/eldritch_smoke(target.drop_location())
 		human_user.extinguish_mob()
-		human_user.adjustBruteLoss(-10, FALSE)
+		human_user.adjustBruteLoss(-7, FALSE) //SKYRAT EDIT - ORIGINAL 10
 		human_user.adjustFireLoss(-10, FALSE)
-		human_user.adjustStaminaLoss(-10, FALSE)
-		human_user.adjustToxLoss(-10, FALSE)
-		human_user.adjustOxyLoss(-10)
+		human_user.adjustStaminaLoss(-7, FALSE) //SKYRAT EDIT - ORIGINAL 10
+		human_user.adjustToxLoss(-8, FALSE) //SKYRAT EDIT - ORIGINAL 10
+		human_user.adjustOxyLoss(-6) //SKYRAT EDIT - ORIGINAL 10
 
 /obj/effect/proc_holder/spell/pointed/manse_link
 	name = "Mansus Link"

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -504,7 +504,7 @@
 
 /obj/effect/proc_holder/spell/targeted/fiery_rebirth
 	name = "Nightwatcher's Rebirth"
-	desc = "Drains nearby alive people that are engulfed in flames. It heals a low amount of each damage type per person, favoring burn. If a target is in critical condition it drains the last of their vitality, killing them."
+	desc = "Drains nearby alive people that are engulfed in flames. It heals a low amount of each damage type per person, favoring burn. If a target is in critical condition it drains the last of their vitality, killing them." //SKYRAT EDIT - ORIGINAL: "Drains nearby alive people that are engulfed in flames. It heals 10 of each damage type per person. If a target is in critical condition it drains the last of their vitality, killing them."
 	invocation = "GL'RY T' TH' N'GHT'W'TCH'ER"
 	invocation_type = INVOCATION_WHISPER
 	school = SCHOOL_FORBIDDEN

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -188,7 +188,7 @@
 	gain_text = "The Nightwatcher found the rite and shared it amongst mankind! For now I am one with the fire, WITNESS MY ASCENSION!"
 	desc = "Bring 3 corpses onto a transmutation rune, you will become immune to fire, the vacuum of space, cold and other enviromental hazards and become overall sturdier to all other damages. You will gain a spell that passively creates ring of fire around you as well ,as you will gain a powerful ability that lets you create a wave of flames all around you."
 	required_atoms = list(/mob/living/carbon/human)
-	cost = 5
+	cost = 5 //SKYRAT EDIT - ORIGINAL: 3
 	route = PATH_ASH
 	var/list/trait_list = list(
 		TRAIT_RESISTHEAT,

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -188,7 +188,7 @@
 	gain_text = "The Nightwatcher found the rite and shared it amongst mankind! For now I am one with the fire, WITNESS MY ASCENSION!"
 	desc = "Bring 3 corpses onto a transmutation rune, you will become immune to fire, the vacuum of space, cold and other enviromental hazards and become overall sturdier to all other damages. You will gain a spell that passively creates ring of fire around you as well ,as you will gain a powerful ability that lets you create a wave of flames all around you."
 	required_atoms = list(/mob/living/carbon/human)
-	cost = 5 //SKYRAT EDIT - ORIGINAL: 3
+	cost = 4 //SKYRAT EDIT - ORIGINAL: 3
 	route = PATH_ASH
 	var/list/trait_list = list(
 		TRAIT_RESISTHEAT,

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -188,7 +188,7 @@
 	gain_text = "The Nightwatcher found the rite and shared it amongst mankind! For now I am one with the fire, WITNESS MY ASCENSION!"
 	desc = "Bring 3 corpses onto a transmutation rune, you will become immune to fire, the vacuum of space, cold and other enviromental hazards and become overall sturdier to all other damages. You will gain a spell that passively creates ring of fire around you as well ,as you will gain a powerful ability that lets you create a wave of flames all around you."
 	required_atoms = list(/mob/living/carbon/human)
-	cost = 3
+	cost = 5
 	route = PATH_ASH
 	var/list/trait_list = list(
 		TRAIT_RESISTHEAT,

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -188,7 +188,7 @@
 	gain_text = "The Nightwatcher found the rite and shared it amongst mankind! For now I am one with the fire, WITNESS MY ASCENSION!"
 	desc = "Bring 3 corpses onto a transmutation rune, you will become immune to fire, the vacuum of space, cold and other enviromental hazards and become overall sturdier to all other damages. You will gain a spell that passively creates ring of fire around you as well ,as you will gain a powerful ability that lets you create a wave of flames all around you."
 	required_atoms = list(/mob/living/carbon/human)
-	cost = 4 //SKYRAT EDIT - ORIGINAL: 3
+	cost = 5 //SKYRAT EDIT - ORIGINAL: 3
 	route = PATH_ASH
 	var/list/trait_list = list(
 		TRAIT_RESISTHEAT,

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -225,7 +225,7 @@
 	gain_text = "Men of this world. Hear me, for the time of the Lord of Arms has come! The Emperor of Flesh guides my army!"
 	desc = "Bring 3 bodies onto a transmutation rune to shed your human form and ascend to untold power."
 	required_atoms = list(/mob/living/carbon/human)
-	cost = 3
+	cost = 5 //SKYRAT EDIT - ORIGINAL: 3
 	route = PATH_FLESH
 
 /datum/eldritch_knowledge/final/flesh_final/on_finished_recipe(mob/living/user, list/atoms, loc)

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -159,7 +159,7 @@
 	name = "Rustbringer's Oath"
 	desc = "Bring 3 corpses onto the transmutation rune. After you finish the ritual rust will now automatically spread from the rune. Your healing on rust is also tripled, while you become extremely more resillient."
 	gain_text = "Champion of rust. Corruptor of steel. Fear the dark for the Rustbringer has come! Rusted Hills, CALL MY NAME!"
-	cost = 6 //SKYRAT EDIT - ORIGINAL: 3
+	cost = 4 //SKYRAT EDIT - ORIGINAL: 3
 	required_atoms = list(/mob/living/carbon/human)
 	route = PATH_RUST
 	var/list/conditional_immunities = list(TRAIT_STUNIMMUNE,TRAIT_SLEEPIMMUNE,TRAIT_PUSHIMMUNE,TRAIT_SHOCKIMMUNE,TRAIT_NOSLIPALL,TRAIT_RADIMMUNE,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_RESISTCOLD,TRAIT_RESISTHEAT,TRAIT_PIERCEIMMUNE,TRAIT_BOMBIMMUNE,TRAIT_NOBREATH)
@@ -200,11 +200,11 @@
 	if(!istype(user_loc_turf, /turf/open/floor/plating/rust) || !isliving(user) || !finished)
 		return
 	var/mob/living/carbon/human/human_user = user
-	human_user.adjustBruteLoss(-4, FALSE)
+	human_user.adjustBruteLoss(-3, FALSE) //SKYRAT EDIT - ORIGINAL: 4
 	human_user.adjustFireLoss(-4, FALSE)
-	human_user.adjustToxLoss(-4, FALSE, forced = TRUE)
+	human_user.adjustToxLoss(-2, FALSE, forced = TRUE) //SKYRAT EDIT - ORIGINAL: 4
 	human_user.adjustOxyLoss(-4, FALSE)
-	human_user.adjustStaminaLoss(-20)
+	human_user.adjustStaminaLoss(-10) //SKYRAT EDIT - ORIGINAL: 20
 
 /**
  * #Rust spread datum

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -159,7 +159,7 @@
 	name = "Rustbringer's Oath"
 	desc = "Bring 3 corpses onto the transmutation rune. After you finish the ritual rust will now automatically spread from the rune. Your healing on rust is also tripled, while you become extremely more resillient."
 	gain_text = "Champion of rust. Corruptor of steel. Fear the dark for the Rustbringer has come! Rusted Hills, CALL MY NAME!"
-	cost = 3
+	cost = 6
 	required_atoms = list(/mob/living/carbon/human)
 	route = PATH_RUST
 	var/list/conditional_immunities = list(TRAIT_STUNIMMUNE,TRAIT_SLEEPIMMUNE,TRAIT_PUSHIMMUNE,TRAIT_SHOCKIMMUNE,TRAIT_NOSLIPALL,TRAIT_RADIMMUNE,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_RESISTCOLD,TRAIT_RESISTHEAT,TRAIT_PIERCEIMMUNE,TRAIT_BOMBIMMUNE,TRAIT_NOBREATH)

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -159,7 +159,7 @@
 	name = "Rustbringer's Oath"
 	desc = "Bring 3 corpses onto the transmutation rune. After you finish the ritual rust will now automatically spread from the rune. Your healing on rust is also tripled, while you become extremely more resillient."
 	gain_text = "Champion of rust. Corruptor of steel. Fear the dark for the Rustbringer has come! Rusted Hills, CALL MY NAME!"
-	cost = 6
+	cost = 6 //SKYRAT EDIT - ORIGINAL: 3
 	required_atoms = list(/mob/living/carbon/human)
 	route = PATH_RUST
 	var/list/conditional_immunities = list(TRAIT_STUNIMMUNE,TRAIT_SLEEPIMMUNE,TRAIT_PUSHIMMUNE,TRAIT_SHOCKIMMUNE,TRAIT_NOSLIPALL,TRAIT_RADIMMUNE,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_RESISTCOLD,TRAIT_RESISTHEAT,TRAIT_PIERCEIMMUNE,TRAIT_BOMBIMMUNE,TRAIT_NOBREATH)

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -159,7 +159,7 @@
 	name = "Rustbringer's Oath"
 	desc = "Bring 3 corpses onto the transmutation rune. After you finish the ritual rust will now automatically spread from the rune. Your healing on rust is also tripled, while you become extremely more resillient."
 	gain_text = "Champion of rust. Corruptor of steel. Fear the dark for the Rustbringer has come! Rusted Hills, CALL MY NAME!"
-	cost = 4 //SKYRAT EDIT - ORIGINAL: 3
+	cost = 5 //SKYRAT EDIT - ORIGINAL: 3
 	required_atoms = list(/mob/living/carbon/human)
 	route = PATH_RUST
 	var/list/conditional_immunities = list(TRAIT_STUNIMMUNE,TRAIT_SLEEPIMMUNE,TRAIT_PUSHIMMUNE,TRAIT_SHOCKIMMUNE,TRAIT_NOSLIPALL,TRAIT_RADIMMUNE,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_RESISTCOLD,TRAIT_RESISTHEAT,TRAIT_PIERCEIMMUNE,TRAIT_BOMBIMMUNE,TRAIT_NOBREATH)

--- a/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/void_lore.dm
@@ -175,7 +175,7 @@
 	name = "Waltz at the End of Time"
 	desc = "Bring 3 corpses onto the transmutation rune. After you finish the ritual you will automatically silence people around you and will summon a snow storm around you."
 	gain_text = "The world falls into darkness. I stand in an empty plane, small flakes of ice fall from the sky. Aristocrat stand before me, he motions to me. We will play a waltz to the whispers of dying reality, as the world is destroyed before our eyes."
-	cost = 3
+	cost = 5 //SKYRAT EDIT - ORIGINAL: 3
 	required_atoms = list(/mob/living/carbon/human)
 	route = PATH_VOID
 	///soundloop for the void theme


### PR DESCRIPTION
## About The Pull Request
This is episode two of the series, this one will more then likely be focusing on cost adjusting the easier abilities, to keep them in line with the other much harder, and often times, less rewarding ones.

This will be accompanied with mild buffs to their lower tier abilities, so they aren't entirely cursed with their slower ascensions, but the primary attention is toning them(Rust and Ash) back because they are slightly over-bearing compared to the other two.
## Why It's Good For The Game

keeping heretic paths vaguely aligned in power to reward, and more importantly, toning back the path(s) of least resistance hahaha get it because they're called paths.

## As always, feedback is a requirement.
## Changelog
:cl:
balance: All ascensions cost more, to be in line with the ideal that ascension shouldn't be a semi-common event.
balance: fiery-rebirth is less overkill on a server where most people won't actually try to fight you
balance: kicked rust ascension in the shins, due to their cheap teleport, along with potions making them nigh-unkillable.
/:cl:
