### PR TITLE
Fix playtime requirements for Civil Disputes Officer.

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/junior_officer/junior_officer.dm
+++ b/modular_skyrat/modules/sec_haul/code/junior_officer/junior_officer.dm
@@ -8,8 +8,8 @@
 	supervisors = "the head of security, security sergeants and security officers"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 120
-	exp_type = EXP_TYPE_MEDICAL
+	exp_requirements = 60
+	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/junior_officer
 	plasmaman_outfit = /datum/outfit/plasmaman/security


### PR DESCRIPTION
## About The Pull Request

Civil Disputes Officer requires medical playtime currently, I was told by admins this is a bug.
I changed it to require (I think) 60 minutes of general crew playtime. Also as already present in the code, it additionally requires your account to be a week old. Even this could be a _little_ excessive for what is basically a hall monitor job, so if you want these requirements lowered or even done away with, let me know.

This should work without a hitch, but I don't think it's actually possible for me to test this locally at all, because database stuff.

## Changelog
:cl:
fix: Civil Disputes Officer no longer requires medical playtime.
/:cl:
