### PR TITLE
Moving the cargo chatroom and supply request console. (Metastation)

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -159,7 +159,16 @@
 "aaK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/bounty_board/directional/east,
-/turf/open/floor/iron/white,
+/obj/machinery/computer/cargo/request{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/medical/medbay/central)
 "aaP" = (
 /obj/structure/table,
@@ -22563,7 +22572,16 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
+/obj/machinery/modular_computer/console/preset/cargochat/medical{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/medical/medbay/central)
 "cus" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -45000,16 +45018,17 @@
 	dir = 4
 	},
 /obj/machinery/duct,
-/obj/machinery/computer/cargo/request{
-	dir = 4
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "kfZ" = (
 /obj/structure/table/wood,
@@ -45358,16 +45377,16 @@
 /obj/structure/sign/warning/coldtemp{
 	pixel_y = 32
 	},
-/obj/machinery/modular_computer/console/preset/cargochat/medical{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "kno" = (
 /obj/effect/landmark/start/bartender,


### PR DESCRIPTION
## About The Pull Request

Moves medbay's cargo chatroom and supply request console to the medbay central hallway, rather than blocking a maintenance airlock in the exam room.

## Why It's Good For The Game

Allows access to a previously blocked airlock.

![medbay](https://user-images.githubusercontent.com/84609863/122197805-2e104d00-ce5e-11eb-8963-82ab35a3b8f8.png)

## Changelog
:cl:
fix: Moved the cargo chatroom and supply request console.
/:cl: