### PR TITLE
ports back the cit disabling of regen jelly no long permanently changing someone's hair color

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1071,7 +1071,8 @@
 	var/mob/living/carbon/human/exposed_human = exposed_mob
 	exposed_human.hair_color = "C2F"
 	exposed_human.facial_hair_color = "C2F"
-	exposed_human.update_hair() */ skyrat edit 
+	exposed_human.update_hair()
+**/ // SKYRAT EDIT END 
 	
 
 /datum/reagent/medicine/regen_jelly/on_mob_life(mob/living/carbon/M, delta_time, times_fired)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1067,13 +1067,11 @@
 	if(!ishuman(exposed_mob) || (reac_volume < 0.5))
 		return
 
-	var/mob/living/carbon/human/exposed_human = exposed_mob
+	/* var/mob/living/carbon/human/exposed_human = exposed_mob
 	exposed_human.hair_color = "C2F"
 	exposed_human.facial_hair_color = "C2F"
-	exposed_human.update_hair()
-	// SKYRAT EDIT ADDITION BEGIN
-	exposed_human.update_mutant_bodyparts(force_update=TRUE)
-	// SKYRAT EDIT END
+	exposed_human.update_hair() */ skyrat edit 
+	
 
 /datum/reagent/medicine/regen_jelly/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjustBruteLoss(-1.5 * REM * delta_time, 0)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1067,7 +1067,8 @@
 	if(!ishuman(exposed_mob) || (reac_volume < 0.5))
 		return
 
-	/* var/mob/living/carbon/human/exposed_human = exposed_mob
+/** SKYRAT EDIT BEGIN - Regen Jelly no longer overrides hair color
+	var/mob/living/carbon/human/exposed_human = exposed_mob
 	exposed_human.hair_color = "C2F"
 	exposed_human.facial_hair_color = "C2F"
 	exposed_human.update_hair() */ skyrat edit 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

regen jelly no longer makes your hair permanently purple 

## Why It's Good For The Game

on tg its just a slight thing that no one really cares about, but on a player base like ours being someone with white fur but you're given what's support to be a healing chem just permanently changes your hair to be a mismatched purple. changing the color of some one is such a minor thing but its the major reason its avoided on this server. we already removed it back on old base years ago because we saw the problem then. this wasn't suppose to be such a major detriment, but in our environment it is. 

## Changelog
:cl:
del: removed regen jelly permanently making your hair purple 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
