### PR TITLE
[NON-MODULAR] changes map voting to exclude both box maps if one would be excluded

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -122,12 +122,12 @@ SUBSYSTEM_DEF(persistence)
 				run++
 		if(run >= 2) //If run twice in the last KEEP_ROUNDS_MAP + 1 (including current) rounds, disable map for voting and rotation.
 			blocked_maps += VM.map_name
-		//SKYRAT EDIT START - this way to do this sucks, but i don't expect icebox or journey to get renamed anytime soon
-		if(VM.map_name == "Ice Box Station")
-			blocked_maps += "NSS Journey"
-		if(VM.map_name == "NSS Journey")
-			blocked_maps += "Ice Box Station"
-		//SKYRAT EDIT END
+			//SKYRAT EDIT START - this way to do this sucks, but i don't expect icebox or journey to get renamed anytime soon
+			if(VM.map_name == "Ice Box Station")
+				blocked_maps += "NSS Journey"
+			if(VM.map_name == "NSS Journey")
+				blocked_maps += "Ice Box Station"
+			//SKYRAT EDIT END
 
 /datum/controller/subsystem/persistence/proc/SetUpTrophies(list/trophy_items)
 	for(var/A in GLOB.trophy_cases)

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -122,6 +122,12 @@ SUBSYSTEM_DEF(persistence)
 				run++
 		if(run >= 2) //If run twice in the last KEEP_ROUNDS_MAP + 1 (including current) rounds, disable map for voting and rotation.
 			blocked_maps += VM.map_name
+		//SKYRAT EDIT START - this way to do this sucks, but i don't expect icebox or journey to get renamed anytime soon
+		if(VM.map_name == "Ice Box Station")
+			blocked_maps += "NSS Journey"
+		if(VM.map_name == "NSS Journey")
+			blocked_maps += "Ice Box Station"
+		//SKYRAT EDIT END
 
 /datum/controller/subsystem/persistence/proc/SetUpTrophies(list/trophy_items)
 	for(var/A in GLOB.trophy_cases)

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -122,7 +122,7 @@ SUBSYSTEM_DEF(persistence)
 				run++
 		if(run >= 2) //If run twice in the last KEEP_ROUNDS_MAP + 1 (including current) rounds, disable map for voting and rotation.
 			blocked_maps += VM.map_name
-			//SKYRAT EDIT START - this way to do this sucks, but i don't expect icebox or journey to get renamed anytime soon
+			//SKYRAT EDIT START
 			if(VM.map_name == "Ice Box Station")
 				blocked_maps += "NSS Journey"
 			if(VM.map_name == "NSS Journey")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title. If either icebox or journey is put on the blocked_maps list, the other one will be as well. (the blocked_maps list handles excluding maps from voting and rotation)

## Why It's Good For The Game

icebox and journey are fundamentally the same map; not having this change can, and has, lead to streaks of only box being played, which is part of what the blocked_maps list is designed to prevent.

"well actually icebox is multi-Z and journey isn't" fuck off immensely. the fact that the phrase "box maps" is understood to refer to both of them illustrates that they are the same map for >90% of intents and purposes.

## Changelog
:cl:
fix: box maps are treated as one map for map voting/rotation purposes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
