### PR TITLE
Fix stasis sleeper open/close message

### DIFF
--- a/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
+++ b/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
@@ -55,9 +55,9 @@
 	if(!user.canUseTopic(src, !issilicon(user)))
 		return
 	if(!panel_open)
-		user.visible_message("<span class='notice'>\The [src] [state_open ? "hisses as it swings open." : "hisses as it seals shut."].</span>", \
+		user.visible_message("<span class='notice'>\The [src] [state_open ? "hisses as it seals shut." : "hisses as it swings open."].</span>", \
 						"<span class='notice'>You [state_open ? "close" : "open"] \the [src].</span>", \
-						"<span class='hear'>You hear a nearby machine [state_open ? "hiss open." : "seal shut."].</span>")
+						"<span class='hear'>You hear a nearby machine [state_open ? "seal shut." : "swing open."].</span>")
 	if(state_open)
 		close_machine()
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
yeah
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Stasis sleepers now correctly say when they open close
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
