### PR TITLE
[NON-MODULAR] Only roboticists can repair prosthetics

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -123,11 +123,25 @@
 
 	if(affecting && affecting.status == BODYPART_ROBOTIC && !user.combat_mode)
 		if(src.use_tool(H, user, 0, volume=50, amount=1))
+//SKYRAT EDIT BEGIN
+			/*
 			if(user == H)
 				user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [H]'s [affecting.name].</span>",
 					"<span class='notice'>You start fixing some of the dents on [H == user ? "your" : "[H]'s"] [affecting.name].</span>")
 				if(!do_mob(user, H, 50))
 					return
+			*/
+			if(user == H)
+				to_chat(user, "<span class='warning'>You can't fix \the [affecting.name] on your own!</span>")
+				return
+			if(!(user.mind?.assigned_role == "Roboticist"))
+				to_chat(user, "<span class='warning'>You.. don't know how to do that.</span>")
+				return
+			user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [H]'s [affecting.name].</span>",
+					"<span class='notice'>You start fixing some of the dents on [H]'s [affecting.name].</span>")
+			if(!do_mob(user, H, 50))
+				return
+//SKYRAT EDIT END
 			item_heal_robotic(H, user, 15, 0)
 	else
 		return ..()

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -134,7 +134,7 @@
 		if(user == H)
 			to_chat(user, "<span class='warning'>You can't fix \the [affecting.name] on your own!</span>")
 			return
-		if(!(user.mind?.assigned_role == "Roboticist"))
+		if(!HAS_TRAIT(user, TRAIT_KNOW_CYBORG_WIRES))
 			to_chat(user, "<span class='warning'>You.. don't know how to do that.</span>")
 			return
 		if(!src.use_tool(H, user, 0, volume=50, amount=1))

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -122,25 +122,26 @@
 	var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
 
 	if(affecting && affecting.status == BODYPART_ROBOTIC && !user.combat_mode)
-		if(src.use_tool(H, user, 0, volume=50, amount=1))
 //SKYRAT EDIT BEGIN
-			/*
+		/*
+		if(src.use_tool(H, user, 0, volume=50, amount=1))
 			if(user == H)
 				user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [H]'s [affecting.name].</span>",
 					"<span class='notice'>You start fixing some of the dents on [H == user ? "your" : "[H]'s"] [affecting.name].</span>")
 				if(!do_mob(user, H, 50))
 					return
 			*/
-			if(user == H)
-				to_chat(user, "<span class='warning'>You can't fix \the [affecting.name] on your own!</span>")
-				return
-			if(!(user.mind?.assigned_role == "Roboticist"))
-				to_chat(user, "<span class='warning'>You.. don't know how to do that.</span>")
-				return
-			user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [H]'s [affecting.name].</span>",
-					"<span class='notice'>You start fixing some of the dents on [H]'s [affecting.name].</span>")
-			if(!do_mob(user, H, 50))
-				return
+		if(user == H)
+			to_chat(user, "<span class='warning'>You can't fix \the [affecting.name] on your own!</span>")
+			return
+		if(!(user.mind?.assigned_role == "Roboticist"))
+			to_chat(user, "<span class='warning'>You.. don't know how to do that.</span>")
+			return
+		if(!src.use_tool(H, user, 0, volume=50, amount=1))
+			return
+		user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [H]'s [affecting.name].</span>",
+				"<span class='notice'>You start fixing some of the dents on [H]'s [affecting.name].</span>")
+		if(do_mob(user, H, 50))
 //SKYRAT EDIT END
 			item_heal_robotic(H, user, 15, 0)
 	else

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -557,7 +557,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 		if(user == H)
 			to_chat(user, "<span class='warning'>You can't fix [affecting.name] on your own!</span>")
 			return
-		if(!(user.mind?.assigned_role == "Roboticist"))
+		if(!HAS_TRAIT(user, TRAIT_KNOW_CYBORG_WIRES))
 			to_chat(user, "<span class='warning'>You.. don't know how to do that.</span>")
 			return
 		user.visible_message("<span class='notice'>[user] starts to fix some of the wires in [H]'s [affecting.name].</span>", "<span class='notice'>You start fixing some of the wires in [H]'s [affecting.name].</span>")

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -547,10 +547,23 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 
 	var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
 	if(affecting && affecting.status == BODYPART_ROBOTIC)
+//SKYRAT EDIT BEGIN
+		/*
 		if(user == H)
 			user.visible_message("<span class='notice'>[user] starts to fix some of the wires in [H]'s [affecting.name].</span>", "<span class='notice'>You start fixing some of the wires in [H == user ? "your" : "[H]'s"] [affecting.name].</span>")
 			if(!do_mob(user, H, 50))
 				return
+		*/
+		if(user == H)
+			to_chat(user, "<span class='warning'>You can't fix [affecting.name] on your own!</span>")
+			return
+		if(!(user.mind?.assigned_role == "Roboticist"))
+			to_chat(user, "<span class='warning'>You.. don't know how to do that.</span>")
+			return
+		user.visible_message("<span class='notice'>[user] starts to fix some of the wires in [H]'s [affecting.name].</span>", "<span class='notice'>You start fixing some of the wires in [H]'s [affecting.name].</span>")
+		if(!do_mob(user, H, 50))
+			return
+//SKYRAT EDIT END
 		if(item_heal_robotic(H, user, 0, 15))
 			use(1)
 		return


### PR DESCRIPTION
## About The Pull Request

Title. If you don't have ~~roboticist as your assigned job~~ roboticists' skillchip, you physically can't repair prosthetics. Also you can't repair prosthetics on your own.

## Why It's Good For The Game

­> Gives roboticists something to do, past just "make borgs"
­> Few if any jobs besides roboticist should even have the knowledge of how to fix prosthetics, maybe engineer but even that is stretching it
­> Encourages cross-department interactions (and interactions in general), as medical can't fix the prosthetics on their own

## Changelog
:cl:
balance: you can no longer self-repair prosthetic limbs, you need to have the roboticist fix them for you
/:cl: