### PR TITLE
Removes Late-Join cyborg slots

### DIFF
--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -2,7 +2,7 @@
 	title = "Cyborg"
 	auto_deadmin_role_flags = DEADMIN_POSITION_SILICON
 	faction = "Station"
-	total_positions = 3	// SKYRAT EDIT: Original value (0)
+	total_positions = 0
 	spawn_positions = 3	// SKYRAT EDIT: Original value (1)
 	supervisors = "your laws and the AI" //Nodrak
 	selection_color = "#ddffdd"

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -52,4 +52,4 @@ Security Medic=1,1
 Corrections Officer 1,1
 
 AI=1,1
-Cyborg=3,3
+Cyborg=0,3


### PR DESCRIPTION
## About The Pull Request

Removes Late-Join cyborg slots.
If you wish to play a cyborg after round-start.
You can do it by getting borged, or by ghosting and using a PosiBrain.

## Why It's Good For The Game

The reason for this is two-fold. Currently if you late-join as a cyborg you won't be law-synced and linked with the current AI correctly. We have had a number of PRs that attempted to fix this issue, but it is still causing problems.
Second of all. If you want to join as a cyborg after the start of the round. You should just do it via the methods that already exist for it. We have the ectoscopic sniffer to detect ghosts, you can poke Robotics to print brains with it.
Making more cyborgs is a core part of their job.

I decided to go ahead and leave the amount of round-start slots at three instead of the normal one.
Because if a couple of people want to do it then when the tech for brains isn't ready, that is fine.
But with how long our rounds are, if you join late, all the stuff you need to spawn should already be there.

## Changelog
:cl:
balance: Late-Join cyborgs not being linked to the AI correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
