### PR TITLE
[MODULAR] Re-adds gas miners and layer adapters back to atmos

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -20166,6 +20166,7 @@
 /area/engineering/atmos)
 "aXW" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "aXX" = (
@@ -21613,6 +21614,7 @@
 /area/engineering/atmos)
 "bbO" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "bbP" = (
@@ -22652,6 +22654,7 @@
 /area/engineering/atmos)
 "bev" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bew" = (
@@ -24322,6 +24325,7 @@
 /area/engineering/atmos)
 "bhw" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "bhx" = (
@@ -25861,6 +25865,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide{
 	valve_open = 1
 	},
+/obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bkI" = (
@@ -100687,10 +100692,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "kZv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible{
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible{
 	dir = 4
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "kZN" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -5193,6 +5193,7 @@
 /area/engineering/break_room)
 "cdH" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "cdJ" = (
@@ -12875,7 +12876,7 @@
 /area/cargo/qm)
 "feB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -19637,6 +19638,7 @@
 /area/maintenance/starboard/aft)
 "hOw" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "hOy" = (
@@ -22162,6 +22164,11 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall,
 /area/cargo/miningdock)
+"iNq" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "iNt" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
@@ -33878,6 +33885,7 @@
 /area/science/mixing)
 "nwg" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "nwy" = (
@@ -40868,6 +40876,7 @@
 /area/security/prison)
 "qsq" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "qsM" = (
@@ -46103,6 +46112,7 @@
 /area/security/prison)
 "syd" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "syn" = (
@@ -49417,7 +49427,7 @@
 /area/hallway/primary/central)
 "tWG" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "tWQ" = (
@@ -93284,7 +93294,7 @@ eRv
 oHY
 knR
 bLt
-tWG
+iNq
 mmI
 qyN
 fQo

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -16280,6 +16280,7 @@
 /area/engineering/atmos)
 "aDA" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "aDC" = (
@@ -16287,6 +16288,7 @@
 /area/engineering/atmos)
 "aDD" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "aDE" = (
@@ -17030,14 +17032,17 @@
 /area/medical/exam_room)
 "aFm" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "aFn" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "aFo" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "aFp" = (
@@ -18891,13 +18896,13 @@
 /turf/closed/wall,
 /area/maintenance/central)
 "aIO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible,
 /turf/closed/wall,
 /area/engineering/atmos)
 "aIP" = (
@@ -19792,10 +19797,10 @@
 	},
 /area/maintenance/starboard)
 "aKm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible,
 /turf/closed/wall/rust,
 /area/engineering/atmos)
 "aKn" = (
@@ -56362,7 +56367,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible{
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible{
 	dir = 4
 	},
 /turf/closed/wall,

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -35087,13 +35087,6 @@
 /obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"fFp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "fFr" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
@@ -39032,6 +39025,7 @@
 /area/security/brig)
 "hdc" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "hdh" = (
@@ -46800,7 +46794,7 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "kmD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -47427,9 +47421,7 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "kyM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
@@ -47490,10 +47482,10 @@
 /turf/open/floor/iron/dark,
 /area/commons/locker)
 "kzE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "kzK" = (
@@ -48354,10 +48346,10 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "kQd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "kQw" = (
@@ -54981,6 +54973,7 @@
 /area/engineering/supermatter/room)
 "ntx" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "ntZ" = (
@@ -69901,10 +69894,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "sVq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "sVD" = (
@@ -71591,6 +71584,7 @@
 /area/command/heads_quarters/hop)
 "tGx" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "tGF" = (
@@ -75312,6 +75306,7 @@
 /area/security/prison)
 "vaC" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "vaK" = (
@@ -81695,6 +81690,7 @@
 /area/maintenance/port/aft)
 "xuL" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "xvg" = (
@@ -128566,11 +128562,11 @@ kcJ
 cor
 hnN
 cor
-fFp
+kmD
 cor
 hnN
 byG
-kcJ
+kmD
 cor
 hnN
 cor

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -29801,6 +29801,14 @@
 	},
 /turf/open/openspace,
 /area/security/prison)
+"eOA" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "eOC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44411,6 +44419,7 @@
 /area/maintenance/port/central)
 "lpr" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "lpF" = (
@@ -50596,6 +50605,7 @@
 /area/cargo/miningdock)
 "olj" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "ols" = (
@@ -55895,6 +55905,7 @@
 /area/hallway/primary/tram/center)
 "qEi" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "qEz" = (
@@ -63474,6 +63485,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"tWT" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "tXi" = (
 /turf/closed/wall/r_wall,
 /area/security/office)
@@ -71745,6 +71761,7 @@
 /area/engineering/atmos)
 "xFX" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "xGb" = (
@@ -72269,6 +72286,7 @@
 /area/maintenance/solars/starboard)
 "xPD" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "xPR" = (
@@ -107068,7 +107086,7 @@ lGS
 iVY
 pHm
 uKH
-gFR
+tWT
 gED
 swO
 hEH
@@ -108096,7 +108114,7 @@ gVz
 tau
 whV
 iFE
-gFR
+tWT
 gED
 swO
 qih
@@ -109624,15 +109642,15 @@ bJW
 mgz
 fTV
 yhr
-bJW
+eOA
 mgz
 fTV
 noT
-bJW
+eOA
 mgz
 fTV
 noT
-bJW
+eOA
 mgz
 fTV
 noT


### PR DESCRIPTION
## About The Pull Request

Map resets go brrrr and we keep forgetting to add these back

## Why It's Good For The Game

Allows atmos techs to do their weird shit without accidentally using up all the oxygen. Also can't really think of anything else cause i'm sick af. Anyway, just lets atmos techs kinda have something to do during the shift without worrying about compromising the air supply by using all the N2 or O2. Plus if NSS Journey can have it, why not everyone else *dab

## Changelog
:cl:
add: Atmospherics now has gas miners along with layer adapters to make Atmospheric Techs happy
/:cl:
