### PR TITLE
[MODULAR] Removes antimagic protection from the ez-craft crucifix

### DIFF
--- a/modular_skyrat/modules/modular_items/code/game/objects/items/cross.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/cross.dm
@@ -11,10 +11,6 @@
 	throwforce = 15
 	w_class = WEIGHT_CLASS_TINY
 
-//obj/item/crucifix/Initialize()
-//	. = ..()
-//	AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, ITEM_SLOT_HANDS, null, FALSE) //Its a cross, so of course its Holy.
-
 /datum/crafting_recipe/cross
 	name = "Ornate Cross"
 	result = /obj/item/crucifix

--- a/modular_skyrat/modules/modular_items/code/game/objects/items/cross.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/cross.dm
@@ -11,9 +11,9 @@
 	throwforce = 15
 	w_class = WEIGHT_CLASS_TINY
 
-/obj/item/crucifix/Initialize()
-	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, ITEM_SLOT_HANDS, null, FALSE) //Its a cross, so of course its Holy.
+//obj/item/crucifix/Initialize()
+//	. = ..()
+//	AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, ITEM_SLOT_HANDS, null, FALSE) //Its a cross, so of course its Holy.
 
 /datum/crafting_recipe/cross
 	name = "Ornate Cross"


### PR DESCRIPTION
## About The Pull Request
Removes antimagic properties from the restrictionless cross, now that two antags use magic.

## Why It's Good For The Game

an item that can be crafted by anyone, with just two sheets of ore, that almost completely negates two antags probably isn't a good balancing idea.

## Changelog
balance: commented out antimagic from the crafting menu crucifix.
/:cl:
