### PR TITLE
[modular] [danger!] Character Customization Colors now uses full depth RRGGBB hex instead of converting to RGB

### DIFF
--- a/code/__HELPERS/~skyrat_helpers/unsorted.dm
+++ b/code/__HELPERS/~skyrat_helpers/unsorted.dm
@@ -13,3 +13,11 @@
 	M.Scale(squishx, squishy)
 	animate(src, transform = M, time = halftime, easing = BOUNCE_EASING)
 	animate(src, transform = OM, time = halftime, easing = BOUNCE_EASING)
+
+/proc/validate_mutant_RGB(color)
+	// 19-5-2021: making our customization work with RRGGBB instead of RGB would break every stored character without this. Whelp!
+	// This is because of how colors are now stored as RGB, with length 3. They need to become length 6, otherwise handling mutant matrixed color in species.dm breaks.
+	// It adds '00' as alpha to the end of the color, which would give it length 5, which readRGB() can't handle.
+	if(length(color) == 3)
+		color = sanitize_hexcolor(color, 6) // Turn the 3 length RGB into 6 length RRGGBB by duplicating the values.
+	return color

--- a/modular_skyrat/modules/customization/modules/client/preferences.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences.dm
@@ -1767,7 +1767,7 @@ GLOBAL_LIST_INIT(food, list(
 					if(new_color)
 						if(!loadout[path])
 							return
-						loadout[path] = sanitize_hexcolor(new_color)
+						loadout[path] = sanitize_hexcolor(new_color, 6)
 				if(LOADOUT_INFO_THREE_COLORS)
 					var/color_slot = text2num(href_list["color_slot"])
 					if(color_slot)
@@ -1776,7 +1776,7 @@ GLOBAL_LIST_INIT(food, list(
 						if(new_color)
 							if(!loadout[path])
 								return
-							color_list[color_slot] = sanitize_hexcolor(new_color)
+							color_list[color_slot] = sanitize_hexcolor(new_color, 6)
 							loadout[path] = color_list.Join("|")
 				if(LOADOUT_INFO_STYLE)
 					return
@@ -1830,7 +1830,7 @@ GLOBAL_LIST_INIT(food, list(
 					if(new_color)
 						if(!body_markings[zone] || !body_markings[zone][name])
 							return
-						body_markings[zone][name] = sanitize_hexcolor(new_color)
+						body_markings[zone][name] = sanitize_hexcolor(new_color, 6)
 				if("marking_move_up")
 					var/zone = href_list["key"]
 					var/name = href_list["name"]
@@ -1978,7 +1978,7 @@ GLOBAL_LIST_INIT(food, list(
 						return
 					var/new_color = input(user, "Choose your character's [key] color:", "Character Preference","#[colorlist[index]]") as color|null
 					if(new_color)
-						colorlist[index] = sanitize_hexcolor(new_color)
+						colorlist[index] = sanitize_hexcolor(new_color, 6)
 				if("reset_color")
 					var/key = href_list["key"]
 					if(!mutant_bodyparts[key])
@@ -2172,7 +2172,7 @@ GLOBAL_LIST_INIT(food, list(
 					needs_update = TRUE
 					var/new_hair = input(user, "Choose your character's hair colour:", "Character Preference","#"+hair_color) as color|null
 					if(new_hair)
-						hair_color = sanitize_hexcolor(new_hair)
+						hair_color = sanitize_hexcolor(new_hair, 6)
 
 				if("hairstyle")
 					needs_update = TRUE
@@ -2192,7 +2192,7 @@ GLOBAL_LIST_INIT(food, list(
 					needs_update = TRUE
 					var/new_facial = input(user, "Choose your character's facial-hair colour:", "Character Preference","#"+facial_hair_color) as color|null
 					if(new_facial)
-						facial_hair_color = sanitize_hexcolor(new_facial)
+						facial_hair_color = sanitize_hexcolor(new_facial, 6)
 
 				if("facial_hairstyle")
 					needs_update = TRUE
@@ -2217,19 +2217,19 @@ GLOBAL_LIST_INIT(food, list(
 					needs_update = TRUE
 					var/new_underwear_color = input(user, "Choose your character's underwear color:", "Character Preference","#"+underwear_color) as color|null
 					if(new_underwear_color)
-						underwear_color = sanitize_hexcolor(new_underwear_color)
+						underwear_color = sanitize_hexcolor(new_underwear_color, 6)
 
 				if("undershirt_color")
 					needs_update = TRUE
 					var/new_undershirt_color = input(user, "Choose your character's undershirt color:", "Character Preference","#"+undershirt_color) as color|null
 					if(new_undershirt_color)
-						undershirt_color = sanitize_hexcolor(new_undershirt_color)
+						undershirt_color = sanitize_hexcolor(new_undershirt_color, 6)
 
 				if("socks_color")
 					needs_update = TRUE
 					var/new_socks_color = input(user, "Choose your character's socks color:", "Character Preference","#"+socks_color) as color|null
 					if(new_socks_color)
-						socks_color = sanitize_hexcolor(new_socks_color)
+						socks_color = sanitize_hexcolor(new_socks_color, 6)
 
 				if("undershirt")
 					needs_update = TRUE
@@ -2248,7 +2248,7 @@ GLOBAL_LIST_INIT(food, list(
 					needs_update = TRUE
 					var/new_eyes = input(user, "Choose your character's eye colour:", "Character Preference","#"+eye_color) as color|null
 					if(new_eyes)
-						eye_color = sanitize_hexcolor(new_eyes)
+						eye_color = sanitize_hexcolor(new_eyes, 6)
 
 				if("show_body_size")
 					needs_update = TRUE
@@ -2314,7 +2314,7 @@ GLOBAL_LIST_INIT(food, list(
 						if(new_mutantcolor == "#000000")
 							features["mcolor"] = pref_species.default_color
 						else
-							features["mcolor"] = sanitize_hexcolor(new_mutantcolor)
+							features["mcolor"] = sanitize_hexcolor(new_mutantcolor, 6)
 						if(!allow_advanced_colors)
 							reset_colors()
 
@@ -2325,7 +2325,7 @@ GLOBAL_LIST_INIT(food, list(
 						if(new_mutantcolor == "#000000")
 							features["mcolor2"] = pref_species.default_color
 						else
-							features["mcolor2"] = sanitize_hexcolor(new_mutantcolor)
+							features["mcolor2"] = sanitize_hexcolor(new_mutantcolor, 6)
 						if(!allow_advanced_colors)
 							reset_colors()
 
@@ -2336,7 +2336,7 @@ GLOBAL_LIST_INIT(food, list(
 						if(new_mutantcolor == "#000000")
 							features["mcolor3"] = pref_species.default_color
 						else
-							features["mcolor3"] = sanitize_hexcolor(new_mutantcolor)
+							features["mcolor3"] = sanitize_hexcolor(new_mutantcolor, 6)
 						if(!allow_advanced_colors)
 							reset_colors()
 
@@ -3121,7 +3121,7 @@ GLOBAL_LIST_INIT(food, list(
 
 /datum/preferences/proc/set_skin_tone(new_skin_tone)
 	skin_tone = new_skin_tone
-	features["skin_color"] = sanitize_hexcolor(skintone2hex(skin_tone), 3, 0)
+	features["skin_color"] = sanitize_hexcolor(skintone2hex(skin_tone), 6, 0)
 	if(!allow_advanced_colors)
 		reset_colors()
 

--- a/modular_skyrat/modules/customization/modules/client/preferences_savefile.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences_savefile.dm
@@ -513,10 +513,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	undershirt = sanitize_inlist(undershirt, GLOB.undershirt_list)
 	socks = sanitize_inlist(socks, GLOB.socks_list)
 	age = sanitize_integer(age, AGE_MIN, AGE_MAX, initial(age))
-	hair_color = sanitize_hexcolor(hair_color, 3, 0)
-	facial_hair_color = sanitize_hexcolor(facial_hair_color, 3, 0)
-	underwear_color = sanitize_hexcolor(underwear_color, 3, 0)
-	eye_color = sanitize_hexcolor(eye_color, 3, 0)
+	hair_color = sanitize_hexcolor(hair_color, 6, 0)
+	facial_hair_color = sanitize_hexcolor(facial_hair_color, 6, 0)
+	underwear_color = sanitize_hexcolor(underwear_color, 6, 0)
+	eye_color = sanitize_hexcolor(eye_color, 6, 0)
 	skin_tone = sanitize_inlist(skin_tone, GLOB.skin_tones)
 	backpack = sanitize_inlist(backpack, GLOB.backpacklist, initial(backpack))
 	jumpsuit_style = sanitize_inlist(jumpsuit_style, GLOB.jumpsuitlist, initial(jumpsuit_style))
@@ -572,10 +572,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	READ_FILE(S["augment_limb_styles"] , augment_limb_styles)
 
 	READ_FILE(S["undershirt_color"], undershirt_color)
-	undershirt_color			= sanitize_hexcolor(undershirt_color, 3, 0)
+	undershirt_color			= sanitize_hexcolor(undershirt_color, 6, 0)
 
 	READ_FILE(S["socks_color"], socks_color)
-	socks_color			= sanitize_hexcolor(socks_color, 3, 0)
+	socks_color			= sanitize_hexcolor(socks_color, 6, 0)
 
 	READ_FILE(S["foodlikes"], foodlikes)
 	READ_FILE(S["fooddislikes"], fooddislikes)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -149,9 +149,9 @@ GLOBAL_LIST_EMPTY(customizable_races)
 							var/list/color_list = mutant_bodyparts[key][MUTANT_INDEX_COLOR_LIST]
 							var/alpha_value = specific_alpha //this is here and not with the alpha setting code below as setting the alpha on a matrix color mutable appearance breaks it (at least in this case)
 							var/list/finished_list = list()
-							finished_list += ReadRGB("[color_list[1]]0")
-							finished_list += ReadRGB("[color_list[2]]0")
-							finished_list += ReadRGB("[color_list[3]]0")
+							finished_list += ReadRGB("[validate_mutant_RGB(color_list[1])]00")
+							finished_list += ReadRGB("[validate_mutant_RGB(color_list[2])]00")
+							finished_list += ReadRGB("[validate_mutant_RGB(color_list[3])]00")
 							finished_list += list(0,0,0,alpha_value)
 							for(var/index in 1 to finished_list.len)
 								finished_list[index] /= 255


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, when saving a color for anything in your character customization, it gets reduced from the #RRGGBB value you saved, to the depth of #RGB. For example, saving your wing color as #A46D2E would be stored as #AA6622 instead.

With this PR, colors are properly saved without such losses. This allows for a much, _much_ wider range of coloring and shading on your characters, especially noticeable with shades of black and white.

Danger PR because this makes changes to prefs and color saving, and reverting this might break people's colors. Nothing they can't fix by reselecting, but still.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better customization.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Selected colors for your character bodyparts are now stored at full hexadecimal depth, instead of duplicating the first hex character. Basically, it will no longer round to a different shade than the one you selected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
