### PR TITLE
Ghost role bans

### DIFF
--- a/code/__DEFINES/~skyrat_defines/banning.dm
+++ b/code/__DEFINES/~skyrat_defines/banning.dm
@@ -2,3 +2,5 @@
 #define BAN_DONOTREVIVE "Do not revive ban"
 #define BAN_RESPAWN "Respawn ban"
 #define BAN_MOB_CONTROL "Ghost mob control ban"
+#define BAN_GHOST_ROLE_SPAWNER "Ghost role spawner ban"
+#define BAN_GHOST_TAKEOVER "Ghost take control ban"

--- a/code/__DEFINES/~skyrat_defines/banning.dm
+++ b/code/__DEFINES/~skyrat_defines/banning.dm
@@ -1,3 +1,4 @@
 #define BAN_PACIFICATION "Pacification ban"
 #define BAN_DONOTREVIVE "Do not revive ban"
 #define BAN_RESPAWN "Respawn ban"
+#define BAN_MOB_CONTROL "Ghost mob control ban"

--- a/code/__DEFINES/~skyrat_defines/banning.dm
+++ b/code/__DEFINES/~skyrat_defines/banning.dm
@@ -3,4 +3,4 @@
 #define BAN_RESPAWN "Respawn ban"
 #define BAN_MOB_CONTROL "Ghost mob control ban"
 #define BAN_GHOST_ROLE_SPAWNER "Ghost role spawner ban"
-#define BAN_GHOST_TAKEOVER "Ghost take control ban"
+#define BAN_GHOST_TAKEOVER "Ghost candidate ban"

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -434,8 +434,8 @@
 		if(!M.key || !M.client || (ignore_category && GLOB.poll_ignore[ignore_category] && (M.ckey in GLOB.poll_ignore[ignore_category])))
 			continue
 		//SKYRAT EDIT ADDITION BEGIN
-		if(is_banned_from(G.ckey, BAN_GHOST_TAKEOVER))
-			to_chat(G, "There was a ghost prompt for: [question], unfortunately you are banned from ghost takeovers.")
+		if(is_banned_from(M.ckey, BAN_GHOST_TAKEOVER))
+			to_chat(M, "There was a ghost prompt for: [Question], unfortunately you are banned from ghost takeovers.")
 			continue
 		//SKYRAT EDIT END
 		if(be_special_flag)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -433,6 +433,11 @@
 		var/mob/M = m
 		if(!M.key || !M.client || (ignore_category && GLOB.poll_ignore[ignore_category] && (M.ckey in GLOB.poll_ignore[ignore_category])))
 			continue
+		//SKYRAT EDIT ADDITION BEGIN
+		if(is_banned_from(G.ckey, BAN_GHOST_TAKEOVER))
+			to_chat(G, "There was a ghost prompt for: [question], unfortunately you are banned from ghost takeovers.")
+			continue
+		//SKYRAT EDIT END
 		if(be_special_flag)
 			if(!(M.client.prefs) || !(be_special_flag in M.client.prefs.be_special))
 				continue

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -350,7 +350,8 @@
 			"Skyrat Ban Options" = list(
 				BAN_PACIFICATION,
 				BAN_DONOTREVIVE,
-				BAN_RESPAWN
+				BAN_RESPAWN,
+				BAN_MOB_CONTROL
 			),//SKYRAT EDIT ADDITION - EXTRA_BANS
 		)
 		for(var/department in long_job_lists)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -51,6 +51,10 @@
 	if(SSticker.mode.type in excluded_gamemodes)
 		to_chat(user, "<span class='warning'>Error, unable to spawn.</span>")
 		return
+
+	if(is_banned_from(user.ckey, BAN_GHOST_ROLE_SPAWNER))
+		to_chat(user, "Error, you are banned from playing ghost roles!")
+		return
 	//SKYRAT EDIT ADDITION END
 
 	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(flags_1 & ADMIN_SPAWNED_1))

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -30,7 +30,6 @@
 
 	var/list/vines = list()
 
-	ghost_controllable = TRUE //SKYRAT EDIT ADDITION
 
 /obj/structure/alien/resin/flower_bud/Initialize()
 	. = ..()
@@ -139,6 +138,8 @@
 	var/vine_grab_distance = 4 //SKYRAT EDIT - Original 5
 	/// Whether or not this plant is ghost possessable
 	var/playable_plant = TRUE
+
+	ghost_controllable = TRUE //SKYRAT EDIT ADDITION
 
 
 /mob/living/simple_animal/hostile/venus_human_trap/Life(delta_time = SSMOBS_DT, times_fired)

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -30,6 +30,8 @@
 
 	var/list/vines = list()
 
+	ghost_controllable = TRUE //SKYRAT EDIT ADDITION
+
 /obj/structure/alien/resin/flower_bud/Initialize()
 	. = ..()
 	countdown = new(src)
@@ -185,7 +187,7 @@
 	. = ..()
 	if(. || !(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER))
 		return
-	humanize_plant(user)
+	//humanize_plant(user) SKYRAT EDIT REMOVAL
 
 /**
  * Sets a ghost to control the plant if the plant is eligible

--- a/modular_skyrat/master_files/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -1,0 +1,25 @@
+/mob/living/simple_animal
+	/// If set to TRUE, ghosts will be able to click on the simple mob and take control of it.
+	var/ghost_controllable = FALSE
+
+/mob/living/simple_animal/attack_ghost(mob/dead/observer/user)
+	. = ..()
+	if(.)
+		return
+	if(ghost_controllable)
+		take_control(user)
+
+/mob/living/simple_animal/proc/take_control(mob/user)
+	if(key || stat)
+		return
+	if(is_banned_from(user.ckey, BAN_MOB_CONTROL))
+		to_chat(user, "Error, you are banned from taking control of player controlled mobs!")
+		return
+	var/query = tgui_alert("Become a [src]?", "Take mob control", list("Yes", "No"))
+	if(query == "No" || !src || QDELETED(src))
+		return
+	if(key)
+		to_chat(user, "<span class='warning'>Someone else already took this mob!</span>")
+		return
+	key = user.key
+	log_game("[key_name(src)] took control of [name].")

--- a/modular_skyrat/modules/events/code/event_spawner.dm
+++ b/modular_skyrat/modules/events/code/event_spawner.dm
@@ -27,6 +27,9 @@
 	if(ckey_whitelist && !(lowertext(user.ckey) in ckey_whitelist))
 		alert(user, "Sorry, This spawner is not for you!", "", "Ok")
 		return
+	if(is_banned_from(user.ckey, BAN_GHOST_ROLE_SPAWNER))
+		to_chat(user, "Error, you are banned from playing ghost roles!")
+		return
 	var/species_string
 	if(species_whitelist)
 		species_string = ""

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3624,6 +3624,7 @@
 #include "modular_skyrat\master_files\code\modules\mob\living\emote_popup.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\carbon_say.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\dead\new_player\new_player.dm"
+#include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\simple_animal.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\friendly\bumbles.dm"
 #include "modular_skyrat\master_files\code\modules\power\lighting.dm"
 #include "modular_skyrat\master_files\code\modules\projectiles\guns\gun.dm"


### PR DESCRIPTION
Admins can now ban players from the following:
Ghost mob control ban - This restricts you from pressing on a player controllable mob and taking control(think: Venus traps, bullsquids.)
Ghost role spawner ban - This restricts you from partaking in ghost roles such as DS1, any "spawner pod" basically.
Ghost candidate ban - This prevents you from partaking in ANY ghost offered positions. Think: Xenos, blob etc.

## Changelog
:cl:
add: You can now be banned from playing ghost related things.
/:cl:
