### PR TITLE
[Non-Modular] Stops borgs from being a glorified departmental comms loudspeaker

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -386,6 +386,7 @@
 	subspace_transmission = TRUE
 	subspace_switchable = TRUE
 	dog_fashion = null
+	canhear_range = 0 // Skyrat Edit - Stops borgs being a loudspeaker and contains it to the tile they're on
 
 /obj/item/radio/borg/resetChannels()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Hey turns out they use a station bounced radio which is why they're like a freebie to listening to departmental drama

## Why It's Good For The Game

Well lets say being an AI shell isn't a good time when you're trying to vibe somewhere public and everyone can hear how command likes their burrito with extra beanz or how security thinks the funny gray man is looking sus

Jokes aside it stops comms bleeding out when you know.., you're a robot... communications would be internal...

Also you can still hear comms if you're on the same tile as the borg so for example. You're riding their back or underneath them *dab

## Changelog
:cl:
fix: Fixed borgs being a loudspeaker for people to listen in on departmental stuff
/:cl:


