### PR TITLE
[MODULAR][HOST-REQUEST] Minimum Length Flavor Text Requirement

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/living/dead/new_player/new_player.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/dead/new_player/new_player.dm
@@ -128,6 +128,10 @@
 		return TRUE
 
 	if(href_list["lobby_ready"])
+		if(!client.prefs.check_flavor_text())
+			ready = PLAYER_NOT_READY
+			return
+
 		if(SSticker.current_state <= GAME_STATE_PREGAME)
 			client << output(null, "lobbybrowser:imgsrc")
 			ready = !ready
@@ -167,6 +171,9 @@
 		return
 
 	if(href_list["lobby_join"])
+		if(!client.prefs.check_flavor_text())
+			return
+
 		if(!SSticker?.IsRoundInProgress())
 			to_chat(usr, "<span class='boldwarning'>The round is either not ready, or has already finished...</span>")
 			return
@@ -195,6 +202,9 @@
 
 
 	if(href_list["SelectedJob"])
+		if(!client.prefs.check_flavor_text())
+			return
+
 		if(!SSticker?.IsRoundInProgress())
 			to_chat(usr, "<span class='danger'>The round is either not ready, or has already finished...</span>")
 			return
@@ -476,6 +486,10 @@
 	popup.open(FALSE) // 0 is passed to open so that it doesn't use the onclose() proc
 
 /mob/dead/new_player/proc/create_character(transfer_after)
+	if(!client.prefs.check_flavor_text())
+		GLOB.joined_player_list -= client.ckey
+		return
+
 	spawning = 1
 	close_spawn_windows()
 

--- a/modular_skyrat/modules/customization/modules/client/preferences.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences.dm
@@ -270,6 +270,18 @@ GLOBAL_LIST_INIT(food, list(
 
 #define APPEARANCE_CATEGORY_COLUMN "<td valign='top' width='14%'>"
 #define MAX_MUTANT_ROWS 4
+#define FLAVORTEXT_JOIN_MINIMUM 150
+
+/datum/preferences/proc/check_flavor_text(inform_client = TRUE)
+	if(!features["flavor_text"])
+		if(inform_client)
+			to_chat(parent, "<span class='userdanger'>You must have a flavor text!</span>")
+		return FALSE
+	if(length(replacetext(features["flavor_text"], " ", "")) < FLAVORTEXT_JOIN_MINIMUM) // No you can't use whitespace to meet the requirement
+		if(inform_client)
+			to_chat(parent, "<span class='userdanger'>Your flavor text must be longer than [FLAVORTEXT_JOIN_MINIMUM] characters!</span>")
+		return FALSE
+	return TRUE
 
 /datum/preferences/proc/ShowChoices(mob/user)
 	if(!user || !user.client)

--- a/modular_skyrat/modules/customization/modules/client/preferences.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences.dm
@@ -274,18 +274,22 @@ GLOBAL_LIST_INIT(food, list(
 
 /datum/preferences/proc/check_flavor_text(inform_client = TRUE)
 	if(!features["flavor_text"])
+		if(check_rights(R_ADMIN))
+			var/resp = tgui_input_list(usr, "Do you want to bypass the flavor text requirement?", "Confirmation", list("Yes", "No"), 1 MINUTES)
+			if(resp=="Yes")
+				message_admins("[usr] is bypassing the flavor text requirements.")
+				return TRUE
 		if(inform_client)
 			to_chat(parent, "<span class='userdanger'>You must have a flavor text!</span>")
-		if(check_rights(R_ADMIN))
-			message_admins("[usr] is bypassing the flavor text requirements.")
-			return TRUE
 		return FALSE
 	if(length(replacetext(features["flavor_text"], " ", "")) < FLAVORTEXT_JOIN_MINIMUM) // No you can't use whitespace to meet the requirement
+		if(check_rights(R_ADMIN))
+			var/resp = tgui_input_list(usr, "Do you want to bypass the flavor text requirement?", "Confirmation", list("Yes", "No"), 1 MINUTES)
+			if(resp=="Yes")
+				message_admins("[usr] is bypassing the flavor text requirements.")
+				return TRUE
 		if(inform_client)
 			to_chat(parent, "<span class='userdanger'>Your flavor text must be longer than [FLAVORTEXT_JOIN_MINIMUM] characters!</span>")
-		if(check_rights(R_ADMIN))
-			message_admins("[usr] is bypassing the flavor text requirements.")
-			return TRUE
 		return FALSE
 	return TRUE
 

--- a/modular_skyrat/modules/customization/modules/client/preferences.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences.dm
@@ -276,10 +276,14 @@ GLOBAL_LIST_INIT(food, list(
 	if(!features["flavor_text"])
 		if(inform_client)
 			to_chat(parent, "<span class='userdanger'>You must have a flavor text!</span>")
+		if(check_rights(R_ADMIN))
+			message_admins("[usr] is bypassing the flavor text requirements.")
 		return FALSE
 	if(length(replacetext(features["flavor_text"], " ", "")) < FLAVORTEXT_JOIN_MINIMUM) // No you can't use whitespace to meet the requirement
 		if(inform_client)
 			to_chat(parent, "<span class='userdanger'>Your flavor text must be longer than [FLAVORTEXT_JOIN_MINIMUM] characters!</span>")
+		if(check_rights(R_ADMIN))
+			message_admins("[usr] is bypassing the flavor text requirements.")
 		return FALSE
 	return TRUE
 

--- a/modular_skyrat/modules/customization/modules/client/preferences.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences.dm
@@ -278,12 +278,14 @@ GLOBAL_LIST_INIT(food, list(
 			to_chat(parent, "<span class='userdanger'>You must have a flavor text!</span>")
 		if(check_rights(R_ADMIN))
 			message_admins("[usr] is bypassing the flavor text requirements.")
+			return TRUE
 		return FALSE
 	if(length(replacetext(features["flavor_text"], " ", "")) < FLAVORTEXT_JOIN_MINIMUM) // No you can't use whitespace to meet the requirement
 		if(inform_client)
 			to_chat(parent, "<span class='userdanger'>Your flavor text must be longer than [FLAVORTEXT_JOIN_MINIMUM] characters!</span>")
 		if(check_rights(R_ADMIN))
 			message_admins("[usr] is bypassing the flavor text requirements.")
+			return TRUE
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
## Host Request

Simply put; if you do not have a flavor text, or it is shorter than the cut off set by staff, you cannot ready up or join an active round.

**Verified Host Input - See Comment Section by Host:** It's a 150 character limits without whitespace:

**Example:** Here is a human who is rather plain in appearance with short, brown hair and freckles. Looking well into his thirties, he appears constantly tired if not exhausted. Some parts of his body part appear rather slimy

That's 178 characters without a whitespace. It's really not that much. I wrote that in half a minute.

Anyways, this will be merged in some form once we announce our character/species standard guideline which has been in discussion for over a month now in public.

