### PR TITLE
[NON-MODULAR] Re-adds ability to hang trashbags off the Janitor Winter Coat

### DIFF
--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -83,7 +83,7 @@
 	armor = list(MELEE = 10, BULLET = 15, LASER = 15, ENERGY = 25, BOMB = 10, BIO = 0, RAD = 0, FIRE = 0, ACID = 35)
 	allowed = list(
 		/obj/item/melee/classic_baton/telescopic,
-	)	
+	)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/hop
 
 /obj/item/clothing/head/hooded/winterhood/hop
@@ -129,6 +129,7 @@
 		/obj/item/reagent_containers/glass/bucket,
 		/obj/item/reagent_containers/spray,
 		/obj/item/soap,
+		/obj/item/storage/bag/trash, //Skyrat Edit - Basically reverts recent TG change of trashbag not allowed in the slot
 	)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/janitor
 
@@ -202,12 +203,12 @@
 	inhand_icon_state = "coatcmo"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, RAD = 0, FIRE = 20, ACID = 30)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/medical/cmo
-	
+
 /obj/item/clothing/suit/hooded/wintercoat/medical/cmo/Initialize()
 	. = ..()
 	allowed += list(
 		/obj/item/melee/classic_baton/telescopic,
-	)	
+	)
 
 /obj/item/clothing/head/hooded/winterhood/medical/cmo
 	desc = "A blue winter coat hood."
@@ -285,12 +286,12 @@
 	inhand_icon_state = "coatrd"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 20, BIO = 0, RAD = 0, FIRE = 30, ACID = 0)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/science/rd
-	
+
 /obj/item/clothing/suit/hooded/wintercoat/science/rd/Initialize()
 	. = ..()
 	allowed += list(
 		/obj/item/melee/classic_baton/telescopic,
-	)		
+	)
 
 /obj/item/clothing/head/hooded/winterhood/science/rd
 	desc = "A white winter coat hood. It smells faintly of hair gel."
@@ -355,7 +356,7 @@
 	. = ..()
 	allowed += list(
 		/obj/item/melee/classic_baton/telescopic,
-	)		
+	)
 
 /obj/item/clothing/head/hooded/winterhood/engineering/ce
 	desc = "A white winter coat hood. Feels surprisingly heavy. The tag says that it's not child safe."


### PR DESCRIPTION
## About The Pull Request
TG basically removed having the trashbag go on the coat slot as it was apparently not intended #5641 

## Why It's Good For The Game
Letting janitors kinda hang them off their winter coat was easier on the weary mind. We don't exactly have to worry about some of the issues trashbags had on TG so re-adding the ability should be fine

## Changelog
:cl:
add: Trashbags can go back onto the Janitor Winter Coat
/:cl: