### PR TITLE
[MODULAR] Icebox Elevator Shaft Fix

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -5477,7 +5477,7 @@
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp)
 "Ox" = (
-/turf/open/floor/iron/elevatorshaft,
+/turf/open/floor/plating/elevatorshaft,
 /area/mine/storage)
 "Oy" = (
 /obj/structure/cable,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So uh, the icebox elevator shaft doesn't lead directly to space anymore. That's it.

<img width="123" alt="aaa" src="https://user-images.githubusercontent.com/73589390/117200768-db049e00-adb9-11eb-8e23-c8b5b843bd32.PNG">


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Having a portal to space on your asteroid is wack

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Icebox's mining elevator no longer has a portal to space.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
