### PR TITLE
Revert "[NONMODULAR] Balances wizard points (Staff request)"

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -669,7 +669,7 @@
 	throw_speed = 2
 	throw_range = 5
 	w_class = WEIGHT_CLASS_TINY
-	var/uses = 16 //SKYRAT EDIT - ORIGINAL VALUE (10)
+	var/uses = 10
 	var/temp = null
 	var/mob/living/carbon/human/owner
 	var/list/entries = list()


### PR DESCRIPTION
Reverts Skyrat-SS13/Skyrat-tg#4542

Upon Host request, reverts wizard points to their original value. Ideally this will be followed with a rebalance of spell pricing/damage to encourage people to buy utility ones over combat ones.

![image](https://user-images.githubusercontent.com/26744576/117392153-19cc4e00-aeb7-11eb-8383-6bcdc199e919.png)

:cl:
balance: Resets wizard points to 10.
\:cl: