### PR TITLE
Demilitarizes Expeditionary Troopers.

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -57,7 +57,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		"Scientist" = 31,
 		"Roboticist" = 32,
 		"Geneticist" = 33,
-		"Vanguard Operative" = 34, //SKYRAT EDIT ADDITION
+		"Expeditionist" = 34, //SKYRAT EDIT ADDITION
 		// 40-49: Engineering
 		"Chief Engineer" = 40,
 		"Station Engineer" = 41,

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -57,7 +57,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		"Scientist" = 31,
 		"Roboticist" = 32,
 		"Geneticist" = 33,
-		"Expeditionist" = 34, //SKYRAT EDIT ADDITION
+		"Vanguard Explorer" = 34, //SKYRAT EDIT ADDITION
 		// 40-49: Engineering
 		"Chief Engineer" = 40,
 		"Station Engineer" = 41,

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -28,7 +28,7 @@ GLOBAL_LIST_INIT(science_positions, list(
 	"Scientist",
 	"Geneticist",
 	"Roboticist",
-	"Vanguard Operative")) //SKYRAT EDIT ADDITION
+	"Expeditionist")) //SKYRAT EDIT ADDITION
 
 
 GLOBAL_LIST_INIT(supply_positions, list(

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -28,7 +28,7 @@ GLOBAL_LIST_INIT(science_positions, list(
 	"Scientist",
 	"Geneticist",
 	"Roboticist",
-	"Expeditionist")) //SKYRAT EDIT ADDITION
+	"Vanguard Explorer")) //SKYRAT EDIT ADDITION
 
 
 GLOBAL_LIST_INIT(supply_positions, list(

--- a/modular_skyrat/master_files/code/datums/id_trim/jobs.dm
+++ b/modular_skyrat/master_files/code/datums/id_trim/jobs.dm
@@ -135,7 +135,7 @@
 		access |= list(ACCESS_MAINT_TUNNELS)
 
 /datum/id_trim/job/expeditionary_trooper
-	assignment = "Expeditionist"
+	assignment = "Vanguard Explorer"
 	trim_icon = 'modular_skyrat/master_files/icons/obj/card.dmi'
 	trim_state = "trim_expeditionarytrooper"
 	full_access = list(ACCESS_MAINT_TUNNELS, ACCESS_EVA, ACCESS_EXTERNAL_AIRLOCKS, ACCESS_TELEPORTER, ACCESS_GATEWAY, ACCESS_TECH_STORAGE,

--- a/modular_skyrat/master_files/code/datums/id_trim/jobs.dm
+++ b/modular_skyrat/master_files/code/datums/id_trim/jobs.dm
@@ -135,7 +135,7 @@
 		access |= list(ACCESS_MAINT_TUNNELS)
 
 /datum/id_trim/job/expeditionary_trooper
-	assignment = "Vanguard Operative"
+	assignment = "Expeditionist"
 	trim_icon = 'modular_skyrat/master_files/icons/obj/card.dmi'
 	trim_state = "trim_expeditionarytrooper"
 	full_access = list(ACCESS_MAINT_TUNNELS, ACCESS_EVA, ACCESS_EXTERNAL_AIRLOCKS, ACCESS_TELEPORTER, ACCESS_GATEWAY, ACCESS_TECH_STORAGE,

--- a/modular_skyrat/modules/exp_corps/code/clothing.dm
+++ b/modular_skyrat/modules/exp_corps/code/clothing.dm
@@ -3,8 +3,7 @@
 	icon_state = "exp_corps"
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/uniforms.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/uniform.dmi'
-	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 10, RAD = 10, FIRE = 30, ACID = 30, WOUND = 10)
-	strip_delay = 70
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, RAD = 10, FIRE = 50, ACID = 20)
 	alt_covers_chest = TRUE
 	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
@@ -33,13 +32,14 @@
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/feet.dmi'
 	icon_state = "exp_corps"
 	inhand_icon_state = "exp_corps"
-	armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 40, BOMB = 40, BIO = 0, RAD = 40, FIRE = 80, ACID = 100, WOUND = 30)
+	armor = list(MELEE = 5, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 10, BIO = 10, RAD = 10, FIRE = 50, ACID = 50)
 
 /obj/item/clothing/gloves/combat/expeditionary_corps
 	name = "expeditionary corps gloves"
 	icon_state = "exp_corps"
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/gloves.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/hands.dmi'
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 
 /obj/item/storage/backpack/duffelbag/expeditionary_corps
 	name = "expeditionary corps bag"
@@ -58,7 +58,7 @@
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
 	body_parts_covered = CHEST|GROIN|ARMS
-	armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 40, BOMB = 40, BIO = 0, RAD = 40, FIRE = 80, ACID = 100, WOUND = 30)
+	armor = list(MELEE = 30, BULLET = 10, LASER = 10, ENERGY = 20, BOMB = 40, BIO = 0, RAD = 40, FIRE = 50, ACID = 75, WOUND = 15)
 	cold_protection = CHEST|GROIN|ARMS
 	heat_protection = CHEST|GROIN|ARMS
 	dog_fashion = null
@@ -70,21 +70,20 @@
 		/obj/item/gun,
 		/obj/item/kitchen/knife,
 		/obj/item/reagent_containers,
-		/obj/item/restraints/handcuffs,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman
 		)
 
 /obj/item/clothing/suit/space/hardsuit/expeditionary_corps
 	name = "expeditionary corps hardsuit"
-	desc = "An advanced hardsuit designed for exploratory missions."
+	desc = "A lightweight hardsuit designed for exploration missions."
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
 	icon_state = "hardsuit-hexp_corps"
 	inhand_icon_state = "eng_hardsuit"
 	hardsuit_type = "hexp_corps"
-	armor = list(MELEE = 42, BULLET = 42, LASER = 42, ENERGY = 42, BOMB = 60, BIO = 0, RAD = 100, FIRE = 80, ACID = 100, WOUND = 30)
-	allowed = list(/obj/item/gun, /obj/item/ammo_box,/obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/transforming/energy/sword/saber, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
+	armor = list(MELEE = 25, BULLET = 5, LASER = 10, ENERGY = 20, BOMB = 50, BIO = 100, RAD = 50, FIRE = 50, ACID = 75, WOUND = 15)
+	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/flashlight, /obj/item/tank/internals, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/expeditionary_corps
 	jetpack = /obj/item/tank/jetpack/suit
 	cell = /obj/item/stock_parts/cell/hyper
@@ -93,13 +92,13 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/expeditionary_corps
 	name = "expeditionary corps hardsuit helmet"
-	desc = "An advanced hardsuit helmet designed for exploratory missions."
+	desc = "A lightweight hardsuit helmet designed for exploration missions."
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/hats.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/head.dmi'
 	icon_state = "hardsuit0-hexp_corps"
 	inhand_icon_state = "sec_helm"
 	hardsuit_type = "hexp_corps"
-	armor = list(MELEE = 42, BULLET = 42, LASER = 42, ENERGY = 42, BOMB = 60, BIO = 0, RAD = 100, FIRE = 80, ACID = 100, WOUND = 30)
+	armor = list(MMELEE = 25, BULLET = 5, LASER = 10, ENERGY = 20, BOMB = 50, BIO = 100, RAD = 50, FIRE = 50, ACID = 75, WOUND = 15)
 	visor_flags_inv = HIDEMASK|HIDEEYES|HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 	visor_flags = STOPSPRESSUREDAMAGE
 	slowdown = 0.5
@@ -110,7 +109,7 @@
 	icon_state = "exp_corps"
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/hats.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/head.dmi'
-	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 30, BIO = 0, RAD = 40, FIRE = 80, ACID = 100, WOUND = 30)
+	armor = list(MELEE = 30, BULLET = 10, LASER = 10, ENERGY = 20, BOMB = 40, BIO = 0, RAD = 40, FIRE = 50, ACID = 75, WOUND = 15)
 	mutant_variants = NONE
 	var/nightvision = FALSE
 	var/mob/living/carbon/current_user

--- a/modular_skyrat/modules/exp_corps/code/expeditionary_trooper.dm
+++ b/modular_skyrat/modules/exp_corps/code/expeditionary_trooper.dm
@@ -1,5 +1,5 @@
 /datum/job/expeditionary_trooper
-	title = "Expeditionist"
+	title = "Vanguard Explorer"
 	department_head = list("Captain")
 	faction = "Station"
 	total_positions = 4
@@ -24,11 +24,11 @@
 
 /datum/job/expeditionary_trooper/after_spawn(mob/living/carbon/human/H, mob/M)
 	. = ..()
-	to_chat(M, "<span class='redtext'>As an Expeditionist you are not part of security! You must not perform security duties unless absolutely nessecary. \
+	to_chat(M, "<span class='redtext'>As a Vanguard Explorer you are not part of security! You must not perform security duties unless absolutely nessecary. \
 	Do not valid hunt using your equipment. Use common sense. Failure to follow these simple rules will result in a job ban.")
 
 /datum/outfit/job/expeditionary_trooper
-	name = "Expeditionist"
+	name = "Vanguard Explorer"
 	jobtype = /datum/job/expeditionary_trooper
 
 	shoes = /obj/item/clothing/shoes/combat/expeditionary_corps
@@ -50,7 +50,7 @@
 	belt = /obj/item/pda/expeditionary_corps
 
 /obj/effect/landmark/start/expeditionary_corps
-	name = "Expeditionist"
+	name = "Vanguard Explorer"
 	icon_state = "Security Officer"
 
 /obj/item/pda/expeditionary_corps

--- a/modular_skyrat/modules/exp_corps/code/expeditionary_trooper.dm
+++ b/modular_skyrat/modules/exp_corps/code/expeditionary_trooper.dm
@@ -1,5 +1,5 @@
 /datum/job/expeditionary_trooper
-	title = "Vanguard Operative"
+	title = "Expeditionist"
 	department_head = list("Captain")
 	faction = "Station"
 	total_positions = 4
@@ -24,11 +24,11 @@
 
 /datum/job/expeditionary_trooper/after_spawn(mob/living/carbon/human/H, mob/M)
 	. = ..()
-	to_chat(M, "<span class='redtext'>As a Vanguard Operative you are not part of security! You must not perform security duties unless absolutely nessecary. \
+	to_chat(M, "<span class='redtext'>As an Expeditionist you are not part of security! You must not perform security duties unless absolutely nessecary. \
 	Do not valid hunt using your equipment. Use common sense. Failure to follow these simple rules will result in a job ban.")
 
 /datum/outfit/job/expeditionary_trooper
-	name = "Vanguard Operative"
+	name = "Expeditionist"
 	jobtype = /datum/job/expeditionary_trooper
 
 	shoes = /obj/item/clothing/shoes/combat/expeditionary_corps
@@ -50,7 +50,7 @@
 	belt = /obj/item/pda/expeditionary_corps
 
 /obj/effect/landmark/start/expeditionary_corps
-	name = "Vanguard Operative"
+	name = "Expeditionist"
 	icon_state = "Security Officer"
 
 /obj/item/pda/expeditionary_corps
@@ -85,7 +85,7 @@
 	max_integrity = 5000
 
 /obj/structure/closet/crate/secure/exp_corps/PopulateContents()
-	new /obj/item/storage/firstaid/tactical(src)
+	new /obj/item/storage/firstaid/advanced(src)
 	new /obj/item/storage/box/expeditionary_survival(src)
 	new /obj/item/clothing/suit/space/hardsuit/expeditionary_corps(src)
 	new /obj/item/radio(src)

--- a/modular_skyrat/modules/exp_corps/code/tomahawk.dm
+++ b/modular_skyrat/modules/exp_corps/code/tomahawk.dm
@@ -8,9 +8,9 @@
 	righthand_file = 'modular_skyrat/modules/exp_corps/icons/tomahawk_r.dmi'
 	worn_icon = 'modular_skyrat/modules/exp_corps/icons/tomahawk_worn.dmi'
 	flags_1 = CONDUCT_1
-	force = 25
+	force = 18
 	w_class = WEIGHT_CLASS_SMALL
-	throwforce = 25
+	throwforce = 18
 	throw_speed = 4
 	throw_range = 8
 	embedding = list("pain_mult" = 6, "embed_chance" = 60, "fall_chance" = 10)


### PR DESCRIPTION
## About The Pull Request

Renames "Vanguard Operatives" to "Vanguard Explorers" to better reflect their intended purpose. Let me know if you have a better name for them though.

Drastically reduces the armor of all "Vanguard Explorer" Gear to be more in line with mining equipment, and adjusts some of the suit slot options to be more exploration friendly. Additionally reduces the tomahawk's damage from a super strong 25 to a more sensible 18 and also replaces tactical medkit with advanced ones.

![image](https://user-images.githubusercontent.com/42078130/121790566-5f5ef380-cba6-11eb-9202-cc6ddd86371f.png)

## Why It's Good For The Game

The Expeditionary Corps are about exploring and scavenging, so it makes absolutely no sense why they have syndicate+ tier gear. This addresses that and gives them a name more fitting to the role's purpose. On top of that most maps are and should be designed in such a way that you scavenge gear to help deal with tougher threats, and when Vanguard Explorers start out with too much power it breaks that flow.

This also encourages the Vanguard Explorers to actually interact with the station a bit more to get extra supplies and such.

## Changelog
:cl: Tupinambis
tweak: Vanguard Operatives have been renamed to Vanguard Explorers.
balance: Expeditionary Corps armor has had its armor lowered to roughtly miner hardsuit equivalent levels. Slight alterations to suit slot options.
balance: Tomahawk damage from 25 -> 18 to be in between survival and combat knives.
/:cl: