### PR TITLE
Effectively disables spiders from rolling mid-round.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -723,6 +723,7 @@
 	requirements = list(101,101,101,80,60,50,30,20,10,10)
 	repeatable = TRUE
 	var/spawncount = 2
+	minimum_players = 999 //SKYRAT EDIT ADDITION - SALT PR
 
 /datum/dynamic_ruleset/midround/spiders/execute()
 	create_midwife_eggs(spawncount)


### PR DESCRIPTION

## About The Pull Request

Makes it so that Skyrat requires 999 players for Spiders to occur mid-round. Make sure you bring a friend so this can roll!

## Why It's Good For The Game

>be spider with a brain the size of a dog
>be smart enough to somehow figure out that, despite having no need for lights nor being affected by it, that I should be smashing every glass object that emits light
>be smart enough to somehow figure out that there is a non-organic lifeform watching us and that destroying the swivelling metal things near the top of the ceiling on the wall will help us
>be smart enough to somehow figure out that gygax plates are important and do everything I can to keep them out of the hands of robotisists
>be smart enough to somehow understand that these glowing boxes on walls are very important to the station's functionality
>be smart enough to somehow understand that these tanks of liquids are also important to the station's functionality, and that they should be spilled as much as they can
>be smart enough to somehow understand that the area with the 6 airlocks next to the chapel called "departures" is very important even though I don't know why, and that that I should consistently make my nest next to it just in case they need to leave.
>be smart enough to somehow have no self-preservation because for some reason I know that I will be reborn again, somehow, even though I won't be the same person.
>be spider with a brain the size of a dog
>still smarter than whoever thinks that spiders are a good mid-round antagonist type and that any amount of policy would change this
>still smarter than whoever thinks that spiders can be a great gamemode as long as people ahelp the very specific spider (546) in the middle of combat with spider (536), spider (754), spider (453), spider (634), and spider (758)

For some reason we removed Ninja because of validhunters, powergames, and moderate lack of roleplay on both sides, yet we're keeping Spiders, a mid-round event famous for validhunting and powergaming (not to mention the constant rulebreaking), as well as it nearly being completely devoid of rp because of the language barrier as well as the strong desire for security and assistants to unga.

Honestly I think every other round containing spiders also contains an announcement from a very annoyed admin stating that spiders are supposed to be animals and not understanding of the nuisances of destroying a watertank to make security slip so that their guns can be stolen. It doesn't seem to be registering within the community and I don't think it ever will. A lot of mechanics/features/ect have been removed for much less.

Only one good thing came out of spiders, and it's Wooo.

## Changelog
:cl: BurgerBB
del: Removes spiders from mid-round rotation.
/:cl: