### PR TITLE
[NON-MODULAR] Doing Surgery in the correct area now gives you a boost to its speed.

### DIFF
--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -57,6 +57,7 @@
 	return FALSE
 
 #define SURGERY_SLOWDOWN_CAP_MULTIPLIER 2 //increase to make surgery slower but fail less, and decrease to make surgery faster but fail more
+#define SURGERY_SPEEDUP_AREA 2 // Skyrat Edit Addition - reward for doing surgery in surgery
 
 /datum/surgery_step/proc/initiate(mob/living/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	// Only followers of Asclepius have the ability to use Healing Touch and perform miracle feats of surgery.
@@ -84,6 +85,12 @@
 
 	fail_prob = min(max(0, modded_time - (time * SURGERY_SLOWDOWN_CAP_MULTIPLIER)),99)//if modded_time > time * modifier, then fail_prob = modded_time - time*modifier. starts at 0, caps at 99
 	modded_time = min(modded_time, time * SURGERY_SLOWDOWN_CAP_MULTIPLIER)//also if that, then cap modded_time at time*modifier
+
+	// Skyrat Edit Addition - reward for doing surgery in surgery
+	if(istype(get_area(target), /area/medical/surgery) && (TRAIT_FASTMED in user.status_traits))
+		modded_time /= SURGERY_SPEEDUP_AREA
+		to_chat(user, "<span class='notice'>You breathe in relief as all the tools and equipment you need are in easy reach!</span>")
+	// Skyrat Edit End
 
 	if(iscyborg(user))//any immunities to surgery slowdown should go in this check.
 		modded_time = time

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -87,7 +87,7 @@
 	modded_time = min(modded_time, time * SURGERY_SLOWDOWN_CAP_MULTIPLIER)//also if that, then cap modded_time at time*modifier
 
 	// Skyrat Edit Addition - reward for doing surgery in surgery
-	if(istype(get_area(target), /area/medical/surgery) && (TRAIT_FASTMED in user.status_traits))
+	if(is_type_in_list(get_area(target), list(/area/medical/surgery, /area/science/robotics)) && (TRAIT_FASTMED in user.status_traits) || (TRAIT_QUICK_CARRY in user.status_traits))
 		modded_time *= SURGERY_SPEEDUP_AREA
 		to_chat(user, "<span class='notice'>You breathe in relief as all the tools and equipment you need are in easy reach!</span>")
 	// Skyrat Edit End

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -57,7 +57,7 @@
 	return FALSE
 
 #define SURGERY_SLOWDOWN_CAP_MULTIPLIER 2 //increase to make surgery slower but fail less, and decrease to make surgery faster but fail more
-#define SURGERY_SPEEDUP_AREA 2 // Skyrat Edit Addition - reward for doing surgery in surgery
+#define SURGERY_SPEEDUP_AREA 0.5 // Skyrat Edit Addition - reward for doing surgery in surgery
 
 /datum/surgery_step/proc/initiate(mob/living/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	// Only followers of Asclepius have the ability to use Healing Touch and perform miracle feats of surgery.
@@ -88,7 +88,7 @@
 
 	// Skyrat Edit Addition - reward for doing surgery in surgery
 	if(istype(get_area(target), /area/medical/surgery) && (TRAIT_FASTMED in user.status_traits))
-		modded_time /= SURGERY_SPEEDUP_AREA
+		modded_time *= SURGERY_SPEEDUP_AREA
 		to_chat(user, "<span class='notice'>You breathe in relief as all the tools and equipment you need are in easy reach!</span>")
 	// Skyrat Edit End
 

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -91,7 +91,6 @@
 		modded_time *= SURGERY_SPEEDUP_AREA
 		to_chat(user, "<span class='notice'>You breathe in relief as all the tools and equipment you need are in easy reach!</span>")
 	// Skyrat Edit End
-
 	if(iscyborg(user))//any immunities to surgery slowdown should go in this check.
 		modded_time = time
 


### PR DESCRIPTION
## About The Pull Request

This makes it so that if doctors perform surgery inside of surgery and with the correct gear, nitrile or latex gloves, you get a bonus to your speed for the operation, which is currently twice as fast.

## Why It's Good For The Game

We punish people for not doing surgery in surgery by rewarding the people who do surgery in surgery.
I wanted to nerf not doing surgery in surgery with a speed penalty but I got told no.

## Changelog
:cl:
balance: Doing surgery in surgery or robotics with the correct equipment now gives you a multiplier to your operation speed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
