### PR TITLE
moves a misplaced vendor + fixes minor piping mishap in sec

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -28890,8 +28890,9 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "hEm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/vending/security_peacekeeper,
-/obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "hEs" = (
@@ -91456,7 +91457,7 @@ iXb
 iXb
 ygN
 iXb
-iXb
+hEm
 mfe
 xdg
 wlA
@@ -91713,7 +91714,7 @@ iNC
 aNC
 und
 cSP
-hEm
+rMM
 iKG
 ktk
 rMM


### PR DESCRIPTION
## About The Pull Request

moved a funny little vendor in the sec equipment room that got a little out of line and decided to block an airlock. also added scrubber and vent pipes under where said vendor was, because apparently they didn't exist. until i fixed it.

## Why It's Good For The Game

it is not very enjoyable having to go through the armory and manually shove this vendor back into place every shift on ice box!

chicka boo-yah! (funny quip for nineball)

![unknown](https://user-images.githubusercontent.com/84609863/122012153-79552d80-cd82-11eb-87c7-f96728c83849.png)

## Changelog
:cl:
fix: moved vendor + fixed atmos piping in sec
/:cl:
