### PR TITLE
Fixes Metaprison vacuum (IMPORTANT MAP FIX) 

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -1588,6 +1588,7 @@
 /obj/machinery/turnstile{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "ahz" = (
@@ -1598,6 +1599,7 @@
 /area/security/prison)
 "ahA" = (
 /obj/machinery/turnstile,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "ahD" = (
@@ -3647,27 +3649,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"arf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Armory";
-	req_access_txt = "3"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
 "arh" = (
 /obj/item/reagent_containers/glass/bottle/toxin{
 	pixel_x = 4;
@@ -5517,9 +5498,6 @@
 	req_access_txt = "3"
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29728,6 +29706,26 @@
 /obj/item/paicard,
 /turf/open/floor/iron,
 /area/commons/locker)
+"dUa" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Armory";
+	req_access_txt = "3"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "dUA" = (
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
@@ -32476,6 +32474,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/yellow/side{
 	dir = 9
 	},
@@ -33413,6 +33412,7 @@
 	pixel_y = 16
 	},
 /obj/machinery/dish_drive,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/yellow/side{
 	dir = 5
 	},
@@ -56468,6 +56468,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"oIa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/security/prison)
 "oIk" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral{
@@ -59328,6 +59334,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/yellow/side{
 	dir = 1
 	},
@@ -62669,7 +62676,7 @@
 /area/security/prison)
 "qZz" = (
 /obj/machinery/smartfridge,
-/turf/open/space/basic,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "qZK" = (
 /obj/structure/sign/warning/securearea,
@@ -67898,6 +67905,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "sWz" = (
@@ -73322,15 +73330,6 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"ved" = (
-/obj/structure/cable,
-/obj/machinery/button/door/directional/south{
-	id = "armory";
-	name = "Armory Shutters";
-	req_access_txt = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
 "veq" = (
 /obj/machinery/camera{
 	c_tag = "Security - Secure Gear Storage";
@@ -80240,6 +80239,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"xMF" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/security/prison)
 "xMK" = (
 /obj/structure/table/wood,
 /obj/item/hand_tele,
@@ -99164,11 +99169,11 @@ aaa
 fwb
 aaa
 aax
-abN
-abN
-abN
-aep
-aep
+xMF
+xMF
+xMF
+oIa
+oIa
 aax
 lMJ
 aaa
@@ -99420,13 +99425,13 @@ lMJ
 lMJ
 fwb
 lMJ
-abN
+xMF
 qyz
 bKX
 pxk
 nTD
 dGS
-abN
+xMF
 lMJ
 aaa
 aaa
@@ -99677,13 +99682,13 @@ aaa
 aaa
 fwb
 aaa
-abN
+xMF
 sTd
 pNg
 jTv
 bVx
 xXB
-abN
+xMF
 lMJ
 lMJ
 lMJ
@@ -99934,7 +99939,7 @@ aaa
 aaa
 fwb
 aaa
-abN
+xMF
 hJB
 pcp
 qyz
@@ -100697,9 +100702,9 @@ aaa
 lMJ
 aaa
 aax
-aep
-aep
-aep
+oIa
+oIa
+oIa
 aax
 aax
 hXC
@@ -101229,7 +101234,7 @@ oab
 iyN
 aVG
 pWH
-aep
+oIa
 aaa
 aaj
 aav
@@ -101486,7 +101491,7 @@ vvx
 xpJ
 aVG
 luF
-aep
+oIa
 aaa
 vrW
 aav
@@ -101997,7 +102002,7 @@ hNd
 xeX
 guu
 abe
-aep
+oIa
 shg
 agH
 iDL
@@ -102233,8 +102238,8 @@ fwb
 lMJ
 gJK
 lMJ
-aep
-aep
+oIa
+oIa
 mov
 clD
 etf
@@ -102244,16 +102249,16 @@ pna
 afd
 iBI
 lXo
-aep
-aep
-aep
+oIa
+oIa
+oIa
 abe
 abe
 gNS
 aPN
 wLN
 vVt
-aep
+oIa
 sOd
 uNn
 agH
@@ -102490,7 +102495,7 @@ fwb
 aaa
 gJK
 aaa
-aep
+oIa
 tzT
 ptc
 qXD
@@ -102508,7 +102513,7 @@ oUe
 abe
 abe
 sVR
-aep
+oIa
 abe
 abe
 abz
@@ -102747,7 +102752,7 @@ fwb
 aaa
 gJK
 aaa
-aep
+oIa
 aAs
 xSW
 xSW
@@ -103004,7 +103009,7 @@ lMJ
 aaa
 gJK
 aaa
-aep
+oIa
 gRw
 bxa
 nId
@@ -103261,7 +103266,7 @@ fwb
 aaa
 gJK
 aaa
-aep
+oIa
 lYp
 xSW
 iCI
@@ -103518,8 +103523,8 @@ fwb
 lMJ
 gJK
 lMJ
-aep
-aep
+oIa
+oIa
 dfb
 smj
 nta
@@ -103776,7 +103781,7 @@ aaa
 gJK
 aQj
 aaa
-aep
+oIa
 aax
 aax
 fWv
@@ -104295,9 +104300,9 @@ lMJ
 aax
 aax
 aax
-aep
-aep
-aep
+oIa
+oIa
+oIa
 aax
 aax
 aax
@@ -107670,7 +107675,7 @@ akK
 anl
 aou
 apJ
-arb
+aeq
 asq
 ava
 anB
@@ -107927,7 +107932,7 @@ aff
 aeq
 aga
 apJ
-arb
+dUa
 jFW
 ahF
 auY
@@ -108183,7 +108188,7 @@ aeq
 aeq
 aeq
 agb
-ved
+wlr
 aeq
 ass
 luX
@@ -108440,8 +108445,8 @@ akC
 alU
 ann
 agc
-wlr
-aeq
+apJ
+xtK
 ast
 avY
 awZ
@@ -108698,7 +108703,7 @@ qmq
 ano
 agK
 apN
-xtK
+arb
 mRK
 luX
 ajx
@@ -108955,7 +108960,7 @@ alW
 iUC
 vav
 xeQ
-arf
+arb
 asv
 qEQ
 azb
@@ -109711,7 +109716,7 @@ aaa
 aaa
 aaa
 aaa
-brO
+aaf
 kel
 qbS
 teZ
@@ -109968,7 +109973,7 @@ aaa
 aaa
 aaa
 aaa
-brO
+aaf
 fNA
 jNm
 nge
@@ -110225,7 +110230,7 @@ aaa
 aaa
 aaa
 aaa
-brO
+aaf
 kel
 xNR
 exP

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -516,8 +516,11 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "abN" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/airlock/external{
+	name = "Security External Airlock";
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/security/prison)
 "abO" = (
@@ -598,28 +601,6 @@
 	dir = 5
 	},
 /turf/open/floor/iron/white,
-/area/security/prison)
-"aci" = (
-/obj/machinery/door/airlock/external{
-	name = "Security External Airlock";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"acj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
 /area/security/prison)
 "ack" = (
 /obj/structure/lattice/catwalk,
@@ -814,7 +795,6 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/curtain/bounty,
 /turf/open/floor/iron/dark/blue,
 /area/security/prison)
 "adk" = (
@@ -11245,6 +11225,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/genpop,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 5
 	},
@@ -27251,13 +27232,13 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/plumbed,
 /obj/structure/water_source{
 	dir = 8;
 	name = "sink";
 	pixel_x = 12;
 	pixel_y = -6
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "dha" = (
@@ -29942,6 +29923,7 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "dZe" = (
@@ -30031,6 +30013,10 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"ebb" = (
+/obj/structure/curtain/bounty,
+/turf/open/floor/iron/dark/blue,
+/area/security/prison)
 "ebh" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -30102,6 +30088,13 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/service/janitor)
+"ecC" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/security/prison)
 "ecJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -37066,9 +37059,6 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "gNS" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
 /obj/item/radio/intercom{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
 	name = "Prison Intercom (General)";
@@ -40209,6 +40199,13 @@
 "idB" = (
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"idU" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "idW" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/bot,
@@ -41335,18 +41332,8 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "iGJ" = (
-/obj/structure/rack,
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/storage/inflatable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/purple/side{
 	dir = 6
@@ -42640,6 +42627,7 @@
 	id = "PermaLockdown";
 	name = "Lockdown Shutters"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/security/brig)
 "jhH" = (
@@ -47511,6 +47499,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "leV" = (
@@ -51297,6 +51286,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "mGA" = (
@@ -58662,6 +58652,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"pvh" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/wood,
+/area/security/prison)
 "pvn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/vehicle/sealed/mecha/working/ripley/cargo,
@@ -59025,6 +59019,9 @@
 	dir = 1
 	},
 /obj/machinery/chem_master/condimaster,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
 /turf/open/floor/iron/dark/yellow/side{
 	dir = 4
 	},
@@ -61926,6 +61923,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"qHb" = (
+/turf/open/floor/carpet,
+/area/security/prison)
 "qHq" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three"
@@ -63900,6 +63900,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"rxe" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "rxh" = (
 /obj/item/toy/beach_ball{
 	desc = "The simple beach ball is one of Nanotrasen's most popular products. 'Why do we make beach balls? Because we can! (TM)' - Nanotrasen";
@@ -64417,6 +64428,16 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"rGa" = (
+/obj/machinery/door/airlock/external{
+	name = "Security External Airlock";
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "rGb" = (
 /obj/machinery/requests_console/directional/north{
 	department = "Chapel";
@@ -65036,6 +65057,7 @@
 	name = "Prison Wing";
 	req_access_txt = "1"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "rSe" = (
@@ -66308,6 +66330,10 @@
 	},
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
+"soT" = (
+/obj/machinery/firealarm,
+/turf/closed/wall,
+/area/security/prison)
 "soZ" = (
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
@@ -66931,6 +66957,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/lab)
+"szX" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/storage/inflatable,
+/turf/open/floor/iron,
+/area/security/prison)
 "sAk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
@@ -67455,6 +67494,16 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 9
 	},
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/storage/inflatable,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "sOe" = (
@@ -68646,6 +68695,7 @@
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "tmN" = (
@@ -71155,6 +71205,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/genetics)
+"umR" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light,
+/turf/open/floor/iron/dark/green,
+/area/security/prison)
 "unb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -73528,6 +73583,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"vhO" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron,
+/area/security/prison)
 "vic" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -76185,16 +76244,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
-"wiZ" = (
-/obj/machinery/door/airlock/external{
-	name = "Security External Airlock";
-	req_access_txt = "1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "wjf" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -77424,7 +77473,6 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/crowbar,
 /obj/item/plant_analyzer,
-/obj/machinery/light,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
@@ -78181,6 +78229,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "wWE" = (
@@ -78992,16 +79041,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"xmc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/bed/roller,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "xmd" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -101005,7 +101044,7 @@ tOw
 dgX
 vSn
 ilw
-trJ
+umR
 aax
 vrW
 vrW
@@ -101248,7 +101287,7 @@ nCu
 ltI
 snh
 bNP
-xSW
+pvh
 rxQ
 eZQ
 haK
@@ -102540,7 +102579,7 @@ rUo
 bBU
 oUe
 abe
-abe
+soT
 sVR
 oIa
 abe
@@ -104100,9 +104139,9 @@ fQi
 niF
 cvX
 aeJ
-abN
-abN
-abN
+xMF
+xMF
+xMF
 dne
 awS
 aRG
@@ -104347,7 +104386,7 @@ acv
 acv
 acv
 acv
-acI
+idU
 gjy
 vVP
 alL
@@ -106657,7 +106696,7 @@ eYJ
 eXu
 rMk
 cbk
-abN
+xMF
 nvU
 fyo
 fyo
@@ -107168,10 +107207,10 @@ lHB
 oxZ
 twK
 kFW
-xmc
+eXu
 qWF
 ezO
-abN
+xMF
 bgX
 mNE
 jEE
@@ -107429,10 +107468,10 @@ aNJ
 aNJ
 xdf
 jVe
-aci
+abe
 abe
 acO
-abe
+fvz
 naq
 adW
 aep
@@ -107685,10 +107724,10 @@ kFW
 eXu
 poo
 adg
-aax
-acj
+vhO
 abe
-fvz
+qHb
+ebb
 adi
 iCO
 aep
@@ -107942,8 +107981,8 @@ aax
 eXu
 poo
 adg
-aax
-wiZ
+szX
+abe
 aax
 aax
 aax
@@ -108198,10 +108237,10 @@ aax
 aax
 eXu
 poo
-adg
-abN
-ack
-lAu
+rxe
+aax
+aax
+aax
 aaa
 aaf
 aaa
@@ -108457,8 +108496,8 @@ poo
 poo
 mGl
 abN
-aox
-aox
+ecC
+rGa
 aaf
 aaf
 srq
@@ -108713,9 +108752,9 @@ aax
 jkP
 kqi
 wWt
-abN
-aaa
-aaa
+aax
+aax
+aax
 aaa
 aaf
 rmG

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -2197,6 +2197,10 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "PermaLockdown";
+	name = "Lockdown Shutters"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "akz" = (
@@ -3915,14 +3919,17 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "asq" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -3948,6 +3955,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -37317,6 +37327,11 @@
 	dir = 4;
 	req_one_access_txt = "2;63;81"
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "PermaLockdown";
+	name = "Lockdown Shutters"
+	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "gTG" = (
@@ -42618,6 +42633,15 @@
 /obj/item/paper,
 /turf/open/floor/wood,
 /area/commons/dorms)
+"jhv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "PermaLockdown";
+	name = "Lockdown Shutters"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "jhH" = (
 /obj/item/reagent_containers/spray/plantbgone,
 /obj/item/reagent_containers/spray/pestspray{
@@ -51863,11 +51887,11 @@
 /turf/closed/wall,
 /area/medical/treatment_center)
 "mRK" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "mRQ" = (
@@ -75450,6 +75474,10 @@
 	dir = 8;
 	req_one_access_txt = "2;63;81"
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "PermaLockdown";
+	name = "Lockdown Shutters"
+	},
 /turf/open/floor/iron/dark/blue,
 /area/security/prison)
 "vTZ" = (
@@ -81507,6 +81535,7 @@
 	name = "Lockdown Shutters"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/security/prison)
 "ykk" = (
@@ -106126,8 +106155,8 @@ ahx
 ahx
 agJ
 ahx
-aiq
-aiq
+jhv
+jhv
 akw
 ahx
 ang


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43841046/120691145-f1565600-c45a-11eb-99fc-d63051c71476.png)

DAMN YOU SPACE TILES

Also adds emergency shutters and moves the armoury shutters

![image](https://user-images.githubusercontent.com/43841046/120693888-6bd4a500-c45e-11eb-945b-26c8d4828cb4.png)

1. Replaces space tile under smart fridge with a normal floor (i.e. no more spacing)
2. Adds emergency shutters to prison windows, kitchen, and entrance
3. Moves armoury shutters to be in line with armoury hall thing