### PR TITLE
[NONMODULAR] [READY] Goliath Cloaks protect against cold.

### DIFF
--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -85,6 +85,10 @@
 	armor = list(MELEE = 35, BULLET = 10, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 0, RAD = 0, FIRE = 60, ACID = 60) //a fair alternative to bone armor, requiring alternative materials and gaining a suit slot
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/goliath
 	body_parts_covered = CHEST|GROIN|ARMS
+	//SKYRAT ADDITION START -GOLIATH CLOAK EDIT
+	cold_protection = CHEST|GROIN|ARMS
+	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
+	//SKYRAT ADDITION END
 
 /obj/item/clothing/head/hooded/cloakhood/goliath
 	name = "goliath cloak hood"

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -88,7 +88,6 @@
 	//SKYRAT ADDITION START -GOLIATH CLOAK EDIT
 	cold_protection = CHEST|GROIN|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	//SKYRAT ADDITION END
 
 /obj/item/clothing/head/hooded/cloakhood/goliath
 	name = "goliath cloak hood"
@@ -98,6 +97,9 @@
 	clothing_flags = SNUG_FIT
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR
 	transparent_protection = HIDEMASK
+	cold_protection = CHEST|GROIN|ARMS
+	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
+	//SKYRAT ADDITION END
 
 /obj/item/clothing/suit/hooded/cloak/drake
 	name = "drake armour"


### PR DESCRIPTION
Adds cold protection to the Goliath Cloak, so it can be used on the split mining map z-level.

## About The Pull Request

Basically adds cold_temp_protect to the Goliath Cloak, so that you can use it in cold weather. Because it looks cool, and this way tribals on the split mining LZ can go over to the ice wastes side.

## Why It's Good For The Game

Opens up content to ash walkers + functional drip.

## Changelog
:cl: Gonenoculer5
balance: Goliath Cloaks now protect against cold, and are a good alternative to bone armor for early shift tribals who want to go into the ice wastes on the split LZ.
/:cl: