### PR TITLE
[non-modular] Disables broken shuttle catastrophe event

### DIFF
--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -1,8 +1,8 @@
 /datum/round_event_control/shuttle_catastrophe
 	name = "Shuttle Catastrophe"
 	typepath = /datum/round_event/shuttle_catastrophe
-	weight = 0 // Skyrat edit -- disabled due to our custom shuttle
-	max_occurrences = 1
+	weight = 10 
+	max_occurrences = 0 // Skyrat edit -- disabled due to our custom shuttle
 
 /datum/round_event_control/shuttle_catastrophe/canSpawnEvent(players, gamemode)
 	if(SSshuttle.shuttle_purchased == SHUTTLEPURCHASE_FORCED)

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/shuttle_catastrophe
 	name = "Shuttle Catastrophe"
 	typepath = /datum/round_event/shuttle_catastrophe
-	weight = 10 
+	weight = 10
 	max_occurrences = 0 // Skyrat edit -- disabled due to our custom shuttle
 
 /datum/round_event_control/shuttle_catastrophe/canSpawnEvent(players, gamemode)

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/shuttle_catastrophe
 	name = "Shuttle Catastrophe"
 	typepath = /datum/round_event/shuttle_catastrophe
-	weight = 10
+	weight = 0 // Skyrat edit -- disabled due to our custom shuttle
 	max_occurrences = 1
 
 /datum/round_event_control/shuttle_catastrophe/canSpawnEvent(players, gamemode)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Doesn't work with our current shuttle, setting occurrences to 0 makes it not roll and fail every now and then.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Made shuttle catastrophe unable to roll and fail, wasting an event roll.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
