### PR TITLE
Adds Blueshield/Captain/Chief engineer to veteran crew - AWARENESS PR

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -32,6 +32,8 @@
 		/obj/item/reagent_containers/food/drinks/bottle/champagne = 10
 	)
 
+	veteran_only = TRUE //SKYRAT EDIT ADDITION
+
 /datum/job/captain/announce(mob/living/carbon/human/H, announce_captaincy = TRUE)
 	..()
 	if(announce_captaincy)

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -37,6 +37,8 @@
 		/obj/effect/spawner/lootdrop/space/fancytool/engineonly = 3
 	)
 
+	veteran_only = TRUE //SKYRAT EDIT ADDITION
+
 /datum/job/chief_engineer/announce(mob/living/carbon/human/H, announce_captaincy = FALSE)
 	..()
 	if(announce_captaincy)

--- a/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
@@ -31,6 +31,8 @@
 		/obj/projectile/bullet/advanced/b10mm/b460 = 1
 	)
 
+	veteran_only = TRUE
+
 /datum/outfit/job/blueshield
 	name = "Blueshield"
 	jobtype = /datum/job/blueshield


### PR DESCRIPTION
# This is a prospective PR, take it with a grain of salt. 

To apply for this role, see: https://forum.skyrat13.tk/viewforum.php?f=78

## Changelog
:cl:
add: Blueshield, Captain and Chief Engineer now require you to be a veteran crew.
/:cl:
