### PR TITLE
[modular][ready] Gives the Blueshield their own Family Heirlooms and mail.

### DIFF
--- a/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
@@ -22,7 +22,7 @@
 	family_heirlooms = list(/obj/item/bedsheet/captain, /obj/item/clothing/head/beret/blueshield)
 
 	mail_goodies = list(
-		/obj/item/storage/fancy/cigarette = 10,
+		/obj/item/storage/fancy/cigarettes/cigars/havana = 10,
 		/obj/item/stack/spacecash/c500 = 3,
 		/obj/item/disk/nuclear/fake/obvious = 2,
 		/obj/item/clothing/head/collectable/captain = 4,

--- a/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
@@ -17,6 +17,8 @@
 	outfit = /datum/outfit/job/blueshield
 	plasmaman_outfit = /datum/outfit/plasmaman/blueshield
 	display_order = JOB_DISPLAY_ORDER_BLUESHIELD
+	bounty_types = CIV_JOB_SEC
+	departments = DEPARTMENT_COMMAND
 	liver_traits = list(TRAIT_ROYAL_METABOLISM)
 
 	family_heirlooms = list(/obj/item/bedsheet/captain, /obj/item/clothing/head/beret/blueshield)

--- a/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
@@ -24,6 +24,7 @@
 	mail_goodies = list(
 		/obj/item/storage/fancy/cigarette = 10,
 		/obj/item/stack/spacecash/c500 = 3,
+		/obj/item/disk/nuclear/fake/obvious = 2,
 		/obj/item/clothing/head/collectable/captain = 4,
 		/obj/projectile/bullet/advanced/b10mm/b460 = 1
 	)

--- a/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
@@ -23,8 +23,7 @@
 
 	mail_goodies = list(
 		/obj/item/storage/fancy/cigarette = 10,
-		/obj/item/stack/spacecash/c500, = 3,
-		/obj/item/disk/nuclear/fake = 2,
+		/obj/item/stack/spacecash/c500 = 3,
 		/obj/item/clothing/head/collectable/captain = 4,
 		/obj/projectile/bullet/advanced/b10mm/b460 = 1
 	)

--- a/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
@@ -15,9 +15,9 @@
 	paycheck_department = ACCOUNT_SEC
 
 	outfit = /datum/outfit/job/blueshield
-
+	plasmaman_outfit = /datum/outfit/plasmaman/blueshield
 	display_order = JOB_DISPLAY_ORDER_BLUESHIELD
-	outfit = /datum/outfit/job/blueshield
+	liver_traits = list(TRAIT_ROYAL_METABOLISM)
 
 	family_heirlooms = list(/obj/item/bedsheet/captain, /obj/item/clothing/head/beret/blueshield)
 

--- a/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
@@ -21,6 +21,14 @@
 
 	family_heirlooms = list(/obj/item/bedsheet/captain, /obj/item/clothing/head/beret/blueshield)
 
+	mail_goodies = list(
+		/obj/item/storage/fancy/cigarette = 10,
+		/obj/item/stack/spacecash/c500, = 3,
+		/obj/item/disk/nuclear/fake = 2,
+		/obj/item/clothing/head/collectable/captain = 4,
+		/obj/projectile/bullet/advanced/b10mm/b460 = 1
+	)
+
 /datum/outfit/job/blueshield
 	name = "Blueshield"
 	jobtype = /datum/job/blueshield

--- a/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
@@ -19,7 +19,7 @@
 	display_order = JOB_DISPLAY_ORDER_BLUESHIELD
 	outfit = /datum/outfit/job/blueshield
 
-	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec)
+	family_heirlooms = list(/obj/item/bedsheet/captain, /obj/item/clothing/head/beret/blueshield)
 
 /datum/outfit/job/blueshield
 	name = "Blueshield"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4238,6 +4238,7 @@
 #include "modular_skyrat\modules\nsfw\shockcollar\code\shock_collar.dm"
 #include "modular_skyrat\modules\nsfw\vendors\code\item_overrides.dm"
 #include "modular_skyrat\modules\nsfw\vendors\code\naughty_vendor.dm"
+#include "modular_skyrat\modules\officestuff\code\officestuff.dm"
 #include "modular_skyrat\modules\organs\lungs.dm"
 #include "modular_skyrat\modules\panicbunker\code\panicbunker.dm"
 #include "modular_skyrat\modules\pixel_shift\code\pixel_shift.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4238,7 +4238,6 @@
 #include "modular_skyrat\modules\nsfw\shockcollar\code\shock_collar.dm"
 #include "modular_skyrat\modules\nsfw\vendors\code\item_overrides.dm"
 #include "modular_skyrat\modules\nsfw\vendors\code\naughty_vendor.dm"
-#include "modular_skyrat\modules\officestuff\code\officestuff.dm"
 #include "modular_skyrat\modules\organs\lungs.dm"
 #include "modular_skyrat\modules\panicbunker\code\panicbunker.dm"
 #include "modular_skyrat\modules\pixel_shift\code\pixel_shift.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

## Why It's Good For The Game

blueshield should get their own things, and not sec stuff, if its that high a demand, I'll add the old ones as well

I cant have a change log because I have a perfect -69 delta

but I have been forced

🆑 
fix: blueshield now gets their own mail and heirlooms instead of sex stuff
🆑 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
