### PR TITLE
The sun's wrath is bound to it's designated intensity, minimal ejections will no longer change strength of their own will (CME strength fix)

### DIFF
--- a/modular_skyrat/modules/cme/code/_cme_defines.dm
+++ b/modular_skyrat/modules/cme/code/_cme_defines.dm
@@ -12,7 +12,7 @@ GLOBAL_LIST_INIT(cme_loot_list, list(
 
 /obj/item/strange
 
-#define CME_RANDOM "random"
+#define CME_UNKNOWN "unknown"
 #define CME_MINIMAL "minimal"
 #define CME_MODERATE "moderate"
 #define CME_EXTREME "extreme"

--- a/modular_skyrat/modules/cme/code/cme.dm
+++ b/modular_skyrat/modules/cme/code/cme.dm
@@ -24,7 +24,7 @@ Armageddon is truly going to fuck the station, use it sparingly.
 	startWhen = 6
 	endWhen	= 66
 	announceWhen = 10
-	var/cme_intensity
+	var/cme_intensity = CME_MINIMAL
 	var/cme_frequency_lower
 	var/cme_frequency_upper
 	var/list/cme_start_locs = list()

--- a/modular_skyrat/modules/cme/code/cme.dm
+++ b/modular_skyrat/modules/cme/code/cme.dm
@@ -13,7 +13,7 @@ Armageddon is truly going to fuck the station, use it sparingly.
 */
 
 /datum/round_event_control/cme
-	name = "Coronal Mass Ejection: Minimal"
+	name = "Coronal Mass Ejection: Random"
 	typepath = /datum/round_event/cme
 	weight = 10
 	min_players = 30
@@ -24,19 +24,28 @@ Armageddon is truly going to fuck the station, use it sparingly.
 	startWhen = 6
 	endWhen	= 66
 	announceWhen = 10
-	var/cme_intensity = CME_MINIMAL
+	var/cme_intensity
 	var/cme_frequency_lower
 	var/cme_frequency_upper
 	var/list/cme_start_locs = list()
 
-/datum/round_event_control/cme/random
-	name = "Coronal Mass Ejection: Random"
-	typepath = /datum/round_event/cme/random
+/datum/round_event_control/cme/unknown
+	name = "Coronal Mass Ejection: Unknown"
+	typepath = /datum/round_event/cme/unknown
 	weight = 0
 	max_occurrences = 0
 
-/datum/round_event/cme/random
-	cme_intensity = CME_RANDOM
+/datum/round_event/cme/unknown
+	cme_intensity = CME_UNKNOWN
+	
+/datum/round_event_control/cme/minimal
+	name = "Coronal Mass Ejection: Minimal"
+	typepath = /datum/round_event/cme/minimal
+	weight = 0
+	max_occurrences = 0
+
+/datum/round_event/cme/minimal
+	cme_intensity = "CME_MINIMAL
 
 /datum/round_event_control/cme/moderate
 	name = "Coronal Mass Ejection: Moderate"
@@ -67,9 +76,9 @@ Armageddon is truly going to fuck the station, use it sparingly.
 
 /datum/round_event/cme/setup()
 	if(!cme_intensity)
-		cme_intensity = pick(CME_MINIMAL, CME_RANDOM, CME_MODERATE, CME_EXTREME)
+		cme_intensity = pick(CME_MINIMAL, CME_UNKNOWN, CME_MODERATE, CME_EXTREME)
 	switch(cme_intensity)
-		if(CME_RANDOM)
+		if(CME_UNKNOWN)
 			cme_frequency_lower = CME_MODERATE_FREQUENCY_LOWER
 			cme_frequency_upper = CME_MODERATE_FREQUENCY_UPPER
 			startWhen = rand(CME_MODERATE_START_LOWER, CME_MODERATE_START_UPPER)
@@ -110,7 +119,7 @@ Armageddon is truly going to fuck the station, use it sparingly.
 		Ensure all sensitive equipment is shielded.", "Solar Event", sound('modular_skyrat/modules/cme/sound/cme_warning.ogg'))
 	else
 		switch(cme_intensity)
-			if(CME_RANDOM)
+			if(CME_UNKNOWN)
 				priority_announce("Coronal mass ejection detected! Expected intensity: UNKNOWN. Impact in: [round((startWhen * SSevents.wait) * 0.1, 0.1)] seconds. \
 				All synthetic and non-organic lifeforms should seek shelter immediately! \
 				Neutralize magnetic field bubbles at all costs.", "Solar Event", sound('modular_skyrat/modules/cme/sound/cme_warning.ogg'))
@@ -138,7 +147,7 @@ Armageddon is truly going to fuck the station, use it sparingly.
 		spawn_cme(spawnpoint, cme_intensity)
 
 /datum/round_event/cme/proc/spawn_cme(var/turf/spawnpoint, intensity)
-	if(intensity == CME_RANDOM)
+	if(intensity == CME_UNKNOWN)
 		intensity = pick(CME_MINIMAL, CME_MODERATE, CME_EXTREME)
 	var/area/loc_area_name = get_area(spawnpoint)
 	minor_announce("WARNING! [uppertext(intensity)] PULSE EXPECTED IN: [loc_area_name.name]", "Solar Flare Log:")

--- a/modular_skyrat/modules/cme/code/cme.dm
+++ b/modular_skyrat/modules/cme/code/cme.dm
@@ -45,7 +45,7 @@ Armageddon is truly going to fuck the station, use it sparingly.
 	max_occurrences = 0
 
 /datum/round_event/cme/minimal
-	cme_intensity = "CME_MINIMAL
+	cme_intensity = CME_MINIMAL
 
 /datum/round_event_control/cme/moderate
 	name = "Coronal Mass Ejection: Moderate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.

The minimal CME event was changed to not only use minimal intensity, without updating the name of the event accordingly. This caused issues, to the point where admins force-stopped the CME event beacause they thought the minimal discharge was broken (even though it was intended behaviour.)

This changes the minimal CME event to correctly use minimal intensity, while introducing a new CME event called "CME: Random" which randomly chooses a strength from minimal-extreme. Note that the old "CME: Random" is now "CME: Unknown" to reflect the unknown intensity of the CMEs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix for intended behaviour (I think) Fixes #5863 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Minimal CMEs are now minimal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
