### PR TITLE
[NON-MODULAR] Fixes heretic books created by the ritual coming with charges.  

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_book.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_book.dm
@@ -144,3 +144,6 @@
 
 /obj/item/forbidden_book/debug
 	charge = 100
+
+/obj/item/forbidden_book/ritual  //SKYRAT EDIT
+	charge = 0

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -320,5 +320,5 @@
 	gain_text = "Their hand is at your throat, yet you see Them not."
 	cost = 0
 	required_atoms = list(/obj/item/organ/eyes,/obj/item/stack/sheet/animalhide/human,/obj/item/storage/book/bible,/obj/item/pen)
-	result_atoms = list(/obj/item/forbidden_book)
+	result_atoms = list(/obj/item/forbidden_book/ritual) //SKYRAT EDIT
 	route = "Start"


### PR DESCRIPTION
## About The Pull Request

Makes it so that the ritual to make a new book, only grants you a new book instead of also coming with points.

## Why It's Good For The Game

While this may not stop Heretics from ascending round-start with three monkeys, I think it is a step in the right direction.
I mean, not that anyone really abused this yet, but I noticed and yeah it is dumb.

## Changelog
:cl:
fix: No free charges with the book ritual.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
