### PR TITLE
You can unachor the gun vendor now

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
@@ -12,6 +12,10 @@
 	max_integrity = 2000
 	density = TRUE
 
+/obj/structure/gun_vendor/wrench_act(mob/living/user, obj/item/item)
+	default_unfasten_wrench(user, item, 120)
+	return TRUE
+
 /obj/machinery/gun_vendor/attacked_by(obj/item/I, mob/living/user)
 	if(istype(I, /obj/item/armament_token))
 		RedeemToken(I, user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Puts a basic wrench unfasten on the gun vendor.

I considered making these buildable or cargo bought (which makes more sense since it should be coming directly from Armadyne) but I felt that made gun smuggling too easy. 

Contact Centcomm directly for a replacement vendor if you lose yours.

## Why It's Good For The Game

Consistency since every other vendor in the game can be moved around
The vendor can be stolen now without forcing me to ahelp
Makes the absolute monopoly on armoury weapons that security has a little less ridiculous

## Changelog
:cl: YakumoChen
qol: you can unanchor the gun vendor with a wrench. Better make sure nobody steals it...
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
