### PR TITLE
[Non-Modular] Implements the Engineering Plumbing Constructor for Protolathes

### DIFF
--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -51,6 +51,7 @@
 	build_path = /obj/item/construction/rcd/loaded
 	category = list("Tool Designs")
 	departmental_flags =  DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
+
 //SKYRAT EDIT ADDITION//
 /datum/design/engi_plumbing
 	name = "Engineering Plumbing Constructor"

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -51,7 +51,17 @@
 	build_path = /obj/item/construction/rcd/loaded
 	category = list("Tool Designs")
 	departmental_flags =  DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
-
+//SKYRAT EDIT ADDITION//
+/datum/design/engi_plumbing
+	name = "Engineering Plumbing Constructor"
+	desc = "A tool that can construct several plumbing devices, useful for liquid management."
+	id = "engi_plumbing"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 60000, /datum/material/glass = 5000)  // Costs the same as an RCD.
+	build_path = /obj/item/construction/plumbing/engineering
+	category = list("Tool Designs")
+	departmental_flags =  DEPARTMENTAL_FLAG_ENGINEERING
+//SKYRAT EDIT END//
 
 /datum/design/rcd_upgrade/frames
 	name = "RCD frames designs upgrade"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -60,7 +60,7 @@
 	design_ids = list("cybernetic_liver", "cybernetic_heart", "cybernetic_lungs","cybernetic_stomach", "cybernetic_eyes", "scalpel",
 					"blood_filter", "circular_saw", "bonesetter", "surgicaldrill", "retractor", "cautery", "hemostat",
 					"stethoscope", "surgical_drapes", "hospital_gown", "syringe", "plumbing_rcd", "beaker", "large_beaker", "xlarge_beaker",
-					"dropper", "defibmountdefault", "surgical_tape", "portable_chem_mixer")	//SKYRAT EDIT ADDITION: added "surgical_drapes"
+					"dropper", "defibmountdefault", "surgical_tape", "portable_chem_mixer", "engi_plumbing")	//SKYRAT EDIT ADDITION: added "surgical_drapes", "engi_plumbing"
 
 /datum/techweb_node/basic_circuitry
 	id = "basic_circuitry"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows the engi plumberer to be made at the engineering lathe / away lathes. That is all.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
pool good...
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Protolathes can now manufacture the engineering plumbing RCD.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
