### PR TITLE
update out of date species helpers

### DIFF
--- a/code/__HELPERS/~skyrat_helpers/is_helpers.dm
+++ b/code/__HELPERS/~skyrat_helpers/is_helpers.dm
@@ -1,7 +1,11 @@
 //Human sub species helpers
-#define issynthliz(A) (is_species(A,/datum/species/synthliz))
+#define isrobotic(A) (is_species(A,/datum/species/robotic))
+#define isipc(A) (is_species(A,/datum/species/robotic/ipc))
+#define issynthliz(A) (is_species(A,/datum/species/robotic/synthliz))
+#define issynthanthro(A) (is_species(A,/datum/species/robotic/synthetic_mammal))
+#define issynthhuman(A) (is_species(A,/datum/species/robotic/synthetic_human))
+
 #define isvox(A) (is_species(A,/datum/species/vox))
-#define isipc(A) (is_species(A,/datum/species/ipc))
 #define ismammal(A) (is_species(A,/datum/species/mammal))
 #define ispodweak(A) (is_species(A,/datum/species/pod/podweak))
 #define isxenohybrid(A) (is_species(A,/datum/species/xeno))


### PR DESCRIPTION
synth species are now inhereted from species/robotic

this updates helpers to reflect

## Changelog
:cl:
code: Species helpers for robotic species are up to date
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
