### PR TITLE
[NONMODULAR] Completely disables teleportation in gateway missions.

### DIFF
--- a/code/game/area/areas/away_content.dm
+++ b/code/game/area/areas/away_content.dm
@@ -10,6 +10,7 @@ Unused icons for new areas are "awaycontent1" ~ "awaycontent30"
 	has_gravity = STANDARD_GRAVITY
 	ambience_index = AMBIENCE_AWAY
 	sound_environment = SOUND_ENVIRONMENT_ROOM
+	area_flags = NOTELEPORT //SKYRAT EDIT - ADDITION
 
 /area/awaymission/beach
 	name = "Beach"


### PR DESCRIPTION
## About The Pull Request

It is no longer possible, by any means other than the gateway itself, to teleport out of gateway missions, unless defined to be allowed by the area makers. 

## Why It's Good For The Game

People were gamering it.

## Changelog
:cl:
fix: Teleportation now blocked at gateway missions
/:cl: