### PR TITLE
Ghosts can no longer extract cells from items

### DIFF
--- a/modular_skyrat/modules/cell_component/code/cell_component.dm
+++ b/modular_skyrat/modules/cell_component/code/cell_component.dm
@@ -144,6 +144,9 @@ component_cell_out_of_charge/component_cell_removed proc using loc where necessa
 	if(!cell_can_be_removed)
 		return
 
+	if(!isliving(user))
+		return
+
 	if(inserted_cell)
 		to_chat(user, "<span class='notice'>You remove [inserted_cell] from [equipment]!</span>")
 		playsound(equipment, 'sound/weapons/magout.ogg', 40, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Did you know ghosts can extract cells from items? This PR fixes that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ghosts shouldn't affect the living, unless it's a special event.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:GoldenAlpharex
fix: Nanotrasen's Paranormal Containment Team has been hard at work, rendering all of their cell-powered equipment unable to be tampered with by the dead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
