### PR TITLE
[MODULAR] Removes tacticool turtleneck and skirtleneck from the loadout.

### DIFF
--- a/modular_skyrat/modules/customization/modules/client/loadout/uniform.dm
+++ b/modular_skyrat/modules/customization/modules/client/loadout/uniform.dm
@@ -504,10 +504,6 @@
 /datum/loadout_item/uniform/sweater
 	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_SWEATERS
 
-/datum/loadout_item/uniform/sweater/turtleneck
-	name = "Tactitool Turtleneck"
-	path = /obj/item/clothing/under/syndicate/tacticool
-
 /datum/loadout_item/uniform/sweater/tactical1
 	name = "Irish Tactical Sweater"
 	path = /obj/item/clothing/under/misc/tactical1
@@ -515,10 +511,6 @@
 /datum/loadout_item/uniform/sweater/tactical2
 	name = "British Tactical Sweater"
 	path = /obj/item/clothing/under/uvf
-
-/datum/loadout_item/uniform/sweater/turtleneck/skirt
-	name = "Tactitool Skirtleneck"
-	path = /obj/item/clothing/under/syndicate/tacticool/skirt
 
 /datum/loadout_item/uniform/sweater/creamsweater
 	name = "Cream Commando Sweater"


### PR DESCRIPTION
## About The Pull Request

Removes tacticool turtleneck and skirtleneck from the loadout.
You are still able to get them in the actual game.
Alternative to https://github.com/Skyrat-SS13/Skyrat-tg/pull/6445

## Why It's Good For The Game

Those items are pretty much low-level contraband, and are supposed to be a fun little reward if you track them down.
Being able to get them in the load-out removes all of that, and the fact that you could just show up to work with them is contradictory from a lore standpoint.

## Changelog
:cl:
del: Tacticool turtleneck and skirtleneck from the loadout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
