### PR TITLE
Prevent Shrinking of Certain Small Borg Chassis w/ Small Refactor

### DIFF
--- a/code/__DEFINES/~skyrat_defines/robot_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/robot_defines.dm
@@ -4,7 +4,10 @@
 #define ROBOT_REST_SITTING 2
 #define ROBOT_REST_BELLY_UP 3
 
-//Defines for model traits that are simple yes/no/boolean - Are they a dogborg? Is the model small? etc.
+//Defines for model features, set in the model_features list of a robot model datum. Are they a dogborg? Is the model small? etc.
+/// Cyborgs with unique sprites for when they get totally broken down.
 #define R_TRAIT_UNIQUEWRECK	"unique_wreck"
-#define R_TRAIT_WIDE		"wide_borg"		//Represents wide/quadruped/dogborg type models.
-#define R_TRAIT_SMALL		"small_chassis"	//Any model small enough to reject the shrinker upgrade.
+/// Represents wide/quadruped/dogborg type models.
+#define R_TRAIT_WIDE		"wide_borg"
+/// Any model small enough to reject the shrinker upgrade.
+#define R_TRAIT_SMALL		"small_chassis"

--- a/code/__DEFINES/~skyrat_defines/robot_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/robot_defines.dm
@@ -3,3 +3,8 @@
 #define ROBOT_REST_NORMAL 1
 #define ROBOT_REST_SITTING 2
 #define ROBOT_REST_BELLY_UP 3
+
+//Defines for model traits that are simple yes/no/boolean - Are they a dogborg? Is the model small? etc.
+#define R_TRAIT_UNIQUEWRECK	"unique_wreck"
+#define R_TRAIT_WIDE		"wide_borg"		//Represents wide/quadruped/dogborg type models.
+#define R_TRAIT_SMALL		"small_chassis"	//Any model small enough to reject the shrinker upgrade.

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -135,9 +135,8 @@
 	R.update_module_innate()
 	RM.rebuild_modules()
 	R.radio.recalculateChannels()
-	//SKYRAT EDIT ADDITION BEGIN - ALTBORGS
-	if(R_TRAIT_WIDE in RM.model_features)
-		R.dogborg = TRUE
+	//SKYRAT EDIT ADDITION BEGIN - ALTBORGS - Old check for 'dogborg' var no longer necessary, refactored into model_features instead.
+	if(R.is_dogborg()) //Should pass because model was set previously.
 		RM.dogborg_equip()
 	//SKYRAT EDIT ADDITION END
 	INVOKE_ASYNC(RM, .proc/do_transform_animation)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -136,7 +136,7 @@
 	RM.rebuild_modules()
 	R.radio.recalculateChannels()
 	//SKYRAT EDIT ADDITION BEGIN - ALTBORGS
-	if(RM.dogborg)
+	if(R_TRAIT_WIDE in RM.model_features)
 		R.dogborg = TRUE
 		RM.dogborg_equip()
 	//SKYRAT EDIT ADDITION END

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot.dm
@@ -22,7 +22,7 @@
 	set name = "Switch Rest Style"
 	set category = "Robot Commands"
 	set desc = "Select your resting pose."
-	if(!dogborg)
+	if(!is_dogborg())
 		to_chat(src, "<span class='warning'>You can't do that!</span>")
 		return
 	var/choice = tgui_alert(src, "Select resting pose", "", list("Resting", "Sitting", "Belly up"))
@@ -40,7 +40,7 @@
 /mob/living/silicon/robot/proc/robot_lay_down()
 	set name = "Lay down"
 	set category = "Robot Commands"
-	if(!dogborg)
+	if(!is_dogborg())
 		to_chat(src, "<span class='warning'>You can't do that!</span>")
 		return
 	if(stat != CONSCIOUS) //Make sure we don't enable movement when not concious
@@ -58,7 +58,7 @@
 
 /mob/living/silicon/robot/update_resting()
 	. = ..()
-	if(dogborg)
+	if(is_dogborg())
 		robot_resting = FALSE
 		update_icons()
 
@@ -69,12 +69,12 @@
 
 /mob/living/silicon/robot/start_pulling(atom/movable/AM, state, force, supress_message)
 	. = ..()
-	if(dogborg)
+	if(is_dogborg())
 		pixel_x = -16
 
 /mob/living/silicon/robot/stop_pulling()
 	. = ..()
-	if(dogborg)
+	if(is_dogborg())
 		pixel_x = -16
 
 /mob/living/silicon/robot/pick_model()
@@ -96,3 +96,12 @@
 	else
 		model.transform_to(skyratmodel[input_model_sk])
 		return
+/**
+ * Safe check of the cyborg's model_features list to see if they're 'wide'/dogborg/drakeborg/etc.
+ *
+ * model_features is defined in modular_skyrat\modules\altborgs\code\modules\mob\living\silicon\robot\robot_model.dm.
+ */
+/mob/living/silicon/robot/proc/is_dogborg()
+	if(model && model.model_features && (R_TRAIT_WIDE in model.model_features))
+		return TRUE
+	return FALSE

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -1,7 +1,6 @@
 /mob/living/silicon/robot
 	var/robot_resting = FALSE
 	var/robot_rest_style = ROBOT_REST_NORMAL
-	var/dogborg = FALSE
 
 /mob/living/silicon/robot/model/miner/skyrat
 	set_model = /obj/item/robot_model/miner/skyrat

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -1,10 +1,9 @@
 /obj/item/robot_model
 	var/icon/cyborg_icon_override
 	var/sleeper_overlay
-	var/has_snowflake_deadsprite
 	var/cyborg_pixel_offset
 	var/model_select_alternate_icon
-	var/dogborg = FALSE //Is this model a wider borg?
+	var/list/model_features //Traits unique to this model, i.e. having a unique dead sprite, being wide or being small enough to reject shrinker modules. Leverages defines in code\__DEFINES\~skyrat_defines\robot_defines.dm
 
 //SERVICE
 /obj/item/robot_model/service/skyrat

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -4,7 +4,7 @@
 	var/cyborg_pixel_offset
 	var/model_select_alternate_icon
 	/// Traits unique to this model, i.e. having a unique dead sprite, being wide or being small enough to reject shrinker modules. Leverages defines in code\__DEFINES\~skyrat_defines\robot_defines.dm
-	var/list/model_features
+	var/list/model_features = list()
 
 //SERVICE
 /obj/item/robot_model/service/skyrat

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -3,7 +3,8 @@
 	var/sleeper_overlay
 	var/cyborg_pixel_offset
 	var/model_select_alternate_icon
-	var/list/model_features //Traits unique to this model, i.e. having a unique dead sprite, being wide or being small enough to reject shrinker modules. Leverages defines in code\__DEFINES\~skyrat_defines\robot_defines.dm
+	/// Traits unique to this model, i.e. having a unique dead sprite, being wide or being small enough to reject shrinker modules. Leverages defines in code\__DEFINES\~skyrat_defines\robot_defines.dm
+	var/list/model_features
 
 //SERVICE
 /obj/item/robot_model/service/skyrat

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -756,7 +756,7 @@
 		if("Zoomba")
 			cyborg_base_icon = "zoomba_green"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_serv.dmi'
-			list(model_features = R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
+			model_features = list(model_features = R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 		if("Mech")
 			cyborg_base_icon = "lloyd"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_serv.dmi'

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,5 +1,4 @@
 /obj/item/robot_model/proc/dogborg_equip()
-	has_snowflake_deadsprite = TRUE
 	cyborg_pixel_offset = -16
 	hat_offset = INFINITY
 	basic_modules += new /obj/item/dogborg_nose(src)
@@ -49,22 +48,23 @@
 	switch(standard_borg_icon)
 		if("Default")
 			cyborg_base_icon = "robot"
+			model_features = list(R_TRAIT_SMALL)
 		if("Marina")
 			cyborg_base_icon = "marinasd"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK)
 		if("Heavy")
 			cyborg_base_icon = "heavysd"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK)
 		if("Eyebot")
 			cyborg_base_icon = "eyebotsd"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 		if("Robot")
 			cyborg_base_icon = "robot_old"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK)
 		if("Bootyborg")
 			cyborg_base_icon = "bootysd"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
@@ -82,7 +82,7 @@
 			cyborg_base_icon = "k69"
 			sleeper_overlay = "k9sleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
-			dogborg = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		else
 			return FALSE
 	return ..()
@@ -120,10 +120,11 @@
 	switch(med_borg_icon)
 		if("Default")
 			cyborg_base_icon = "medical"
+			model_features = list(R_TRAIT_SMALL)
 		if("Zoomba")
 			cyborg_base_icon = "zoomba_med"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 		if("Droid")
 			cyborg_base_icon = "medical"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
@@ -137,7 +138,7 @@
 		if("Eyebot")
 			cyborg_base_icon = "eyebotmed"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 		if("Heavy")
 			cyborg_base_icon = "heavymed"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
@@ -172,24 +173,21 @@
 			sleeper_overlay = "msleeper"
 			model_select_icon = "medihound"
 			model_select_alternate_icon = 'modular_skyrat/modules/altborgs/icons/ui/screen_cyborg.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Darkhound")
 			cyborg_base_icon = "medihounddark"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_med.dmi'
 			sleeper_overlay = "mdsleeper"
 			model_select_icon = "medihound"
 			model_select_alternate_icon = 'modular_skyrat/modules/altborgs/icons/ui/screen_cyborg.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Vale")
 			cyborg_base_icon = "valemed"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_med.dmi'
 			sleeper_overlay = "valemedsleeper"
 			model_select_icon = "medihound"
 			model_select_alternate_icon = 'modular_skyrat/modules/altborgs/icons/ui/screen_cyborg.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Alina")
 			cyborg_base_icon = "alina-med"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_med.dmi'
@@ -197,24 +195,21 @@
 			sleeper_overlay = "alinasleeper"
 			model_select_icon = "medihound"
 			model_select_alternate_icon = 'modular_skyrat/modules/altborgs/icons/ui/screen_cyborg.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Drake")
 			cyborg_base_icon = "drakemed"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_med.dmi'
 			sleeper_overlay = "drakemedsleeper"
 			model_select_icon = "medihound"
 			model_select_alternate_icon = 'modular_skyrat/modules/altborgs/icons/ui/screen_cyborg.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Borgi")
 			cyborg_base_icon = "borgi-medi"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_med.dmi'
 			sleeper_overlay = "borgi-medi-sleeper"
 			model_select_icon = "medihound"
 			model_select_alternate_icon = 'modular_skyrat/modules/altborgs/icons/ui/screen_cyborg.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE, R_TRAIT_SMALL)
 		else
 			return FALSE
 	return ..()
@@ -254,10 +249,11 @@
 	switch(engi_borg_icon)
 		if("Default")
 			cyborg_base_icon = "engineer"
+			model_features = list(R_TRAIT_SMALL)
 		if("Zoomba")
 			cyborg_base_icon = "zoomba_engi"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_eng.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 		if("Default - Treads")
 			cyborg_base_icon = "engi-tread"
 			special_light_key = "engineer"
@@ -265,7 +261,7 @@
 		if("Loader")
 			cyborg_base_icon = "loaderborg"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_eng.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK)
 		if("Handy")
 			cyborg_base_icon = "handyeng"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_eng.dmi'
@@ -305,57 +301,49 @@
 		if("Eyebot")
 			cyborg_base_icon = "eyeboteng"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_eng.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 		//Dogborgs
 		if("Pup Dozer")
 			cyborg_base_icon = "pupdozer"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 			sleeper_overlay = "dozersleeper"
-			has_snowflake_deadsprite = TRUE
-			dogborg = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Vale")
 			cyborg_base_icon = "valeeng"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 			sleeper_overlay = "valeengsleeper"
-			has_snowflake_deadsprite = TRUE
-			dogborg = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Hound")
 			cyborg_base_icon = "engihound"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 			sleeper_overlay = "engihoundsleeper"
-			has_snowflake_deadsprite = TRUE
-			dogborg = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Darkhound")
 			cyborg_base_icon = "engihounddark"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 			sleeper_overlay = "engihounddarksleeper"
-			has_snowflake_deadsprite = TRUE
-			dogborg = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Alina")
 			cyborg_base_icon = "alina-eng"
 			special_light_key = "alina"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 			sleeper_overlay = "alinasleeper"
-			has_snowflake_deadsprite = TRUE
-			dogborg = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Drake")
 			cyborg_base_icon = "drakeeng"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 			sleeper_overlay = "drakesecsleeper"
-			has_snowflake_deadsprite = TRUE
-			dogborg = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Borgi")
 			cyborg_base_icon = "borgi-eng"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 			sleeper_overlay = "borgi-eng-sleeper"
-			has_snowflake_deadsprite = TRUE
-			dogborg = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE, R_TRAIT_SMALL)
 		if("Otie")
 			cyborg_base_icon = "otiee"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 			sleeper_overlay = "otiee-sleeper"
-			has_snowflake_deadsprite = TRUE
-			dogborg = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		else
 			return FALSE
 	return ..()
@@ -396,7 +384,7 @@
 		if("Zoomba")
 			cyborg_base_icon = "zoomba_sec"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_sec.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 		if("Default - Treads")
 			cyborg_base_icon = "sec-tread"
 			special_light_key = "sec"
@@ -431,7 +419,7 @@
 		if("Eyebot")
 			cyborg_base_icon = "eyebotsec"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_sec.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 		if("Insekt")
 			cyborg_base_icon = "insekt-Sec"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_sec.dmi'
@@ -443,45 +431,38 @@
 			cyborg_base_icon = "k9"
 			sleeper_overlay = "ksleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Otie")
 			cyborg_base_icon = "oties"
 			sleeper_overlay = "otiessleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Alina")
 			cyborg_base_icon = "alina-sec"
 			special_light_key = "alina"
 			sleeper_overlay = "alinasleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Darkhound")
 			cyborg_base_icon = "k9dark"
 			sleeper_overlay = "k9darksleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Vale")
 			cyborg_base_icon = "valesec"
 			sleeper_overlay = "valesecsleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Drake")
 			cyborg_base_icon = "drakesec"
 			sleeper_overlay = "drakesecsleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Borgi")
 			cyborg_base_icon = "borgi-sec"
 			sleeper_overlay = "borgi-sec-sleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE, R_TRAIT_SMALL)
 		else
 			return FALSE
 	return ..()
@@ -516,14 +497,15 @@
 		if("Sleek")
 			cyborg_base_icon = "sleekpeace"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK)
 		if("Spider")
 			cyborg_base_icon = "whitespider"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
+			model_features = list(R_TRAIT_SMALL)
 		if("Marina")
 			cyborg_base_icon = "marinapeace"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK)
 		if("Bootyborg")
 			cyborg_base_icon = "bootypeace"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
@@ -539,25 +521,23 @@
 		if("Omni")
 			cyborg_base_icon = "omoikane"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
+			model_features = list(R_TRAIT_SMALL) //No tennis-ball sized cyborgs.
 		//Dogborgs
 		if("Drake")
 			cyborg_base_icon = "drakepeace"
 			sleeper_overlay = "drakepeacesleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_pk.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Borgi")
 			cyborg_base_icon = "borgi"
 			sleeper_overlay = "borgi-sleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_pk.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE, R_TRAIT_SMALL)
 		if("Vale")
 			cyborg_base_icon = "valepeace"
 			sleeper_overlay = "valepeace-sleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_pk.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		else
 			return FALSE
 	return ..()
@@ -598,7 +578,7 @@
 		if("Zoomba")
 			cyborg_base_icon = "zoomba_jani"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_jani.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 		if("Marina")
 			cyborg_base_icon = "marinajan"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_jani.dmi'
@@ -629,7 +609,7 @@
 		if("Eyebot")
 			cyborg_base_icon = "eyebotjani"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_jani.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 		if("Insekt")
 			cyborg_base_icon = "insekt-Sci"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_jani.dmi'
@@ -644,32 +624,27 @@
 			cyborg_base_icon = "scrubpup"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_jani.dmi'
 			sleeper_overlay = "jsleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Otie")
 			cyborg_base_icon = "otiej"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_jani.dmi'
 			sleeper_overlay = "otiejsleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Drake")
 			cyborg_base_icon = "drakejanit"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_jani.dmi'
 			sleeper_overlay = "drakesecsleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Vale")
 			cyborg_base_icon = "J9"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_jani.dmi'
 			sleeper_overlay = "J9-sleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Borgi")
 			cyborg_base_icon = "borgi-jani"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_jani.dmi'
 			sleeper_overlay = "borgi-jani-sleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE, R_TRAIT_SMALL)
 		else
 			return FALSE
 	return ..()
@@ -699,7 +674,7 @@
 		if("Marina")
 			cyborg_base_icon = "marina_mommy"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_clown.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK)
 		if("Garish")
 			cyborg_base_icon = "garish"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_clown.dmi'
@@ -709,7 +684,7 @@
 		if("Sleek")
 			cyborg_base_icon = "clownman"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_clown.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK)
 		else
 			return FALSE
 	return ..()
@@ -781,7 +756,7 @@
 		if("Zoomba")
 			cyborg_base_icon = "zoomba_green"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_serv.dmi'
-			has_snowflake_deadsprite = TRUE
+			list(model_features = R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 		if("Mech")
 			cyborg_base_icon = "lloyd"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_serv.dmi'
@@ -793,32 +768,27 @@
 			cyborg_base_icon = "k50"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
 			sleeper_overlay = "ksleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Vale")
 			cyborg_base_icon = "valeserv"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
 			sleeper_overlay = "valeservsleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("ValeDark")
 			cyborg_base_icon = "valeservdark"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
 			sleeper_overlay = "valeservsleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Partyhound")
 			cyborg_base_icon = "k69"
 			sleeper_overlay = "k9sleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Borgi")
 			cyborg_base_icon = "borgi-serv"
 			sleeper_overlay = "borgi-sleeper"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE, R_TRAIT_SMALL)
 		else
 			return FALSE
 	return TRUE
@@ -895,47 +865,42 @@
 		if("Drone")
 			cyborg_base_icon = "miningdrone"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_mine.dmi'
+			model_features = list(R_TRAIT_SMALL)
 		if("Zoomba")
 			cyborg_base_icon = "zoomba_miner"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_mine.dmi'
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 		//Dogborgs
 		if("Blade")
 			cyborg_base_icon = "blade"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_mine.dmi'
 			sleeper_overlay = "bladesleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Vale")
 			cyborg_base_icon = "valemine"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_mine.dmi'
 			sleeper_overlay = "valeminesleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Drake")
 			cyborg_base_icon = "drakemine"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_mine.dmi'
 			sleeper_overlay = "drakeminesleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Hound")
 			cyborg_base_icon = "cargohound"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_mine.dmi'
 			sleeper_overlay = "cargohound-sleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Darkhound")
 			cyborg_base_icon = "cargohounddark"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_mine.dmi'
 			sleeper_overlay = "cargohounddark-sleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		if("Otie")
 			cyborg_base_icon = "otiec"
 			cyborg_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_mine.dmi'
 			sleeper_overlay = "otiec_sleeper"
-			dogborg = TRUE
-			has_snowflake_deadsprite = TRUE
+			model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 		else
 			return FALSE
 	return TRUE

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/update_icons.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/update_icons.dm
@@ -23,9 +23,6 @@
 	//if(sleeper_r && model.sleeper_overlay)
 	//	add_overlay("[model.sleeper_overlay]_r[sleeper_nv ? "_nv" : ""]")
 
-	if(stat == DEAD && model.has_snowflake_deadsprite)
-		icon_state = "[model.cyborg_base_icon]-wreck"
-
 	if(model.cyborg_pixel_offset != null)
 		pixel_x = model.cyborg_pixel_offset
 
@@ -34,7 +31,7 @@
 		pixel_x = initial(pixel_x)
 
 	if(robot_resting)
-		if(stat != DEAD && model.dogborg)
+		if(stat != DEAD && (R_TRAIT_WIDE in model.model_features))
 			switch(robot_resting)
 				if(ROBOT_REST_NORMAL)
 					icon_state = "[model.cyborg_base_icon]-rest"
@@ -48,8 +45,7 @@
 	else
 		icon_state = "[model.cyborg_base_icon]"
 
-	if(stat == DEAD && model.has_snowflake_deadsprite)
+	if(stat == DEAD && (R_TRAIT_UNIQUEWRECK in model.model_features))
 		icon_state = "[model.cyborg_base_icon]-wreck"
+
 	update_fire()
-
-

--- a/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/update_icons.dm
+++ b/modular_skyrat/modules/altborgs/code/modules/mob/living/silicon/robot/update_icons.dm
@@ -31,7 +31,7 @@
 		pixel_x = initial(pixel_x)
 
 	if(robot_resting)
-		if(stat != DEAD && (R_TRAIT_WIDE in model.model_features))
+		if(stat != DEAD && is_dogborg())
 			switch(robot_resting)
 				if(ROBOT_REST_NORMAL)
 					icon_state = "[model.cyborg_base_icon]-rest"

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -13,6 +13,9 @@
 		if(R.hasShrunk)
 			to_chat(usr, "<span class='warning'>This unit already has a shrink module installed!</span>")
 			return FALSE
+		if(R_TRAIT_SMALL in R.model.model_features)
+			to_chat(usr, "<span class='warning'>This unit's chassis cannot be shrunk any further.</span>")
+			return FALSE
 
 		R.notransform = TRUE
 		var/prev_lockcharge = R.lockcharge

--- a/modular_skyrat/modules/shapeshifting_module/code/game/objects/items/borg_shapeshifter.dm
+++ b/modular_skyrat/modules/shapeshifting_module/code/game/objects/items/borg_shapeshifter.dm
@@ -13,7 +13,7 @@
 	var/savedOverride
 	var/savedPixelOffset
 	var/savedModelName
-	var/savedDogborg
+	var/savedModelFeatures
 	var/savedSpecialLightKey
 	var/active = FALSE
 	var/activationCost = 100
@@ -21,7 +21,7 @@
 	var/disguise = null
 	var/disguise_icon_override = null
 	var/disguise_pixel_offset = 0
-	var/disguise_dogborg = FALSE
+	var/disguise_model_features
 	var/disguise_special_light_key = null
 	var/mob/listeningTo
 	var/list/signalCache = list( // list here all signals that should break the camouflage
@@ -183,18 +183,23 @@
 					if("Default")
 						disguise = "robot"
 						disguise_icon_override = 'icons/mob/robots.dmi'
+						disguise_model_features = list(R_TRAIT_SMALL)
 					if("Marina")
 						disguise = "marinasd"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK)
 					if("Heavy")
 						disguise = "heavysd"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK)
 					if("Eyebot")
 						disguise = "eyebotsd"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 					if("Robot")
 						disguise = "robot_old"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK)
 					if("Bootyborg")
 						disguise = "bootysd"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
@@ -212,7 +217,7 @@
 						disguise = "k69"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					else
 						return FALSE
 
@@ -247,6 +252,7 @@
 					if("Default")
 						disguise = "medical"
 						disguise_icon_override = 'icons/mob/robots.dmi'
+						disguise_model_features = list(R_TRAIT_SMALL)
 					if("Droid")
 						disguise = "medical"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
@@ -259,6 +265,7 @@
 					if("Eyebot")
 						disguise = "eyebotmed"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 					if("Heavy")
 						disguise = "heavymed"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
@@ -280,6 +287,7 @@
 					if("Zoomba")
 						disguise = "zoomba_med"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 					if("Arachne")
 						disguise = "arachne"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_med.dmi'
@@ -294,27 +302,27 @@
 						disguise = "medihound"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_med.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Medihound Dark")
 						disguise = "medihounddark"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_med.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Vale")
 						disguise = "valemed"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_med.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Drake")
 						disguise = "drakemed"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_med.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Borgi")
 						disguise = "borgi-medi"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_med.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE, R_TRAIT_SMALL)
 					else
 						return FALSE
 
@@ -351,9 +359,11 @@
 					if("Default")
 						disguise = "engineer"
 						disguise_icon_override = 'icons/mob/robots.dmi'
+						disguise_model_features = list(R_TRAIT_SMALL)
 					if("Zoomba")
 						disguise = "zoomba_engi"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_eng.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 					if("Default - Treads")
 						disguise = "engi-tread"
 						disguise_special_light_key = "engineer"
@@ -361,6 +371,7 @@
 					if("Loader")
 						disguise = "loaderborg"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_eng.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK)
 					if("Handy")
 						disguise = "handyeng"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_eng.dmi'
@@ -394,6 +405,7 @@
 					if("Eyebot")
 						disguise = "eyeboteng"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_eng.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 					if("Mech")
 						disguise = "conagher"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_eng.dmi'
@@ -405,38 +417,38 @@
 						disguise = "pupdozer"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Vale")
 						disguise = "valeeng"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Alina")
 						disguise = "alina-eng"
 						disguise_special_light_key = "alina"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Drake")
 						disguise = "drakeeng"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Hound")
 						disguise = "engihound"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Darkhound")
 						disguise = "engihounddark"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Borgi")
 						disguise = "borgi-eng"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_eng.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE, R_TRAIT_SMALL)
 					else
 						return FALSE
 			if("Security")
@@ -473,6 +485,7 @@
 					if("Zoomba")
 						disguise = "zoomba_sec"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_sec.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 					if("Default - Treads")
 						disguise = "sec-tread"
 						disguise_special_light_key = "sec"
@@ -509,38 +522,38 @@
 						disguise = "k9"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Alina")
 						disguise = "alina-sec"
 						disguise_special_light_key = "alina"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Darkhound")
 						disguise = "k9dark"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Vale")
 						disguise = "valesec"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Drake")
 						disguise = "drakesec"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Otie")
 						disguise = "oties"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Borgi")
 						disguise = "borgi-sec"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_sec.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE, R_TRAIT_SMALL)
 					else
 						return FALSE
 			if("Service")
@@ -647,6 +660,7 @@
 					if("(Janitor) Zoomba")
 						disguise = "zoomba_jani"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 					if("(Janitor) Bootyborg")
 						disguise = "bootyjanitor"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots.dmi'
@@ -665,53 +679,53 @@
 						disguise = "k50"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("(Service) Vale")
 						disguise = "valeserv"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("(Service) Partyhound")
 						disguise = "k69"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("(Service) ValeDark")
 						disguise = "valeservdark"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("(Service) Borgi")
 						disguise = "borgi-serv"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_serv.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE, R_TRAIT_SMALL)
 
 					if("(Janitor) Drake")
 						disguise = "drakejanit"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_jani.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("(Janitor) Otie")
 						disguise = "otiej"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_jani.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("(Janitor) Scrubpuppy")
 						disguise = "scrubpup"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_jani.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("(Janitor) Vale")
 						disguise = "J9"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_jani.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("(Janitor) Borgi")
 						disguise = "borgi-jani"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_jani.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE, R_TRAIT_SMALL)
 					else
 						return FALSE
 			if("Miner")
@@ -781,38 +795,40 @@
 					if("Zoomba")
 						disguise = "zoomba_miner"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_mine.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_SMALL)
 					if("Mech")
 						disguise = "ishimura"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_mine.dmi'
 					if("Drone")
 						disguise = "miningdrone"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_mine.dmi'
+						disguise_model_features = list(R_TRAIT_SMALL)
 					//Dogborgs
 					if("Drake")
 						disguise = "drakemine"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_mine.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Blade")
 						disguise = "blade"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_mine.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Vale")
 						disguise = "valemine"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_mine.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Hound")
 						disguise = "cargohound"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_mine.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Darkhound")
 						disguise = "cargohounddark"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_mine.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					else
 						return FALSE
 			if("Peacekeeper")
@@ -843,12 +859,15 @@
 					if("Sleek")
 						disguise = "sleekpeace"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK)
 					if("Spider")
 						disguise = "whitespider"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
+						disguise_model_features = list(R_TRAIT_SMALL)
 					if("Marina")
 						disguise = "marinapeace"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK)
 					if("Bootyborg")
 						disguise = "bootypeace"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
@@ -864,17 +883,18 @@
 					if("Omni")
 						disguise = "omoikane"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_pk.dmi'
+						disguise_model_features = list(R_TRAIT_SMALL) //No tennis-ball shaped disguised cyborgs.
 					//Dogborgs
 					if("Drake")
 						disguise = "drakepeace"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_pk.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE)
 					if("Borgi")
 						disguise = "borgi"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/widerobot_pk.dmi'
 						disguise_pixel_offset = -16
-						disguise_dogborg = TRUE
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK, R_TRAIT_WIDE, R_TRAIT_SMALL)
 					else
 						return FALSE
 			if("Clown")
@@ -903,6 +923,7 @@
 					if("Marina")
 						disguise = "marina_mommy"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_clown.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK)
 					if("Garish")
 						disguise = "garish"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_clown.dmi'
@@ -912,6 +933,7 @@
 					if("Sleek")
 						disguise = "clownman"
 						disguise_icon_override = 'modular_skyrat/modules/altborgs/icons/mob/robots_clown.dmi'
+						disguise_model_features = list(R_TRAIT_UNIQUEWRECK)
 					else
 						return FALSE
 			if("Syndicate")
@@ -1057,13 +1079,13 @@
 	savedOverride = user.model.cyborg_icon_override
 	savedPixelOffset = user.model.cyborg_pixel_offset
 	savedModelName = user.model.name
-	savedDogborg = user.model.dogborg
+	savedModelFeatures = user.model.model_features
 	savedSpecialLightKey = user.model.special_light_key
 	user.model.name = disguiseModelName
 	user.model.cyborg_base_icon = disguise
 	user.model.cyborg_icon_override = disguise_icon_override
 	user.model.cyborg_pixel_offset = disguise_pixel_offset
-	user.model.dogborg = disguise_dogborg
+	user.model.model_features = disguise_model_features
 	user.model.special_light_key = disguise_special_light_key
 	user.bubble_icon = "robot"
 	active = TRUE
@@ -1089,13 +1111,12 @@
 	user.model.cyborg_base_icon = savedIcon
 	user.model.cyborg_icon_override = savedOverride
 	user.model.cyborg_pixel_offset = savedPixelOffset
-	user.model.dogborg = savedDogborg
+	user.model.model_features = savedModelFeatures
 	user.model.special_light_key = savedSpecialLightKey
 	user.bubble_icon = savedBubbleIcon
 	active = FALSE
 	user.update_icons()
 	disguise_pixel_offset = 0
-	disguise_dogborg = FALSE
 	src.user = user
 
 /obj/item/borg_shapeshifter/proc/disrupt(mob/living/silicon/robot/user)

--- a/modular_skyrat/modules/shapeshifting_module/code/game/objects/items/borg_shapeshifter.dm
+++ b/modular_skyrat/modules/shapeshifting_module/code/game/objects/items/borg_shapeshifter.dm
@@ -21,7 +21,8 @@
 	var/disguise = null
 	var/disguise_icon_override = null
 	var/disguise_pixel_offset = 0
-	var/disguise_model_features
+	/// Traits unique to this model (deadsprite, wide/dogborginess, etc.). Mirrors the definition in modular_skyrat\modules\altborgs\code\modules\mob\living\silicon\robot\robot_model.dm
+	var/list/disguise_model_features = list()
 	var/disguise_special_light_key = null
 	var/mob/listeningTo
 	var/list/signalCache = list( // list here all signals that should break the camouflage


### PR DESCRIPTION
## About The Pull Request
This PR exists b/c #5211 got closed, an ultimatum PR (#6210) got created and I'd really like to keep the ability to shrink borgs (who aren't already dangerously small)!

The OG PR 5211 missed the very model that people like to screenshot for this issue but this PR catches it.

This also refactors the `dogborg` and `has_snowflake_deadsprite` variables into this list of features.

## Why It's Good For The Game
You can't shrink borgs that are small off the get-go so they're still clickable in combat, and cleans up code - making altborgs a bit more flexible if we choose to further leverage the features list in the future while also keeping the borg shrinker module's function for those who enjoy it with most other chassis types.

## Changelog
:cl:
rscdel: The borg shinker module will no longer work on certain compact chassis models, providing a feedback message. This includes the peacekeeper-ball, vroomba, eyeborg, mining drone and some others.
tweak: SkyRat Altborg code's been refactored - indicating that a model is small, is a dogborg or has unique wreck sprites is now done in a features list.
/:cl:
