### PR TITLE
Security Officers now spawn with Disablers instead of Sidearms

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -196,8 +196,8 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	shoes = /obj/item/clothing/shoes/combat/peacekeeper //SKYRAT EDIT CHANGE - SEC_HAUL
 	l_pocket = /obj/item/restraints/handcuffs
 	r_pocket = /obj/item/assembly/flash/handheld
-	//suit_store = /obj/item/gun/energy/disabler //SKYRAT EDIT REMOVAL - SEC_HAU&L
-	backpack_contents = list(/obj/item/melee/classic_baton/peacekeeper, /obj/item/armament_token/sidearm) //SKYRAT EDIT CHANGE - SEC_HAUL - ORIGINAL: backpack_contents = list(/obj/item/melee/baton/loaded=1)
+	suit_store = /obj/item/gun/energy/disabler
+	backpack_contents = list(/obj/item/melee/classic_baton/peacekeeper) //SKYRAT EDIT CHANGE - SEC_HAUL - ORIGINAL: backpack_contents = list(/obj/item/melee/baton/loaded=1)
 
 	backpack = /obj/item/storage/backpack/security/peacekeeper //SKYRAT EDIT CHANGE - SEC_HAUL - ORIGINAL: backpack = /obj/item/storage/backpack/security
 	satchel = /obj/item/storage/backpack/satchel/sec/peacekeeper //SKYRAT EDIT CHANGE - SEC_HAUL

--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
@@ -60,6 +60,7 @@
 	name = "sidearm armament holochip"
 	desc = "A holochip used in any armament vendor, this is for sidearms. Do not bend."
 	icon_state = "token_sidearm"
+	minimum_sec_level = SEC_LEVEL_BLUE
 
 /obj/item/armament_token/sidearm/get_available_gunsets()
 	return list(


### PR DESCRIPTION

## About The Pull Request

Security Officers now spawn with disablers instead of sidearm tokens. Additionally sidearm tokens are now restricted to blue and above security levels.

## Why It's Good For The Game

Security having lethal capable weapons round start strikes me as strange. As a target of security you don't know whether or not lethals are loaded from a glance. As a security officer, healing the person you shot after the engagement is annoying and it's hard to tell when shots fired from a distance are excessive force or not.

Disablers are unambiguously non-lethal and seem a lot more appropriate as a roundstart ranged takedown option.

The intent isn't to remove ballistic sec, but to give energy weapons more of a presence within security again where it makes sense, such as in the case of non-lethally taking down suspects. 

## Changelog
:cl: Tupinambis
balance: Security Officers now start with disablers. Sidearm tokens now restricted to security level blue.
/:cl: