### PR TITLE
[NONMODULAR] Ports Arcing APCs from paradise.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1402,7 +1402,7 @@
 				if(shock_mobs.len)
 					var/mob/living/living_target = pick(shock_mobs)
 					living_target.electrocute_act(rand(5, 25), "electrical arc")
-					playsound(get_turf(living_target), 'sound/machines/defib_zap.ogg', 75, TRUE) //Man the defib zap sound is cool and also I couldn't find the proper sound.
+					playsound(get_turf(living_target), 'sound/magic/lightningshock.ogg', 75, TRUE)
 					Beam(living_target, icon_state = "lightning[rand(1, 12)]", icon = 'icons/effects/beam.dmi', time = 5) // SKYRAT EDIT ADD END
 
 	else // no cell, switch everything off

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -161,6 +161,8 @@
 	var/icon_update_needed = FALSE
 	var/obj/machinery/computer/apc_control/remote_control = null
 
+	var/shock_proof = FALSE // SKYRAT EDIT ADD - APC Arcing. If TRUE, APCs will not arc.
+
 /obj/machinery/power/apc/unlocked
 	locked = FALSE
 
@@ -1362,6 +1364,23 @@
 		else // chargemode off
 			charging = APC_NOT_CHARGING
 			chargecount = 0
+
+		if(excess >= 2500000 && !shock_proof) // SKYRAT EDIT ADD - APC Arcing
+			var/shock_chance = 5 // 5%
+			if(excess >= 7500000)
+				shock_chance = 15
+			else if(excess >= 5000000)
+				shock_chance = 10
+			if(prob(shock_chance))
+				var/list/shock_mobs = list()
+				for(var/creature in view(get_turf(src), 5)) //We only want to shock a single random mob in range, not every one.
+					if(isliving(creature))
+						shock_mobs += creature
+				if(shock_mobs.len)
+					var/mob/living/living_target = pick(shock_mobs)
+					living_target.electrocute_act(rand(5, 25), "electrical arc")
+					playsound(get_turf(living_target), 'sound/machines/defib_zap.ogg', 75, TRUE) //Man the defib zap sound is cool and also I couldn't find the proper sound.
+					Beam(living_target, icon_state = "lightning[rand(1, 12)]", icon = 'icons/effects/beam.dmi', time = 5) // SKYRAT EDIT ADD END
 
 	else // no cell, switch everything off
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -58,13 +58,14 @@
 /// The wire value used to reset the APCs wires after one's EMPed.
 #define APC_RESET_EMP "emp"
 
-// Arcing:
+// Arcing: - SKYRAT EDIT ADD
 /// Lower excess value for APC arcing, 5% chance to arc
 #define APC_ARC_LOWERLIMIT 2500000
 /// Moderate excess value for APC arcing, 10% chance to arc
 #define APC_ARC_MEDIUMLIMIT 5000000
 /// Upper excess value for for APC arcing, 15% chance to arc
 #define APC_ARC_UPPERLIMIT 7500000
+// SKYRAT EDIT ADD END
 
 // update_state
 // Bitshifts: (If you change the status values to be something other than an int or able to exceed 3 you will need to change these too)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -739,6 +739,20 @@
 		return
 	else if(panel_open && !opened && is_wire_tool(W))
 		wires.interact(user)
+	// SKYRAT EDIT ADD - SHOCK-PROOFING APCS
+	else if(istype(W, /obj/item/stack/sheet/bronze) && panel_open)
+		if(shock_proof)
+			to_chat(user, "<span class='warning'>This APC has already been shock proofed!</span>")
+		else
+			var/obj/item/stack/sheet/bronze/bronze = W
+			bronze.use(1)
+			to_chat(user, "<span class='notice'>You form the bronze sheet into a grounding component, preventing the APC from arcing!</span>")
+			shock_proof = TRUE
+	else if(W.tool_behaviour == TOOL_WRENCH && panel_open && shock_proof)
+		to_chat(user, "<span class='notice'>You unwrench the grounding component and discard it!</span>")
+		shock_proof = FALSE
+		W.play_tool_sound(src, 50)
+	//SKYRAT EDIT END
 	else
 		return ..()
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -58,6 +58,14 @@
 /// The wire value used to reset the APCs wires after one's EMPed.
 #define APC_RESET_EMP "emp"
 
+// Arcing:
+/// Lower excess value for APC arcing, 5% chance to arc
+#define APC_ARC_LOWERLIMIT 2500000
+/// Moderate excess value for APC arcing, 10% chance to arc
+#define APC_ARC_MEDIUMLIMIT 5000000
+/// Upper excess value for for APC arcing, 15% chance to arc
+#define APC_ARC_UPPERLIMIT 7500000
+
 // update_state
 // Bitshifts: (If you change the status values to be something other than an int or able to exceed 3 you will need to change these too)
 /// The bit shift for the APCs cover status.
@@ -1365,11 +1373,11 @@
 			charging = APC_NOT_CHARGING
 			chargecount = 0
 
-		if(excess >= 2500000 && !shock_proof) // SKYRAT EDIT ADD - APC Arcing
+		if(excess >= APC_ARC_LOWERLIMIT && !shock_proof) // SKYRAT EDIT ADD - APC Arcing
 			var/shock_chance = 5 // 5%
-			if(excess >= 7500000)
+			if(excess >= APC_ARC_UPPERLIMIT)
 				shock_chance = 15
-			else if(excess >= 5000000)
+			else if(excess >= APC_ARC_MEDIUMLIMIT)
 				shock_chance = 10
 			if(prob(shock_chance))
 				var/list/shock_mobs = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
https://github.com/ParadiseSS13/Paradise/blob/365fc87dbfbeb11f73485547849db2b99b85cde6/code/modules/power/apc.dm#L1207
## About The Pull Request
Does what it says on the tin.

When an APC has 2.5 MW in excess, it has a 5% chance to shoot one living mob (any living mob, including cyborgs, and simplemobs) in range with an electrical arc that deals 5-25 damage, every process() tick, which, as I've been told, occurs every two seconds (therefore, every 8 seconds in skyrat time).
This chance increases to 10% at 5MW, and 15% at 7.5MW

Also adds the variable "shock_proof" to APCs. This defaults to FALSE, and does exactly what you'd expect. If set to TRUE, it will prevent the APC from arcing.

APCs can be upgraded to be shock proof with a single sheet of bronze, and can be un-shock-proofed with a wrench.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds a bit more depth to engineering's job. SMES are now actually important, as opposed to being able to be bypassed by hotwiring. Super-fuck-shit-superreactors that produce the power of a small star carry a little more danger to them, if handled poorly

And it's just fun for the station to momentarily panic as APCs begin zapping people, for like, 30 seconds until engineering fixes it, which is easy fixed. And then the dust settles and all the station pets are dead.

### Why I'm PRing this down here, and not TG
This one's simple, I'm PRing this down here, as I personally feel this change would not be well received at TG, as it would interact with the balance of the game, and I have no idea how the average TG round plays, so, me touching their balance is a bad idea.

If a maintainer wishes for me to PR it up there, I will do so, but do know that I am 100% throwing you under the bus by saying "I PRed this downstream and was told to bring it up here, so here you go"
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: NanoTrasen have modified their APC designs, they're now approximately 0.1% cheaper to create! Unfortunately, they also have a flaw in that when overcharged, they are prone to arcing.
add: Luckily, the ingenious engineers of the frontiers have found what was removed! A single bronze panel on an APC will make them arc-proof once more!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
