### PR TITLE
[Modular] Preference-based laughs

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -45,6 +45,12 @@
 		var/datum/scream_type/S = new spath()
 		GLOB.scream_types[S.name] = spath
 	sortList(GLOB.scream_types, /proc/cmp_typepaths_asc)
+
+	//Laugh types
+	for(var/spath in subtypesof(/datum/laugh_type))
+		var/datum/scream_type/S = new spath()
+		GLOB.laugh_types[S.name] = spath
+	sortList(GLOB.laugh_types, /proc/cmp_typepaths_asc)
 	//SKYRAT EDIT END
 
 	//Species

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -44,6 +44,7 @@
 	var/jumpsuit_style = PREF_SUIT //suit/skirt
 
 	var/datum/scream_type/selected_scream //SKRYAT EDIT ADDITION
+	var/datum/laugh_type/selected_laugh //SKYRAT EDIT ADDITION
 
 	//Equipment slots
 	var/obj/item/clothing/wear_suit = null

--- a/modular_skyrat/modules/customization/modules/client/preferences.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences.dm
@@ -106,6 +106,7 @@ GLOBAL_LIST_INIT(food, list(
 	var/skin_tone = "caucasian1" //Skin color
 	var/eye_color = "000" //Eye color
 	var/datum/scream_type/pref_scream = new /datum/scream_type/human() //Scream type
+	var/datum/laugh_type/pref_laugh = new /datum/laugh_type/human() //Laugh type
 	var/datum/species/pref_species = new /datum/species/human()	//Mutant race
 	//Has to include all information that extra organs from mutant bodyparts would need. (so far only genitals now)
 	var/list/features = MANDATORY_FEATURE_LIST
@@ -443,6 +444,7 @@ GLOBAL_LIST_INIT(food, list(
 					dat += "<table width='100%'><tr><td width='17%' valign='top'>"
 					dat += "<b>Species:</b><BR><a href='?_src_=prefs;preference=species;task=input'>[pref_species.name]</a><BR>"
 					dat += "<b>Scream:</b><BR><a href='?_src_=prefs;preference=scream;task=input'>[pref_scream.name]</a><BR>"
+					dat += "<b>Laugh:</b><BR><a href='?_src_=prefs;preference=laugh;task=input'>[pref_laugh.name]</a><BR>"
 					dat += "<b>Species Naming:</b><BR><a href='?_src_=prefs;preference=custom_species;task=input'>[(features["custom_species"]) ? features["custom_species"] : "Default"]</a><BR>"
 					dat += "<b>Sprite body size:</b><BR><a href='?_src_=prefs;preference=body_size;task=input'>[(features["body_size"] * 100)]%</a> <a href='?_src_=prefs;preference=show_body_size;task=input'>[show_body_size ? "Hide preview" : "Show preview"]</a><BR>"
 					dat += "<h2>Flavor Text</h2>"
@@ -2285,6 +2287,22 @@ GLOBAL_LIST_INIT(food, list(
 						pref_scream = new scream
 						SEND_SOUND(user, pick(pref_scream.male_screamsounds))
 
+				if("laugh")
+					var/list/available_laughs = list()
+					for(var/spath in subtypesof(/datum/laugh_type)) //We need to build a custom list of available laughs!
+						var/datum/laugh_type/laugh = spath
+						if(initial(laugh.restricted_species_type))
+							if(!istype(pref_species, initial(laugh.restricted_species_type)))
+								continue
+						if(initial(laugh.donator_only) && !GLOB.donator_list[parent.ckey] && !check_rights(R_ADMIN, FALSE))
+							continue
+						available_laughs[initial(laugh.name)] = spath
+					var/new_laugh_id = input(user, "Choose your character's laugh:", "Character Scream")  as null|anything in available_laughs
+					var/datum/laugh_type/laugh = available_laughs[new_laugh_id]
+					if(laugh)
+						pref_laugh = new laugh
+						SEND_SOUND(user, pick(pref_laugh.male_laughsounds))
+
 				if("species")
 					ShowSpeciesMenu(user)
 					return TRUE
@@ -3002,6 +3020,7 @@ GLOBAL_LIST_INIT(food, list(
 	character.jumpsuit_style = jumpsuit_style
 
 	character.selected_scream = pref_scream
+	character.selected_laugh = pref_laugh
 
 	var/datum/species/chosen_species
 	chosen_species = pref_species.type

--- a/modular_skyrat/modules/customization/modules/client/preferences_savefile.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences_savefile.dm
@@ -398,6 +398,18 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	else
 		pref_scream = new /datum/scream_type/human
 
+	//Laughs
+	var/laugh_id
+	READ_FILE(S["laugh"], laugh_id)
+	if(laugh_id)
+		var/new_type = GLOB.laugh_types[laugh_id]
+		if(new_type)
+			pref_laugh = new new_type
+		else
+			pref_laugh = new /datum/laugh_type/human
+	else
+		pref_laugh = new /datum/laugh_type/human
+
 	/*if(!S["features["mcolor"]"] || S["features["mcolor"]"] == "#000")
 		WRITE_FILE(S["features["mcolor"]"]	, "#FFF")
 
@@ -690,6 +702,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["species"] , pref_species.id)
 	WRITE_FILE(S["phobia"], phobia)
 	WRITE_FILE(S["scream"], pref_scream.name)
+	WRITE_FILE(S["laugh"], pref_laugh.name)
 	/*WRITE_FILE(S["feature_mcolor"] , features["mcolor"])
 	WRITE_FILE(S["feature_ethcolor"] , features["ethcolor"])
 	WRITE_FILE(S["feature_lizard_tail"] , features["tail_lizard"])

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -276,33 +276,6 @@
 		return FALSE
 	return ..()
 
-/datum/emote/living/laugh
-	key = "laugh"
-	key_third_person = "laughs"
-	message = "laughs."
-	message_mime = "laughs silently!"
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
-
-/datum/emote/living/laugh/get_sound(mob/living/user)
-	if(isfelinid(user))
-		return pick('modular_skyrat/modules/emotes/sound/emotes/nyahaha1.ogg',
-			'modular_skyrat/modules/emotes/sound/emotes/nyahaha2.ogg',
-			'modular_skyrat/modules/emotes/sound/emotes/nyaha.ogg',
-			'modular_skyrat/modules/emotes/sound/emotes/nyahehe.ogg')
-	if(ismoth(user))
-		return 'modular_skyrat/modules/emotes/sound/emotes/mothlaugh.ogg'
-	if(isinsect(user))
-		return 'modular_skyrat/modules/emotes/sound/emotes/mothlaugh.ogg'
-	if(iscarbon(user))
-		if(user.gender == MALE)
-			return pick('sound/voice/human/manlaugh1.ogg',
-						'sound/voice/human/manlaugh2.ogg')
-		return pick('modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg',
-					'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg')
-	return
-
 /datum/emote/living/headtilt
 	key = "tilt"
 	key_third_person = "tilts"

--- a/modular_skyrat/modules/emotes/code/laugh_datums.dm
+++ b/modular_skyrat/modules/emotes/code/laugh_datums.dm
@@ -1,0 +1,40 @@
+GLOBAL_LIST_EMPTY(laugh_types)
+
+/datum/laugh_type
+	var/name
+	var/donator_only = FALSE
+	var/list/male_laughsounds
+	var/list/female_laughsounds
+	var/restricted_species_type
+
+/datum/laugh_type/none //Why would you want this?
+	name = "No Laugh"
+	male_laughsounds = null
+	female_laughsounds = null
+
+/datum/laugh_type/human
+	name = "Human Laugh"
+	male_laughsounds = list('sound/voice/human/manlaugh1.ogg',
+						'sound/voice/human/manlaugh2.ogg')
+	female_laughsounds = list('modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg',
+					'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg')
+
+/datum/laugh_type/felinid
+	name = "Felinid Laugh"
+	male_laughsounds = list('modular_skyrat/modules/emotes/sound/emotes/nyahaha1.ogg',
+			'modular_skyrat/modules/emotes/sound/emotes/nyahaha2.ogg',
+			'modular_skyrat/modules/emotes/sound/emotes/nyaha.ogg',
+			'modular_skyrat/modules/emotes/sound/emotes/nyahehe.ogg')
+	female_laughsounds = null
+
+/datum/laugh_type/moth
+	name = "Moth Laugh"
+	male_laughsounds = list('modular_skyrat/modules/emotes/sound/emotes/mothlaugh.ogg')
+	female_laughsounds = null
+	restricted_species_type = /datum/species/moth
+
+/datum/laugh_type/insect
+	name = "Insect Laugh"
+	male_laughsounds = list('modular_skyrat/modules/emotes/sound/emotes/mothlaugh.ogg')
+	female_laughsounds = null
+	restricted_species_type = /datum/species/insect

--- a/modular_skyrat/modules/emotes/code/laugh_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/laugh_emotes.dm
@@ -1,0 +1,24 @@
+/datum/emote/living/laugh
+	key = "laugh"
+	key_third_person = "laughs"
+	message = "laughs."
+	message_mime = "laughs silently!"
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
+
+/datum/emote/living/laugh/get_sound(mob/living/user)
+	if(iscarbon(user))
+		var/mob/living/carbon/human/H = user
+		if(isnull(H.selected_laugh)) //For things that don't have a selected laugh(npcs)
+			if(user.gender == MALE)
+				return pick('sound/voice/human/manlaugh1.ogg',
+						'sound/voice/human/manlaugh2.ogg')
+			else
+				return pick('modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_1.ogg',
+					'modular_skyrat/modules/emotes/sound/emotes/female/female_giggle_2.ogg')
+		if(user.gender == MALE || !LAZYLEN(H.selected_laugh.female_laughsounds))
+			return pick(H.selected_laugh.male_laughsounds)
+		else
+			return pick(H.selected_laugh.female_laughsounds)
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4000,6 +4000,8 @@
 #include "modular_skyrat\modules\electric_welder\code\electric_welder.dm"
 #include "modular_skyrat\modules\emotes\code\dna_screams.dm"
 #include "modular_skyrat\modules\emotes\code\emotes.dm"
+#include "modular_skyrat\modules\emotes\code\laugh_datums.dm"
+#include "modular_skyrat\modules\emotes\code\laugh_emotes.dm"
 #include "modular_skyrat\modules\emotes\code\scream_datums.dm"
 #include "modular_skyrat\modules\emotes\code\scream_emote.dm"
 #include "modular_skyrat\modules\emotes\code\silicon_emotes.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hubert bullied Sarmenti into making the Felinids laugh into something atrocious and I couldn't tolerate it. So, I decided to make laughs into a preference-based thing. Enjoy.
(Credits to Gandalf for the original code, I just adapted what he did for the scream preference to what I needed for laughs)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
That way, if you hear "NYA HA HA" in-game, you know it's on purpose.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:GoldenAlpharex
qol: Laughs are now preference-based, with the possibility to easily add more in the future.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
