### PR TITLE
Makes stasis units only play the power sound when they're actually putting someone in stasis

### DIFF
--- a/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
+++ b/modular_skyrat/modules/stasisrework/code/game/machinery/stasissleeper.dm
@@ -28,18 +28,19 @@
 	if(!state_open && !panel_open)
 		if(occupant)
 			thaw_them(occupant)
+			play_power_sound()
 		playsound(src, 'sound/machines/click.ogg', 60, TRUE)
-		play_power_sound()
 		flick("[initial(icon_state)]-anim", src)
 		..()
 
 /obj/machinery/stasissleeper/close_machine(mob/user)
 	if((isnull(user) || istype(user)) && state_open && !panel_open)
-		play_power_sound()
 		playsound(src, 'sound/machines/click.ogg', 60, TRUE)
 		flick("[initial(icon_state)]-anim", src)
 		..(user)
 		var/mob/living/mob_occupant = occupant
+		if(occupant)
+			play_power_sound()
 		if(mob_occupant && mob_occupant.stat != DEAD)
 			to_chat(mob_occupant, "[enter_message]")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Stasis units only power up when there is someone to put on stasis.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
