### PR TITLE
[NON-MODULAR] Minorly nerfs the stealth implant, now 5 seconds instead of 2 to cloak

### DIFF
--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -19,7 +19,7 @@
 	move_speed_multiplier = 0.5
 
 /obj/structure/closet/cardboard/agent/proc/go_invisible()
-	animate(src, , alpha = 0, time = 20)
+	animate(src, , alpha = 0, time = 5 SECONDS) // SKYRAT EDIT - ORIGINAL time = 20
 
 /obj/structure/closet/cardboard/agent/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Maaaaaybe outright removing is a LITTLE too much. And no, this isn't a salt PR, please don't give me that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
But I do feel like this needs a nerf.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Stealth implant now takes 5 seconds to cloak, instead of 2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
