### PR TITLE
[MODULAR] Update OneClickAntag to handle Obsessed removal properly

### DIFF
--- a/modular_skyrat/modules/oneclickantag/oneclickantag.dm
+++ b/modular_skyrat/modules/oneclickantag/oneclickantag.dm
@@ -20,8 +20,10 @@
 			src.oneclickantag += ROLE_FAMILIES
 		if(/datum/antagonist/heretic)
 			src.oneclickantag += ROLE_HERETIC
+		if(/datum/antagonist/obsessed)
+			src.oneclickantag += ROLE_OBSESSED
 		else
-			message_admins("Unable to update [src]'s previous antag list for One Click Antag. Blame coders.")
+			message_admins("Unable to update [src]'s previous antag list for One Click Antag. Unhandled datum '[datum]'. Ping ZephyrTFA.")
 	return ..()
 
 /datum/mind/proc/make_antag(antagtype, opt = null)


### PR DESCRIPTION
Resolves an issue where OneClickAntag would die if you removed someone's obsessed antag datum

## Changelog
:cl:
fix: OneClickAntag no longer dies when you remove someone's obsessed role
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
