### PR TITLE
[Modular] Okay I remapped the listening post, shut up.

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -201,14 +201,14 @@
 	name = "Crashed Ship"
 	description = "Among civilian vessels the most common cause of tragedy is lack of food. \
 	This ship was outfitted with a multitude of food-generating features, then summarily ran into an asteroid shortly after takeoff."
-
+/* //SKYRAT EDIT REMOVAL//
 /datum/map_template/ruin/space/listeningstation
 	id = "listeningstation"
 	suffix = "listeningstation.dmm"
 	name = "Syndicate Listening Station"
 	description = "Listening stations form the backbone of the syndicate's information-gathering operations. \
 	Assignment to these stations is dreaded by most agents, as it entails long and lonely shifts listening to nearby stations chatter incessantly about the most meaningless things."
-
+*/ //SKYRAT EDIT REMOVAL END
 /datum/map_template/ruin/space/old_ai_sat
 	id = "oldAIsat"
 	suffix = "oldAIsat.dmm"

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -153,13 +153,13 @@
 	short_desc = "You are a syndicate agent, assigned to a small listening post station situated near your hated enemy's top secret research facility: Space Station 13."
 	flavour_text = "Monitor enemy activity as best you can, and try to keep a low profile. Monitor enemy activity as best you can, and try to keep a low profile. Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!"
 	important_info = "DO NOT abandon the base."
