### PR TITLE
[MODULAR] Fixes Stock Market cap being stupidly high

### DIFF
--- a/modular_skyrat/modules/stock_market/code/stocks.dm
+++ b/modular_skyrat/modules/stock_market/code/stocks.dm
@@ -17,7 +17,7 @@
 	var/desc = "A company that does not exist."
 	var/list/values = list()
 	var/current_value = 10
-	var/value_cap = 450000
+	var/value_cap = 5000
 	var/last_value = 10
 	var/list/products = list()
 
@@ -146,7 +146,7 @@
 	if(i_hate_this_code < fucking_stock_spikes || i_hate_this_code > piece_of_shit_fuck)
 		current_value += i_hate_this_code
 	if(current_value > value_cap)
-		current_value = 450000
+		current_value = value_cap
 	if (current_value < 5)
 		current_value = 5
 


### PR DESCRIPTION
## About The Pull Request

Cargo got 22 million, questions raised, solution found

## Why It's Good For The Game

Because having stock allow to spike to the price cap of 450k is stupid. The new cap is 5k so if a stock manages to have a huge spike. It won't become a major issue of just getting cargo stupid rich from this happening from blind luck

I appreciate someone telling me that the stock jumped to a specific price which helped me find the issue
## Changelog
:cl:
balance: Changed Stock price cap from 450k to 5k
/:cl: