### PR TITLE
Gateway ID lock

### DIFF
--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -268,6 +268,7 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 /obj/machinery/computer/gateway_control
 	name = "Gateway Control"
 	desc = "Human friendly interface to the mysterious gate next to it."
+	req_access = list(ACCESS_CENT_GENERAL) //SKYRAT EDIT ADDITION
 	var/obj/machinery/gateway/G
 
 /obj/machinery/computer/gateway_control/Initialize(mapload, obj/item/circuitboard/C)
@@ -302,6 +303,13 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 			try_to_linkup()
 			return TRUE
 		if("activate")
+			//SKYRAT EDIT ADDITION BEGIN
+			if(ishuman(usr))
+				var/mob/living/carbon/human/interacting_human = usr
+				if(!allowed(interacting_human))
+					to_chat(interacting_human, "<span class='notice'>Error, you do not have the required access to link up the gateway.</span>")
+					return FALSE
+			//SKYRAT EDIT END
 			var/datum/gateway_destination/D = locate(params["destination"]) in GLOB.gateway_destinations
 			try_to_connect(D)
 			return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Locks it to CENT GENERAL - Only vanguard and central command can activate it.

## Changelog
:cl:
add: The gateway can no longer be accessed by measly assistants.
/:cl:
