### PR TITLE
Makes some emote sounds send to view(1)

### DIFF
--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -98,19 +98,6 @@
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/snap3.ogg'
 
-/datum/emote/living/awoo
-	key = "awoo"
-	key_third_person = "awoos"
-	message = "lets out an awoo!"
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-
-/datum/emote/living/nya
-	key = "nya"
-	key_third_person = "nyas"
-	message = "lets out a nya!"
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
 
 /datum/emote/living/weh
 	key = "weh"
@@ -325,13 +312,6 @@
 	message_AI = "shows an image of a random blepping animal. Blep."
 	message_robot = "bleps their robo-tongue out. Blep."
 
-/datum/emote/living/bork
-	key = "bork"
-	key_third_person = "borks"
-	message = "lets out a bork."
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-
 /datum/emote/living/hoot
 	key = "hoot"
 	key_third_person = "hoots"
@@ -349,13 +329,6 @@
 	muzzle_ignore = TRUE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/growl.ogg'
-
-/datum/emote/living/woof
-	key = "woof"
-	key_third_person = "woofs"
-	message = "lets out a woof."
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
 
 /datum/emote/living/baa
 	key = "baa"
@@ -380,14 +353,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/wurble.ogg'
-
-/datum/emote/living/awoo2
-	key = "awoo2"
-	key_third_person = "awoos"
-	message = "lets out an awoo!"
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	//cooldown = 3 SECONDS -- Removed as the current global cooldown is larger
 
 /datum/emote/living/rattle
 	key = "rattle"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -98,6 +98,27 @@
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/snap3.ogg'
 
+/datum/emote/living/awoo
+	key = "awoo"
+	key_third_person = "awoos"
+	message = "lets out an awoo!"
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+
+/datum/emote/living/awoo/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	SEND_SOUND(user, sound('modular_skyrat/modules/emotes/sound/voice/awoo.ogg'))
+
+/datum/emote/living/nya
+	key = "nya"
+	key_third_person = "nyas"
+	message = "lets out a nya!"
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+
+/datum/emote/living/nya/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	SEND_SOUND(user, sound('modular_skyrat/modules/emotes/sound/voice/nya.ogg'))
 
 /datum/emote/living/weh
 	key = "weh"
@@ -312,6 +333,17 @@
 	message_AI = "shows an image of a random blepping animal. Blep."
 	message_robot = "bleps their robo-tongue out. Blep."
 
+/datum/emote/living/bork
+	key = "bork"
+	key_third_person = "borks"
+	message = "lets out a bork."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+
+/datum/emote/living/bork/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	SEND_SOUND(user, sound('modular_skyrat/modules/emotes/sound/voice/bork.ogg'))
+
 /datum/emote/living/hoot
 	key = "hoot"
 	key_third_person = "hoots"
@@ -329,6 +361,18 @@
 	muzzle_ignore = TRUE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/growl.ogg'
+
+/datum/emote/living/woof
+	key = "woof"
+	key_third_person = "woofs"
+	message = "lets out a woof."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+
+/datum/emote/living/woof/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	SEND_SOUND(user, sound('modular_skyrat/modules/emotes/sound/voice/woof.ogg'))
+
 
 /datum/emote/living/baa
 	key = "baa"
@@ -353,6 +397,19 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/wurble.ogg'
+
+/datum/emote/living/awoo2
+	key = "awoo2"
+	key_third_person = "awoos"
+	message = "lets out an awoo!"
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	//cooldown = 3 SECONDS -- Removed as the current global cooldown is larger
+
+/datum/emote/living/awoo2/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	SEND_SOUND(user, sound('modular_skyrat/modules/emotes/sound/voice/long_awoo.ogg'))
+
 
 /datum/emote/living/rattle
 	key = "rattle"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -107,7 +107,9 @@
 
 /datum/emote/living/awoo/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	SEND_SOUND(user, sound('modular_skyrat/modules/emotes/sound/voice/awoo.ogg'))
+	for(var/i in view(1, user))
+		var/mob/user_to_play_to = i
+		user_to_play_to.playsound_local(user, 'modular_skyrat/modules/emotes/sound/voice/awoo.ogg')
 
 /datum/emote/living/nya
 	key = "nya"
@@ -118,7 +120,9 @@
 
 /datum/emote/living/nya/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	SEND_SOUND(user, sound('modular_skyrat/modules/emotes/sound/voice/nya.ogg'))
+	for(var/i in view(1, user))
+		var/mob/user_to_play_to = i
+		user_to_play_to.playsound_local(user, 'modular_skyrat/modules/emotes/sound/voice/nya.ogg')
 
 /datum/emote/living/weh
 	key = "weh"
@@ -341,9 +345,9 @@
 	vary = TRUE
 
 /datum/emote/living/bork/run_emote(mob/user, params, type_override, intentional)
-	. = ..()
-	SEND_SOUND(user, sound('modular_skyrat/modules/emotes/sound/voice/bork.ogg'))
-
+	for(var/i in view(1, user))
+		var/mob/user_to_play_to = i
+		user_to_play_to.playsound_local(user, 'modular_skyrat/modules/emotes/sound/voice/bork.ogg')
 /datum/emote/living/hoot
 	key = "hoot"
 	key_third_person = "hoots"
@@ -371,8 +375,9 @@
 
 /datum/emote/living/woof/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	SEND_SOUND(user, sound('modular_skyrat/modules/emotes/sound/voice/woof.ogg'))
-
+	for(var/i in view(1, user))
+		var/mob/user_to_play_to = i
+		user_to_play_to.playsound_local(user, 'modular_skyrat/modules/emotes/sound/voice/woof.ogg')
 
 /datum/emote/living/baa
 	key = "baa"
@@ -408,8 +413,9 @@
 
 /datum/emote/living/awoo2/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	SEND_SOUND(user, sound('modular_skyrat/modules/emotes/sound/voice/long_awoo.ogg'))
-
+	for(var/i in view(1, user))
+		var/mob/user_to_play_to = i
+		user_to_play_to.playsound_local(user, 'modular_skyrat/modules/emotes/sound/voice/long_awoo.ogg')
 
 /datum/emote/living/rattle
 	key = "rattle"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -98,21 +98,6 @@
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/snap3.ogg'
 
-/datum/emote/living/awoo
-	key = "awoo"
-	key_third_person = "awoos"
-	message = "lets out an awoo!"
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/awoo.ogg'
-
-/datum/emote/living/nya
-	key = "nya"
-	key_third_person = "nyas"
-	message = "lets out a nya!"
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/nya.ogg'
 
 /datum/emote/living/weh
 	key = "weh"
@@ -327,14 +312,6 @@
 	message_AI = "shows an image of a random blepping animal. Blep."
 	message_robot = "bleps their robo-tongue out. Blep."
 
-/datum/emote/living/bork
-	key = "bork"
-	key_third_person = "borks"
-	message = "lets out a bork."
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/bork.ogg'
-
 /datum/emote/living/hoot
 	key = "hoot"
 	key_third_person = "hoots"
@@ -352,14 +329,6 @@
 	muzzle_ignore = TRUE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/growl.ogg'
-
-/datum/emote/living/woof
-	key = "woof"
-	key_third_person = "woofs"
-	message = "lets out a woof."
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/woof.ogg'
 
 /datum/emote/living/baa
 	key = "baa"
@@ -384,15 +353,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/wurble.ogg'
-
-/datum/emote/living/awoo2
-	key = "awoo2"
-	key_third_person = "awoos"
-	message = "lets out an awoo!"
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-	sound = 'modular_skyrat/modules/emotes/sound/voice/long_awoo.ogg'
-	//cooldown = 3 SECONDS -- Removed as the current global cooldown is larger
 
 /datum/emote/living/rattle
 	key = "rattle"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -98,6 +98,19 @@
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/snap3.ogg'
 
+/datum/emote/living/awoo
+	key = "awoo"
+	key_third_person = "awoos"
+	message = "lets out an awoo!"
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+
+/datum/emote/living/nya
+	key = "nya"
+	key_third_person = "nyas"
+	message = "lets out a nya!"
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
 
 /datum/emote/living/weh
 	key = "weh"
@@ -312,6 +325,13 @@
 	message_AI = "shows an image of a random blepping animal. Blep."
 	message_robot = "bleps their robo-tongue out. Blep."
 
+/datum/emote/living/bork
+	key = "bork"
+	key_third_person = "borks"
+	message = "lets out a bork."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+
 /datum/emote/living/hoot
 	key = "hoot"
 	key_third_person = "hoots"
@@ -329,6 +349,13 @@
 	muzzle_ignore = TRUE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/growl.ogg'
+
+/datum/emote/living/woof
+	key = "woof"
+	key_third_person = "woofs"
+	message = "lets out a woof."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
 
 /datum/emote/living/baa
 	key = "baa"
@@ -353,6 +380,14 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/voice/wurble.ogg'
+
+/datum/emote/living/awoo2
+	key = "awoo2"
+	key_third_person = "awoos"
+	message = "lets out an awoo!"
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	//cooldown = 3 SECONDS -- Removed as the current global cooldown is larger
 
 /datum/emote/living/rattle
 	key = "rattle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nothing shatters immersion more than hearing a dog go awooooooOUOUoouoOUouOUouOUO 10 tiles away.

No.

It now uses a cringe based view() byond proc to send the sound.

*awoo
*awoo2
*bork
*woof
*nya

have all been sent to the incinerator

## Changelog
:cl:
del: Several bad emotes have been nerfed.
/:cl:

