### PR TITLE
[MODULAR] Goliath Cloak Hood Now Appears on Non-Humans

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/non_anthro_clothes.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/non_anthro_clothes.dm
@@ -149,6 +149,9 @@
 /obj/item/clothing/head/hooded/cloakhood/drake
 	mutant_variants = NONE
 
+/obj/item/clothing/head/hooded/cloakhood/goliath
+	mutant_variants = NONE
+
 //EARS>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 //EYES>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>


### PR DESCRIPTION
Since the glorious drake helm works now, might as well fix this too!

## About The Pull Request

This PR is a follow-up to #5773 which allows the goliath cloak's good to render on non-Human characters.

## Why It's Good For The Game

Vanity, O vanity! It looks good and we want to see it, that's all.

## Changelog
:cl:
fix: Like the Drake armour, the Goliath cloak's good will now be visible when worn by non-human characters.
/:cl:
