### PR TITLE
Gives stasis units an internal health analyzer when interacting with a free hand.

### DIFF
--- a/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
+++ b/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
@@ -155,7 +155,7 @@
 			to_chat(user, "<span class='notice'>You read the vitals readout on the side of the stasis unit.</span>")
 		healthscan(user, occupant, SCANNER_VERBOSE, TRUE)
 	else
-		to_chat(user, "span class='warning'>The vitals readout is empty, the stasis unit is unoccupied!</span>")
+		to_chat(user, "span class='warning'>The vitals readout is blank, the stasis unit is unoccupied!</span>")
 
 /obj/machinery/stasissleeper/attack_hand_secondary(mob/user)
 	if(occupant)
@@ -165,6 +165,6 @@
 			to_chat(user, "<span class='notice'>You read the bloodstream readout on the side of the stasis unit.</span>")
 		chemscan(user, occupant)
 	else
-		to_chat(user, "<span class='warning'>The bloodstream readout is empty, the stasis unit is unoccupied!</span>")
+		to_chat(user, "<span class='warning'>The bloodstream readout is blank, the stasis unit is unoccupied!</span>")
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 #undef SCANNER_VERBOSE

--- a/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
+++ b/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
@@ -165,5 +165,5 @@
 			to_chat(user, "<span class='notice'>You read the vitals readout on the side of the stasis unit.</span>")
 		chemscan(user, occupant)
 	else
-		to_chat(user, "span class='warning'>The vitals readout is empty, the stasis unit is unoccupied!</span>")
+		to_chat(user, "<span class='warning'>The vitals readout is empty, the stasis unit is unoccupied!</span>")
 #undef SCANNER_VERBOSE

--- a/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
+++ b/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
@@ -160,10 +160,11 @@
 /obj/machinery/stasissleeper/attack_hand_secondary(mob/user)
 	if(occupant)
 		if(occupant == user)
-			to_chat(user, "<span class='notice'>You read the vitals readout on the inside of the stasis unit.</span>")
+			to_chat(user, "<span class='notice'>You read the bloodstream readout on the inside of the stasis unit.</span>")
 		else
-			to_chat(user, "<span class='notice'>You read the vitals readout on the side of the stasis unit.</span>")
+			to_chat(user, "<span class='notice'>You read the bloodstream readout on the side of the stasis unit.</span>")
 		chemscan(user, occupant)
 	else
-		to_chat(user, "span class='warning'>The vitals readout is empty, the stasis unit is unoccupied!</span>")
+		to_chat(user, "<span class='warning'>The bloodstream readout is empty, the stasis unit is unoccupied!</span>")
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 #undef SCANNER_VERBOSE

--- a/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
+++ b/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
@@ -11,6 +11,7 @@
 	active_power_usage = 340
 	var/enter_message = "<span class='notice'><b>You feel cool air surround you. You go numb as your senses turn inward.<b></span>"
 	var/last_stasis_sound = FALSE
+	var/scanner = new /obj/item/healthanalyzer/advanced
 	fair_market_price = 10
 	payment_department = ACCOUNT_MED
 
@@ -21,7 +22,7 @@
 	. = ..()
 	. += "<span class='notice'>Alt-click to [state_open ? "close" : "open"] the machine.</span>"
 	. += "<span class='notice'>A light blinking on the side indicates that it is [occupant ? "occupied" : "vacant"].</span>"
-	. += "<span class='notice'>It has a port on the side to plug in a health analyzer and scan the occupant.</span>"
+	. += "<span class='notice'>It has a screen on the side displaying the vitals of the occupant. Interact to read it.</span>"
 
 /obj/machinery/stasissleeper/open_machine()
 	if(!state_open && !panel_open)
@@ -146,10 +147,12 @@
 		visible_message("<span class='notice'>[usr] pries open [src].</span>", "<span class='notice'>You pry open [src].</span>")
 		open_machine()
 
-/obj/machinery/stasissleeper/attackby(obj/item/weapon, mob/user)
-	if(istype(weapon, /obj/item/healthanalyzer))
-		if(occupant)
-			to_chat(user, "<span class='notice'>You plug the health analyzer into the stasis bed.</span>")
-			weapon.attack(occupant, user)
+/obj/machinery/stasissleeper/attack_hand(mob/user)
+	if(occupant)
+		if(occupant == user)
+			to_chat(user, "<span class='notice'>You read the vitals readout on the inside of the stasis unit.</span>")
 		else
-			to_chat(user, "<span class='notice'>You plug the health analyzer into the stasis bed... but there's no one inside!</span>")
+			to_chat(user, "<span class='notice'>You read the vitals readout on the side of the stasis unit.</span>")
+		scanner.attack(occupant, user)
+	else
+		to_chat(user, "span class='warning'>The vitals readout is empty, the stasis unit is unoccupied!</span>")

--- a/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
+++ b/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
@@ -11,6 +11,7 @@
 	active_power_usage = 340
 	var/enter_message = "<span class='notice'><b>You feel cool air surround you. You go numb as your senses turn inward.<b></span>"
 	var/last_stasis_sound = FALSE
+	var/internal_scanner_mode = SCANNER_VERBOSE
 	fair_market_price = 10
 	payment_department = ACCOUNT_MED
 
@@ -152,7 +153,7 @@
 			to_chat(user, "<span class='notice'>You read the vitals readout on the inside of the stasis unit.</span>")
 		else
 			to_chat(user, "<span class='notice'>You read the vitals readout on the side of the stasis unit.</span>")
-		healthscan(user, occupant, mode, TRUE)
+		healthscan(user, occupant, internal_scanner_mode, TRUE)
 	else
 		to_chat(user, "span class='warning'>The vitals readout is empty, the stasis unit is unoccupied!</span>")
 

--- a/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
+++ b/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
@@ -152,7 +152,7 @@
 			to_chat(user, "<span class='notice'>You read the vitals readout on the inside of the stasis unit.</span>")
 		else
 			to_chat(user, "<span class='notice'>You read the vitals readout on the side of the stasis unit.</span>")
-		healthscan(user, occupant, SCANNER_VERBOSE, TRUE)
+		healthscan(user, occupant, mode, TRUE)
 	else
 		to_chat(user, "span class='warning'>The vitals readout is empty, the stasis unit is unoccupied!</span>")
 

--- a/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
+++ b/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
@@ -12,7 +12,6 @@
 	active_power_usage = 340
 	var/enter_message = "<span class='notice'><b>You feel cool air surround you. You go numb as your senses turn inward.<b></span>"
 	var/last_stasis_sound = FALSE
-	var/internal_scanner_mode = SCANNER_VERBOSE
 	fair_market_price = 10
 	payment_department = ACCOUNT_MED
 
@@ -154,7 +153,7 @@
 			to_chat(user, "<span class='notice'>You read the vitals readout on the inside of the stasis unit.</span>")
 		else
 			to_chat(user, "<span class='notice'>You read the vitals readout on the side of the stasis unit.</span>")
-		healthscan(user, occupant, internal_scanner_mode, TRUE)
+		healthscan(user, occupant, SCANNER_VERBOSE, TRUE)
 	else
 		to_chat(user, "span class='warning'>The vitals readout is empty, the stasis unit is unoccupied!</span>")
 

--- a/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
+++ b/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
@@ -1,3 +1,4 @@
+#define SCANNER_VERBOSE 1
 /obj/machinery/stasissleeper
 	name = "lifeform stasis unit"
 	desc = "A somewhat comfortable looking bed with a cover over it. It will keep someone in stasis."
@@ -166,3 +167,4 @@
 		chemscan(user, occupant)
 	else
 		to_chat(user, "span class='warning'>The vitals readout is empty, the stasis unit is unoccupied!</span>")
+#undef SCANNER_VERBOSE

--- a/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
+++ b/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
@@ -11,7 +11,6 @@
 	active_power_usage = 340
 	var/enter_message = "<span class='notice'><b>You feel cool air surround you. You go numb as your senses turn inward.<b></span>"
 	var/last_stasis_sound = FALSE
-	var/scanner = new /obj/item/healthanalyzer/advanced
 	fair_market_price = 10
 	payment_department = ACCOUNT_MED
 
@@ -153,6 +152,16 @@
 			to_chat(user, "<span class='notice'>You read the vitals readout on the inside of the stasis unit.</span>")
 		else
 			to_chat(user, "<span class='notice'>You read the vitals readout on the side of the stasis unit.</span>")
-		scanner.attack(occupant, user)
+		healthscan(user, occupant, SCANNER_VERBOSE, TRUE)
+	else
+		to_chat(user, "span class='warning'>The vitals readout is empty, the stasis unit is unoccupied!</span>")
+
+/obj/machinery/stasissleeper/attack_hand_secondary(mob/user)
+	if(occupant)
+		if(occupant == user)
+			to_chat(user, "<span class='notice'>You read the vitals readout on the inside of the stasis unit.</span>")
+		else
+			to_chat(user, "<span class='notice'>You read the vitals readout on the side of the stasis unit.</span>")
+		chemscan(user, occupant)
 	else
 		to_chat(user, "span class='warning'>The vitals readout is empty, the stasis unit is unoccupied!</span>")

--- a/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
+++ b/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
@@ -21,6 +21,7 @@
 	. = ..()
 	. += "<span class='notice'>Alt-click to [state_open ? "close" : "open"] the machine.</span>"
 	. += "<span class='notice'>A light blinking on the side indicates that it is [occupant ? "occupied" : "vacant"].</span>"
+	. += "<span class='notice'>It has a port on the side to plug in a health analyzer and scan the occupant.</span>"
 
 /obj/machinery/stasissleeper/open_machine()
 	if(!state_open && !panel_open)
@@ -145,5 +146,10 @@
 		visible_message("<span class='notice'>[usr] pries open [src].</span>", "<span class='notice'>You pry open [src].</span>")
 		open_machine()
 
-/obj/machinery/stasis/nap_violation(mob/violator)
-	open_machine()
+/obj/machinery/stasissleeper/attackby(obj/item/weapon, mob/user)
+	if(istype(weapon, /obj/item/healthanalyzer))
+		if(occupant)
+			to_chat(user, "<span class='notice'>You plug the health analyzer into the stasis bed.</span>")
+			weapon.attack(occupant, user)
+		else
+			to_chat(user, "<span class='notice'>You plug the health analyzer into the stasis bed... but there's no one inside!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title

May not work, haven't been able to test
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes new stasis beds a lil' easier to use
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: NT have installed health scanners in their stasis units!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
