### PR TITLE
[MODULAR] Nerfs peacekeeper boots by request

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
@@ -296,6 +296,7 @@
 	icon_state = "peacekeeper_boots"
 	inhand_icon_state = "jackboots"
 	worn_icon_state = "peacekeeper"
+	armor = list(MELEE = 15, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 20, BIO = 10, RAD = 0, FIRE = 60, ACID = 35)
 
 /obj/item/clothing/shoes/combat/peacekeeper/ComponentInitialize()
 	. = ..()

--- a/modular_skyrat/modules/stormtrooper/code/stormtrooper_clothes.dm
+++ b/modular_skyrat/modules/stormtrooper/code/stormtrooper_clothes.dm
@@ -28,6 +28,7 @@
 	icon = 'modular_skyrat/modules/stormtrooper/icons/items.dmi'
 	worn_icon = 'modular_skyrat/modules/stormtrooper/icons/feet.dmi'
 	icon_state = "stormtrooper_boots"
+	armor = list(MELEE = 15, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 20, BIO = 10, RAD = 0, FIRE = 60, ACID = 35)
 	strip_delay = 80
 	mutant_variants = NONE
 


### PR DESCRIPTION
## About The Pull Request
Nerfs peacekeeper boots by request of Duboris, to: 10 armor, 5 bullet, 5 laser, 5 energy, 30 bomb resistance.

## Why It's Good For The Game

Peacekeeper boots are a child of nukeop boots, which are just shy of deathsquad boots, and certainly far-to-good for security to casually have. (they prevent most of the damage from c4)

## Changelog
:cl:
balance: tones back the armor values of peacekeeper boots.
/:cl:
