### PR TITLE
Gives the secmed and HoP gunsets an extra mag each

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
@@ -299,7 +299,8 @@
 /obj/item/storage/box/gunset/pdh_hop/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/pistol/pdh/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src))
 	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src)
 	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src)
 

--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
@@ -299,8 +299,8 @@
 /obj/item/storage/box/gunset/pdh_hop/PopulateContents()
 	. = ..()
 	new /obj/item/gun/ballistic/automatic/pistol/pdh/nomag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src
-	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src))
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src)
 	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src)
 	new /obj/item/ammo_box/magazine/multi_sprite/pdh/rubber(src)
 

--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
@@ -346,6 +346,7 @@
 	new /obj/item/ammo_box/magazine/multi_sprite/firefly/rubber(src)
 	new /obj/item/ammo_box/magazine/multi_sprite/firefly/rubber(src)
 	new /obj/item/ammo_box/magazine/multi_sprite/firefly/rubber(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/firefly/rubber(src)
 
 //LASER
 /obj/item/storage/box/gunset/laser


### PR DESCRIPTION
## About The Pull Request

Secmed and HoP got three mags instead of the standard four, for some reason.

## Why It's Good For The Game

fix

## Changelog
:cl:
fix: the sec medic  and HoP now get four mags in their gunsets, same as everyone else
/:cl: