### PR TITLE
Adds the blueshield (And just the blueshield) to the veteran crew list.

### DIFF
--- a/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
@@ -30,6 +30,8 @@
 		/obj/item/clothing/head/collectable/captain = 4,
 		/obj/projectile/bullet/b460 = 1
 	)
+	
+	veteran_only = TRUE
 
 /datum/outfit/job/blueshield
 	name = "Blueshield"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
gaming
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
After #6242, I've not seen a single person say adding the blueshield to the veteran crew list was bad, and most people agreed that blueshield is one of the roles that should very much be on there. Like Vanguards, it's not a security role, and veteran crew are trusted to not abuse their roles to validhunt. Obviously, I'm not policy team, but, I'm very confident this is the right play here. Especially considering the NT Rep PR.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
idfk what to mark this as in my changelog that doesn't even work so I'm just not gonna and save my GBP 😎 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
