### PR TITLE
The space hotel floats in space, her APCs should not float off the walls

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacehotel_skyrat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel_skyrat.dmm
@@ -259,6 +259,12 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/guestroom/room_2)
+"bz" = (
+/obj/machinery/power/apc/auto_name/south{
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus
+	},
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel/workroom)
 "bE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -5466,10 +5472,6 @@
 /area/ruin/space/has_grav/hotel)
 "JZ" = (
 /obj/structure/table,
-/obj/machinery/power/apc/highcap/five_k{
-	name = "Laundry APC";
-	pixel_y = 23
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/hotel/workroom)
@@ -9566,7 +9568,7 @@ aC
 nf
 Py
 bW
-di
+bz
 JZ
 bZ
 GI


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
i dunno if it works i'm not much of a mapper and have also never touched directional apcs but tries to fix #5698 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: the power of flight has been removed from the space hotel's APCs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
