### PR TITLE
Metastation Prison Remap

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -280,6 +280,13 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aaU" = (
@@ -313,13 +320,9 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "abb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
-"abc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "abd" = (
@@ -363,8 +366,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "abp" = (
@@ -494,14 +495,6 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/security/prison)
-"abL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
 /area/security/prison)
 "abM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -784,6 +777,9 @@
 "add" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/beach_ball/holoball,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "ade" = (
@@ -810,7 +806,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/blue/side{
-	dir = 9
+	dir = 8
 	},
 /area/security/prison)
 "adi" = (
@@ -828,21 +824,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"adq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "adr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -852,18 +833,12 @@
 "ads" = (
 /obj/structure/punching_bag,
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/security/prison)
 "adt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -875,9 +850,6 @@
 "adw" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -1468,8 +1440,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/button/door/directional/east{
 	id = "Prison Gate";
 	name = "Prison Wing Lockdown";
@@ -1792,8 +1762,9 @@
 /obj/structure/sign/warning/pods{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/arrows/red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "aix" = (
@@ -7707,6 +7678,7 @@
 "aNJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "aNL" = (
@@ -15341,6 +15313,21 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/grimy,
 /area/tcommsat/computer)
+"bGk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "bGo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -16185,6 +16172,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"bOq" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/security/execution/education)
 "bOv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -18598,6 +18599,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"cbk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "cbq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -23801,7 +23818,6 @@
 /turf/open/floor/carpet,
 /area/service/theater)
 "cEm" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -24320,6 +24336,9 @@
 /area/engineering/atmos)
 "cHo" = (
 /obj/effect/landmark/start/brigoff,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "cHv" = (
@@ -28237,8 +28256,6 @@
 /area/maintenance/starboard/fore)
 "dtX" = (
 /obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "dua" = (
@@ -29674,6 +29691,17 @@
 /obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
+"dSR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison)
 "dSW" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -30074,12 +30102,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"ecR" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/blue/side{
-	dir = 1
-	},
-/area/security/prison)
 "ecY" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -30372,6 +30394,12 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"ejw" = (
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 1
+	},
+/area/security/prison)
 "ejE" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -30890,17 +30918,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
-"ewR" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "exh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31588,6 +31605,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"eJq" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "eJs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -35444,6 +35477,12 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/cafeteria)
+"gjy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "gjM" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -37273,6 +37312,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
+"gSY" = (
+/obj/machinery/turnstile{
+	dir = 4;
+	req_one_access_txt = "2;63;81"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "gTG" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/camera{
@@ -38667,11 +38713,9 @@
 "hyP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/blue/side{
-	dir = 9
+/obj/structure/cable,
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 1
 	},
 /area/security/prison)
 "hyS" = (
@@ -39452,16 +39496,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
-"hRv" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "hRA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40301,6 +40335,9 @@
 "ihT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/prisoner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "ihY" = (
@@ -45784,9 +45821,7 @@
 /area/cargo/sorting)
 "kxc" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark/blue/corner{
-	dir = 1
-	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kxl" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -47972,9 +48007,6 @@
 /area/science/lab)
 "lse" = (
 /obj/effect/turf_decal/stripes/white/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "lsC" = (
@@ -48476,6 +48508,9 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "lEa" = (
@@ -48708,6 +48743,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
+"lIG" = (
+/obj/effect/turf_decal/arrows/red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison)
 "lJj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -50464,20 +50507,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
-"mqn" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "mqo" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "maintwarehouse"
@@ -51325,6 +51354,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "mIU" = (
@@ -52446,6 +52478,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/maintenance/aft/secondary)
+"nds" = (
+/obj/effect/turf_decal/arrows/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "ndG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -52934,6 +52974,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -55238,26 +55281,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"okP" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/dropper,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "olk" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -57654,23 +57677,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"pck" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "pcn" = (
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
@@ -64681,6 +64687,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_c)
+"rMk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "rMz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -70133,6 +70148,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"tTG" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "tTJ" = (
 /obj/machinery/mass_driver/toxins,
 /turf/open/floor/plating,
@@ -72705,6 +72730,16 @@
 	},
 /turf/open/floor/iron,
 /area/commons/toilet/auxiliary)
+"uUI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "uUP" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
@@ -73098,21 +73133,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
-"vaL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "vaT" = (
 /obj/structure/cable,
 /turf/open/floor/iron/goonplaque,
@@ -74241,6 +74261,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"vvt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
+/obj/effect/turf_decal/delivery/blue,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "vvx" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/grassybush,
@@ -75525,9 +75560,6 @@
 "vVP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "vVS" = (
@@ -78789,6 +78821,10 @@
 "xif" = (
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"xih" = (
+/obj/effect/turf_decal/arrows/red,
+/turf/open/floor/iron/dark/blue/side,
+/area/security/prison)
 "xiC" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/machinery/light/directional/east,
@@ -78930,7 +78966,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xmc" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -79393,6 +79428,26 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"xvi" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/dropper,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/execution/education)
 "xvo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Gamer Lair";
@@ -80037,14 +80092,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/main)
-"xIJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/blue/corner{
-	dir = 1
-	},
-/area/security/prison)
 "xIK" = (
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
@@ -102982,8 +103029,8 @@ iMA
 kDQ
 ejE
 adS
-adS
-adq
+bGk
+orI
 orI
 aej
 mki
@@ -103239,8 +103286,8 @@ jAY
 pew
 pew
 xsq
-anc
 adr
+anc
 pgX
 aem
 eda
@@ -103753,8 +103800,8 @@ jib
 mzr
 vim
 acE
-adb
 fos
+adb
 htR
 aem
 bIL
@@ -104267,7 +104314,7 @@ acv
 acv
 acv
 acI
-poo
+gjy
 vVP
 alL
 aem
@@ -105033,7 +105080,7 @@ aaC
 aaI
 mIS
 abb
-abo
+tTG
 abG
 acb
 acv
@@ -105041,7 +105088,7 @@ acJ
 lDT
 adw
 qQE
-adb
+nds
 ajm
 ajm
 ajm
@@ -105289,14 +105336,14 @@ acv
 acv
 acv
 aaS
-abc
 rdt
 acv
 acv
 acv
-aax
+acv
 aax
 ykb
+gSY
 tOL
 vTQ
 ajm
@@ -105546,14 +105593,14 @@ aaa
 aaa
 acv
 aaT
-ewR
 abq
 acv
-mqn
+bOq
 iGI
 acL
 aep
 adx
+lIG
 adh
 nIW
 ajm
@@ -105803,15 +105850,15 @@ aax
 aax
 acv
 acv
-acv
 abr
 abJ
-okP
+xvi
 nyH
 jgM
 ade
+dSR
 hyP
-xIJ
+ibS
 iBI
 ahx
 afP
@@ -106060,7 +106107,6 @@ jNJ
 ftV
 eYJ
 tNn
-poo
 mhA
 abe
 ace
@@ -106068,6 +106114,7 @@ acx
 acM
 aep
 osH
+poo
 ibS
 fKX
 ahx
@@ -106317,20 +106364,20 @@ uYK
 uYK
 urv
 ibS
-aNJ
 ezO
 abe
 aep
 aep
 aep
 aep
-ecR
+osH
+poo
 ibS
-iBI
+xih
 ahy
 afR
 wpm
-vaL
+ahy
 iac
 bCu
 fNU
@@ -106573,23 +106620,23 @@ xVh
 fnu
 dLD
 eYJ
-hRv
-bQs
-mhA
-abL
+eXu
+rMk
+cbk
+abN
 nvU
 fyo
 fyo
-fyo
+ejw
 kxc
 ibS
 ehM
 pcG
 rpQ
-wpm
-aiq
-uql
-uql
+eJq
+vvt
+uUI
+uUI
 skD
 uql
 uql
@@ -106831,7 +106878,7 @@ aax
 aax
 aax
 cEm
-poo
+bQs
 ksA
 rRW
 jiV
@@ -106844,7 +106891,7 @@ iBI
 ahA
 afR
 agM
-pck
+ahA
 aiw
 dtX
 gnj

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -44,7 +44,7 @@
 /turf/open/space,
 /area/space)
 "aaw" = (
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "aax" = (
@@ -91,22 +91,6 @@
 /obj/machinery/bounty_board/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"aaE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "aaG" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
@@ -5578,6 +5562,20 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"azl" = (
+/obj/structure/closet/secure_closet/freezer/meat{
+	req_access = null
+	},
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/security/prison)
 "azr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7707,18 +7705,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aNJ" = (
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen/interrogation{
-	name = "isolation room monitor";
-	network = list("isolation");
-	pixel_y = 31
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "aNL" = (
@@ -7729,6 +7717,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "aNS" = (
@@ -8361,10 +8350,11 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "aTb" = (
@@ -8798,6 +8788,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/fore)
+"aUX" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/grass,
+/area/security/prison)
 "aVk" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -9353,13 +9350,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
-"aWP" = (
-/obj/structure/lattice,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "aWQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10551,7 +10541,13 @@
 /obj/structure/bed,
 /obj/item/bedsheet/red,
 /obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron/dark,
+/obj/machinery/button/curtain{
+	id = "prisoncell2";
+	pixel_x = -24
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
 /area/security/prison/safe)
 "bca" = (
 /obj/machinery/door/poddoor{
@@ -15795,6 +15791,10 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
+"bKX" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/security/prison)
 "bLb" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -16383,15 +16383,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bQs" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "bQx" = (
@@ -17204,6 +17196,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"bVx" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/grass,
+/area/security/prison)
 "bVC" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating{
@@ -22398,10 +22394,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"csL" = (
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "csT" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable,
@@ -22783,7 +22775,9 @@
 /obj/structure/toilet/greyscale{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
 /area/security/prison/safe)
 "cwc" = (
 /obj/effect/turf_decal/stripes/line,
@@ -23806,6 +23800,46 @@
 	},
 /turf/open/floor/carpet,
 /area/service/theater)
+"cEm" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/interrogation{
+	name = "isolation room monitor";
+	network = list("isolation");
+	pixel_y = 31
+	},
+/obj/machinery/button/flasher{
+	id = "IsolationFlash2";
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/machinery/button/door{
+	id = "isolationshutter2";
+	name = "Isolation Shutter";
+	pixel_x = 8;
+	pixel_y = -1;
+	req_access_txt = "63"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "isolationshutter";
+	name = "Isolation Shutter";
+	pixel_x = -8;
+	pixel_y = -1;
+	req_access_txt = "63"
+	},
+/obj/machinery/button/flasher{
+	id = "IsolationFlash";
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "cEz" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -23970,6 +24004,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"cFq" = (
+/obj/machinery/biogenerator,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "cFt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -23986,18 +24026,6 @@
 	dir = 1
 	},
 /area/engineering/atmos)
-"cFu" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron/dark/yellow/side{
-	dir = 8
-	},
-/area/security/prison)
 "cFv" = (
 /obj/structure/chair{
 	dir = 1
@@ -26071,12 +26099,6 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cPK" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "cPO" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Port Aft";
@@ -26371,6 +26393,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"cSJ" = (
+/obj/machinery/cryopod,
+/obj/effect/turf_decal/delivery/white{
+	color = "#00ff00";
+	name = "green"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "cSP" = (
 /obj/docking_port/stationary/random{
 	id = "pod_lavaland";
@@ -27214,6 +27244,13 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/plumbed,
+/obj/structure/water_source{
+	dir = 8;
+	name = "sink";
+	pixel_x = 12;
+	pixel_y = -6
+	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "dha" = (
@@ -27789,6 +27826,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
+"dnI" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "dnM" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/south,
@@ -29100,6 +29145,13 @@
 /obj/structure/table/glass,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"dFl" = (
+/obj/structure/table,
+/obj/machinery/door/window/southleft{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "dFB" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -29116,31 +29168,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"dFK" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/hatchet,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/secateurs,
-/obj/item/secateurs,
-/obj/item/wrench,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/crowbar,
-/obj/item/plant_analyzer,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "dGb" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -29155,6 +29182,17 @@
 /obj/structure/training_machine,
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
+"dGS" = (
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7
+	},
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/security/prison)
 "dGY" = (
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
@@ -29359,6 +29397,17 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"dLD" = (
+/obj/structure/bed,
+/obj/item/toy/plush/beeplushie{
+	desc = "Maybe hugging this will make you feel better about yourself.";
+	name = "Therabee"
+	},
+/obj/item/bedsheet/blue,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
+/area/security/prison)
 "dLM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30636,6 +30685,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"erB" = (
+/obj/structure/chair/pew/right{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/grass,
+/area/security/prison)
 "erC" = (
 /obj/structure/table,
 /obj/item/clothing/head/soft/grey{
@@ -31023,6 +31079,7 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "ezS" = (
@@ -31290,22 +31347,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
-"eEe" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "eEi" = (
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 4
@@ -31346,6 +31387,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/locker)
+"eEF" = (
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/structure/table/rolling,
+/obj/item/storage/crayons{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/storage/crayons{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 4
+	},
+/area/security/prison)
 "eET" = (
 /obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -31548,6 +31611,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"eKB" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/security/prison)
 "eKL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/southright{
@@ -32199,6 +32266,15 @@
 	},
 /turf/open/floor/plating,
 /area/science/server)
+"eXu" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "eXv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -32294,19 +32370,12 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "eYJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "isolationshutter"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
+/turf/open/floor/plating,
 /area/security/prison)
 "eYQ" = (
 /obj/structure/disposalpipe/segment{
@@ -33047,6 +33116,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
+"fnu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/easel,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/security/prison)
 "fnK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -33266,24 +33348,20 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "ftV" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/toilet/greyscale{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/mirror{
+	pixel_x = -27
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
 	},
-/obj/machinery/camera{
-	c_tag = "Prison Isolation Cell";
-	dir = 8;
-	network = list("ss13","prison","isolation")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
 /area/security/prison)
 "fud" = (
 /obj/structure/table,
@@ -35076,7 +35154,6 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "gfP" = (
-/obj/machinery/chem_master/condimaster,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -35085,6 +35162,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/yellow/side{
 	dir = 4
@@ -35994,6 +36075,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"gvh" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_y = 26
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "gvn" = (
 /obj/structure/chair/sofa/corp/left{
 	desc = "Looks like someone threw it out. Covered in donut crumbs.";
@@ -36024,16 +36114,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"gwQ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "gxk" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -36289,6 +36369,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "gCa" = (
@@ -36929,44 +37010,17 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "gNS" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/storage/box/drinkingglasses,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
 /obj/item/radio/intercom{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/machinery/microwave,
+/obj/structure/table,
 /turf/open/floor/iron/dark/yellow/side{
 	dir = 5
 	},
@@ -39089,6 +39143,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"hJB" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/floor/grass,
+/area/security/prison)
 "hJF" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/rglass{
@@ -39359,6 +39417,15 @@
 /obj/structure/table,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"hPE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison/safe)
 "hPW" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8
@@ -39378,6 +39445,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"hRv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "hRA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39597,6 +39674,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"hVJ" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/thinplating/corner,
+/turf/open/floor/grass,
+/area/security/prison)
 "hVM" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/light_switch/directional/west,
@@ -39699,6 +39784,26 @@
 /obj/machinery/teleport/hub,
 /turf/open/floor/plating,
 /area/command/teleporter)
+"hXC" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
+	},
+/obj/machinery/light/small/directional/north,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	list_reagents = list(/datum/reagent/consumable/enzyme = 500);
+	name = "universe-sized universal enyzyme";
+	volume = 500
+	},
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/security/prison)
 "hYh" = (
 /obj/machinery/camera{
 	c_tag = "Teleporter Room";
@@ -39725,19 +39830,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
-"hYl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron/dark/yellow/side{
-	dir = 8
-	},
-/area/security/prison)
 "hYx" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -40384,6 +40476,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "ilJ" = (
@@ -40877,16 +40970,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/item/radio/intercom{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "iyV" = (
@@ -41635,16 +41719,13 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "iQW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark/yellow/side{
 	dir = 8
 	},
@@ -41789,6 +41870,20 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"iTG" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "iTO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_white,
@@ -42633,6 +42728,24 @@
 /area/security/range)
 "jkF" = (
 /turf/open/floor/iron/dark/blue/corner,
+/area/security/prison)
+"jkP" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/clothing/gloves/color/orange,
+/obj/item/restraints/handcuffs,
+/obj/item/reagent_containers/spray/pepper,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jkQ" = (
 /obj/structure/table,
@@ -43564,6 +43677,15 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"jDU" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/grass,
+/area/security/prison)
 "jEp" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -43605,6 +43727,25 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
+"jFo" = (
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/structure/table/rolling,
+/obj/item/storage/crayons{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/storage/crayons{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison)
 "jFu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -44038,28 +44179,12 @@
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
 "jNJ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/iron/dark/blue/side{
 	dir = 8
 	},
-/obj/machinery/flasher{
-	id = "IsolationFlash";
-	pixel_y = 28
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
 /area/security/prison)
 "jNL" = (
 /turf/open/floor/plating,
@@ -44420,6 +44545,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"jTv" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/security/prison)
 "jTA" = (
 /obj/machinery/light_switch{
 	pixel_y = 26
@@ -44461,6 +44596,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jVe" = (
+/obj/structure/sign/warning/pods,
+/turf/closed/wall,
+/area/security/prison)
 "jVf" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
@@ -44795,17 +44934,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/service/cafeteria)
-"keZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "kfx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -45191,26 +45319,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/service/bar)
-"knx" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/button/flasher{
-	id = "IsolationFlash";
-	pixel_x = -23;
-	pixel_y = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "kny" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -45284,6 +45392,20 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
+"kqi" = (
+/obj/item/clothing/suit/straight_jacket,
+/obj/structure/table,
+/obj/item/storage/box/prisoner{
+	pixel_y = 8
+	},
+/obj/item/storage/box/prisoner,
+/obj/item/electropack,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "kqk" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/airalarm/directional/west,
@@ -45381,6 +45503,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
+"ksA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "ksN" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -45571,6 +45699,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "kvt" = (
@@ -45662,9 +45791,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"kxJ" = (
-/turf/open/floor/plating,
-/area/security/prison)
 "kxY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -46062,10 +46188,12 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "kFW" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "isolationshutter2"
 	},
+/turf/open/floor/plating,
 /area/security/prison)
 "kGj" = (
 /obj/structure/window/reinforced{
@@ -46138,10 +46266,10 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "kHL" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
+/obj/machinery/computer/cryopod{
+	pixel_y = -27
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "kHQ" = (
 /obj/item/radio/intercom/directional/north,
@@ -47189,26 +47317,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"lbt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/toy/plush/beeplushie{
-	desc = "Maybe hugging this will make you feel better about yourself.";
-	name = "Therabee"
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "lbB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -47325,13 +47433,13 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "leJ" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Prison Forestry"
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "leV" = (
 /obj/structure/cable,
@@ -47748,9 +47856,16 @@
 /area/medical/medbay/central)
 "lqa" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/kitchen/rollingpin,
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 600);
+	name = "Premium All-Purpose Flour (16KG)";
+	volume = 600
+	},
+/obj/item/reagent_containers/food/condiment/rice{
+	list_reagents = list(/datum/reagent/consumable/rice = 150);
+	name = "Basmati Rice Sack (4KG)";
+	volume = 150
+	},
 /turf/open/floor/iron/dark/yellow/side{
 	dir = 10
 	},
@@ -47925,6 +48040,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"luF" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_y = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "luN" = (
 /turf/closed/wall,
 /area/service/lawoffice)
@@ -48419,6 +48542,7 @@
 /area/service/bar)
 "lGo" = (
 /obj/effect/landmark/start/prisoner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "lGu" = (
@@ -48479,6 +48603,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
+"lHB" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 9
+	},
+/area/security/prison)
 "lHI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -49588,6 +49720,7 @@
 "meC" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "meE" = (
@@ -49920,6 +50053,16 @@
 "mjT" = (
 /turf/closed/wall,
 /area/medical/psychology)
+"mke" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/grass,
+/area/security/prison)
 "mki" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
@@ -51080,6 +51223,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
+"mGl" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "mGA" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -51573,6 +51723,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
+"mQS" = (
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7
+	},
+/obj/machinery/light,
+/turf/open/floor/grass,
+/area/security/prison)
 "mQU" = (
 /obj/structure/plasticflaps,
 /obj/structure/window/reinforced{
@@ -52618,6 +52779,18 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"niF" = (
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/obj/effect/landmark/start/prisoner,
+/obj/machinery/button/curtain{
+	id = "prisoncell1";
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/security/prison/safe)
 "njb" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -52766,6 +52939,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"nlH" = (
+/obj/structure/chair/pew/left{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "nlK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -52778,6 +52963,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"nmW" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/security{
+	name = "Isolation Cell 2";
+	req_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/airless,
+/area/security/prison)
 "nnb" = (
 /obj/machinery/autolathe,
 /obj/machinery/camera{
@@ -53229,6 +53424,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"nxU" = (
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/security/prison)
 "nxX" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/hop)
@@ -54305,6 +54503,11 @@
 /obj/item/construction/plumbing,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"nTD" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/grass,
+/area/security/prison)
 "nTE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54558,6 +54761,21 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/science/nanite)
+"oab" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "oae" = (
 /obj/machinery/door_buttons/access_button{
 	idDoor = "xeno_airlock_interior";
@@ -54774,6 +54992,29 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"ofA" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/secateurs,
+/obj/item/secateurs,
+/obj/item/wrench,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/crowbar,
+/obj/item/plant_analyzer,
+/obj/machinery/light,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "ofB" = (
 /obj/machinery/door/airlock/security{
 	name = "Court Cell";
@@ -55313,12 +55554,12 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "orL" = (
-/obj/machinery/biogenerator,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
+	dir = 8
 	},
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "orS" = (
@@ -55627,6 +55868,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"oxZ" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 8
+	},
+/area/security/prison)
 "oyi" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -56650,12 +56906,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
-"oQB" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
-/turf/open/space/basic,
-/area/space)
 "oQE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -57417,6 +57667,10 @@
 "pcn" = (
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
+"pcp" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/grass,
+/area/security/prison)
 "pcq" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -57608,7 +57862,7 @@
 /area/engineering/break_room)
 "pfe" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -58203,7 +58457,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
 /area/security/prison/safe)
 "psC" = (
 /obj/structure/window/reinforced{
@@ -58512,6 +58768,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"pxk" = (
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/security/prison)
 "pxo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -58712,7 +58972,6 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "pAv" = (
-/obj/machinery/processor,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -58722,6 +58981,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/chem_master/condimaster,
 /turf/open/floor/iron/dark/yellow/side{
 	dir = 4
 	},
@@ -58751,6 +59011,19 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"pAR" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "IsolationFlash";
+	pixel_y = 28
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "pBf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -59303,6 +59576,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"pNg" = (
+/obj/structure/water_source/puddle,
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 5
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "pNt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -59705,6 +59985,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"pWH" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/iron,
+/area/security/prison)
 "pWO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/purple{
@@ -60532,17 +60816,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/dark/green,
 /area/security/prison)
-"qok" = (
-/obj/machinery/seed_extractor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "qpc" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -60745,6 +61018,20 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"qts" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet/greyscale{
+	dir = 8
+	},
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 5
+	},
+/area/security/prison)
 "qtK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
@@ -61059,6 +61346,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"qyz" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/security/prison)
 "qyD" = (
 /obj/structure/rack,
 /obj/item/storage/secure/briefcase,
@@ -61715,20 +62010,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"qLm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "qLx" = (
 /obj/machinery/camera{
 	c_tag = "Secure Tech Storage";
@@ -61797,6 +62078,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
+"qNh" = (
+/obj/effect/turf_decal/siding/thinplating,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/security/prison)
 "qNj" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -62194,7 +62480,9 @@
 /obj/structure/toilet/greyscale{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
 /area/security/prison/safe)
 "qTT" = (
 /obj/structure/table/glass,
@@ -62285,21 +62573,7 @@
 /turf/open/floor/wood,
 /area/cargo/qm)
 "qWF" = (
-/obj/structure/cable,
-/obj/structure/table,
-/obj/item/storage/box/bodybags{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/clothing/gloves/color/orange,
-/obj/item/restraints/handcuffs,
-/obj/item/reagent_containers/spray/pepper,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "qWL" = (
@@ -62379,6 +62653,20 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"qZw" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/storage/bag/tray,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 10
+	},
+/area/security/prison)
+"qZz" = (
+/obj/machinery/smartfridge,
+/turf/open/space/basic,
+/area/security/prison)
 "qZK" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -63613,7 +63901,6 @@
 "rxQ" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -64171,6 +64458,14 @@
 /obj/structure/closet/l3closet,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"rHL" = (
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/item/toy/plush/slimeplushie,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 6
+	},
+/area/security/prison)
 "rHO" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -65236,6 +65531,15 @@
 /obj/effect/spawner/lootdrop/techstorage/engineering,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"saU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "saV" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -65514,23 +65818,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"sfJ" = (
-/obj/item/clothing/suit/straight_jacket,
-/obj/structure/table,
-/obj/structure/cable,
-/obj/item/storage/box/prisoner{
-	pixel_y = 8
-	},
-/obj/item/storage/box/prisoner,
-/obj/item/electropack,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "sfQ" = (
 /obj/structure/closet,
 /obj/item/extinguisher,
@@ -65546,16 +65833,14 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "shg" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 10
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Forestry"
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 10
-	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/security/prison)
 "sht" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -66681,6 +66966,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"sBs" = (
+/obj/machinery/flasher{
+	id = "IsolationFlash2";
+	pixel_y = 28
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
+	},
+/area/security/prison)
 "sBt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -66805,6 +67099,12 @@
 	},
 /turf/open/floor/carpet,
 /area/service/theater)
+"sET" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "sFk" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger{
@@ -67271,7 +67571,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
 /area/security/prison/safe)
 "sQu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67427,6 +67729,13 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron,
 /area/service/bar)
+"sTd" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "sTj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -67574,10 +67883,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"sWw" = (
-/obj/item/bouquet/poppy,
-/turf/open/space/basic,
-/area/space)
 "sWz" = (
 /obj/structure/showcase/mecha/marauder,
 /obj/structure/window/reinforced{
@@ -68694,6 +68999,15 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"tuW" = (
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
+/area/security/prison/safe)
 "tvA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -68750,6 +69064,12 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"twK" = (
+/obj/structure/easel,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
+/area/security/prison)
 "twX" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -69502,15 +69822,21 @@
 /turf/open/space,
 /area/space/nearstation)
 "tNn" = (
-/obj/machinery/door/airlock/security{
-	id_tag = "IsolationCell";
-	name = "Isolation Cell";
-	req_access_txt = "2"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/turf_decal/delivery/blue,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/button/flasher{
+	id = "IsolationFlash";
+	pixel_x = -23;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "tNB" = (
 /obj/effect/turf_decal/stripes/line{
@@ -69562,33 +69888,6 @@
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "tOw" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/item/seeds/onion,
-/obj/item/seeds/garlic,
-/obj/item/seeds/potato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/seeds/tower,
-/obj/item/seeds/chili,
-/obj/item/seeds/corn,
-/obj/item/seeds/cotton,
-/obj/item/seeds/watermelon,
-/obj/item/seeds/tomato/blood,
-/obj/item/seeds/tea,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/cabbage,
-/obj/structure/water_source{
-	dir = 8;
-	name = "sink";
-	pixel_x = 12;
-	pixel_y = -6
-	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
@@ -70437,7 +70736,6 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "ugv" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
@@ -70890,6 +71188,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
+"uoa" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/security/prison)
 "uod" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
@@ -71036,8 +71338,13 @@
 /area/hallway/primary/aft)
 "urv" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/security{
+	name = "Isolation Cell 1";
+	req_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "urx" = (
 /obj/machinery/status_display/ai/directional/north,
@@ -71999,14 +72306,19 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "uNn" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/iron/white,
 /area/security/prison)
 "uNx" = (
@@ -72032,6 +72344,9 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
+"uOM" = (
+/turf/closed/wall/r_wall,
+/area/space)
 "uPg" = (
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
@@ -72631,6 +72946,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"uYK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/airless,
+/area/security/prison)
 "uYL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair{
@@ -72638,6 +72958,24 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"uYT" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/security/prison)
+"uYW" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#00ff00";
+	name = "green"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "uYX" = (
 /obj/structure/sign/poster/contraband/robust_softdrinks{
 	name = "Jim Norton's Quebecois Coffee";
@@ -73552,8 +73890,6 @@
 	},
 /area/service/kitchen)
 "voJ" = (
-/obj/structure/table,
-/obj/machinery/microwave,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -73563,6 +73899,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/processor,
 /turf/open/floor/iron/dark/yellow/side{
 	dir = 4
 	},
@@ -73575,10 +73915,16 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "voY" = (
-/obj/machinery/griddle,
-/turf/open/floor/iron/dark/yellow/side{
-	dir = 10
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/grass,
 /area/security/prison)
 "vpO" = (
 /obj/structure/table,
@@ -73893,6 +74239,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"vvx" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "vwi" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -74667,6 +75023,16 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"vLO" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#00ff00";
+	name = "green"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "vLX" = (
 /obj/structure/table/glass,
 /obj/item/tank/internals/emergency_oxygen{
@@ -74945,17 +75311,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"vRd" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron/dark/yellow/side{
-	dir = 8
-	},
-/area/security/prison)
 "vRp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -74980,8 +75335,8 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/landmark/start/brigoff,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "vSE" = (
@@ -75006,6 +75361,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"vSU" = (
+/obj/machinery/door/airlock/freezer,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "vTe" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/service,
@@ -75108,17 +75467,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"vVl" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "vVn" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/structure/window/reinforced,
@@ -75913,6 +76261,18 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"wlm" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 8
+	},
+/area/security/prison)
 "wlr" = (
 /obj/structure/cable,
 /obj/machinery/button/door{
@@ -76780,6 +77140,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"wEO" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "wFB" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -76969,6 +77343,35 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"wIA" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/seeds/onion,
+/obj/item/seeds/garlic,
+/obj/item/seeds/potato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/carrot,
+/obj/item/seeds/grass,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/tower,
+/obj/item/seeds/chili,
+/obj/item/seeds/corn,
+/obj/item/seeds/cotton,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/tomato/blood,
+/obj/item/seeds/tea,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/cabbage,
+/obj/item/seeds/redbeet,
+/obj/item/seeds/chanter,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "wIU" = (
 /obj/structure/chair{
 	dir = 1
@@ -77698,6 +78101,25 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
+"wWt" = (
+/obj/structure/table,
+/obj/item/storage/box/hug{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/razor{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "wWE" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -78029,19 +78451,13 @@
 /turf/open/space,
 /area/space)
 "xdf" = (
-/obj/structure/table,
-/obj/item/storage/box/hug{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/razor{
-	pixel_x = -8;
-	pixel_y = 3
-	},
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "xdo" = (
@@ -78509,6 +78925,17 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"xmc" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/bed/roller,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "xmd" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -78945,11 +79372,6 @@
 /obj/structure/closet/wardrobe/grey,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xvH" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/space/basic,
-/area/space)
 "xvL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -78997,6 +79419,24 @@
 "xwN" = (
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"xxn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/yellow/side{
+	dir = 4
+	},
+/area/security/prison)
 "xxG" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood{
@@ -79225,12 +79665,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"xBL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "xBS" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -79281,6 +79715,29 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/medical/coldroom)
+"xCB" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/security/prison)
 "xCM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -79765,6 +80222,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"xNW" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/space)
 "xNX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -80138,6 +80598,14 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
+"xVh" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/security/prison)
 "xVl" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -80289,15 +80757,6 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "xXB" = (
-/obj/machinery/camera{
-	c_tag = "Prison Forestry";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/hydroponics/soil{
 	desc = "A patch of fertile soil that you can plant stuff in.";
 	icon = 'icons/turf/floors.dmi';
@@ -80537,7 +80996,6 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "ybE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/hydroponics/soil{
 	desc = "A patch of fertile soil that you can plant stuff in.";
 	icon = 'icons/turf/floors.dmi';
@@ -80545,20 +81003,17 @@
 	layer = 2.0001;
 	plane = -7
 	},
+/obj/machinery/camera{
+	c_tag = "Prison Forestry";
+	dir = 4;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/grass,
 /area/security/prison)
 "ybM" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
-"ybN" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "yce" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -81043,12 +81498,6 @@
 /area/service/cafeteria)
 "ylH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/closet/secure_closet/freezer/meat{
-	req_access = null
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -81058,14 +81507,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/food/meat/slab/monkey,
-/obj/item/food/meat/slab/monkey,
-/obj/item/food/meat/slab/monkey,
-/obj/item/food/meat/slab/monkey,
-/obj/item/food/fishmeat,
-/obj/item/food/fishmeat,
-/obj/item/food/fishmeat,
-/obj/item/food/fishmeat,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/griddle,
 /turf/open/floor/iron/dark/yellow/corner{
 	dir = 4
 	},
@@ -98386,7 +98831,7 @@ aaa
 aaa
 aaa
 aaa
-nYJ
+fwb
 aaa
 lMJ
 aaa
@@ -98643,15 +99088,15 @@ aaa
 aaa
 aaa
 aaa
-lMJ
+fwb
 aaa
-lMJ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aax
+abN
+abN
+abN
+aep
+aep
+aax
 lMJ
 aaa
 bin
@@ -98886,32 +99331,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+fwb
+lMJ
+abN
+qyz
+bKX
+pxk
+nTD
+dGS
+abN
 lMJ
 aaa
-lMJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-lMJ
-aaa
-lMJ
 aaa
 bin
 aaa
@@ -99143,33 +99588,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-nYJ
-aaa
+lMJ
+fwb
+fwb
+fwb
+fwb
+lMJ
+fwb
+fwb
+fwb
+fwb
+fwb
 lMJ
 aaa
 aaa
+fwb
 aaa
-aaa
-aaa
-aaa
-aWP
-aaa
+abN
+sTd
+pNg
+jTv
+bVx
+xXB
+abN
 lMJ
-aaa
+lMJ
+lMJ
+lMJ
 bin
 aaa
 aaa
@@ -99400,29 +99845,29 @@ aaa
 aaa
 aaa
 aaa
+lMJ
+lMJ
 aaa
-aaa
-aaa
-aaa
-aaa
-gJK
-gJK
-gJK
-gJK
-gJK
-gJK
-gJK
 aaa
 aaa
 lMJ
 aaa
-vrW
+lMJ
 aaa
 aaa
 aaa
-aep
-aep
-aep
+lMJ
+aaa
+aaa
+fwb
+aaa
+abN
+hJB
+pcp
+qyz
+jDU
+mQS
+aax
 aax
 aax
 aax
@@ -99656,34 +100101,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-gJK
-gJK
-gJK
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
 lMJ
 lMJ
 fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
 lMJ
-lMJ
-lMJ
-vrW
-lMJ
-lMJ
-aep
-aep
-ybE
+aax
+aax
+aax
+aax
+aax
+gvh
+hVJ
+uYT
+aUX
+xXB
 ybE
 xXB
 ugv
 aax
-aaa
+aax
 rMz
 aaa
 aaa
@@ -99911,12 +100356,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-gJK
-gJK
-aQj
+lMJ
+lMJ
 lMJ
 lMJ
 lMJ
@@ -99925,22 +100366,26 @@ aaa
 aaa
 lMJ
 aaa
+lMJ
 aaa
 aaa
-vrW
-vrW
-vrW
-vrW
 aaa
-aaa
-aep
+lMJ
+aax
+azl
+uoa
+eKB
+aax
+sTd
+qNh
+dnI
 orL
 gBC
 aNL
 kvf
 aST
+trJ
 aax
-aaa
 rMz
 rMz
 rMz
@@ -100168,12 +100613,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
+fwb
 aaa
 gJK
 lMJ
-lMJ
-aQj
+aaa
 aaa
 aaa
 lMJ
@@ -100183,20 +100628,20 @@ aep
 aep
 aep
 aax
-aaa
-aaa
-aaa
-lMJ
-aaa
-aaa
-aaa
-aep
-qok
-csL
+aax
+hXC
+nxU
+xCB
+aax
+nlH
+erB
+iyN
+aaw
+aaw
 lGo
 aaw
 meC
-aax
+qoj
 aax
 aaa
 aaa
@@ -100425,12 +100870,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
+fwb
 aaa
 gJK
 lMJ
 aaa
-lMJ
 aaa
 aaa
 aax
@@ -100440,15 +100885,15 @@ ugQ
 nUp
 mPo
 aax
-aep
 aax
 aax
+vSU
+xKy
 aax
-aax
-aax
-aax
-aax
-dFK
+wEO
+mke
+sET
+tOw
 tOw
 dgX
 vSn
@@ -100682,11 +101127,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lMJ
+fwb
+lMJ
 gJK
 lMJ
-aaa
 lMJ
 lMJ
 lMJ
@@ -100696,21 +101141,21 @@ nCu
 ltI
 snh
 bNP
-nId
+xSW
 rxQ
 eZQ
 haK
 iQW
-hYl
 skI
+qZw
 voY
-aax
-abe
-abe
-abe
+dFl
+qZz
+cFq
+oab
 iyN
 aVG
-qoj
+pWH
 aep
 aaa
 aaj
@@ -100939,12 +101384,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
+fwb
 aaa
 gJK
 lMJ
 aaa
-lMJ
 aaa
 aaa
 aax
@@ -100959,15 +101404,15 @@ pGE
 asn
 xeX
 xeX
-xeX
 jlv
-vRd
-cFu
+wlm
+haK
+haK
 lqa
-abe
-vVl
-ybN
-trJ
+vvx
+iyN
+aVG
+luF
 aep
 aaa
 vrW
@@ -101196,12 +101641,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
+fwb
 aaa
 gJK
 lMJ
 aaa
-lMJ
 aaa
 aaa
 aax
@@ -101221,10 +101666,10 @@ pCI
 abM
 xuw
 bkx
-abe
-aep
+iTG
+wIA
 leJ
-agH
+ofA
 aeJ
 aeJ
 aeJ
@@ -101453,12 +101898,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
+fwb
 aaa
 gJK
 aQj
 aaa
-lMJ
 aep
 aax
 aax
@@ -101470,7 +101915,7 @@ eSd
 iBI
 xaN
 fud
-wLN
+xxn
 gfP
 pAv
 voJ
@@ -101478,8 +101923,8 @@ ylH
 hNd
 xeX
 guu
+abe
 aep
-sOd
 shg
 agH
 iDL
@@ -101710,11 +102155,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lMJ
+fwb
+lMJ
 gJK
 lMJ
-aaa
 aep
 aep
 mov
@@ -101735,8 +102180,8 @@ gNS
 aPN
 wLN
 vVt
-abe
-gwQ
+aep
+sOd
 uNn
 agH
 dPK
@@ -101967,11 +102412,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
+fwb
 aaa
 gJK
-lMJ
-lMJ
+aaa
 aep
 tzT
 ptc
@@ -102224,10 +102669,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
+fwb
 aaa
 gJK
-lMJ
 aaa
 aep
 aAs
@@ -102481,10 +102926,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
+lMJ
 aaa
 gJK
-lMJ
 aaa
 aep
 gRw
@@ -102738,10 +103183,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
+fwb
 aaa
 gJK
-lMJ
 aaa
 aep
 lYp
@@ -102995,11 +103440,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lMJ
+fwb
+lMJ
 gJK
 lMJ
-aaa
 aep
 aep
 dfb
@@ -103252,12 +103697,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
+fwb
 aaa
 gJK
 aQj
-lMJ
-lMJ
+aaa
 aep
 aax
 aax
@@ -103288,8 +103733,8 @@ htR
 aem
 bIL
 afI
-psm
-sQs
+hPE
+tuW
 aeJ
 aaa
 aaa
@@ -103509,13 +103954,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
+fwb
 aaa
 gJK
 lMJ
 aaa
 aaa
-lMJ
 aaa
 aax
 jee
@@ -103545,12 +103990,12 @@ alL
 aem
 mki
 fQi
-bbT
+niF
 cvX
 aeJ
-aaa
-aaa
-oQB
+abN
+abN
+abN
 dne
 awS
 aRG
@@ -103766,14 +104211,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lMJ
 fwb
 lMJ
-aaa
-aaa
+fwb
 lMJ
-aaa
+lMJ
+lMJ
+lMJ
 aax
 aax
 aax
@@ -103805,9 +104250,9 @@ agH
 agH
 agH
 aeJ
-aep
-aep
-aax
+uYW
+vLO
+vLO
 aio
 dne
 dne
@@ -104023,20 +104468,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lMJ
 fwb
+aaa
 lMJ
 lMJ
+aaa
+aaa
+aaa
 lMJ
-aQj
+aaa
 lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
+aaa
+aaa
+aaa
 lMJ
 lMJ
 aaf
@@ -104280,23 +104725,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lMJ
 fwb
-lMJ
-aaa
 aaa
 lMJ
-aaa
-aaa
-aaa
-lMJ
-aaa
-aaa
-aaa
-lMJ
-aaa
-aaa
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
+fwb
 aaf
 kHF
 oaq
@@ -104320,8 +104765,8 @@ tPW
 tPW
 uvm
 iSs
-cPK
 rZU
+cSJ
 aio
 aol
 apD
@@ -104537,15 +104982,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lMJ
 fwb
+aaa
+lMJ
 lMJ
 aaa
 aaa
+aaa
 lMJ
-aaa
-aaa
 aaa
 lMJ
 aaa
@@ -104794,8 +105239,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lMJ
+lMJ
 lMJ
 lMJ
 lMJ
@@ -105052,14 +105497,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
 fwb
 fwb
 fwb
 fwb
 fwb
 fwb
-fwb
+lMJ
 fwb
 fwb
 fwb
@@ -105068,11 +105513,11 @@ fwb
 fwb
 fwb
 lMJ
-lAu
-aaf
-aax
-eEe
-aaE
+aaa
+aaa
+aaa
+aaa
+aaa
 acv
 aaT
 ewR
@@ -105309,27 +105754,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-sWw
-aaa
-aaa
-aaa
-aaa
-aaa
 lMJ
-aaa
-aaf
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
 aax
-lbt
-qLm
+aax
+aax
+aax
 acv
 acv
 acv
@@ -105580,16 +106025,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
 lMJ
 aaa
-aaf
+aaa
 aax
+jFo
 jNJ
 ftV
 eYJ
 tNn
-knx
+poo
 mhA
 abe
 ace
@@ -105836,16 +106281,16 @@ aaa
 aaa
 aaa
 aaa
-xvH
-auC
-aox
-ack
-aox
-rch
+aaa
+lMJ
+aaa
+aaa
 aax
-aax
+pAR
+uYK
+uYK
 urv
-urv
+ibS
 aNJ
 ezO
 abe
@@ -106094,17 +106539,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aox
-aaa
+lMJ
 aaa
 aaa
-aaa
-wOY
-kxJ
 aax
+xVh
+fnu
+dLD
+eYJ
+hRv
 bQs
-ezO
+mhA
 abL
 nvU
 fyo
@@ -106351,17 +106796,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aox
-xcN
+lMJ
 aaa
 aaa
-aaa
-abu
-xBL
-iND
-keZ
-ezO
+aax
+aax
+aax
+aax
+aax
+cEm
+poo
+ksA
 rRW
 jiV
 jYc
@@ -106608,17 +107053,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aox
-aaa
+lMJ
 aaa
 aaa
-aaa
-wOY
-kFW
 aax
+lHB
+oxZ
+twK
+kFW
+xmc
 qWF
-adg
+ezO
 abN
 bgX
 mNE
@@ -106864,19 +107309,19 @@ aaa
 aaa
 aaa
 aaa
-xvH
-auC
-aox
-aox
-aox
-rch
+aaa
+lMJ
+aaa
+aaa
 aax
-aax
-aax
-aax
-sfJ
+sBs
+uYK
+uYK
+nmW
+aNJ
+aNJ
 xdf
-abe
+jVe
 aci
 abe
 acO
@@ -107122,17 +107567,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
 lMJ
 aaa
-aaa
-aaa
-aaa
-lMJ
 aaa
 aax
-aep
-aep
+qts
+eEF
+rHL
+kFW
+eXu
+poo
+adg
 aax
 acj
 abe
@@ -107377,19 +107822,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+quc
 lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-aaa
-aaa
-aaa
-aaa
+aox
+ack
+aox
+rch
+aax
+aax
+aax
+aax
+eXu
+poo
+adg
 aax
 wiZ
 aax
@@ -107636,18 +108081,18 @@ aaa
 aaa
 aaa
 aaa
+aox
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaf
-lMJ
-lMJ
-aaf
-aaa
-lAu
+wOY
+aax
+aax
+eXu
+poo
+adg
+abN
 ack
 lAu
 aaa
@@ -107893,18 +108338,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-lMJ
-lMJ
 aox
+xcN
+aaa
+aaa
+aaa
+abu
+saU
+iND
+poo
+poo
+mGl
+abN
 aox
 aox
 aaf
@@ -108150,18 +108595,18 @@ aaa
 aaa
 aaa
 aaa
+aox
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+wOY
+aax
+aax
+jkP
+kqi
+wWt
+abN
 aaa
 aaa
 aaa
@@ -108405,20 +108850,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+quc
+lMJ
+aox
+aox
+aox
+xNW
+uOM
+uOM
+aax
+aax
+aep
+aep
+aep
+aax
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -16216,12 +16216,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bOQ" = (
-/obj/structure/chair/sofa/corner{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/chair/sofa{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/security/prison)
@@ -21122,7 +21122,7 @@
 /obj/item/camera{
 	pixel_y = 4
 	},
-/obj/machinery/light{
+/obj/structure/window{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -28021,6 +28021,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
+/area/security/prison)
+"dqR" = (
+/obj/structure/chair/sofa/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "dqT" = (
 /turf/closed/wall/r_wall,
@@ -35264,6 +35270,7 @@
 /area/engineering/break_room)
 "ghE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/security/prison)
 "ghG" = (
@@ -45791,6 +45798,12 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"kxs" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "kxY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -50331,6 +50344,9 @@
 	pixel_x = -30
 	},
 /obj/item/storage/photo_album/prison,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/security/prison)
 "moz" = (
@@ -56586,6 +56602,20 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "oKL" = (
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/structure/table/rolling,
+/obj/item/storage/crayons{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/storage/crayons{
+	pixel_x = -6;
+	pixel_y = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -59402,10 +59432,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"pID" = (
-/obj/structure/chair/sofa,
-/turf/open/floor/wood,
-/area/security/prison)
 "pIS" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral{
@@ -64980,6 +65006,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"rRV" = (
+/obj/structure/easel,
+/turf/open/floor/wood,
+/area/security/prison)
 "rRW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78035,6 +78065,10 @@
 	},
 /turf/closed/wall,
 /area/service/bar)
+"wUj" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/security/prison)
 "wUl" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -81389,13 +81423,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
-"yju" = (
-/obj/structure/chair/sofa/left,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "yjD" = (
 /obj/structure/sink{
 	pixel_y = 22
@@ -100877,7 +100904,7 @@ gJK
 lMJ
 aaa
 aaa
-aaa
+aax
 aax
 aax
 aax
@@ -101134,8 +101161,8 @@ gJK
 lMJ
 lMJ
 lMJ
-lMJ
 aax
+dqR
 bOQ
 nCu
 ltI
@@ -101391,9 +101418,9 @@ gJK
 lMJ
 aaa
 aaa
-aaa
 aax
-pID
+lYp
+rBf
 gVr
 omi
 ltI
@@ -101648,11 +101675,11 @@ gJK
 lMJ
 aaa
 aaa
-aaa
 aax
-yju
-rBf
-omi
+kxs
+xSW
+xSW
+ltI
 dxl
 adG
 agN
@@ -101904,9 +101931,9 @@ aaa
 gJK
 aQj
 aaa
-aep
 aax
 aax
+rRV
 ghE
 oKL
 bId
@@ -102165,7 +102192,7 @@ aep
 mov
 clD
 etf
-xSW
+wUj
 tBO
 pna
 afd
@@ -102421,9 +102448,9 @@ aep
 tzT
 ptc
 qXD
-etf
+xSW
 nHF
-tBO
+xSW
 pna
 eSd
 iBI

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -55008,29 +55008,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"ofA" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/hatchet,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/secateurs,
-/obj/item/secateurs,
-/obj/item/wrench,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/crowbar,
-/obj/item/plant_analyzer,
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "ofB" = (
 /obj/machinery/door/airlock/security{
 	name = "Court Cell";
@@ -60837,11 +60814,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"qoj" = (
-/obj/structure/cable,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/iron/dark/green,
-/area/security/prison)
 "qpc" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -77374,28 +77346,26 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wIA" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/item/seeds/onion,
-/obj/item/seeds/garlic,
-/obj/item/seeds/potato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/item/seeds/tower,
-/obj/item/seeds/chili,
-/obj/item/seeds/corn,
-/obj/item/seeds/cotton,
-/obj/item/seeds/watermelon,
-/obj/item/seeds/tomato/blood,
-/obj/item/seeds/tea,
-/obj/item/seeds/cotton/durathread,
-/obj/item/seeds/cabbage,
-/obj/item/seeds/redbeet,
-/obj/item/seeds/chanter,
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/secateurs,
+/obj/item/secateurs,
+/obj/item/wrench,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/crowbar,
+/obj/item/plant_analyzer,
+/obj/machinery/light,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
@@ -79158,6 +79128,35 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"xpJ" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/seeds/onion,
+/obj/item/seeds/garlic,
+/obj/item/seeds/potato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/carrot,
+/obj/item/seeds/grass,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/tower,
+/obj/item/seeds/chili,
+/obj/item/seeds/corn,
+/obj/item/seeds/cotton,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/tomato/blood,
+/obj/item/seeds/tea,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/cabbage,
+/obj/item/seeds/redbeet,
+/obj/item/seeds/chanter,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "xpR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -100668,7 +100667,7 @@ aaw
 lGo
 aaw
 meC
-qoj
+trJ
 aax
 aaa
 aaa
@@ -101437,7 +101436,7 @@ haK
 haK
 lqa
 vvx
-iyN
+xpJ
 aVG
 luF
 aep
@@ -101696,7 +101695,7 @@ bkx
 iTG
 wIA
 leJ
-ofA
+agH
 aeJ
 aeJ
 aeJ


### PR DESCRIPTION
Expands metastation prison hydro, adds cell curtains and cryo cells (again) and adds 2 isolation cells.

![image](https://user-images.githubusercontent.com/43841046/120052426-23d6fd80-bfda-11eb-9fab-3473b4cf60c4.png)

1. Hydro expanded. Adds 3 more plots of dirt, smart fridge connected to kitchen, grinder, and a small grassy outlook. Also adds chanterelle for mushroom recipes.
2. Adds freezer with meatspike and moves fridges in there.
3. Redid all the grilles to have a comprehensive grid and two grille walls (because why not)
4. Isolation hall thing expanded to have 2 isolation rooms, escape pod moved to compensate.
5. Re-adds cryopods to the end of the hall, and cell curtains

![image](https://user-images.githubusercontent.com/43841046/120052435-30f3ec80-bfda-11eb-86af-c060b553ed6e.png)
![image](https://user-images.githubusercontent.com/43841046/120052451-46691680-bfda-11eb-8ef0-8c3e1a65d1a7.png)
