### PR TITLE
Fixes Drake Armour to show up on certain races. Mutation variant to NONE.

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/non_anthro_clothes.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/non_anthro_clothes.dm
@@ -146,6 +146,9 @@
 /obj/item/clothing/head/helmet/durathread
 	mutant_variants = NONE
 
+/obj/item/clothing/head/hooded/cloakhood/drake
+	mutant_variants = NONE
+
 //EARS>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 //EYES>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>


### PR DESCRIPTION
A fix to the drake armour helm not showing up for certain races.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is a request to change the fact there are no mutation variants for the helmet of the ash drake armor, which I think is the main issue with them not showing up on Tajaran and a few other things.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should fix an issue with the helmet not showing up on drake armour for a few of the known races.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Added new line in anthro clothes to put in a 0 mutation variant for the ash drake helmet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
