### PR TITLE
Fixes alt titles not being sorted in the manifest

### DIFF
--- a/modular_skyrat/modules/altjobtitles/code/datacore.dm
+++ b/modular_skyrat/modules/altjobtitles/code/datacore.dm
@@ -19,11 +19,22 @@
 		"Service" = GLOB.service_positions + GLOB.service_alttitles,
 		"Silicon" = GLOB.nonhuman_positions + GLOB.nonhuman_alttitles
 	)
-	var/list/heads = GLOB.command_positions + list("Quartermaster")
+	var/list/heads = GLOB.command_positions + GLOB.command_alttitles
 
 	for(var/datum/data/record/t in GLOB.data_core.general)
 		var/name = t.fields["name"]
 		var/rank = t.fields["rank"]
+
+		var/is_captain = FALSE
+		if(rank == "Captain")
+			is_captain = TRUE
+		for(var/captitle in GLOB.captain_alttitles)
+			if(rank == captitle)
+				is_captain = TRUE
+				break
+			else
+				continue
+
 		var/has_department = FALSE
 		for(var/department in departments)
 			var/list/jobs = departments[department]
@@ -31,7 +42,7 @@
 				if(!manifest_out[department])
 					manifest_out[department] = list()
 				// Append to beginning of list if captain or department head
-				if (rank == "Captain" || (department != "Command" && (rank in heads)))
+				if (is_captain == TRUE || (department != "Command" && (rank in heads)))
 					manifest_out[department] = list(list(
 						"name" = name,
 						"rank" = rank

--- a/modular_skyrat/modules/altjobtitles/code/jobs.dm
+++ b/modular_skyrat/modules/altjobtitles/code/jobs.dm
@@ -1,3 +1,6 @@
+GLOBAL_LIST_INIT(captain_alttitles, list(
+	"Station Commander", "Commanding Officer", "Site Manager")) // for sorting the command part of the manifest
+
 GLOBAL_LIST_INIT(command_alttitles, list(
 	"Station Commander", "Commanding Officer", "Site Manager", //Captain
 	"Executive Officer", "Employment Officer", "Crew Supervisor", //HoP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
titl
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
yes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Command are now sorted at the heads of their department, and captain at the head of command, on the manifest when using alt titles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
