### PR TITLE
[NON-MODULAR] Container swapping for Pandemic machine.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -138,9 +138,12 @@
 
 /obj/machinery/computer/pandemic/proc/eject_beaker()
 	if(beaker)
+		var/obj/item/reagent_containers/B = beaker
 		try_put_in_hand(beaker, usr)
 		beaker = null
 		update_appearance()
+		return B
+	return null
 
 /obj/machinery/computer/pandemic/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -237,14 +240,17 @@
 		. = TRUE //no afterattack
 		if(machine_stat & (NOPOWER|BROKEN))
 			return
+		var/obj/item/reagent_containers/B
 		if(beaker)
-			to_chat(user, "<span class='warning'>A container is already loaded into [src]!</span>")
-			return
+			B = eject_beaker() //now with 100% more swapping
 		if(!user.transferItemToLoc(I, src))
 			return
-
+		if(B)
+			if(user && Adjacent(user) && user.can_hold_items())
+				user.put_in_hands(B)
 		beaker = I
-		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
+		if(B) to_chat(user, "<span class='notice'>You remove [B] and insert [I] into [src].</span>")
+		else to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
 		update_appearance()
 	else
 		return ..()


### PR DESCRIPTION
## About The Pull Request

This lets you swap reagent containers for the pandemic machine, instead of having to eject a container first before inserting a new one. Code shamelessly stolen from https://github.com/Citadel-Station-13/Citadel-Station-13/pull/14574 for the record, because I was pretty sure you could already do it there, and found that.

## Why It's Good For The Game

Quality of life.
Like actually, the current system feels so awful.
This is how it used to work on Old Base, pretty sure anyway.
Its how it works on Citadel now at the very least.

## Changelog
:cl:
qol: The pandemic now actually swaps your container instead of spitting in your face.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