-
+/* //Skyrat Edit Removal//
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms/space/Initialize()
 	. = ..()
 	if(prob(90)) //only has a 10% chance of existing, otherwise it'll just be a NPC syndie.
 		new /mob/living/simple_animal/hostile/syndicate/ranged(get_turf(src))
 		return INITIALIZE_HINT_QDEL
-
+*/ //Skyrat Edit Removal End
 /datum/outfit/lavaland_syndicate/comms
 	name = "Lavaland Syndicate Comms Agent"
 	r_hand = /obj/item/melee/transforming/energy/sword/saber

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/listeningstation_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/listeningstation_skyrat.dmm
@@ -509,7 +509,7 @@
 "jC" = (
 /obj/structure/table,
 /obj/item/food/chocolatebar,
-/turf/open/floor/iron/dark/smooth_edge,
+/turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "jV" = (
 /obj/structure/table,
@@ -524,9 +524,7 @@
 	pixel_x = 2
 	},
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
+/turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "kh" = (
 /obj/structure/sink{
@@ -577,13 +575,17 @@
 	pixel_x = 7;
 	pixel_y = -3
 	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
+/turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "mm" = (
 /obj/machinery/defibrillator_mount/loaded/directional/south,
 /turf/open/floor/iron/white/smooth_edge,
+/area/ruin/unpowered/no_grav)
+"nb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "nh" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -626,7 +628,7 @@
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_corner,
+/turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "ru" = (
 /turf/open/floor/plating/cobblestone,
@@ -864,6 +866,14 @@
 	dir = 4
 	},
 /area/ruin/unpowered/no_grav)
+"JA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered/no_grav)
 "JG" = (
 /obj/structure/closet{
 	icon_door = "black";
@@ -908,6 +918,9 @@
 /obj/structure/flora/rock/pile,
 /turf/open/floor/grass/fakebasalt,
 /area/ruin/unpowered/no_grav)
+"Kb" = (
+/turf/open/floor/wood,
+/area/ruin/unpowered/no_grav)
 "KV" = (
 /turf/open/floor/plating/grass,
 /area/ruin/unpowered/no_grav)
@@ -944,16 +957,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "MQ" = (
 /obj/structure/table,
 /obj/machinery/microwave{
 	pixel_y = 8
 	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
+/turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "PN" = (
 /obj/structure/chair/office{
@@ -1473,7 +1487,7 @@ ab
 ab
 ab
 bH
-be
+Kb
 LY
 jC
 bH
@@ -1513,8 +1527,8 @@ ab
 ab
 bH
 bH
-kE
-tl
+nb
+JA
 MQ
 bH
 bH

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/listeningstation_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/listeningstation_skyrat.dmm
@@ -333,6 +333,7 @@
 "bx" = (
 /obj/machinery/light/blacklight/directional/west,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/obj/machinery/vending/games,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
@@ -365,6 +366,7 @@
 /area/ruin/unpowered/no_grav)
 "bD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/skill_station,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 4
 	},

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/listeningstation_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/listeningstation_skyrat.dmm
@@ -1,0 +1,2342 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/template_noop,
+/area/template_noop)
+"ab" = (
+/turf/closed/mineral/random,
+/area/ruin/unpowered/no_grav)
+"ac" = (
+/obj/structure/filingcabinet,
+/obj/item/paper/fluff/ruins/listeningstation/reports/april,
+/obj/item/paper/fluff/ruins/listeningstation/reports/may,
+/obj/item/paper/fluff/ruins/listeningstation/reports/june,
+/obj/item/paper/fluff/ruins/listeningstation/reports/july,
+/obj/item/paper/fluff/ruins/listeningstation/reports/august,
+/obj/item/paper/fluff/ruins/listeningstation/reports/september,
+/obj/item/paper/fluff/ruins/listeningstation/reports/october,
+/obj/item/paper/fluff/ruins/listeningstation/receipt,
+/obj/item/paper/fluff/ruins/listeningstation/odd_report,
+/obj/structure/railing,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"ae" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/large,
+/area/ruin/unpowered/no_grav)
+"af" = (
+/obj/structure/rack{
+	dir = 8
+	},
+/obj/item/clothing/mask/gas/syndicate{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/clothing/mask/gas/syndicate,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/large,
+/area/ruin/unpowered/no_grav)
+"ah" = (
+/obj/machinery/light/blacklight/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/large,
+/area/ruin/unpowered/no_grav)
+"ai" = (
+/obj/structure/lattice/catwalk/plated,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav)
+"aj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/large,
+/area/ruin/unpowered/no_grav)
+"al" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"am" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
+/area/ruin/unpowered/no_grav)
+"an" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	id_tag = "syndie_listeningpost_external";
+	req_access_txt = "150"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav)
+"ao" = (
+/obj/machinery/light/small/directional/south,
+/obj/structure/sign/warning/vacuum{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav)
+"ap" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	id_tag = "syndie_listeningpost_external";
+	req_access_txt = "150"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav)
+"ar" = (
+/obj/machinery/ore_silo,
+/turf/open/floor/iron/large,
+/area/ruin/unpowered/no_grav)
+"at" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/large,
+/area/ruin/unpowered/no_grav)
+"au" = (
+/turf/open/floor/iron/large,
+/area/ruin/unpowered/no_grav)
+"aw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/ruin/unpowered/no_grav)
+"ax" = (
+/obj/machinery/button/door/directional/east{
+	id = "syndie_listeningpost_external";
+	name = "External Bolt Control";
+	normaldoorcontrol = 1;
+	req_access_txt = "150";
+	specialfunctions = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8;
+	name = "tactical chair"
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"az" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Communications Suite";
+	req_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"aC" = (
+/obj/machinery/door/airlock/hatch{
+	name = "E.V.A. Equipment";
+	req_access_txt = "150"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"aD" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "150"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"aF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/mineral/random,
+/area/ruin/unpowered/no_grav)
+"aG" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav)
+"aH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/ruin/unpowered/no_grav)
+"aJ" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north{
+	req_access_txt = "150"
+	},
+/turf/open/floor/iron/dark/smooth_edge,
+/area/ruin/unpowered/no_grav)
+"aK" = (
+/turf/open/floor/iron/dark/smooth_edge,
+/area/ruin/unpowered/no_grav)
+"aL" = (
+/obj/machinery/light/blacklight/directional/north,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/ruin/unpowered/no_grav)
+"aM" = (
+/obj/effect/spawner/randomsnackvend{
+	hacked = 1
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
+/area/ruin/unpowered/no_grav)
+"aO" = (
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/vending/dorms,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"aS" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"aT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"aW" = (
+/obj/structure/lattice/catwalk/plated/dark,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav)
+"aX" = (
+/obj/effect/spawner/randomcolavend{
+	hacked = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/ruin/unpowered/no_grav)
+"aY" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/item/toy/plush/ratplush,
+/turf/open/floor/grass/fakebasalt,
+/area/ruin/unpowered/no_grav)
+"aZ" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"bb" = (
+/obj/machinery/light/blacklight/directional/south,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"bd" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"be" = (
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"bf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"bg" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"bh" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/item/toy/figure/miner{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/turf/open/floor/grass/fakebasalt,
+/area/ruin/unpowered/no_grav)
+"bn" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"bq" = (
+/obj/machinery/vending/wardrobe/syndie_wardrobe,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
+/area/ruin/unpowered/no_grav)
+"bs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"bt" = (
+/obj/structure/closet/secure_closet/medical1{
+	req_access = null;
+	req_access_txt = "150"
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12
+	},
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 8
+	},
+/area/ruin/unpowered/no_grav)
+"bv" = (
+/obj/structure/lattice/catwalk/plated/dark,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav)
+"bx" = (
+/obj/machinery/light/blacklight/directional/west,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/ruin/unpowered/no_grav)
+"by" = (
+/obj/machinery/vending/clothing,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
+/area/ruin/unpowered/no_grav)
+"bA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/unpowered/no_grav)
+"bB" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/item/clothing/neck/stethoscope,
+/obj/machinery/light/blacklight/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/ruin/unpowered/no_grav)
+"bD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/ruin/unpowered/no_grav)
+"bH" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/unpowered/no_grav)
+"bI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/unpowered/no_grav)
+"bJ" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 6;
+	height = 7;
+	id = "caravansyndicate3_listeningpost";
+	name = "Syndicate Listening Post";
+	width = 15
+	},
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 4;
+	height = 5;
+	id = "caravansyndicate1_listeningpost";
+	name = "Syndicate Listening Post";
+	width = 9
+	},
+/turf/template_noop,
+/area/template_noop)
+"bL" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"cP" = (
+/obj/machinery/rnd/production/circuit_imprinter/offstation,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"cU" = (
+/obj/machinery/syndicatebomb/self_destruct{
+	anchored = 1
+	},
+/obj/machinery/door/window/survival_pod{
+	req_access_txt = "150"
+	},
+/turf/open/floor/circuit/red,
+/area/ruin/unpowered/no_grav)
+"dU" = (
+/obj/machinery/light/blacklight/directional/north,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"ec" = (
+/obj/machinery/holopad{
+	on_network = 0
+	},
+/turf/open/floor/circuit,
+/area/ruin/unpowered/no_grav)
+"eE" = (
+/obj/machinery/door/airlock{
+	name = "Toilet"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/unpowered/no_grav)
+"fc" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/blacklight/directional/north,
+/turf/open/floor/iron/dark/smooth_corner,
+/area/ruin/unpowered/no_grav)
+"fn" = (
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"fy" = (
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/ruin/unpowered/no_grav)
+"fJ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/large,
+/area/ruin/unpowered/no_grav)
+"fT" = (
+/obj/machinery/door/airlock{
+	name = "Cabin"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/grimy,
+/area/ruin/unpowered/no_grav)
+"gl" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/blue,
+/obj/machinery/light/blacklight/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"hv" = (
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
+/area/ruin/unpowered/no_grav)
+"hx" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"iy" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Telecommunications";
+	req_access_txt = "150"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"iO" = (
+/obj/machinery/computer/camera_advanced{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/north,
+/obj/item/radio/intercom/directional/west{
+	freerange = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"jl" = (
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron/large,
+/area/ruin/unpowered/no_grav)
+"jC" = (
+/obj/structure/table,
+/obj/item/food/chocolatebar,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/ruin/unpowered/no_grav)
+"jV" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/ruin/unpowered/no_grav)
+"kh" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/structure/toilet{
+	pixel_y = 18
+	},
+/obj/structure/mirror/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/unpowered/no_grav)
+"kn" = (
+/obj/machinery/autolathe/hacked,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"kE" = (
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
+/area/ruin/unpowered/no_grav)
+"li" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/ruin/unpowered/no_grav)
+"ly" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/ruin/unpowered/no_grav)
+"mc" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = -4;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
+	pixel_x = -3
+	},
+/obj/item/lighter{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/ruin/unpowered/no_grav)
+"mm" = (
+/obj/machinery/defibrillator_mount/loaded/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/ruin/unpowered/no_grav)
+"nh" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"om" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Garden";
+	req_access_txt = "150"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"oH" = (
+/obj/structure/lattice/catwalk/plated/dark,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/item/wrench,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav)
+"oZ" = (
+/obj/machinery/computer/message_monitor{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"pQ" = (
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/unpowered/no_grav)
+"qI" = (
+/obj/machinery/computer/arcade/orion_trail{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_corner,
+/area/ruin/unpowered/no_grav)
+"ru" = (
+/turf/open/floor/plating/cobblestone,
+/area/ruin/unpowered/no_grav)
+"rS" = (
+/obj/machinery/light/small/directional/west,
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/iron/twenty,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/stack/rods/ten,
+/obj/item/storage/box/lights/bulbs,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/stock_parts/cell/high/plus,
+/obj/structure/lattice/catwalk/plated/dark,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav)
+"te" = (
+/obj/structure/railing,
+/obj/structure/rack{
+	dir = 8
+	},
+/obj/item/multitool,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"tl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
+/area/ruin/unpowered/no_grav)
+"tr" = (
+/obj/structure/table/reinforced,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"uS" = (
+/obj/machinery/washing_machine,
+/obj/machinery/door/window/survival_pod{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"vm" = (
+/turf/open/floor/iron/dark/smooth_corner,
+/area/ruin/unpowered/no_grav)
+"vF" = (
+/obj/machinery/computer/message_monitor,
+/obj/item/paper/monitorkey,
+/obj/effect/turf_decal/siding/blue/corner,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"vL" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"vN" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
+/area/ruin/unpowered/no_grav)
+"ww" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Garden";
+	req_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"yr" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/plating/beach/sand{
+	liquid_height = -30;
+	turf_height = -30
+	},
+/area/ruin/unpowered/no_grav)
+"yv" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/light/blacklight/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/large,
+/area/ruin/unpowered/no_grav)
+"yx" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"yS" = (
+/obj/machinery/airalarm/directional/north{
+	req_access = list(150)
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/ruin/unpowered/no_grav)
+"za" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"zC" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"zH" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"zS" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/clothing/head/welding,
+/obj/item/weldingtool/largetank,
+/turf/open/floor/iron/large,
+/area/ruin/unpowered/no_grav)
+"Av" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"AG" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/large,
+/area/ruin/unpowered/no_grav)
+"AP" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/item/storage/box/syndie_kit/chameleon{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"Bo" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 14
+	},
+/obj/machinery/light/small/directional/south,
+/obj/item/soap,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/unpowered/no_grav)
+"Cw" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/paper/fluff/ruins/listeningstation/reports/november,
+/obj/item/pen,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"Cx" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"CF" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/iron/grimy,
+/area/ruin/unpowered/no_grav)
+"ED" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"FB" = (
+/obj/machinery/telecomms/relay/preset/ruskie{
+	use_power = 0
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"FR" = (
+/obj/effect/mob_spawn/human/lavaland_syndicate/comms/space{
+	assignedrole = "Space Syndicate";
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/ruin/unpowered/no_grav)
+"FT" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Fabrication Equipment";
+	req_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"FV" = (
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"GX" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"Hf" = (
+/obj/structure/lattice/catwalk/plated/dark,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav)
+"HF" = (
+/obj/structure/table/wood,
+/obj/item/ammo_box/magazine/m9mm,
+/obj/item/paper/fluff/ruins/listeningstation/briefing,
+/turf/open/floor/iron/grimy,
+/area/ruin/unpowered/no_grav)
+"IB" = (
+/obj/structure/lattice/catwalk/plated/dark,
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav)
+"Jc" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/storage/toolbox/syndicate,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/ruin/unpowered/no_grav)
+"JG" = (
+/obj/structure/closet{
+	icon_door = "black";
+	name = "wardrobe"
+	},
+/obj/item/clothing/under/color/black{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/under/color/black{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/head/soft/black{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/soft/black{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/gloves/fingerless,
+/obj/item/clothing/shoes/sneakers/black{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/shoes/sneakers/black{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/photo_album,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/grimy,
+/area/ruin/unpowered/no_grav)
+"JN" = (
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"JQ" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/flora/rock/pile,
+/turf/open/floor/grass/fakebasalt,
+/area/ruin/unpowered/no_grav)
+"KV" = (
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"Le" = (
+/obj/item/bombcore/badmin{
+	anchored = 1;
+	invisibility = 100
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/unpowered/no_grav)
+"Lz" = (
+/obj/machinery/light/blacklight/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/ruin/unpowered/no_grav)
+"LB" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/blood/o_minus{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/blood/o_minus,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white/smooth_corner,
+/area/ruin/unpowered/no_grav)
+"LY" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"MQ" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"PN" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"PR" = (
+/obj/structure/flora/biolumi/mine,
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"Ql" = (
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"QK" = (
+/turf/open/floor/iron/grimy,
+/area/ruin/unpowered/no_grav)
+"RC" = (
+/turf/open/floor/plating/dirt{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
+	},
+/area/ruin/unpowered/no_grav)
+"RR" = (
+/obj/structure/flora/biolumi/flower,
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"SG" = (
+/obj/structure/flora/biolumi/lamp,
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"TN" = (
+/obj/structure/lattice/catwalk/plated/dark,
+/obj/machinery/light/blacklight/directional/west,
+/turf/open/floor/plating,
+/area/ruin/unpowered/no_grav)
+"Um" = (
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/ruin/unpowered/no_grav)
+"Up" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/turf/open/floor/iron/dark/smooth_corner,
+/area/ruin/unpowered/no_grav)
+"UE" = (
+/obj/machinery/door/airlock{
+	name = "Personal Quarters"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/unpowered/no_grav)
+"UH" = (
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"Vl" = (
+/obj/structure/table/optable,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 4
+	},
+/area/ruin/unpowered/no_grav)
+"WL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+"Xz" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/plating/grass,
+/area/ruin/unpowered/no_grav)
+"XQ" = (
+/obj/machinery/sleeper/syndie/fullupgrade{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"Zj" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/tank_dispenser/oxygen{
+	oxygentanks = 4
+	},
+/turf/open/floor/iron/large,
+/area/ruin/unpowered/no_grav)
+"Zl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/ruin/unpowered/no_grav)
+"ZR" = (
+/obj/machinery/rnd/production/protolathe/offstation,
+/obj/item/multitool{
+	pixel_y = 7
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered/no_grav)
+
+(1,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(3,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+"}
+(4,1,1) = {"
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+bH
+bH
+bH
+bH
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+"}
+(5,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+vm
+fy
+Um
+bH
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+"}
+(6,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+dU
+FB
+aK
+bH
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(7,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+vN
+hv
+FV
+bH
+bH
+bH
+bH
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(8,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+bH
+bH
+bH
+bH
+iy
+bH
+bH
+ab
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(9,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+bH
+bH
+bH
+bH
+ab
+ab
+bH
+bH
+bH
+ab
+ab
+KV
+KV
+ru
+ru
+KV
+hx
+ab
+bH
+bH
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(10,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+qI
+mc
+jV
+bH
+ab
+ab
+bH
+ab
+ab
+ab
+KV
+KV
+Cx
+KV
+ru
+ru
+KV
+ab
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(11,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+be
+LY
+jC
+bH
+ab
+ab
+bH
+ab
+KV
+GX
+KV
+yr
+RC
+KV
+KV
+ru
+KV
+GX
+ab
+bH
+ab
+ab
+ab
+ab
+aa
+aa
+"}
+(12,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+bH
+kE
+tl
+MQ
+bH
+bH
+ab
+bH
+ab
+KV
+RC
+yr
+yr
+yr
+vL
+KV
+ru
+KV
+KV
+ab
+bH
+ab
+ab
+ab
+ab
+aa
+aa
+"}
+(13,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+cU
+UH
+WL
+UH
+uS
+bH
+ab
+bH
+ab
+KV
+yr
+yr
+yr
+yr
+yr
+RC
+ru
+PR
+KV
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(14,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+bH
+bH
+fc
+ly
+Um
+bH
+bH
+bH
+bH
+ab
+KV
+yr
+yr
+yr
+yr
+yr
+RC
+ru
+KV
+ab
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(15,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+Bo
+bH
+Zl
+ED
+aK
+bH
+CF
+bH
+bH
+ab
+KV
+yr
+yr
+yr
+yr
+RC
+KV
+ru
+KV
+ab
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(16,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+kh
+eE
+kE
+tl
+FV
+fT
+QK
+JG
+bH
+ab
+nh
+yr
+yr
+yr
+yr
+KV
+KV
+ru
+KV
+ab
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(17,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+bH
+bH
+bH
+bH
+bH
+bH
+UE
+bH
+bH
+FR
+HF
+bH
+ab
+KV
+KV
+yr
+yr
+KV
+KV
+ru
+ru
+KV
+ab
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(18,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+kn
+fJ
+zS
+bH
+vm
+tl
+Um
+bH
+bH
+bH
+bH
+bH
+ab
+KV
+bL
+KV
+KV
+RR
+ru
+Xz
+KV
+ab
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(19,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+ZR
+AG
+at
+FT
+aH
+aW
+aZ
+aD
+Hf
+TN
+rS
+bH
+KV
+SG
+KV
+Av
+KV
+ru
+ru
+KV
+ab
+ab
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(20,1,1) = {"
+ab
+ab
+ab
+ab
+bH
+bH
+bH
+bH
+cP
+yv
+ar
+bH
+aK
+aW
+be
+bH
+IB
+bv
+oH
+bH
+KV
+yx
+zC
+KV
+KV
+ru
+KV
+JN
+ab
+ab
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(21,1,1) = {"
+ab
+ab
+ab
+bH
+bH
+iO
+oZ
+bH
+bH
+bH
+bH
+Le
+aJ
+aW
+bb
+bH
+bH
+bH
+bH
+bH
+KV
+KV
+KV
+KV
+ru
+ru
+KV
+ab
+ab
+ab
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(22,1,1) = {"
+ab
+ab
+ab
+bH
+vF
+PN
+fn
+ac
+ae
+ah
+au
+bH
+aK
+aT
+be
+bH
+Up
+bx
+bD
+bH
+KV
+KV
+ru
+ru
+KV
+KV
+ab
+ab
+ab
+ab
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(23,1,1) = {"
+aa
+ab
+ab
+bH
+gl
+ec
+zH
+UH
+ae
+ai
+at
+az
+aH
+aS
+bf
+ww
+bf
+ED
+li
+om
+ru
+ru
+ru
+KV
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(24,1,1) = {"
+aa
+ab
+ab
+bH
+AP
+za
+Ql
+te
+ae
+aj
+au
+bH
+aK
+aT
+be
+bH
+bq
+by
+aO
+bH
+KV
+KV
+KV
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(25,1,1) = {"
+aa
+ab
+ab
+bH
+bH
+Cw
+tr
+bH
+bH
+bH
+bH
+bH
+yS
+aW
+bd
+bH
+bH
+bH
+bH
+bH
+ab
+Av
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+bH
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(26,1,1) = {"
+aa
+ab
+ab
+ab
+bH
+bH
+bH
+bH
+jl
+Lz
+Jc
+bH
+aL
+aW
+be
+bH
+LB
+pQ
+Vl
+bH
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+bH
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+"}
+(27,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+bH
+Zj
+al
+aw
+aC
+aw
+aW
+bf
+bn
+bs
+bA
+mm
+bH
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+bH
+bH
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(28,1,1) = {"
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+bH
+af
+am
+ax
+bI
+aM
+aX
+bg
+bH
+bt
+bB
+XQ
+bH
+ab
+ab
+ab
+ab
+bH
+bH
+bH
+bH
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(29,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+bH
+bH
+an
+bH
+bI
+JQ
+aY
+bh
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(30,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+bH
+ao
+bH
+aF
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(31,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bH
+ap
+bH
+aG
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(32,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bJ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/listeningstation_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/listeningstation_skyrat.dmm
@@ -412,6 +412,7 @@
 	anchored = 1
 	},
 /obj/machinery/door/window/survival_pod{
+	dir = 8;
 	req_access_txt = "150"
 	},
 /turf/open/floor/circuit/red,
@@ -435,9 +436,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/unpowered/no_grav)
 "fc" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /obj/structure/closet/crate/bin,
-/obj/machinery/light/blacklight/directional/north,
-/turf/open/floor/iron/dark/smooth_corner,
+/turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "fn" = (
 /obj/effect/turf_decal/siding/blue/corner{
@@ -507,24 +510,13 @@
 /turf/open/floor/iron/large,
 /area/ruin/unpowered/no_grav)
 "jC" = (
-/obj/structure/table,
-/obj/item/food/chocolatebar,
 /turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "jV" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = -2;
-	pixel_y = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
 	},
-/obj/item/storage/box/donkpockets{
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "kh" = (
 /obj/structure/sink{
@@ -553,28 +545,14 @@
 /area/ruin/unpowered/no_grav)
 "ly" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
+/turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "mc" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = -4;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = 3;
-	pixel_y = 11
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
-	pixel_x = -3
-	},
-/obj/item/lighter{
-	pixel_x = 7;
-	pixel_y = -3
-	},
+/obj/item/food/chocolatebar,
 /turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "mm" = (
@@ -582,7 +560,7 @@
 /turf/open/floor/iron/white/smooth_edge,
 /area/ruin/unpowered/no_grav)
 "nb" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/computer/arcade/orion_trail{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -625,7 +603,11 @@
 	},
 /area/ruin/unpowered/no_grav)
 "qI" = (
-/obj/machinery/computer/arcade/orion_trail{
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -663,18 +645,6 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/area/ruin/unpowered/no_grav)
-"tr" = (
-/obj/structure/table/reinforced,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/no_grav)
-"uS" = (
-/obj/machinery/washing_machine,
-/obj/machinery/door/window/survival_pod{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured_large,
 /area/ruin/unpowered/no_grav)
 "vm" = (
 /turf/open/floor/iron/dark/smooth_corner,
@@ -792,6 +762,7 @@
 /obj/item/paper_bin,
 /obj/item/paper/fluff/ruins/listeningstation/reports/november,
 /obj/item/pen,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/unpowered/no_grav)
 "Cx" = (
@@ -867,10 +838,21 @@
 	},
 /area/ruin/unpowered/no_grav)
 "JA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = -4;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
+	pixel_x = -3
+	},
+/obj/item/lighter{
+	pixel_x = 7;
+	pixel_y = -3
 	},
 /turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
@@ -918,9 +900,6 @@
 /obj/structure/flora/rock/pile,
 /turf/open/floor/grass/fakebasalt,
 /area/ruin/unpowered/no_grav)
-"Kb" = (
-/turf/open/floor/wood,
-/area/ruin/unpowered/no_grav)
 "KV" = (
 /turf/open/floor/plating/grass,
 /area/ruin/unpowered/no_grav)
@@ -950,23 +929,19 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white/smooth_corner,
 /area/ruin/unpowered/no_grav)
-"LY" = (
-/obj/structure/chair/stool{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ruin/unpowered/no_grav)
 "MQ" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 8
+/obj/item/storage/box/donkpockets{
+	pixel_x = -2;
+	pixel_y = 6
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/item/storage/box/donkpockets{
+	pixel_y = 3
 	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2
+	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "PN" = (
@@ -1037,9 +1012,13 @@
 	},
 /area/ruin/unpowered/no_grav)
 "WL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/ruin/unpowered/no_grav)
 "Xz" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -1061,10 +1040,9 @@
 /turf/open/floor/iron/large,
 /area/ruin/unpowered/no_grav)
 "Zl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
+/obj/machinery/light/blacklight/directional/north,
+/obj/machinery/washing_machine,
+/turf/open/floor/iron/dark/smooth_corner,
 /area/ruin/unpowered/no_grav)
 "ZR" = (
 /obj/machinery/rnd/production/protolathe/offstation,
@@ -1343,9 +1321,9 @@ vN
 hv
 FV
 bH
-bH
-bH
-bH
+ab
+ab
+ab
 ab
 ab
 ab
@@ -1375,9 +1353,9 @@ ab
 ab
 ab
 ab
-bH
-bH
-bH
+ab
+ab
+ab
 bH
 bH
 iy
@@ -1385,7 +1363,7 @@ bH
 bH
 ab
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1406,16 +1384,16 @@ ab
 ab
 ab
 ab
-bH
-bH
-bH
-bH
-bH
 ab
 ab
-bH
-bH
-bH
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 KV
@@ -1425,8 +1403,8 @@ ru
 KV
 hx
 ab
-bH
-bH
+ab
+ab
 ab
 ab
 ab
@@ -1446,14 +1424,14 @@ ab
 ab
 ab
 ab
-bH
-qI
-mc
-jV
-bH
 ab
 ab
-bH
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -1466,7 +1444,7 @@ ru
 KV
 ab
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1487,13 +1465,13 @@ ab
 ab
 ab
 bH
-Kb
-LY
-jC
+bH
+bH
+bH
 bH
 ab
 ab
-bH
+ab
 ab
 KV
 GX
@@ -1506,7 +1484,7 @@ ru
 KV
 GX
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1525,15 +1503,15 @@ ab
 ab
 ab
 ab
-bH
+ab
 bH
 nb
 JA
 MQ
 bH
-bH
 ab
-bH
+ab
+ab
 ab
 KV
 RC
@@ -1546,7 +1524,7 @@ ru
 KV
 KV
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1565,15 +1543,15 @@ ab
 ab
 ab
 ab
-bH
-cU
-UH
-WL
-UH
-uS
-bH
 ab
 bH
+jC
+WL
+mc
+bH
+ab
+ab
+ab
 ab
 KV
 yr
@@ -1586,7 +1564,7 @@ ru
 PR
 KV
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1609,11 +1587,11 @@ bH
 bH
 fc
 ly
-Um
+qI
 bH
 bH
 bH
-bH
+ab
 ab
 KV
 yr
@@ -1626,7 +1604,7 @@ ru
 KV
 ab
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1648,8 +1626,8 @@ bH
 Bo
 bH
 Zl
-ED
-aK
+jV
+Um
 bH
 CF
 bH
@@ -1666,7 +1644,7 @@ ru
 KV
 ab
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1706,7 +1684,7 @@ ru
 KV
 ab
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1746,7 +1724,7 @@ ru
 KV
 ab
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1786,7 +1764,7 @@ Xz
 KV
 ab
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1826,7 +1804,7 @@ KV
 ab
 ab
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1866,7 +1844,7 @@ JN
 ab
 ab
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1906,7 +1884,7 @@ ab
 ab
 ab
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1946,7 +1924,7 @@ ab
 ab
 ab
 ab
-bH
+ab
 ab
 ab
 ab
@@ -1986,7 +1964,7 @@ ab
 ab
 ab
 ab
-bH
+ab
 ab
 ab
 ab
@@ -2026,7 +2004,7 @@ ab
 ab
 ab
 ab
-bH
+ab
 ab
 ab
 ab
@@ -2041,7 +2019,7 @@ ab
 bH
 bH
 Cw
-tr
+UH
 bH
 bH
 bH
@@ -2065,8 +2043,8 @@ ab
 ab
 ab
 ab
-bH
-bH
+ab
+ab
 ab
 ab
 ab
@@ -2081,7 +2059,7 @@ ab
 ab
 bH
 bH
-bH
+cU
 bH
 jl
 Lz
@@ -2104,8 +2082,8 @@ ab
 ab
 ab
 ab
-bH
-bH
+ab
+ab
 ab
 ab
 aa
@@ -2120,8 +2098,8 @@ aa
 ab
 ab
 ab
-ab
-ab
+bH
+bH
 bH
 Zj
 al
@@ -2142,9 +2120,9 @@ ab
 ab
 ab
 ab
-bH
-bH
-bH
+ab
+ab
+ab
 ab
 ab
 aa
@@ -2179,10 +2157,10 @@ ab
 ab
 ab
 ab
-bH
-bH
-bH
-bH
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -2215,11 +2193,11 @@ bH
 bH
 bH
 bH
-bH
-bH
-bH
-bH
-bH
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab

--- a/modular_skyrat/modules/mapping/code/datums/ruins/space.dm
+++ b/modular_skyrat/modules/mapping/code/datums/ruins/space.dm
@@ -22,6 +22,13 @@
 	name = "Derelict Ferry"
 	description = "Clearly once a ferry fielded by Central Command to send their staff to nearby stations, this ship's seen better days."
 
+/datum/map_template/ruin/space/skyrat/listeningstation
+	id = "listeningstation"
+	suffix = "listeningstation_skyrat.dmm"
+	name = "Syndicate Listening Station"
+	description = "Listening stations form the backbone of the syndicate's information-gathering operations. \
+	Assignment to these stations is dreaded by most agents, as it entails long and lonely shifts listening to nearby stations chatter incessantly about the most meaningless things."
+
 /datum/map_template/ruin/space/skyrat/posterpandamonium
 	id = "posterpandamonium"
 	suffix = "posterpandamonium.dmm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Remaps the listening post. This came to me in a fever dream.
Complaints Addressed:
Comms agents now have shit to do in their tiny ass baby fortress. A garden and lathes. Still can't leave without intervention as the suit storage unit is empty, though.
There's a unlisted holopad now, too. Because that's something you all wanted, I guess?
Oh, also the place is plastitanium now.
If the listening post spawns - a comms agent spawner will, too - guaranteed. This is to make up for the loss of frequency Interdyne comms agents gave the pool. God help us all.
![image](https://user-images.githubusercontent.com/50649185/121272921-1ef53200-c895-11eb-9a54-1c26d74b654a.png)



Also to anyone worried, Comms Agents are hypervalid and you're okay to BTFO them lmfao
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/50649185/120937237-6c796f80-c6da-11eb-90f2-e5cbf2f87739.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The listening post has been remapped. God help us all.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
