### PR TITLE
[Modular] De-Trivializing Medbay - Medical Beamguns

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -89,14 +89,6 @@
 	contains = list(/obj/item/defibrillator/compact)
 	crate_name = "compact defibrillator crate"
 
-/datum/supply_pack/medical/medigun
-	name = "Experimental Medical Beam Crate"
-	desc = "Contains a single experimental NT-tech Medical Beam Gun, a highly experimental device capable of sending temporary healing nanites across a short distance."
-	cost = CARGO_CRATE_VALUE * 75
-	access = ACCESS_CMO
-	contains = list(/obj/item/gun/medbeam)
-	crate_name = "medical beam gun crate"
-
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Security ////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All this does is remove the ability to purchase medical beamguns from cargo. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

These weapons are incredibly powerful tools reserved for ERTs, Syndicate Borgs, and space/gateway traversal. The way medbay actually farms these (putting a bounty console next to the lathe and printing organs/killing monkeys) has 0 risk or exploration involved for what invalidates a lot of medbay's existence.

I'm totally aware this is going to piss a lot of people off, but I'm tired of medical doing nothing, getting a free healies gun, and invalidating all the work chemists, virologists, surgeons, and paramedics do. Medibots are next.

BTW anyone who dislikes this change is bad at med 😎 (joke)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: The Medical Beamgun is no longer available at cargo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
