### PR TITLE
[Modular] Icebox perma cabin has atmospherics again.

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -11622,6 +11622,8 @@
 "eEZ" = (
 /obj/machinery/door/airlock/wood,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/maintenance/space_hut/cabin)
 "eFc" = (
@@ -15948,6 +15950,8 @@
 /area/command/heads_quarters/captain)
 "gpK" = (
 /obj/machinery/door/airlock/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/maintenance/space_hut/cabin)
 "gqf" = (
@@ -20278,6 +20282,8 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/maintenance/space_hut/cabin)
 "iaM" = (
@@ -21939,6 +21945,7 @@
 /area/maintenance/port)
 "iHL" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/maintenance/space_hut/cabin)
 "iHM" = (
@@ -32159,6 +32166,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"mNa" = (
+/obj/machinery/door/airlock/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "mNi" = (
 /obj/machinery/light{
 	dir = 1
@@ -36322,6 +36334,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ouj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/structure/lattice/catwalk{
+	layer = 2.5;
+	plane = -1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors)
 "ouk" = (
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
@@ -39587,6 +39613,8 @@
 	name = "curtain"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/space_hut/cabin)
 "pPl" = (
@@ -40731,6 +40759,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/medical/cryo)
+"qmF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "qmI" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
@@ -45745,6 +45779,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
+"snT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/maintenance/space_hut/cabin)
 "soa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/kitchen,
@@ -50499,6 +50538,7 @@
 /area/maintenance/disposal/incinerator)
 "urc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/maintenance/space_hut/cabin)
 "urm" = (
@@ -51009,6 +51049,16 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/service/hydroponics/garden)
+"uCR" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
+/area/security/prison/safe)
 "uDe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52187,6 +52237,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/blue/side,
 /area/security/prison/safe)
 "veh" = (
@@ -52618,6 +52669,8 @@
 	layer = 2.5;
 	plane = -1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "vmP" = (
@@ -52947,6 +53000,8 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "vta" = (
@@ -55034,6 +55089,8 @@
 	plane = -1
 	},
 /obj/structure/grille,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
 "wkU" = (
@@ -55542,6 +55599,26 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"wwK" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison/safe)
 "wwM" = (
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
@@ -75833,7 +75910,7 @@ eqG
 dfw
 dfw
 dfw
-gpK
+mNa
 dfw
 dfw
 dfw
@@ -76346,8 +76423,8 @@ dfw
 nrW
 urc
 gpK
-lBc
-iHL
+snT
+qmF
 ppn
 iHA
 mzU
@@ -76604,7 +76681,7 @@ krP
 quj
 dfw
 oPa
-iHL
+qmF
 rgz
 rgz
 dfw
@@ -77118,7 +77195,7 @@ dfw
 dfw
 dfw
 kJg
-iHL
+qmF
 tAN
 qZK
 oSn
@@ -79174,7 +79251,7 @@ pMG
 uCh
 uCh
 uCh
-vmq
+ouj
 uCh
 atl
 atl
@@ -79431,7 +79508,7 @@ uCh
 uCh
 hen
 uCh
-vmq
+ouj
 uCh
 atl
 atl
@@ -79688,7 +79765,7 @@ uCh
 uCh
 uCh
 uCh
-vmq
+ouj
 uCh
 uCh
 atl
@@ -79945,7 +80022,7 @@ uCh
 uCh
 wiP
 uCh
-vmq
+ouj
 uCh
 wGy
 uCh
@@ -80202,7 +80279,7 @@ uCh
 uCh
 uCh
 cUw
-vmq
+ouj
 uCh
 ojL
 uCh
@@ -80715,8 +80792,8 @@ wBC
 kCV
 oyw
 wBC
-kCV
-oyw
+wwK
+uCR
 wBC
 vIA
 mBG

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -50539,6 +50539,7 @@
 "urc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/maintenance/space_hut/cabin)
 "urm" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When smart pipes came along, the icebox perma cabin was neglected. This hooks the still-existing vents and scrubbers back into the distro/waste networks via perma.

## Why It's Good For The Game

People using the cabin generally like working atmospherics.

## Changelog
:cl:
fix: icebox perma cabin has piped atmospherics again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
