### PR TITLE
[whoops] Scrubs the O2 indicator out of Delta station's plasma tank, replaces it with a plasma indicator

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -21913,7 +21913,7 @@
 /area/security/prison)
 "beu" = (
 /obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/vg_decals/atmos/oxygen{
+/obj/effect/turf_decal/vg_decals/atmos/plasma{
 	dir = 4
 	},
 /turf/open/floor/engine/plasma,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A.k.a. "Stops CE Chip Shafer having a heart attack"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Delta station's plasma tank is no longer labelled as safe to breathe O2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
