### PR TITLE
[NONMODULAR]Venus Humantraps are no longer capable of immortality

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -111,7 +111,7 @@
 	maxHealth = 40 //SKYRAT EDIT CHANGE
 	ranged = TRUE
 	harm_intent_damage = 5
-	obj_damage = 60
+	obj_damage = 30//Skyrat edit change - Original: 60
 	melee_damage_lower = 20 //SKYRAT EDIT CHANGE - Original: 25
 	melee_damage_upper = 20 //SKYRAT EDIT CHANGE - Original: 25
 	combat_mode = TRUE
@@ -134,7 +134,7 @@
 	/// The maximum amount of vines a plant can have at one time
 	var/max_vines = 4
 	/// How far away a plant can attach a vine to something
-	var/vine_grab_distance = 5
+	var/vine_grab_distance = 2 //SKYRAT EDIT - Original 5
 	/// Whether or not this plant is ghost possessable
 	var/playable_plant = TRUE
 
@@ -174,7 +174,7 @@
 	vines += newVine
 	if(isliving(the_target))
 		var/mob/living/L = the_target
-		L.Paralyze(20)
+		L.Knockdown(2 SECONDS) //Skyrat EDIT - Removes hardstun, bye!
 	ranged_cooldown = world.time + ranged_cooldown_time
 
 /mob/living/simple_animal/hostile/venus_human_trap/Login()

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -134,7 +134,7 @@
 	/// The maximum amount of vines a plant can have at one time
 	var/max_vines = 4
 	/// How far away a plant can attach a vine to something
-	var/vine_grab_distance = 3 //SKYRAT EDIT - Original 5
+	var/vine_grab_distance = 4 //SKYRAT EDIT - Original 5
 	/// Whether or not this plant is ghost possessable
 	var/playable_plant = TRUE
 

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -111,7 +111,7 @@
 	maxHealth = 40 //SKYRAT EDIT CHANGE
 	ranged = TRUE
 	harm_intent_damage = 5
-	obj_damage = 30//Skyrat edit change - Original: 60
+	obj_damage = 60
 	melee_damage_lower = 20 //SKYRAT EDIT CHANGE - Original: 25
 	melee_damage_upper = 20 //SKYRAT EDIT CHANGE - Original: 25
 	combat_mode = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -134,7 +134,7 @@
 	/// The maximum amount of vines a plant can have at one time
 	var/max_vines = 4
 	/// How far away a plant can attach a vine to something
-	var/vine_grab_distance = 2 //SKYRAT EDIT - Original 5
+	var/vine_grab_distance = 3 //SKYRAT EDIT - Original 5
 	/// Whether or not this plant is ghost possessable
 	var/playable_plant = TRUE
 

--- a/modular_skyrat/master_files/code/modules/events/spacevine.dm
+++ b/modular_skyrat/master_files/code/modules/events/spacevine.dm
@@ -578,11 +578,11 @@
 		return
 	for(var/datum/spacevine_mutation/SM in mutations)
 		SM.on_cross(src, AM)
-	if(istype(AM, /mob/living/simple_animal/hostile/venus_human_trap)) //skyrat change: vines heal flytraps 10% on cross
+	if(istype(AM, /mob/living/simple_animal/hostile/venus_human_trap)) //SKYRAT CHANGE - Vines now heal less. Again. Stop forcing our hand by abusing on_entered.
 		var/mob/living/simple_animal/hostile/venus_human_trap/VS = AM
 		if(VS.health >= VS.maxHealth)
 			return
-		VS.adjustHealth(-clamp(VS.health += 5, 0, VS.maxHealth), TRUE, TRUE)
+		VS.adjustHealth(-clamp(VS.health += 2, 0, VS.maxHealth), TRUE, TRUE)
 		to_chat(VS, "<span class='notice'>The vines attempt to regenerate some of your wounds!</span>")
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Massively nerfs vines overall kill potential, regeneration, and ability to cheese security.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Vines are a massive issue. Sayonara hardstun beams.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Venus Humantraps (Should) have proper regen values
tweak: Venus Humantraps now regenerate half of what they used to per on_crossed()
tweak: Venus Humantraps have had their range reduced from 5 to 4 tiles
tweak: Venus Humantraps no longer hardstun, instead use knockdown() as intended by our combat rework
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
