### PR TITLE
[NONMODULAR] Rebalances cost of holopara to match holocarp.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -449,7 +449,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an \
 			organic host as a home base and source of fuel. Holoparasites come in various types and share damage with their host."
 	item = /obj/item/storage/box/syndie_kit/guardian
-	cost = 18
+	cost = 10 //SKYRAT EDIT: Bumps these down properly.
 	surplus = 0
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	player_minimum = 25


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Holoparasite has arguably been overpriced for yearsa; 18 TC for something that makes you rely on another players skill, attention span - and ability to comprehend orders.

Atop that; having a holoparasite gives security a way to deal 100% damage to you regardless of armor, as holoparasite damage reflect transmits all incoming damage without regards to armor - making things like the elite syndicate hardsuit pointless in practice if you buy one.

Holoparasites themselves are extremely loud, easy to notice and otherwise not worth their cost as they can dust the user in question; which sec will almost always do because 'le uncontainable'.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Holoparasite has been very overpriced for a very long time. This brings it in line with the holocarp fishsticks (objectively, and aesthetically more pleasing to use)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Holopara price reduced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
