### PR TITLE
Revert "[Non-Modular] Ghostroles Now Apply Their Loadout Correctly"

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -272,8 +272,6 @@
 		H.dna.species.before_equip_job(null, H)
 		H.regenerate_icons()
 		SSquirks.AssignQuirks(H, user.client, TRUE, TRUE, null, FALSE, H)
-		user.client.prefs.equip_preference_loadout(H, FALSE, null)
-		user.client.prefs.add_packed_items(H, null, FALSE)
 	else
 		if(!random || newname)
 			if(newname)


### PR DESCRIPTION
This needs tweaking - As in, ghost role items should override loadout items.