### PR TITLE
[Modular] Fix for round ID 1739's Syndicate Problem

### DIFF
--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -11216,6 +11216,9 @@
 /obj/item/assembly/timer,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
+/obj/structure/plaque/static_plaque/golden/commission/nssjourney{
+	pixel_x = 32
+	},
 /turf/open/floor/iron,
 /area/command/bridge)
 "aRt" = (
@@ -43749,10 +43752,6 @@
 /obj/machinery/computer/security/labor,
 /turf/open/floor/iron/dark,
 /area/security/processing)
-"iOy" = (
-/obj/structure/plaque/static_plaque/golden/commission/nssjourney,
-/turf/open/floor/iron,
-/area/command/bridge)
 "iOA" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -88559,7 +88558,7 @@ aOE
 aPS
 aRm
 aSy
-iOy
+aTX
 aVk
 aWS
 aYw

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -16373,8 +16373,10 @@
 	},
 /area/centcom/holding/cafe)
 "aQX" = (
-/obj/structure/plaque/static_plaque/golden/commission/assaultops,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/structure/plaque/static_plaque/golden/commission/assaultops{
+	pixel_x = 32
+	},
+/turf/open/floor/glass/reinforced,
 /area/cruiser_dock/bridge)
 "aQY" = (
 /turf/open/floor/wood,
@@ -42937,7 +42939,7 @@ ask
 atE
 aCx
 aML
-aQX
+aUU
 aUU
 aUU
 aHd
@@ -44222,7 +44224,7 @@ ask
 ask
 aPC
 ask
-ask
+aQX
 ask
 aPC
 ask

--- a/modular_skyrat/modules/mapping/code/datums/ruins/icemoon.dm
+++ b/modular_skyrat/modules/mapping/code/datums/ruins/icemoon.dm
@@ -7,6 +7,7 @@
 	cost = 20
 	allow_duplicates = FALSE
 	never_spawn_with = list(/datum/map_template/ruin/lavaland/syndicate_base)
+	always_place = TRUE
 
 /datum/map_template/ruin/icemoon/underground/mining_site_below
 	name = "Mining Site Underground"

--- a/modular_skyrat/modules/mapping/code/datums/ruins/lavaland.dm
+++ b/modular_skyrat/modules/mapping/code/datums/ruins/lavaland.dm
@@ -7,3 +7,4 @@
 	cost = 20
 	allow_duplicates = FALSE
 	never_spawn_with = list(/datum/map_template/ruin/icemoon/underground/syndicate_base)
+	always_place = TRUE

--- a/modular_skyrat/modules/mapping/code/datums/ruins/space.dm
+++ b/modular_skyrat/modules/mapping/code/datums/ruins/space.dm
@@ -4,6 +4,7 @@
 	description = "Cybersun would like to remind it's employees that any battle cruiser will be apropriately maintained, as will it's crew."
 	prefix = "modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/"
 	suffix = "forgottenship_skyrat.dmm"
+	always_place = TRUE
 
 /datum/map_template/ruin/space/oldstation
 	id = "oldstation"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes Cybersun/Interdyne guaranteed spawns, as we did for ashwalkers
We had a round of like 17 syndiechars all stuck on DS-1, and I want to avoid this happening again
2 interdynes still can't spawn together though.
Icebox is a half-exception to this rule (and frankly shouldn't even load a mining map to begin with)

Also some mapping fixes for the new plaques because layering issues
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Feex good! QOL Good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Cybersun and Interdyne are now guaranteed spawns.
fix: Items can no longer be hidden under the plaque on NSS Journey.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
