### PR TITLE
[MODULAR] Makes HUD Eyepatches Craftable

### DIFF
--- a/config/admins.txt
+++ b/config/admins.txt
@@ -4,7 +4,6 @@
 #Ranks will match to those with the same name in admin_ranks.txt, if a match isn't found the user won't be adminned.
 #If SQL-based admin loading is enabled, admins listed here will always be loaded first and will override any duplicate entries in the database.
 
-Bunn7 = Host
 Optimumtact = Host
 CitrusGender = Game Master
 NewSta = Game Master

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -4,6 +4,7 @@
 #Ranks will match to those with the same name in admin_ranks.txt, if a match isn't found the user won't be adminned.
 #If SQL-based admin loading is enabled, admins listed here will always be loaded first and will override any duplicate entries in the database.
 
+Bunn7 = Host
 Optimumtact = Host
 CitrusGender = Game Master
 NewSta = Game Master

--- a/modular_skyrat/modules/modular_items/code/datums/components/crafting/recipes/tailoring.dm
+++ b/modular_skyrat/modules/modular_items/code/datums/components/crafting/recipes/tailoring.dm
@@ -21,3 +21,11 @@
 	tool_behaviors = list(TOOL_WIRECUTTER)
 	time = 15
 	category = CAT_CLOTHING
+
+/datum/crafting_recipe/medpatch
+	name = "Medical Eyepatch Hud"
+	result = /obj/item/clothing/glasses/hud/eyepatch/med
+	reqs = list(/obj/item/clothing/glasses/hud/health = 1, /obj/item/clothing/glasses/eyepatch = 1, /obj/item/stack/cable_coil = 5)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER) //has same values as converting regular huds to sunglass huds//
+	time = 20
+	category = CAT_CLOTHING

--- a/modular_skyrat/modules/modular_items/code/datums/components/crafting/recipes/tailoring.dm
+++ b/modular_skyrat/modules/modular_items/code/datums/components/crafting/recipes/tailoring.dm
@@ -23,9 +23,16 @@
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/medpatch
-	name = "Medical Eyepatch Hud"
+	name = "Medical Eyepatch HUD"
 	result = /obj/item/clothing/glasses/hud/eyepatch/med
 	reqs = list(/obj/item/clothing/glasses/hud/health = 1, /obj/item/clothing/glasses/eyepatch = 1, /obj/item/stack/cable_coil = 5)
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER) //has same values as converting regular huds to sunglass huds//
 	time = 20
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/medpatchremoval
+	name = "Medical Eyepatch HUD removal"
+	result = /obj/item/clothing/glasses/eyepatch
+	reqs = list(/obj/item/clothing/glasses/hud/eyepatch/med = 1)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	category = CAT_CLOTHING

--- a/modular_skyrat/modules/modular_items/code/datums/components/crafting/recipes/tailoring.dm
+++ b/modular_skyrat/modules/modular_items/code/datums/components/crafting/recipes/tailoring.dm
@@ -22,12 +22,26 @@
 	time = 15
 	category = CAT_CLOTHING
 
+//Eyepatches//
+/datum/crafting_recipe/secpatch
+	name = "Security Eyepatch HUD"
+	result = /obj/item/clothing/glasses/hud/eyepatch/sec
+	reqs = list(/obj/item/clothing/glasses/hud/security = 1, /obj/item/clothing/glasses/eyepatch = 1, /obj/item/stack/cable_coil = 5)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER) //Tools needed and requirements are kept the same as craftable HUD sunglasses//
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/secpatchremoval
+	name = "Security Eyepatch HUD removal"
+	result = /obj/item/clothing/glasses/eyepatch
+	reqs = list(/obj/item/clothing/glasses/hud/eyepatch/sec = 1)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	category = CAT_CLOTHING
+
 /datum/crafting_recipe/medpatch
 	name = "Medical Eyepatch HUD"
 	result = /obj/item/clothing/glasses/hud/eyepatch/med
 	reqs = list(/obj/item/clothing/glasses/hud/health = 1, /obj/item/clothing/glasses/eyepatch = 1, /obj/item/stack/cable_coil = 5)
-	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER) //has same values as converting regular huds to sunglass huds//
-	time = 20
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/medpatchremoval
@@ -36,3 +50,32 @@
 	reqs = list(/obj/item/clothing/glasses/hud/eyepatch/med = 1)
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	category = CAT_CLOTHING
+
+/datum/crafting_recipe/robopatch
+	name = "Diagnostic Eyepatch HUD"
+	result = /obj/item/clothing/glasses/hud/eyepatch/diagnostic
+	reqs = list(/obj/item/clothing/glasses/hud/diagnostic = 1, /obj/item/clothing/glasses/eyepatch = 1, /obj/item/stack/cable_coil = 5)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/robopatchremoval
+	name = "Diagnostic Eyepatch HUD removal"
+	result = /obj/item/clothing/glasses/eyepatch
+	reqs = list(/obj/item/clothing/glasses/hud/eyepatch/diagnostic = 1)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/scipatch
+	name = "Science Eyepatch HUD"
+	result = /obj/item/clothing/glasses/hud/eyepatch/sci
+	reqs = list(/obj/item/clothing/glasses/science = 1, /obj/item/clothing/glasses/eyepatch = 1, /obj/item/stack/cable_coil = 5)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/scipatchremoval
+	name = "Science Eyepatch HUD removal"
+	result = /obj/item/clothing/glasses/eyepatch
+	reqs = list(/obj/item/clothing/glasses/hud/eyepatch/sci = 1)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	category = CAT_CLOTHING
+//eyepatches end//


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the HUD Eyepatches from https://github.com/Skyrat-SS13/Skyrat-tg/pull/4621 craftable under the clothing section in the crafting menu. They have the same set of required materials, crafting time, and tools needed as the HUD Sunglasses do.  

 ((I mentioned something about coding this in like a month ago on the original Eyepatch HUD PR but never got around to it until now)) 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds a way for players to make the HUD eyepatches, instead of having them only accessible via loadout.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: HUD Eyepatches are now craftable. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
