### PR TITLE
[Modular] Phases out turf/open/water/overlay in favor of Azarak's liquid mechanics

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -27585,11 +27585,8 @@
 /area/hallway/primary/central)
 "gRh" = (
 /obj/machinery/light/directional/south,
-/turf/open/water/overlay{
-	desc = "It's a pool for swimming in!";
-	icon_state = "hotspring_tile";
-	name = "pool"
-	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
 /area/security/prison)
 "gRQ" = (
 /obj/structure/bed/dogbed/runtime,
@@ -45609,11 +45606,8 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "qAP" = (
-/turf/open/water/overlay{
-	desc = "It's a pool for swimming in!";
-	icon_state = "hotspring_tile";
-	name = "pool"
-	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
 /area/security/prison)
 "qAY" = (
 /obj/machinery/airalarm/directional/east,

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -3235,10 +3235,9 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "arX" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/machinery/disposal/bin,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "arZ" = (
@@ -3320,7 +3319,10 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "asl" = (
-/obj/structure/filingcabinet,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "asm" = (

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -5482,11 +5482,8 @@
 	},
 /area/commons/dorms)
 "azd" = (
-/turf/open/water/overlay{
-	desc = "It's a pool for swimming in!";
-	icon_state = "hotspring_tile";
-	name = "pool"
-	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
 /area/commons/fitness)
 "aze" = (
 /obj/structure/chair/comfy/brown{
@@ -42270,11 +42267,8 @@
 /area/science/mixing)
 "iEy" = (
 /obj/machinery/light/directional/south,
-/turf/open/water/overlay{
-	desc = "It's a pool for swimming in!";
-	icon_state = "hotspring_tile";
-	name = "pool"
-	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
 /area/security/prison)
 "iEH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -45236,11 +45230,8 @@
 /area/security/prison)
 "lFo" = (
 /obj/effect/landmark/start/hangover,
-/turf/open/water/overlay{
-	desc = "It's a pool for swimming in!";
-	icon_state = "hotspring_tile";
-	name = "pool"
-	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
 /area/commons/fitness)
 "lFP" = (
 /obj/machinery/door/airlock/research{
@@ -56446,11 +56437,8 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "wTn" = (
-/turf/open/water/overlay{
-	desc = "It's a pool for swimming in!";
-	icon_state = "hotspring_tile";
-	name = "pool"
-	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
 /area/security/prison)
 "wTp" = (
 /obj/machinery/chem_heater/withbuffer,

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -3315,7 +3315,8 @@
 "aiT" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/plating/beach/water,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/lowered,
 /area/cruiser_dock/commons)
 "aiV" = (
 /obj/effect/turf_decal/tile/green{
@@ -5558,7 +5559,8 @@
 /area/cruiser_dock/research)
 "aoG" = (
 /obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/plating/beach/water,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/lowered,
 /area/cruiser_dock/commons)
 "aoH" = (
 /obj/machinery/door/airlock/vault{
@@ -5974,7 +5976,8 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock/research)
 "apD" = (
-/turf/open/floor/plating/beach/water,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/lowered,
 /area/cruiser_dock/research)
 "apE" = (
 /obj/machinery/door/window/westleft{
@@ -6761,7 +6764,8 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "arD" = (
-/turf/open/floor/plating/beach/water,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/lowered,
 /area/cruiser_dock/commons/dorms)
 "arE" = (
 /obj/structure/table/wood,
@@ -8292,7 +8296,8 @@
 "avD" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/plating/beach/water,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/lowered,
 /area/cruiser_dock/commons)
 "avE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9264,7 +9269,8 @@
 "ayf" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/plating/beach/water,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/lowered,
 /area/cruiser_dock/commons)
 "ayg" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -13739,7 +13745,8 @@
 /obj/machinery/light/warm{
 	dir = 4
 	},
-/turf/open/floor/plating/beach/water,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/lowered,
 /area/cruiser_dock/commons/dorms)
 "aJX" = (
 /obj/structure/sink{
@@ -14127,7 +14134,8 @@
 /area/cruiser_dock/commons)
 "aKZ" = (
 /obj/structure/window/reinforced/spawner,
-/turf/open/floor/plating/beach/water,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/lowered,
 /area/cruiser_dock/commons)
 "aLa" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -15842,7 +15850,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plating/beach/water,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/lowered,
 /area/cruiser_dock/research)
 "aPE" = (
 /obj/effect/turf_decal/delivery,
@@ -18644,7 +18653,8 @@
 "aWS" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/plating/beach/water,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/lowered,
 /area/cruiser_dock/commons)
 "aWT" = (
 /obj/structure/bookcase/manuals/research_and_development,

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/oldstation_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/oldstation_skyrat.dmm
@@ -1013,10 +1013,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/ancientstation/engi)
 "eL" = (
-/turf/open/water/overlay/hotspring{
-	desc = "A pool, for swimming in.";
-	name = "pool"
-	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
 /area/ruin/space/has_grav/ancientstation)
 "eM" = (
 /obj/effect/decal/cleanable/dirt,

--- a/modular_skyrat/modules/ruins/maps/space/polychromicfacility.dmm
+++ b/modular_skyrat/modules/ruins/maps/space/polychromicfacility.dmm
@@ -232,7 +232,6 @@
 /area/ruin/space/has_grav/powered/skyrat/polychromicfacility)
 "T" = (
 /obj/structure/rack,
-/obj/item/integrated_circuit_printer/polychromic,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/skyrat/polychromicfacility)
 "U" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes some of the 'water' tiles to be mechanical liquid
that is all
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
inconsistency bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: turf/water/overlay has been phased out in favor of mechanical liquid - but is still available to use for mappers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
