### PR TITLE
[Modular] Reverts the pre-built SM on newcharlie because fuck smart pipes

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/oldstation_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/oldstation_skyrat.dmm
@@ -23,8 +23,12 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "ak" = (
-/obj/structure/cable,
-/turf/closed/wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "ar" = (
 /obj/structure/railing,
@@ -45,6 +49,13 @@
 /area/ruin/space/has_grav/ancientstation)
 "ay" = (
 /obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/item/card/id/away/old/apc,
 /obj/item/stock_parts/cell{
 	charge = 100;
@@ -53,9 +64,6 @@
 /obj/item/stock_parts/cell{
 	charge = 100;
 	maxcharge = 15000
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
@@ -245,10 +253,19 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "bv" = (
-/obj/structure/cable,
-/obj/machinery/computer/monitor/secret,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer{
+	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
+	name = "Broken Computer"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
@@ -385,11 +402,10 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/ancientstation/betastorage)
 "cn" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/emitter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "cr" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -638,12 +654,10 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/betastorage)
 "dt" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/rad_collector,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "du" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -845,28 +859,35 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/ancientstation)
 "ej" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "ek" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "el" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "en" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "eo" = (
@@ -978,12 +999,15 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/ancientstation/sec)
 "eK" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	brightness = 3;
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -995,18 +1019,22 @@
 	},
 /area/ruin/space/has_grav/ancientstation)
 "eM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "eN" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/machinery/light_switch{
 	pixel_x = 26
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
@@ -1093,10 +1121,11 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/mining)
 "fc" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "fd" = (
@@ -1113,16 +1142,6 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/ancientstation/sec)
-"fe" = (
-/obj/machinery/power/smes/engineering{
-	charge = 0
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "fg" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -1497,11 +1516,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "gw" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "gx" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -1575,6 +1593,7 @@
 /obj/item/stack/sheet/mineral/uranium{
 	amount = 15
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "gI" = (
@@ -1640,6 +1659,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering Storage"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "gT" = (
@@ -1709,21 +1729,12 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation)
 "hl" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
-"hm" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "hp" = (
 /obj/structure/cable,
@@ -1762,8 +1773,18 @@
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "hv" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/gloves/color/fyellow/old,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
@@ -1841,7 +1862,10 @@
 /area/ruin/space/has_grav/ancientstation/proto)
 "hH" = (
 /obj/structure/table/reinforced,
-/obj/item/skillchip/job/roboticist,
+/obj/machinery/power/supermatter_crystal/shard,
+/obj/structure/closet/crate/engineering{
+	name = "supermatter shard crate"
+	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/ancientstation/proto)
 "hI" = (
@@ -1867,34 +1891,47 @@
 /turf/open/floor/mineral/titanium,
 /area/template_noop)
 "hO" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	brightness = 3;
 	dir = 8
 	},
+/obj/effect/decal/cleanable/oil,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "hP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "hQ" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "hR" = (
@@ -1969,36 +2006,42 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation)
 "id" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/item/paper/guides/jobs/engi/solars,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
 	dir = 1;
 	id = "aftport";
 	name = "Station Solar Control"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "ie" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/paper/fluff/ruins/oldstation/generator_manual,
 /obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "if" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "ig" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "ih" = (
@@ -2048,23 +2091,35 @@
 /area/ruin/space/has_grav/ancientstation/proto)
 "iw" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
+/obj/item/storage/toolbox/mechanical/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/multitool,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "ix" = (
 /obj/structure/rack,
+/obj/item/stack/cable_coil,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Charlie Engineering APC";
 	pixel_x = 24;
 	start_charge = 0
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "iy" = (
@@ -2235,6 +2290,8 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "iV" = (
@@ -2242,10 +2299,12 @@
 	charge = 0;
 	name = "backup power storage unit"
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "iW" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/item/wrench,
 /obj/item/wirecutters,
 /turf/open/floor/plating,
@@ -2318,6 +2377,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/atmo)
 "ji" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -2425,8 +2485,12 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/mining)
 "jG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "jI" = (
@@ -2918,12 +2982,6 @@
 "lh" = (
 /turf/closed/mineral/plasma,
 /area/ruin/unpowered)
-"li" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "lk" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -3058,23 +3116,27 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/medbay)
 "lJ" = (
-/obj/machinery/suit_storage_unit{
-	helmet_type = /obj/item/clothing/head/helmet/space/nasavoid/old;
-	mask_type = /obj/item/clothing/mask/breath;
-	suit_type = /obj/item/clothing/suit/space/nasavoid/old
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/space/nasavoid/old,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
+/obj/structure/closet,
+/obj/item/clothing/head/helmet/space/nasavoid/old,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "lK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/machinery/airalarm/all_access{
 	dir = 8;
 	pixel_x = 24
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
@@ -3086,10 +3148,9 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "lO" = (
@@ -3419,40 +3480,33 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/mining)
 "mV" = (
-/obj/structure/table,
-/obj/item/circuitboard/machine/telecomms/broadcaster{
-	pixel_y = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/obj/item/circuitboard/machine/telecomms/bus{
-	pixel_y = 6
+/obj/structure/cable,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access"
 	},
-/obj/item/circuitboard/machine/telecomms/processor{
-	pixel_y = 3
-	},
-/obj/item/circuitboard/machine/telecomms/receiver{
-	pixel_y = -1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "mW" = (
-/obj/item/storage/part_replacer{
-	pixel_y = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/table,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "mX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "mY" = (
-/obj/item/storage/box/stockparts/basic{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "na" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/all_access{
@@ -3503,13 +3557,10 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/atmo)
 "nh" = (
-/obj/item/storage/box/stockparts/basic{
-	pixel_x = 4;
-	pixel_y = 6
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 5
 	},
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "ni" = (
 /obj/structure/lattice,
@@ -3572,9 +3623,13 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "nq" = (
-/obj/effect/spawner/structure/window/hollow/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "nr" = (
 /obj/item/stack/rods,
@@ -3664,11 +3719,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/atmo)
 "nC" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8
-	},
-/turf/template_noop,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "nD" = (
 /obj/machinery/computer{
@@ -3684,15 +3737,19 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/comm)
 "nE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
-/obj/machinery/power/emitter/welded,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "nG" = (
-/obj/structure/reflector/box/mapping{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "nH" = (
 /obj/machinery/computer/crew,
@@ -3898,8 +3955,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/comm)
 "oq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "os" = (
 /obj/machinery/light/small{
@@ -3951,10 +4008,21 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "oy" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
+/obj/structure/table,
+/obj/item/tank/internals/oxygen,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/breath,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "oA" = (
@@ -4069,17 +4137,9 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "oR" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
+/obj/item/shard,
+/turf/template_noop,
+/area/template_noop)
 "oS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4166,6 +4226,8 @@
 /obj/machinery/power/port_gen/pacman/super{
 	name = "\improper emergency power generator"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "ph" = (
@@ -4206,6 +4268,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation)
 "pn" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
@@ -4260,9 +4323,17 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "pV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/turf/closed/wall/rust,
-/area/ruin/space/has_grav/ancientstation/engi)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/secure/engineering{
+	name = "plasma tank crate";
+	req_access_txt = "204"
+	},
+/obj/item/tank/internals/plasma/full,
+/obj/item/tank/internals/plasma/full,
+/obj/item/tank/internals/plasma/full,
+/obj/item/tank/internals/plasma/full,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "qe" = (
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
@@ -4305,12 +4376,10 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/atmo)
 "qv" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "qz" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -4344,16 +4413,20 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "qX" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 25
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "rj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "rv" = (
 /obj/machinery/firealarm{
@@ -4363,14 +4436,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation)
-"rJ" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "rM" = (
 /mob/living/simple_animal/hostile/syndicate/melee/space,
 /turf/open/floor/iron/white,
@@ -4383,9 +4448,6 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/sec)
-"sy" = (
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "sz" = (
 /obj/effect/turf_decal/tile/blue/darkblue,
 /obj/effect/turf_decal/tile/blue/darkblue{
@@ -4427,21 +4489,17 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/ancientstation/medbay)
 "tg" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "tm" = (
-/obj/machinery/light{
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "tn" = (
 /obj/machinery/seed_extractor,
@@ -4489,12 +4547,22 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "tF" = (
-/obj/structure/window/plasma/reinforced/spawner/north,
-/obj/structure/cable,
-/obj/machinery/power/rad_collector/anchored,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/engineering{
+	name = "radiation suit crate"
+	},
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/geiger_counter,
+/obj/item/geiger_counter,
+/obj/item/geiger_counter,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "tG" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -4578,11 +4646,13 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/ancientstation/sec)
 "va" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	dir = 5
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "vj" = (
 /obj/structure/ore_box,
 /turf/open/floor/mineral/titanium/blue,
@@ -4594,11 +4664,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "vx" = (
-/obj/effect/turf_decal/trimline/yellow/filled/end{
-	dir = 8
+/obj/item/shard{
+	icon_state = "small"
 	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
+/turf/template_noop,
+/area/template_noop)
 "vL" = (
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 1
@@ -4638,13 +4708,6 @@
 /obj/machinery/biogenerator,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
-"wi" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "wj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
@@ -4656,13 +4719,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation)
-"wt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/ancientstation/engi)
 "wz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -4670,11 +4726,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation)
-"wF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "wU" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/grass,
@@ -4708,10 +4759,13 @@
 /area/ruin/space/has_grav/ancientstation)
 "xq" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access"
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "xr" = (
@@ -4744,9 +4798,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
-"xQ" = (
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/ancientstation/engi)
 "xR" = (
 /turf/open/floor/iron/white/corner{
 	dir = 4
@@ -4787,34 +4838,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
-"yw" = (
-/obj/effect/spawner/structure/window/hollow/plasma/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "yx" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
-"yz" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
-	},
-/obj/structure/window/plasma/reinforced/spawner/west,
-/obj/structure/cable,
-/obj/machinery/power/rad_collector/anchored,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "yF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/ancientstation/proto)
-"yU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "za" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/mercury{
@@ -4843,15 +4875,6 @@
 /obj/structure/railing,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/ancientstation/deltaai)
-"zf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "zm" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -4864,27 +4887,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/atmo)
-"zt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
-"zx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "zA" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
@@ -4920,10 +4922,6 @@
 /obj/machinery/door/window/eastright,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/ancientstation/proto)
-"zM" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "zR" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 23
@@ -4976,12 +4974,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/ancientstation/proto)
-"Aq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Ax" = (
 /turf/closed/mineral/plasma,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
@@ -5006,28 +4998,14 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/comm)
-"AL" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "AX" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/hollow/reinforced/end,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "Bs" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/ancientstation/atmo)
-"Bw" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "BK" = (
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 4
@@ -5038,12 +5016,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/ancientstation/sec)
-"BM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/bridge_pipe/general/visible,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "BX" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -5079,20 +5051,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/ancientstation/kitchen)
-"Cs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/end{
-	dir = 1
-	},
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 25
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Cu" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue/darkblue{
@@ -5107,12 +5065,6 @@
 /obj/machinery/door/airlock/highsecurity,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/ancientstation/deltaai)
-"CF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "CK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -5120,10 +5072,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation)
 "CP" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
 "De" = (
 /obj/effect/turf_decal/tile/blue/darkblue,
 /obj/effect/turf_decal/tile/blue/darkblue{
@@ -5239,20 +5190,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/atmo)
-"Fd" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
-"Fk" = (
-/obj/machinery/power/supermatter_crystal/shard/engine{
-	engineering_channel = "Common"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Fl" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -5297,9 +5234,8 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/ancientstation/atmo)
 "FL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "FS" = (
@@ -5321,16 +5257,6 @@
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/betastorage)
-"GB" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "GD" = (
 /obj/machinery/door/poddoor{
 	id = "proto"
@@ -5361,31 +5287,6 @@
 /obj/effect/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
-"GY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
-"GZ" = (
-/obj/structure/closet/crate/engineering{
-	name = "radiation suit crate"
-	},
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
-/obj/structure/window/reinforced/spawner,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Hi" = (
 /obj/structure/chair{
 	dir = 4
@@ -5395,11 +5296,6 @@
 "Hn" = (
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/ancientstation/atmo)
-"Hu" = (
-/obj/structure/table,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "HA" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -5415,22 +5311,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
-"HI" = (
-/obj/structure/bed/maint,
-/obj/item/clothing/neck/human_petcollar/locked{
-	pixel_y = -7
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
-"Ik" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "It" = (
 /obj/structure/sink{
 	dir = 8;
@@ -5471,19 +5351,10 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
-"IG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "IM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/ancientstation/sec)
-"IN" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/ancientstation/engi)
 "IT" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/iodine{
@@ -5550,13 +5421,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/ancientstation/deltaai)
-"JE" = (
-/obj/machinery/airalarm/all_access{
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "JG" = (
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
@@ -5588,12 +5452,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation)
-"Kz" = (
-/obj/structure/window/plasma/reinforced/spawner/west,
-/obj/structure/cable,
-/obj/machinery/power/rad_collector/anchored,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "KA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -5628,22 +5486,9 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/medbay)
-"KM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/ancientstation/engi)
 "KO" = (
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
-"KR" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Le" = (
 /obj/machinery/door/airlock/science,
 /obj/machinery/door/firedoor,
@@ -5655,12 +5500,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/ancientstation/atmo)
-"Lm" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Ln" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -5676,12 +5515,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/kitchen)
-"Lv" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Lx" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -5714,13 +5547,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/ancientstation/atmo)
-"Ml" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Mp" = (
 /obj/structure/table/reinforced,
 /obj/item/pen/survival,
@@ -5762,14 +5588,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
-"Nd" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Nw" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/ancientstation/rnd)
@@ -5779,10 +5597,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
-"Nz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "NC" = (
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 4
@@ -5840,15 +5654,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
-"NW" = (
-/obj/machinery/door/window,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
-"On" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "OA" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -5864,10 +5669,6 @@
 "OC" = (
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/ancientstation)
-"OE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/closed/wall/rust,
-/area/ruin/space/has_grav/ancientstation/engi)
 "OL" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = 4;
@@ -5936,21 +5737,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/ancientstation/sec)
-"Pq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Pu" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemical Storage";
@@ -6018,19 +5804,15 @@
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/ancientstation/sec)
-"QE" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "QQ" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/comm)
 "QZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "Re" = (
@@ -6115,8 +5897,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/sec)
 "Sj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
@@ -6141,9 +5923,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "Sv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "Sz" = (
@@ -6180,17 +5961,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/medbay)
-"SM" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/fyellow/old,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "SN" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall,
@@ -6307,13 +6077,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/ancientstation/sec)
-"Uq" = (
-/obj/structure/cable,
-/obj/machinery/power/emitter/welded{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Ur" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6382,20 +6145,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/ancientstation/sec)
-"VI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
-"Wl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Wp" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -6438,11 +6187,12 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
 "WA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "WD" = (
@@ -6477,32 +6227,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/ancientstation/atmo)
-"Xf" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
-"Xg" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Xh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -6535,20 +6259,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/medbay)
 "XJ" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
-"XU" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "XW" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -6559,14 +6272,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
-"XX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Yc" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -6579,6 +6284,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "Yi" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 "Ym" = (
@@ -6594,20 +6300,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
-"Yu" = (
-/obj/structure/window/reinforced/spawner,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Yx" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
+/turf/template_noop,
+/area/template_noop)
 "YA" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "YM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "YN" = (
@@ -6628,16 +6335,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/ancientstation/proto)
-"YY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Ze" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
@@ -6666,23 +6363,15 @@
 /obj/machinery/power/smes/engineering{
 	charge = 0
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "Zo" = (
 /obj/structure/chair,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/ancientstation/proto)
-"Zs" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/ancientstation/engi)
 "Zw" = (
 /obj/effect/turf_decal/tile/blue/darkblue,
 /turf/open/floor/iron/dark,
@@ -6692,10 +6381,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "ZJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/engi)
 
@@ -7115,12 +6803,12 @@ qJ
 GU
 ml
 YA
-ak
-eI
-eI
-dl
-dl
-dl
+ch
+ch
+ch
+bJ
+bJ
+bJ
 hw
 mH
 gJ
@@ -7164,15 +6852,15 @@ oC
 gu
 gU
 YA
-Cs
-Pq
-zt
+aa
+aa
+aa
 oR
-Fd
-dl
 aa
 dF
 aa
+dF
+vx
 dF
 aa
 kQ
@@ -7213,12 +6901,12 @@ oC
 Yh
 YN
 YA
-nE
-nG
-Uq
-zf
-SM
-dl
+aa
+aa
+aa
+aa
+aa
+dF
 aa
 dF
 aa
@@ -7262,12 +6950,12 @@ fZ
 Yh
 YN
 YA
-On
-Yi
-On
-zf
-Hu
-dl
+dF
+dF
+dF
+dF
+dF
+bf
 dF
 bf
 dF
@@ -7311,12 +6999,12 @@ tn
 Yh
 br
 YA
-On
-Yi
-On
-zf
-wi
-dl
+aa
+aa
+aa
+aa
+aa
+dF
 aa
 dF
 aa
@@ -7360,12 +7048,12 @@ uP
 Yh
 YP
 YA
-On
-On
-On
-zx
-CF
-dl
+aa
+aa
+aa
+aa
+aa
+dF
 aa
 dF
 aa
@@ -7409,12 +7097,12 @@ vX
 Yh
 hI
 Fn
-IN
-yw
-IN
-yw
-Xg
-dl
+aa
+aa
+aa
+aa
+aa
+dF
 aa
 dF
 aa
@@ -7458,12 +7146,12 @@ wj
 Yh
 YN
 Fn
-rj
-xQ
-Aq
-tF
-vx
-dl
+aa
+aa
+aa
+aa
+aa
+dF
 aa
 dF
 aa
@@ -7507,12 +7195,12 @@ xP
 KO
 YN
 Fn
-wt
-Fk
-Ml
-tF
-Zs
-dl
+aa
+aa
+aa
+aa
+aa
+dF
 aa
 dF
 aa
@@ -7556,12 +7244,12 @@ xP
 xk
 Vo
 Fn
-KM
-xQ
-XX
-tF
-Zs
-dl
+aa
+aa
+aa
+aa
+aa
+dF
 aa
 dF
 aa
@@ -7605,12 +7293,12 @@ YA
 YA
 ml
 Fn
-yz
-Kz
-yz
-yw
-Zs
-Lv
+aa
+aa
+aa
+aa
+aa
+dF
 aa
 dF
 aa
@@ -7648,21 +7336,21 @@ ch
 Cq
 Iy
 mw
-Yi
-Yi
-Yi
-Yi
-Yi
-dl
-JE
-On
-Nz
-qv
-tg
-va
-qX
-qX
-zM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+dF
+aa
+dF
+aa
 dF
 aa
 aa
@@ -7697,21 +7385,21 @@ mM
 Cq
 Iy
 ch
-Yi
-Yi
-Yi
-Yi
-HI
-pV
-BM
+aa
+aa
+aa
+aa
+aa
+aa
 CP
-wF
-Nd
-Ik
-rJ
-On
-On
-Xf
+CP
+Yx
+Yx
+Yx
+Yx
+Yx
+Yx
+Yx
 dH
 dH
 my
@@ -7746,21 +7434,21 @@ mM
 Cq
 Iy
 ch
-dl
-dl
-dl
-dl
-dl
-OE
-QE
-Nz
-Nz
-KR
-tg
-Lm
-qX
-qX
-zM
+aa
+aa
+aa
+aa
+aa
+aa
+Yx
+aa
+aa
+aa
+aa
+dF
+aa
+dF
+aa
 dF
 aa
 aa
@@ -7795,18 +7483,18 @@ mB
 uR
 Iy
 ch
-mV
-cn
-sy
-GZ
-vx
-YY
+aa
+aa
+aa
+aa
+aa
+aa
 Yx
-Yi
-Yi
-VI
-tg
-Bw
+aa
+aa
+aa
+aa
+dF
 aa
 dF
 aa
@@ -7844,18 +7532,18 @@ gh
 Cq
 na
 ch
-mW
-sy
-sy
-Yu
-AL
-IG
+aa
+aa
+aa
+aa
+aa
+Sj
 xq
 Sj
-Sj
-GB
-tg
-dl
+aa
+aa
+aa
+dF
 aa
 dF
 aa
@@ -7893,18 +7581,18 @@ ga
 zJ
 Iy
 bJ
-mY
-sy
-sy
-Yu
-GY
-Sv
+aa
+aa
+aa
+aa
+aa
+oq
 XJ
-Sv
-Sv
-Sv
-XU
-dl
+oq
+aa
+aa
+aa
+dF
 aa
 dF
 aa
@@ -7942,18 +7630,18 @@ gh
 Nx
 Iy
 bJ
-nh
+aa
+aa
+aa
+aa
+aa
 oq
+XJ
 oq
-NW
-Wl
-oq
-yU
-oq
-jG
-dt
-gw
-dl
+aa
+aa
+aa
+dF
 aa
 dF
 aa
@@ -7991,14 +7679,14 @@ mM
 NV
 Iy
 gV
-nq
-IN
+aa
+eI
 eI
 eI
 tm
-sy
-YM
-sy
+gw
+mV
+nh
 AX
 eI
 eI
@@ -8040,14 +7728,14 @@ mM
 Nx
 Iy
 gV
-nC
-IN
+aa
+eI
 bv
 eK
 fc
 YM
-YM
-YM
+mW
+nq
 hl
 hO
 id
@@ -8089,16 +7777,16 @@ ck
 Na
 Iy
 gV
-IN
-IN
+dl
+eI
 ej
-sy
-hm
+en
+lN
 FL
 FL
 FL
 lN
-sy
+Sv
 ek
 dl
 eI
@@ -8140,16 +7828,16 @@ Iy
 ch
 oy
 Sv
-li
-sy
-fe
+Sv
+Sv
+Zl
 ZJ
 ZJ
 ZJ
 Zl
-sy
-if
 Sv
+if
+rj
 hv
 eI
 iU
@@ -8188,21 +7876,21 @@ IF
 Iy
 ch
 ay
-sy
-sy
+Sv
+en
 eM
 pn
-pn
-sy
+jG
+XJ
 QZ
-QZ
+nC
 hP
-sy
-sy
+Sv
+Sv
 iw
 eI
 iV
-On
+XJ
 pg
 dl
 aa
@@ -8238,16 +7926,16 @@ Iy
 ch
 lJ
 en
-en
+ak
 eN
 lK
 el
 ig
 WA
-ig
+nE
 hQ
-ig
-ig
+nG
+tg
 ix
 eI
 iW
@@ -10640,15 +10328,15 @@ fV
 fV
 GG
 bE
-fV
-fV
-fV
-fV
-fV
-fV
-fV
-fV
-fV
+cn
+cn
+cn
+mY
+mY
+mY
+mY
+pV
+tF
 bE
 AF
 fV
@@ -10689,15 +10377,15 @@ jf
 AF
 ZB
 bE
-fV
-fV
-fV
-fV
-fV
-fV
-fV
-fV
-fV
+cn
+dt
+dt
+mY
+mY
+mY
+mY
+qv
+qv
 bE
 jg
 jz
@@ -10739,14 +10427,14 @@ bE
 bY
 bE
 bE
-fV
-fV
-fV
-fV
-fV
-fV
-fV
-fV
+dt
+dt
+mY
+mY
+mY
+mY
+qX
+va
 bE
 bE
 bE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this keeps causing delams every round
no more. I'm sorry
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
smart pipes bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The SM on charlie station is no longer prebuilt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
