### PR TITLE
[MODULAR] Toggle Admin Auto-Dementor

### DIFF
--- a/modular_skyrat/modules/customization/modules/client/preferences.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences.dm
@@ -33,6 +33,7 @@ GLOBAL_LIST_INIT(food, list(
 	var/lastchangelog = "" //Saved changlog filesize to detect if there was a change
 	var/ooccolor = "#c43b23"
 	var/asaycolor = "#ff4500" //This won't change the color for current admins, only incoming ones.
+	var/auto_dementor = TRUE //To be turned off by admins that don't want to be dementored at round start.
 	/// If we spawn an ERT as an admin and choose to spawn as the briefing officer, we'll be given this outfit
 	var/brief_outfit = /datum/outfit/centcom/commander
 	var/enable_tips = TRUE

--- a/modular_skyrat/modules/mentor/code/client_procs.dm
+++ b/modular_skyrat/modules/mentor/code/client_procs.dm
@@ -7,6 +7,17 @@
 		GLOB.mentors -= src
 	return ..()
 
+/client/verb/toggle_auto_dementor()
+	set name = "Toggle Admin Auto-Dementor"
+	set category = "Mentor"
+
+	if(!holder || !check_rights_for(src, R_ADMIN))
+		return
+
+	prefs.auto_dementor = !prefs.auto_dementor
+	to_chat(src, "You just toggled Auto-Dementor [(prefs.auto_dementor) ? "on" : "off"].")
+	prefs.save_preferences()
+
 /client/proc/mentor_client_procs(href_list)
 	if(href_list["mentor_msg"])
 		if(CONFIG_GET(flag/mentors_mobname_only))
@@ -37,7 +48,7 @@
 		mentor_datum.owner = src
 		GLOB.mentors[src] = TRUE
 		add_mentor_verbs()
-		if(check_rights_for(src, R_ADMIN,0))
+		if(check_rights_for(src, R_ADMIN,0) && prefs.auto_dementor)
 			cmd_mentor_dementor()
 
 /client/proc/is_mentor() // admins are mentors too.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a "Toggle Admin Auto-Dementor" verb to the Mentor tab, should only be visible to staff (if not, oh well, it's not like it matters).
It adds a preference to whether you want to be de-mentored at roundstart or not. By default, it's set to true, as it's what the current behavior is for admins.

It *should* be consistant between rounds, but I haven't been able to test that part locally. But I don't see why it wouldn't work.
Test-merge this first, if possible.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
That way, staff aren't forced to remember every round to re-mentor manually if they want to still be able to help around answering mentorhelp.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:GoldenAlpharex
admin: Staff can now chose whether they're dementored at round start or not.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
