### PR TITLE
[SEMIMODULAR] Station Names for each map!

### DIFF
--- a/_maps/deltastation.json
+++ b/_maps/deltastation.json
@@ -1,8 +1,9 @@
 {
 	"version": 1,
-	"map_name": "NSS Pollux",
+	"map_name": "NSS Pollux - (Delta Station)",
 	"map_path": "map_files/Deltastation",
 	"map_file": "DeltaStation2_skyrat.dmm",
+	"station_name": "NSS Pollux",
 	"shuttles": {
 		"emergency": "emergency_delta",
 		"ferry": "ferry_fancy",

--- a/_maps/deltastation.json
+++ b/_maps/deltastation.json
@@ -1,6 +1,6 @@
 {
 	"version": 1,
-	"map_name": "Delta Station",
+	"map_name": "NSS Pollux",
 	"map_path": "map_files/Deltastation",
 	"map_file": "DeltaStation2_skyrat.dmm",
 	"shuttles": {

--- a/_maps/deltastation.json
+++ b/_maps/deltastation.json
@@ -1,9 +1,9 @@
 {
 	"version": 1,
-	"map_name": "NTSS Pollux - (Delta Station)",
+	"map_name": "NSS Pollux - (Delta Station)",
 	"map_path": "map_files/Deltastation",
 	"map_file": "DeltaStation2_skyrat.dmm",
-	"station_name": "NTSS Pollux",
+	"station_name": "NSS Pollux",
 	"shuttles": {
 		"emergency": "emergency_delta",
 		"ferry": "ferry_fancy",

--- a/_maps/deltastation.json
+++ b/_maps/deltastation.json
@@ -1,9 +1,9 @@
 {
 	"version": 1,
-	"map_name": "NSS Pollux - (Delta Station)",
+	"map_name": "NTSS Pollux - (Delta Station)",
 	"map_path": "map_files/Deltastation",
 	"map_file": "DeltaStation2_skyrat.dmm",
-	"station_name": "NSS Pollux",
+	"station_name": "NTSS Pollux",
 	"shuttles": {
 		"emergency": "emergency_delta",
 		"ferry": "ferry_fancy",

--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -1,6 +1,6 @@
 {
 	"version": 1,
-	"map_name": "Ice Box Station",
+	"map_name": "NSB Boreas",
 	"map_path": "map_files/IceBoxStation",
 	"map_file": [
 		"IcemoonUnderground_Below.dmm",

--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -1,13 +1,13 @@
 {
 	"version": 1,
-	"map_name": "NTSB Boreas - (IceBox Station)",
+	"map_name": "NSB Boreas - (IceBox Station)",
 	"map_path": "map_files/IceBoxStation",
 	"map_file": [
 		"IcemoonUnderground_Below.dmm",
 		"IcemoonUnderground_Above.dmm",
 		"IceBoxStation_skyrat.dmm"
 	],
-	"station_name": "NTSB Boreas",
+	"station_name": "NSB Boreas",
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"shuttles": {

--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -1,13 +1,13 @@
 {
 	"version": 1,
-	"map_name": "NSB Boreas - (IceBox Station)",
+	"map_name": "NTSB Boreas - (IceBox Station)",
 	"map_path": "map_files/IceBoxStation",
 	"map_file": [
 		"IcemoonUnderground_Below.dmm",
 		"IcemoonUnderground_Above.dmm",
 		"IceBoxStation_skyrat.dmm"
 	],
-	"station_name": "NSB Boreas",
+	"station_name": "NTSB Boreas",
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"shuttles": {

--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -1,12 +1,13 @@
 {
 	"version": 1,
-	"map_name": "NSB Boreas",
+	"map_name": "NSB Boreas - (IceBox Station)",
 	"map_path": "map_files/IceBoxStation",
 	"map_file": [
 		"IcemoonUnderground_Below.dmm",
 		"IcemoonUnderground_Above.dmm",
 		"IceBoxStation_skyrat.dmm"
 	],
+	"station_name": "NSB Boreas",
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"shuttles": {

--- a/_maps/kilostation.json
+++ b/_maps/kilostation.json
@@ -1,6 +1,6 @@
 {
 	"version": 1,
-    "map_name": "Kilo Station",
+    "map_name": "NSS Unity",
     "map_path": "map_files/KiloStation",
     "map_file": "KiloStation_skyrat.dmm",
     "space_ruin_levels": 4,

--- a/_maps/kilostation.json
+++ b/_maps/kilostation.json
@@ -1,9 +1,9 @@
 {
 	"version": 1,
-    "map_name": "NSS Unity - (Kilo Station)",
+    "map_name": "NTSS Unity - (Kilo Station)",
     "map_path": "map_files/KiloStation",
     "map_file": "KiloStation_skyrat.dmm",
-	"station_name": "NSS Unity",
+	"station_name": "NTSS Unity",
     "space_ruin_levels": 4,
     "shuttles": {
 	    "emergency": "emergency_kilo",

--- a/_maps/kilostation.json
+++ b/_maps/kilostation.json
@@ -1,9 +1,9 @@
 {
 	"version": 1,
-    "map_name": "NTSS Unity - (Kilo Station)",
+    "map_name": "NSS Unity - (Kilo Station)",
     "map_path": "map_files/KiloStation",
     "map_file": "KiloStation_skyrat.dmm",
-	"station_name": "NTSS Unity",
+	"station_name": "NSS Unity",
     "space_ruin_levels": 4,
     "shuttles": {
 	    "emergency": "emergency_kilo",

--- a/_maps/kilostation.json
+++ b/_maps/kilostation.json
@@ -1,8 +1,9 @@
 {
 	"version": 1,
-    "map_name": "NSS Unity",
+    "map_name": "NSS Unity - (Kilo Station)",
     "map_path": "map_files/KiloStation",
     "map_file": "KiloStation_skyrat.dmm",
+	"station_name": "NSS Unity",
     "space_ruin_levels": 4,
     "shuttles": {
 	    "emergency": "emergency_kilo",

--- a/_maps/metastation.json
+++ b/_maps/metastation.json
@@ -1,8 +1,9 @@
 {
 	"version": 1,
-	"map_name": "NSS Castor",
+	"map_name": "NSS Castor - (Meta Station)",
 	"map_path": "map_files/MetaStation",
 	"map_file": "MetaStation_skyrat.dmm",
+	"station_name": "NSS Castor",
 	"shuttles": {
 		"cargo": "cargo_box",
 		"ferry": "ferry_fancy",

--- a/_maps/metastation.json
+++ b/_maps/metastation.json
@@ -1,9 +1,9 @@
 {
 	"version": 1,
-	"map_name": "NSS Castor - (Meta Station)",
+	"map_name": "NTSS Castor - (Meta Station)",
 	"map_path": "map_files/MetaStation",
 	"map_file": "MetaStation_skyrat.dmm",
-	"station_name": "NSS Castor",
+	"station_name": "NTSS Castor",
 	"shuttles": {
 		"cargo": "cargo_box",
 		"ferry": "ferry_fancy",

--- a/_maps/metastation.json
+++ b/_maps/metastation.json
@@ -1,9 +1,9 @@
 {
 	"version": 1,
-	"map_name": "NTSS Castor - (Meta Station)",
+	"map_name": "NSS Castor - (Meta Station)",
 	"map_path": "map_files/MetaStation",
 	"map_file": "MetaStation_skyrat.dmm",
-	"station_name": "NTSS Castor",
+	"station_name": "NSS Castor",
 	"shuttles": {
 		"cargo": "cargo_box",
 		"ferry": "ferry_fancy",

--- a/_maps/metastation.json
+++ b/_maps/metastation.json
@@ -1,6 +1,6 @@
 {
 	"version": 1,
-	"map_name": "MetaStation",
+	"map_name": "NSS Castor",
 	"map_path": "map_files/MetaStation",
 	"map_file": "MetaStation_skyrat.dmm",
 	"shuttles": {

--- a/_maps/nssjourney.json
+++ b/_maps/nssjourney.json
@@ -1,9 +1,9 @@
 {
 	"version": 1,
-	"map_name": "NTSS Journey (Skryat Box Station)",
+	"map_name": "NSS Journey (Skryat Box Station)",
 	"map_path": "map_files/NSSJourney",
 	"map_file": "NSSJourney.dmm",
-	"station_name": "NTSS Journey",
+	"station_name": "NSS Journey",
 	"shuttles": {
 		"emergency": "emergency_box",
 		"ferry": "ferry_fancy",

--- a/_maps/nssjourney.json
+++ b/_maps/nssjourney.json
@@ -1,8 +1,9 @@
 {
 	"version": 1,
-	"map_name": "NSS Journey",
+	"map_name": "NSS Journey (Skryat Box Station)",
 	"map_path": "map_files/NSSJourney",
 	"map_file": "NSSJourney.dmm",
+	"station_name": "NSS Journey",
 	"shuttles": {
 		"emergency": "emergency_box",
 		"ferry": "ferry_fancy",

--- a/_maps/nssjourney.json
+++ b/_maps/nssjourney.json
@@ -1,9 +1,9 @@
 {
 	"version": 1,
-	"map_name": "NSS Journey (Skryat Box Station)",
+	"map_name": "NTSS Journey (Skryat Box Station)",
 	"map_path": "map_files/NSSJourney",
 	"map_file": "NSSJourney.dmm",
-	"station_name": "NSS Journey",
+	"station_name": "NTSS Journey",
 	"shuttles": {
 		"emergency": "emergency_box",
 		"ferry": "ferry_fancy",

--- a/_maps/tramstation.json
+++ b/_maps/tramstation.json
@@ -1,9 +1,9 @@
 {
 	"version": 1,
-	"map_name": "NSS Gallivant - (Tram Station)",
+	"map_name": "NTSS Gallivant - (Tram Station)",
 	"map_path": "map_files/tramstation",
 	"map_file": "tramstation_skyrat.dmm",
-	"station_name": "NSS Gallivant",
+	"station_name": "NTkSS Gallivant",
 	"shuttles": {
 		"cargo": "cargo_box",
 		"ferry": "ferry_fancy",

--- a/_maps/tramstation.json
+++ b/_maps/tramstation.json
@@ -1,9 +1,9 @@
 {
 	"version": 1,
-	"map_name": "NTSS Gallivant - (Tram Station)",
+	"map_name": "NSS Gallivant - (Tram Station)",
 	"map_path": "map_files/tramstation",
 	"map_file": "tramstation_skyrat.dmm",
-	"station_name": "NTkSS Gallivant",
+	"station_name": "NSS Gallivant",
 	"shuttles": {
 		"cargo": "cargo_box",
 		"ferry": "ferry_fancy",

--- a/_maps/tramstation.json
+++ b/_maps/tramstation.json
@@ -1,8 +1,9 @@
 {
 	"version": 1,
-	"map_name": "NSS Gallivant",
+	"map_name": "NSS Gallivant - (Tram Station)",
 	"map_path": "map_files/tramstation",
 	"map_file": "tramstation_skyrat.dmm",
+	"station_name": "NSS Gallivant",
 	"shuttles": {
 		"cargo": "cargo_box",
 		"ferry": "ferry_fancy",

--- a/_maps/tramstation.json
+++ b/_maps/tramstation.json
@@ -1,6 +1,6 @@
 {
 	"version": 1,
-	"map_name": "Tramstation",
+	"map_name": "NSS Gallivant",
 	"map_path": "map_files/tramstation",
 	"map_file": "tramstation_skyrat.dmm",
 	"shuttles": {

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -40,7 +40,6 @@ GLOBAL_VAR(command_name)
 			newname = config_station_name
 		else
 			newname = new_station_name()
-
 		set_station_name(newname)
 	return GLOB.station_name
 */

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -31,15 +31,19 @@ GLOBAL_VAR(command_name)
 	GLOB.command_name = name
 
 	return name
-
+/* SKYRAT EDIT MOVAL - OVERWRITTEN IN MODULAR MASTER FILES
 /proc/station_name()
 	if(!GLOB.station_name)
-		SSmapping.HACK_LoadMapConfig()
-		var/mapname = SSmapping.config.map_name
-		set_station_name(mapname)
+		var/newname
+		var/config_station_name = CONFIG_GET(string/stationname)
+		if(config_station_name)
+			newname = config_station_name
+		else
+			newname = new_station_name()
 
+		set_station_name(newname)
 	return GLOB.station_name
-
+*/
 /proc/set_station_name(newname)
 	GLOB.station_name = newname
 

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -34,14 +34,9 @@ GLOBAL_VAR(command_name)
 
 /proc/station_name()
 	if(!GLOB.station_name)
-		var/newname
-		var/config_station_name = CONFIG_GET(string/stationname)
-		if(config_station_name)
-			newname = config_station_name
-		else
-			newname = new_station_name()
-
-		set_station_name(newname)
+		SSmapping.HACK_LoadMapConfig()
+		var/mapname = SSmapping.config.map_name
+		set_station_name(mapname)
 
 	return GLOB.station_name
 

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -40,6 +40,7 @@ GLOBAL_VAR(command_name)
 			newname = config_station_name
 		else
 			newname = new_station_name()
+
 		set_station_name(newname)
 	return GLOB.station_name
 */

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -29,6 +29,8 @@
 
 /datum/config_entry/string/serversqlname // short form server name used for the DB
 
+/datum/config_entry/flag/mapname_as_stationname // whether to use the map's name as the station name, overrides stationname - SKYRAT ADD
+
 /datum/config_entry/string/stationname // station name (the name of the station in-game)
 
 /datum/config_entry/number/lobby_countdown // In between round countdown.

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -29,9 +29,9 @@
 
 /datum/config_entry/string/serversqlname // short form server name used for the DB
 
-/datum/config_entry/flag/holidaystationnames // generate station name based on holidays
+/datum/config_entry/flag/holidaystationnames // generate station name based on holidays - SKYRAT ADD
 
-/datum/config_entry/flag/mapname_as_stationname // whether to use the map's name as the station name, overrides stationname - SKYRAT ADD
+/datum/config_entry/flag/map_stationname // whether to use the station name defined in the map's .json as the station name - SKYRAT ADD
 
 /datum/config_entry/string/stationname // station name (the name of the station in-game)
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -29,6 +29,8 @@
 
 /datum/config_entry/string/serversqlname // short form server name used for the DB
 
+/datum/config_entry/flag/holidaystationnames // generate station name based on holidays
+
 /datum/config_entry/flag/mapname_as_stationname // whether to use the map's name as the station name, overrides stationname - SKYRAT ADD
 
 /datum/config_entry/string/stationname // station name (the name of the station in-game)

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -176,7 +176,7 @@ SUBSYSTEM_DEF(events)
 	if(holidays)
 		holidays = shuffle(holidays)
 		// regenerate station name because holiday prefixes.
-		set_station_name(new_station_name())
+		// set_station_name(new_station_name()) // no
 		world.update_status()
 
 /datum/controller/subsystem/events/proc/toggleWizardmode()

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -175,7 +175,7 @@ SUBSYSTEM_DEF(events)
 
 	if(holidays)
 		holidays = shuffle(holidays)
-		if(CONFIG_GET(holidaystationnames)) // SKYRAT EDIT - BIND STATION NAMES TO CONFIG
+		if(CONFIG_GET(flag/holidaystationnames)) // SKYRAT EDIT - BIND STATION NAMES TO CONFIG
 			// regenerate station name because holiday prefixes.
 			set_station_name(new_station_name())
 		world.update_status()

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -176,7 +176,7 @@ SUBSYSTEM_DEF(events)
 	if(holidays)
 		holidays = shuffle(holidays)
 		// regenerate station name because holiday prefixes.
-		// set_station_name(new_station_name()) // no
+		// set_station_name(new_station_name()) // SKYRAT EDIT REMOVAL - PER MAP STATION NAMES
 		world.update_status()
 
 /datum/controller/subsystem/events/proc/toggleWizardmode()

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -175,8 +175,9 @@ SUBSYSTEM_DEF(events)
 
 	if(holidays)
 		holidays = shuffle(holidays)
-		// regenerate station name because holiday prefixes.
-		// set_station_name(new_station_name()) // SKYRAT EDIT REMOVAL - PER MAP STATION NAMES
+		if(CONFIG_GET(holidaystationnames)) // SKYRAT EDIT - BIND STATION NAMES TO CONFIG
+			// regenerate station name because holiday prefixes.
+			set_station_name(new_station_name())
 		world.update_status()
 
 /datum/controller/subsystem/events/proc/toggleWizardmode()

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -17,6 +17,7 @@
 	var/map_name = "Meta Station"
 	var/map_path = "map_files/MetaStation"
 	var/map_file = "MetaStation.dmm"
+	var/station_name = "NSS Pollux" //SKYRAT EDIT ADD - STATION NAMES FOR EACH MAP
 
 	var/traits = null
 	var/space_ruin_levels = 7

--- a/config/config.txt
+++ b/config/config.txt
@@ -28,6 +28,9 @@ $include interviews.txt
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
 # SERVERSQLNAME tgstation
 
+## Map Name as Station Name: When uncommented, will set the station's in-game name to the name of the map (as defined in the map's .json file). This overrides STATIONNAME and random name generation.
+MAPNAME_AS_STATIONNAME
+
 ## Station name: The name of the station as it is referred to in-game. If commented out, the game will generate a random name instead.
 STATIONNAME Space Station 13
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -28,6 +28,9 @@ $include interviews.txt
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
 # SERVERSQLNAME tgstation
 
+## Holiday Station Names: When uncommented, randomly generates the station's in game name based on whatever global real world holiday.
+# HOLIDAYSTATIONNAMES
+
 ## Map Name as Station Name: When uncommented, will set the station's in-game name to the name of the map (as defined in the map's .json file). This overrides STATIONNAME and random name generation.
 MAPNAME_AS_STATIONNAME
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -28,11 +28,11 @@ $include interviews.txt
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
 # SERVERSQLNAME tgstation
 
-## Holiday Station Names: When uncommented, randomly generates the station's in game name based on whatever global real world holiday.
+## Holiday Station Names: When uncommented, randomly generates the station's in game name based on whatever global real world holiday is active. Overrides STATIONNAME and MAP_STATIONNAME.
 # HOLIDAYSTATIONNAMES
 
-## Map Name as Station Name: When uncommented, will set the station's in-game name to the name of the map (as defined in the map's .json file). This overrides STATIONNAME and random name generation.
-MAPNAME_AS_STATIONNAME
+## Map Station Name: When uncommented, will set the station's in-game name to the name of the station (as defined in the map's .json file). This overrides STATIONNAME and random name generation.
+MAP_STATIONNAME
 
 ## Station name: The name of the station as it is referred to in-game. If commented out, the game will generate a random name instead.
 STATIONNAME Space Station 13

--- a/modular_skyrat/master_files/code/__HELPERS/names.dm
+++ b/modular_skyrat/master_files/code/__HELPERS/names.dm
@@ -2,11 +2,11 @@
 	if(!GLOB.station_name)
 		var/newname
 		var/config_station_name = CONFIG_GET(string/stationname)
-		if(CONFIG_GET(flag/mapname_as_stationname))
+		if(CONFIG_GET(flag/map_stationname))
 			SSmapping.HACK_LoadMapConfig()
-			var/config_map_name = SSmapping.config.map_name
-			set_station_name(config_map_name)
-			return GLOB.station_name
+			if(SSmapping.config.station_name)
+				set_station_name(SSmapping.config.station_name)
+				return GLOB.station_name
 		if(config_station_name)
 			newname = config_station_name
 		else

--- a/modular_skyrat/master_files/code/__HELPERS/names.dm
+++ b/modular_skyrat/master_files/code/__HELPERS/names.dm
@@ -1,3 +1,16 @@
 /proc/station_name()
-	SSmapping.HACK_LoadMapConfig()
-	set_station_name(SSmapping.config.map_name)
+	if(!GLOB.station_name)
+		var/newname
+		var/config_station_name = CONFIG_GET(string/stationname)
+		if(CONFIG_GET(flag/mapname_as_stationname))
+			SSmapping.HACK_LoadMapConfig()
+			var/config_map_name = SSmapping.config.map_name
+			set_station_name(config_map_name)
+			return GLOB.station_name
+		if(config_station_name)
+			newname = config_station_name
+		else
+			newname = new_station_name()
+
+		set_station_name(newname)
+	return GLOB.station_name

--- a/modular_skyrat/master_files/code/__HELPERS/names.dm
+++ b/modular_skyrat/master_files/code/__HELPERS/names.dm
@@ -1,0 +1,3 @@
+/proc/station_name()
+	SSmapping.HACK_LoadMapConfig()
+	set_station_name(SSmapping.config.map_name)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3554,6 +3554,7 @@
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
+#include "modular_skyrat\master_files\code\__HELPERS\names.dm"
 #include "modular_skyrat\master_files\code\_globalvars\configuration.dm"
 #include "modular_skyrat\master_files\code\_globalvars\maint_loot_common.dm"
 #include "modular_skyrat\master_files\code\_globalvars\maint_loot_oddity.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR changes the code for station names. Depending on config settings, station names can be preset (a la "Space Station 13) as they could before, they can be randomly generated, with split configs for standard random generation and holiday random generation, and the main feature of this PR, using the current map's name (in the map's .json) as the station's name.

For instance, if the map is "NSS Journey," this would make the station name, ICly, the "NSS Journey."
To be extra clear, there's two more config flags

HOLIDAYSTATIONNAMES which allows for randomly generating a holiday station name (note that holiday station names will override set names, both with the STATIONNAME flag, and the next flag. Standard name generation will also not generate holiday names if this flag is disabled)
and
MAP_STATIONNAME which takes the station_name value in the map's .json file and sets it to the station name. If this is enabled, it will override the STATIONNAME config. If there is no station_name, name generation will fall back on STATIONNAME or random generation

Note that this does not hinder the captain's ability to rename the station, if they so desire.

Obviously, "Delta station" isn't a very good name for our setting, so, each map's name has been updated accordingly (subject to change, with suggestions)
(Note: NSS = NanoTrasen Science Station, NSB = NanoTrasen Science Base)
Delta - NSS Pollux - courtesy of @Snakebittenn 
Meta - NSS Castor - courtesy of @Snakebittenn
Icebox - NSB Boreas - courtesy of @thestubborn 
Tram - NSS Gallivant
Kilo - NSS Unity (get it... cause it's... small... and cramped... so everyone's forced into unity 🤣 )

I have also edited the station name of each file to read NTS Pollux - (Delta Station). This preserves the original map name, for voting and status display, while providing the new name, too add flavour. NSS Journey has also gotten this treatment, being called "NSS Journey - (Skyrat Box Station)" in map_name, and remaining NSS Journey in the station_name

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
RP, flavour that doesn't break immersion and is more than random words (but also doesn't restrict that ability, via configs)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Each map now has a unique name!
add: Delta station is now the NSS Pollux
add: Meta station is now the NSS Castor
add: Icebox is now the NSB Boreas
add: Tram is now the NsS Gallivant
add: Kilo is now the NSS Unity
config: Added new config flag - HOLIDAYSTATIONNAMES - allows/disallows generating random holiday station names
config: Added new config flag - MAP_AS_STATIONNAME - takes the aforementioned map names and makes the station name it, if enabled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
