### PR TITLE
Tiny runtime fix

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -8,7 +8,7 @@
 	name = "CFA Wildcat Magazine (.32)"
 	desc = "Magazines taking .32 ammunition; it fits in the CFA Wildcat. Alt+click to reskin it."
 	icon = 'modular_skyrat/modules/modular_weapons/icons/obj/ammo.dmi'
-	icon_state = "smg32"
+	icon_state = "smg32-full"
 	possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_AP, AMMO_TYPE_RUBBER, AMMO_TYPE_INCENDIARY)
 	ammo_type = /obj/item/ammo_casing/c32
 	caliber = "c32acp"


### PR DESCRIPTION
## About The Pull Request
• Fixes the node for 32 acp magazines to use the right icon_state.

## Why It's Good For The Game
Fixes one runtime that didn't appear when the change got PRed.

Non-player facing changes, no CL.