### PR TITLE
[MODULAR] Gives built buttons the same fancy icon as the roundstart ones

### DIFF
--- a/modular_skyrat/modules/aesthetics/buttons/code/buttons.dm
+++ b/modular_skyrat/modules/aesthetics/buttons/code/buttons.dm
@@ -1,4 +1,4 @@
-/obj/machinery/button/door
+/obj/machinery/button
 	icon = 'modular_skyrat/modules/aesthetics/buttons/icons/buttons.dmi'
 	var/light_mask = "button-light-mask"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what it says in the title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now players can make good-looking buttons too, rejoice!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:GoldenAlpharex
imageadd: Player-made buttons now use the same sprite as the ones that can be found on the maps at round-start.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
