### PR TITLE
give plasmafolk genitals in char setup

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -303,7 +303,7 @@ GLOBAL_LIST_EMPTY(customizable_races)
 
 /datum/species/plasmaman
 	mutant_bodyparts = list()
-	can_have_genitals = FALSE
+	can_have_genitals = TRUE
 	can_augment = FALSE
 	learnable_languages = list(/datum/language/common, /datum/language/calcic)
 


### PR DESCRIPTION
## About The Pull Request

Removes genitals restriction for plasmafolks in character setup.
Was integrated in old skyrat code, had to tweak a bit but is the same thing generally.
 
## Why It's Good For The Game

It enables more opportunity for players - with little, to zero harm done in any way.
As it's a distinct choice to enable genetalia in setup, the people who don't want to play plasmafolk with genitals are really not obliged to choose them, either. Works out for everyone, _potentially_ upsets no one.

I'm redoing this PR because, as it's merged on the old Skyrat code, it isn't merged here.
Link to old PR: https://github.com/Skyrat-SS13/Skyrat13/pull/1568

Screenshots:
![image](https://user-images.githubusercontent.com/13970003/117575522-31225b80-b0b0-11eb-8438-f609baa273ff.png)
![image](https://user-images.githubusercontent.com/13970003/117575525-34b5e280-b0b0-11eb-8519-d771314c5bea.png)

## Changelog
:cl:
tweak: plasmafolk can now enable genitalia in the player setup screen
/:cl: