### PR TITLE
[MODULAR] Supermatter Surge Event.

### DIFF
--- a/modular_skyrat/master_files/code/modules/events/supermatter_surge.dm
+++ b/modular_skyrat/master_files/code/modules/events/supermatter_surge.dm
@@ -1,0 +1,39 @@
+/datum/round_event_control/supermatter_surge
+	name = "Supermatter Surge"
+	typepath = /datum/round_event/supermatter_surge
+	weight = 20
+	max_occurrences = 4
+	earliest_start = 10 MINUTES
+
+/datum/round_event_control/supermatter_surge/canSpawnEvent()
+	if(GLOB.main_supermatter_engine?.has_been_powered)
+		return ..()
+
+/datum/round_event/supermatter_surge
+	var/power = 2000
+
+/datum/round_event/supermatter_surge/setup()
+	if(prob(70))
+		power = rand(200,100000)
+	else
+		power = rand(200,200000)
+
+/datum/round_event/supermatter_surge/announce()
+	var/severity = ""
+	switch(power)
+		if(-INFINITY to 100000)
+			var/low_threat_perc = 100-round(100*((power-200)/(100000-200)))
+			if(prob(low_threat_perc))
+				if(prob(low_threat_perc))
+					severity = "low; the supermatter should return to normal operation shortly."
+				else
+					severity = "medium; the supermatter should return to normal operation, but check NT CIMS to ensure this."
+			else
+				severity = "high; if the supermatter's cooling is not fortified, coolant may need to be added."
+		if(100000 to INFINITY)
+			severity = "extreme; emergency action is likely to be required even if coolant loop is fine."
+	if(power > 20000 || prob(round(power/200)))
+		priority_announce("Supermatter surge detected. Estimated severity is [severity]", "Anomaly Alert")
+
+/datum/round_event/supermatter_surge/start()
+	GLOB.main_supermatter_engine.matter_power += power

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3612,6 +3612,7 @@
 #include "modular_skyrat\master_files\code\modules\clothing\outfits\ert.dm"
 #include "modular_skyrat\master_files\code\modules\events\spacevine.dm"
 #include "modular_skyrat\master_files\code\modules\events\spider_infestation.dm"
+#include "modular_skyrat\master_files\code\modules\events\supermatter_surge.dm"
 #include "modular_skyrat\master_files\code\modules\jobs\job_types\cyborg.dm"
 #include "modular_skyrat\master_files\code\modules\language\language_holders.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\emote_popup.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports Citadel-Station-13/Citadel-Station-13#14307, all credit to them. I just saw it, and thought it was neat.
Adds an event that makes the supermatter power up a good deal for a short time. That's it. Only happens if there is a supermatter and it has been turned on, otherwise it won't try.

## Why It's Good For The Game

Fun stress-test for the Supermatter, gives engineering some stuff to do.
It seemed fairly mild during my local testing of it, can always tweak numbers if needed.

## Changelog
:cl:
add:  "Supermatter surge" event, which might cause problems if the supermatter is not sufficiently cooled (i.e. the setup is messed up in some way)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
