### PR TITLE
Amber alert energy weapons, and the return of the energy gun.

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/gunsets.dm
@@ -357,6 +357,12 @@
 	. = ..()
 	new /obj/item/gun/energy/laser(src)
 
+/obj/item/storage/box/gunset/e_gun
+
+/obj/item/storage/box/gunset/e_gun/PopulateContents()
+	. = ..()
+	new /obj/item/gun/energy/e_gun(src)
+
 //PEPPERBALLS
 /obj/item/storage/box/gunset/pepperball
 	name = "pepperball supply box"

--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
@@ -146,13 +146,17 @@
 	desc = "A holochip used in any armament vendor, this is for energy weapons. Do not bend."
 	icon_state = "token_energy"
 	custom_premium_price = PAYCHECK_HARD * 3
-	minimum_sec_level = SEC_LEVEL_RED
+	minimum_sec_level = SEC_LEVEL_AMBER
 
 /obj/item/armament_token/energy/get_available_gunsets()
 	return list(
 	/obj/item/storage/box/gunset/laser = image(
 		icon = 'modular_skyrat/modules/sec_haul/icons/guns/gunsets.dmi',
 		icon_state = "laser"
+		),
+	/obj/item/storage/box/gunset/e_gun = image(
+		icon = 'modular_skyrat/modules/sec_haul/icons/guns/gunsets.dmi',
+		icon_state = "blaster"
 		)
 	)
 


### PR DESCRIPTION
## About The Pull Request

Energy weapons are now authorized at security level amber, and energy guns are now available at vendors with the use of an energy weapon token.

## Why It's Good For The Game

We have three security tokens for energy weapons... of which the only option is the laser gun. This adds the option for the use of the energy gun which has a disabler setting at the cost of overall efficiency.

Additionally, energy weapons fall behind the lethal ballistics in terms of usefulness and are almost always overlooked in red alert situations. Amber seems to be a good niche for them to fill relative to their power level.

## Changelog
:cl: Tupinambis
balance: Energy weapon tokens are now locked to Amber instead of Red security. 
balance: Energy guns may now be acquired using energy weapon tokens.
/:cl: