### PR TITLE
Typo in old PR that made a laser gun have the capacity of an ancient Eldritch pensioner's bladder.

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -8,7 +8,7 @@
 	name = "CFA Wildcat Magazine (.32)"
 	desc = "Magazines taking .32 ammunition; it fits in the CFA Wildcat. Alt+click to reskin it."
 	icon = 'modular_skyrat/modules/modular_weapons/icons/obj/ammo.dmi'
-	icon_state = "smg32"
+	icon_state = "smg32-full"
 	possible_types = list(AMMO_TYPE_LETHAL, AMMO_TYPE_AP, AMMO_TYPE_RUBBER, AMMO_TYPE_INCENDIARY)
 	ammo_type = /obj/item/ammo_casing/c32
 	caliber = "c32acp"

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/energy.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/energy.dm
@@ -171,7 +171,7 @@
 
 /obj/item/ammo_casing/energy/laser/double
 	projectile_type = /obj/projectile/beam/laser/double
-	e_cost = 150
+	e_cost = 100
 	select_name = "lethal"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 


### PR DESCRIPTION
## About The Pull Request
• Adminspawn-only weapon changed to have more ammo.

## Why It's Good For The Game
I didn't realise the e_cost for lasers, which used to be 83, was lowered to 71. I was balancing this around the assumption that it was still 83. After giving this a test-run, I also found this kinda... had so little charge capacity they were almost useless. 12% of the battery gone in one shot compared to the laser's 2%.

As this is currently adminspawn only, it isn't a player-facing change, so no CL.