### PR TITLE
Moves multi-cell charger empty to right click

### DIFF
--- a/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
@@ -15,6 +15,10 @@
 	var/charge_rate_base = 250 // Amount of charge we gain from a level one capacitor
 	var/charge_rate_max = 4000 // The highest we allow the charge rate to go
 
+/obj/machinery/cell_charger_multi/Initialize()
+	. = ..()
+	RegisterSignal(src, COMSIG_PARENT_ATTACKBY, .proc/RightClick)
+
 /obj/machinery/cell_charger_multi/update_overlays()
 	. = ..()
 
@@ -31,13 +35,14 @@
 		. += new /mutable_appearance(charge_overlay)
 		. += new /mutable_appearance(cell_overlay)
 
-/obj/machinery/cell_charger_multi/CtrlShiftClick(mob/user)
+/obj/machinery/cell_charger_multi/RightClick(mob/user)
 	. = ..()
 	if(!can_interact(user))
 		return
 	to_chat(user, "<span class='notice'>You press the quick release as all the cells pop out!</span>")
 	for(var/i in charging_batteries)
 		removecell()
+	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/cell_charger_multi/examine(mob/user)
 	. = ..()
@@ -49,10 +54,10 @@
 			. += "There's [charging] cell in the charger, current charge: [round(charging.percent(), 1)]%."
 	if(in_range(user, src) || isobserver(user))
 		. += "<span class='notice'>The status display reads: Charging power: <b>[charge_rate]W</b>.</span>"
-	. += "<span class='notice'>Ctrl+shift click it to remove all the cells at once!</span>"
+	. += "<span class='notice'>Right click it to remove all the cells at once!</span>"
 
-/obj/machinery/cell_charger_multi/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/stock_parts/cell) && !panel_open)
+/obj/machinery/cell_charger_multi/attackby(obj/item/tool, mob/user, params)
+	if(istype(tool, /obj/item/stock_parts/cell) && !panel_open)
 		if(machine_stat & BROKEN)
 			to_chat(user, "<span class='warning'>[src] is broken!</span>")
 			return
@@ -63,24 +68,24 @@
 			to_chat(user, "<span class='warning'>[src] is full, and cannot hold anymore cells!</span>")
 			return
 		else
-			var/area/a = loc.loc // Gets our locations location, like a dream within a dream
-			if(!isarea(a))
+			var/area/current_area = loc.loc // Gets our locations location, like a dream within a dream
+			if(!isarea(current_area))
 				return
-			if(a.power_equip == 0) // There's no APC in this area, don't try to cheat power!
+			if(current_area.power_equip == 0) // There's no APC in this area, don't try to cheat power!
 				to_chat(user, "<span class='warning'>[src] blinks red as you try to insert the cell!</span>")
 				return
-			if(!user.transferItemToLoc(W,src))
+			if(!user.transferItemToLoc(tool,src))
 				return
 
-			charging_batteries += W
+			charging_batteries += tool
 			user.visible_message("<span class='notice'>[user] inserts a cell into [src].</span>", "<span class='notice'>You insert a cell into [src].</span>")
 			update_appearance()
 	else
-		if(!charging_batteries.len && default_deconstruction_screwdriver(user, icon_state, icon_state, W))
+		if(!charging_batteries.len && default_deconstruction_screwdriver(user, icon_state, icon_state, tool))
 			return
-		if(default_deconstruction_crowbar(W))
+		if(default_deconstruction_crowbar(tool))
 			return
-		if(!charging_batteries.len && default_unfasten_wrench(user, W))
+		if(!charging_batteries.len && default_unfasten_wrench(user, tool))
 			return
 		return ..()
 

--- a/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
@@ -39,6 +39,10 @@
 		. += new /mutable_appearance(charge_overlay)
 		. += new /mutable_appearance(cell_overlay)
 
+/obj/machinery/cell_charger_multi/CtrlShiftClick(mob/user) // Remove this after like a month - starting 11-Jun-21
+	. = ..()
+	to_chat(user, "<span class='warning'>This action has been moved to Right Click.</span>")
+
 /obj/machinery/cell_charger_multi/RightClick(mob/user)
 	. = ..()
 	if(!can_interact(user) || !charging_batteries.len)

--- a/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
@@ -17,7 +17,11 @@
 
 /obj/machinery/cell_charger_multi/Initialize()
 	. = ..()
-	RegisterSignal(src, COMSIG_PARENT_ATTACKBY, .proc/RightClick)
+	RegisterSignal(src, COMSIG_PARENT_ATTACKBY, /atom.proc/RightClick)
+
+/obj/machinery/cell_charger_multi/Destroy()
+	UnregisterSignal(src, COMSIG_PARENT_ATTACKBY)
+	. = ..()
 
 /obj/machinery/cell_charger_multi/update_overlays()
 	. = ..()
@@ -37,7 +41,7 @@
 
 /obj/machinery/cell_charger_multi/RightClick(mob/user)
 	. = ..()
-	if(!can_interact(user))
+	if(!can_interact(user) || !charging_batteries.len)
 		return
 	to_chat(user, "<span class='notice'>You press the quick release as all the cells pop out!</span>")
 	for(var/i in charging_batteries)


### PR DESCRIPTION
## About The Pull Request

Title. Might move cell removal from the component to right click also but that's outside the scope of this PR. Adds a warning that the action has been rebound to right click when the old binding is used (can remove this in a month or so)

Also small code cleanup with variable names.

## Why It's Good For The Game

Gets rid of an unnecessarily complex keybind.

## Changelog
:cl:
qol: Multi-cell chargers now dump all their cells with right-click instead of Ctrl+Shift+Click
/:cl: