### PR TITLE
[Non-Modular] Ghostroles Now Apply Their Loadout Correctly

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -272,6 +272,8 @@
 		H.dna.species.before_equip_job(null, H)
 		H.regenerate_icons()
 		SSquirks.AssignQuirks(H, user.client, TRUE, TRUE, null, FALSE, H)
+		user.client.prefs.equip_preference_loadout(H, FALSE, null)
+		user.client.prefs.add_packed_items(H, null, FALSE)
 	else
 		if(!random || newname)
 			if(newname)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Implements the loadout for ghostroles, as I originally intended wayy back with the quirk PR (but was too smallbrained to do)
I don't see this as problematic for the feature freeze considering it's simply bringing parity with the character event spawner and is expanding the use of a feature we already use. Tested with the syndicate prisoner role and worked just fine!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to stylize is.. nice... 😳 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: Ghostroles now have their loadouts applied to them, bringing complete feature parity with character event spawners.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
