### PR TITLE
[MODULAR] Adds Ashwalker/Golem Fingers Quirk

### DIFF
--- a/code/__DEFINES/~skyrat_defines/jobs.dm
+++ b/code/__DEFINES/~skyrat_defines/jobs.dm
@@ -2,5 +2,6 @@
 #define JOB_UNAVAILABLE_SPECIES 7
 #define JOB_UNAVAILABLE_LANGUAGE 7
 
-#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE
-#define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE
+#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE
+#define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE
+#define TECH_RESTRICTED_QUIRKS "Chunky Fingers" = TRUE

--- a/modular_skyrat/master_files/code/datums/traits/negative.dm
+++ b/modular_skyrat/master_files/code/datums/traits/negative.dm
@@ -36,9 +36,9 @@
 
 /datum/quirk/ashwalkertalons
 	name = "Chunky Fingers"
-	desc = "Your digits are thick and tough, making firing non-adapted firearms impossible."
-	gain_text = "<span class='notice'>Your fingers feel thicker and slightly less dextrous. Trigger guards seem unusably small now, and might need modification before you can fire a gun.</span>"
-	lose_text = "<span class='notice'>Your digits feel lithe and capable of operating a trigger.</span>"
-	medical_record_text = "Patient's digits are thick and incapable of operating some fine devices, tools or non-adapted firearms."
-	value = -4
+	desc = "Your digits are thick and tough and unable to use modular computers including tablets, certain devices like laser pointers, and non-adapted firearms."
+	gain_text = "<span class='notice'>Your fingers feel thicker and slightly less dextrous. You expect you'll have a difficult time using computers, certain small devices and firearms.</span>"
+	lose_text = "<span class='notice'>Your digits feel lithe and capable once more.</span>"
+	medical_record_text = "Patient's digits are thick and lack the dexterity for operating some small devices, computers and non-adapted firearms."
+	value = -8
 	mob_trait = TRAIT_CHUNKYFINGERS

--- a/modular_skyrat/master_files/code/datums/traits/negative.dm
+++ b/modular_skyrat/master_files/code/datums/traits/negative.dm
@@ -33,3 +33,12 @@
 	. = ..()
 	var/mob/living/carbon/human/H = quirk_holder
 	H?.cure_trauma_type(/datum/brain_trauma/severe/monophobia, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/ashwalkertalons
+	name = "Chunky Fingers"
+	desc = "Your digits are thick and tough, making firing non-adapted firearms impossible."
+	gain_text = "<span class='notice'>Your fingers feel thicker and slightly less dextrous. Trigger guards seem unusably small now, and might need modification before you can fire a gun.</span>"
+	lose_text = "<span class='notice'>Your digits feel lithe and capable of operating a trigger.</span>"
+	medical_record_text = "Patient's digits are thick and incapable of operating some fine devices, tools or non-adapted firearms."
+	value = -4
+	mob_trait = TRAIT_CHUNKYFINGERS

--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -11,7 +11,7 @@
 	var/list/species_whitelist
 	//Blacklist of species for this job.
 	var/list/species_blacklist
-	/// Which languages does the job require, associative to LANGUAGE_UNDERSTOOD or LANGUAGE_SPOKEN 
+	/// Which languages does the job require, associative to LANGUAGE_UNDERSTOOD or LANGUAGE_SPOKEN
 	var/list/required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/proc/has_banned_quirk(datum/preferences/pref)
@@ -49,7 +49,7 @@
 
 /datum/job/security_sergeant
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
-	
+
 /datum/job/security_medic
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 
@@ -100,6 +100,27 @@
 
 /datum/job/prisoner
 	required_languages = null
+
+/datum/job/station_engineer
+	banned_quirks = list(TECH_RESTRICTED_QUIRKS)
+
+/datum/job/atmospheric_technician
+	banned_quirks = list(TECH_RESTRICTED_QUIRKS)
+
+/datum/job/doctor
+	banned_quirks = list(TECH_RESTRICTED_QUIRKS)
+
+/datum/job/virologist
+	banned_quirks = list(TECH_RESTRICTED_QUIRKS)
+
+/datum/job/chemist
+	banned_quirks = list(TECH_RESTRICTED_QUIRKS)
+
+/datum/job/roboticist
+	banned_quirks = list(TECH_RESTRICTED_QUIRKS)
+
+/datum/job/scientist
+	banned_quirks = list(TECH_RESTRICTED_QUIRKS)
 
 /datum/job/proc/has_required_languages(datum/preferences/pref)
 	if(!required_languages)

--- a/modular_skyrat/modules/ssd_indicator/code/mob.dm
+++ b/modular_skyrat/modules/ssd_indicator/code/mob.dm
@@ -4,24 +4,16 @@ GLOBAL_VAR_INIT(ssd_indicator_overlay, mutable_appearance('modular_skyrat/module
 	var/ssd_indicator = FALSE
 	var/lastclienttime = 0
 
-/mob/living/proc/set_ssd_indicator(var/state, var/toggled)
+/mob/living/proc/set_ssd_indicator(var/state)
 	if(state == ssd_indicator)
 		return
 	ssd_indicator = state
 	if(ssd_indicator)
 		add_overlay(GLOB.ssd_indicator_overlay)
-		if(toggled)
-			log_message("<font color='green'>has toggled on their SSD indicator.</font>", INDIVIDUAL_ATTACK_LOG)
-			to_chat(src, "<span class='notice'>You have turned ON your SSD indicator. (Please do not abuse)")
-		else
-			log_message("<font color='green'>has went SSD and got their indicator!</font>", INDIVIDUAL_ATTACK_LOG)
+		log_message("<font color='green'>has went SSD and got their indicator!</font>", INDIVIDUAL_ATTACK_LOG)
 	else
 		cut_overlay(GLOB.ssd_indicator_overlay)
-		if(toggled)
-			log_message("<font color='green'>has toggled off their SSD indicator.</font>", INDIVIDUAL_ATTACK_LOG)
-			to_chat(src, "<span class='notice'>You have turned OFF your SSD indicator. (Please do not abuse)")
-		else
-			log_message("<font color='green'>is no longer SSD and lost their indicator!</font>", INDIVIDUAL_ATTACK_LOG)
+		log_message("<font color='green'>is no longer SSD and lost their indicator!</font>", INDIVIDUAL_ATTACK_LOG)
 
 /mob/living/Login()
 	. = ..()
@@ -44,14 +36,3 @@ GLOBAL_VAR_INIT(ssd_indicator_overlay, mutable_appearance('modular_skyrat/module
 	..()
 	set_ssd_indicator(FALSE)
 */
-
-/mob/living/verb/toggle_ssd_indicator()
-	set category = "OOC"
-	set name = "Toggle SSD Indicator"
-	set desc = "Toggle your SSD indicator on/off to show you're away/unresponsive. Not to be abused for ambushes."
-
-	to_chat(src, "Toggling SSD indicator, please wait...")
-	if(do_after(src, 5 SECONDS, src))
-		set_ssd_indicator(!ssd_indicator, TRUE) //Toggle the SSD indicator, log the action and inform the user appropriately.
-	else
-		to_chat(src, "<span class='notice'>You were interrupted while toggling your SSD indicator.")

--- a/modular_skyrat/modules/ssd_indicator/code/mob.dm
+++ b/modular_skyrat/modules/ssd_indicator/code/mob.dm
@@ -4,16 +4,24 @@ GLOBAL_VAR_INIT(ssd_indicator_overlay, mutable_appearance('modular_skyrat/module
 	var/ssd_indicator = FALSE
 	var/lastclienttime = 0
 
-/mob/living/proc/set_ssd_indicator(var/state)
+/mob/living/proc/set_ssd_indicator(var/state, var/toggled)
 	if(state == ssd_indicator)
 		return
 	ssd_indicator = state
 	if(ssd_indicator)
 		add_overlay(GLOB.ssd_indicator_overlay)
-		log_message("<font color='green'>has went SSD and got their indicator!</font>", INDIVIDUAL_ATTACK_LOG)
+		if(toggled)
+			log_message("<font color='green'>has toggled on their SSD indicator.</font>", INDIVIDUAL_ATTACK_LOG)
+			to_chat(src, "<span class='notice'>You have turned ON your SSD indicator. (Please do not abuse)")
+		else
+			log_message("<font color='green'>has went SSD and got their indicator!</font>", INDIVIDUAL_ATTACK_LOG)
 	else
 		cut_overlay(GLOB.ssd_indicator_overlay)
-		log_message("<font color='green'>is no longer SSD and lost their indicator!</font>", INDIVIDUAL_ATTACK_LOG)
+		if(toggled)
+			log_message("<font color='green'>has toggled off their SSD indicator.</font>", INDIVIDUAL_ATTACK_LOG)
+			to_chat(src, "<span class='notice'>You have turned OFF your SSD indicator. (Please do not abuse)")
+		else
+			log_message("<font color='green'>is no longer SSD and lost their indicator!</font>", INDIVIDUAL_ATTACK_LOG)
 
 /mob/living/Login()
 	. = ..()
@@ -34,5 +42,16 @@ GLOBAL_VAR_INIT(ssd_indicator_overlay, mutable_appearance('modular_skyrat/module
 //This proc should stop mobs from having the overlay when someone keeps jumping control of mobs, unfortunately it causes Aghosts to have their character without the SSD overlay, I wasn't able to find a better proc unfortunately
 /mob/living/transfer_ckey(mob/new_mob, send_signal = TRUE)
 	..()
-	set_ssd_indicator(FALSE) 
+	set_ssd_indicator(FALSE)
 */
+
+/mob/living/verb/toggle_ssd_indicator()
+	set category = "OOC"
+	set name = "Toggle SSD Indicator"
+	set desc = "Toggle your SSD indicator on/off to show you're away/unresponsive. Not to be abused for ambushes."
+
+	to_chat(src, "Toggling SSD indicator, please wait...")
+	if(do_after(src, 5 SECONDS, src))
+		set_ssd_indicator(!ssd_indicator, TRUE) //Toggle the SSD indicator, log the action and inform the user appropriately.
+	else
+		to_chat(src, "<span class='notice'>You were interrupted while toggling your SSD indicator.")


### PR DESCRIPTION
## About The Pull Request
Adds negative quirk that works exactly like Ashwalker or Golem fingers which...

Prevents you from using Modular Computers (including tablets): https://github.com/Skyrat-SS13/Skyrat-tg/blob/a00c7131e9d789324edead7be7aebadaca8f1e06/code/modules/modular_computers/computers/item/computer_ui.dm#L16
Also stops from using laser pointers: https://github.com/Skyrat-SS13/Skyrat-tg/blob/a00c7131e9d789324edead7be7aebadaca8f1e06/code/game/objects/items/devices/laserpointer.dm#L81
And non-adapted guns: https://github.com/Skyrat-SS13/Skyrat-tg/blob/a00c7131e9d789324edead7be7aebadaca8f1e06/code/modules/mob/living/carbon/human/human_helpers.dm#L103

## Why It's Good For The Game
Improves character customization, provides another option for a strong negative quirk mindful of Ashwalker/other backgrounds.

## Changelog
:cl:
add: Adds a new 8-point negative quirk preventing you from using most firearms, modular computers/tablets and laser pointers like an Ashwalker or Golem. KAs can be adapted w/ a modkit. You cannot be command, security, engineering, atmos, doctor, virologist, chemist, roboticist or scientist with this trait.
/:cl:
