### PR TITLE
[Modular] Interdyne Fixes/Major Tweak.

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/IceRuins/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/IceRuins/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -424,6 +424,7 @@
 "eb" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "ec" = (
@@ -1423,6 +1424,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
+"jB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jC" = (
 /obj/structure/closet/crate/internals,
 /obj/item/tank/internals/oxygen/yellow,
@@ -1898,11 +1905,10 @@
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "mx" = (
-/obj/machinery/computer/message_monitor,
-/obj/item/paper/monitorkey,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
+/obj/structure/frame/computer,
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "mE" = (
@@ -2149,10 +2155,6 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "oB" = (
 /obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Syndicate Radio Intercom"
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
@@ -2390,10 +2392,6 @@
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "rf" = (
 /obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Syndicate Radio Intercom"
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
@@ -2853,7 +2851,6 @@
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
 "xs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
@@ -3833,6 +3830,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "Ij" = (
@@ -4255,12 +4253,10 @@
 "MB" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m9mm,
-/obj/item/storage/box/syndie_kit/chameleon{
-	pixel_y = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "MD" = (
@@ -4272,8 +4268,9 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "MF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "MH" = (
@@ -4392,6 +4389,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "NF" = (
@@ -4643,10 +4641,9 @@
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "QS" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms{
-	dir = 4
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
 	},
-/turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "QT" = (
 /obj/structure/disposalpipe/trunk{
@@ -4669,6 +4666,7 @@
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
 "Rn" = (
 /obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "Ro" = (
@@ -5407,6 +5405,12 @@
 "YN" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/unpowered/syndicate_lava_base/main)
+"YO" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
 /area/ruin/unpowered/syndicate_lava_base/main)
 "YP" = (
 /obj/structure/railing{
@@ -7438,7 +7442,7 @@ lZ
 Ci
 CG
 HU
-dw
+jB
 MF
 Rn
 ha
@@ -7497,7 +7501,7 @@ wr
 gQ
 nQ
 ha
-TC
+YO
 NB
 eb
 ha

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -660,7 +660,7 @@
 "gB" = (
 /obj/structure/chair/stool,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
@@ -945,6 +945,11 @@
 	req_access_txt = "150";
 	specialfunctions = 4
 	},
+/turf/open/floor/iron,
+/area/ruin/unpowered/syndicate_lava_base/main)
+"iV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "jh" = (
@@ -2035,11 +2040,10 @@
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "tI" = (
-/obj/machinery/computer/message_monitor,
-/obj/item/paper/monitorkey,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
+/obj/structure/frame/computer,
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "tO" = (
@@ -2282,14 +2286,11 @@
 "wB" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "wC" = (
 /obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Syndicate Radio Intercom"
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
@@ -2456,10 +2457,6 @@
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
 "yh" = (
 /obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Syndicate Radio Intercom"
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
@@ -2727,6 +2724,12 @@
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
+"Bo" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/ruin/unpowered/syndicate_lava_base/main)
 "Bp" = (
 /obj/machinery/door/airlock/science{
 	name = "Xenobiology";
@@ -3527,6 +3530,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "IG" = (
@@ -4140,12 +4144,10 @@
 "Od" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m9mm,
-/obj/item/storage/box/syndie_kit/chameleon{
-	pixel_y = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "Oe" = (
@@ -4254,6 +4256,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
+"Pf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/unpowered/syndicate_lava_base/main)
 "Pg" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -4297,6 +4305,7 @@
 "Pr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "PC" = (
@@ -4314,6 +4323,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "PR" = (
@@ -4531,10 +4541,9 @@
 /turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "RJ" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms{
-	dir = 4
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
 	},
-/turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "RK" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
@@ -4548,6 +4557,7 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "RL" = (
 /obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "RO" = (
@@ -7433,7 +7443,7 @@ HV
 Qw
 Ic
 IF
-Sr
+Pf
 Pr
 RL
 Qr
@@ -7492,7 +7502,7 @@ AG
 mQ
 LX
 Qr
-Qp
+Bo
 PM
 wB
 Qr
@@ -7969,7 +7979,7 @@ ld
 Wr
 Na
 EK
-Za
+iV
 ij
 AD
 No

--- a/modular_skyrat/modules/mapping/code/modules/ruins/lavaland_ruin_code.dm
+++ b/modular_skyrat/modules/mapping/code/modules/ruins/lavaland_ruin_code.dm
@@ -40,6 +40,10 @@
 	short_desc = "You are a syndicate Deck Officer, employed in a top secret research facility developing biological weapons."
 	outfit = /datum/outfit/lavaland_syndicate/shaftminer/deckofficer
 
+/obj/effect/mob_spawn/human/lavaland_syndicate/deckofficer/Destroy()
+	new/obj/structure/fluff/empty_sleeper/syndicate/captain(get_turf(src))
+	return ..()
+
 //ITEMS
 
 /obj/item/radio/headset/interdyne


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the Chameleon Kit, Comms Agent, Freerange Intercomms, and PDA Message Monitor From Interdyne. Also some fixes.
The Comms Agent's Room is now abandoned, crudely barricaded off. The Deck Officer's sleeper now emits a GPS Signal when they awaken instead of the GPS mask the comms agent wears.

This does not remove the space comms agent.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/50649185/117765002-540d5680-b1fb-11eb-8552-12ca78a8a38a.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Interdyne's Comms agent has been fired.
code: Interdyne's GPS Signal now relies on the Deck Officer's sleeper, rather than a GPS mask.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
