### PR TITLE
[modular][ready][fix]es the brig skirt to point to the right file

### DIFF
--- a/modular_skyrat/modules/brigoff/code/modules/clothing/under/jobs/security.dm
+++ b/modular_skyrat/modules/brigoff/code/modules/clothing/under/jobs/security.dm
@@ -22,10 +22,12 @@
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/uniforms.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/uniform.dmi'
 	icon_state = "brigguardsweat"
+	mutant_variants = NONE
 
 /obj/item/clothing/under/rank/security/brigguard/sweater/women
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/uniforms.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/uniform.dmi'
-	icon_state = "brigguardsweatw"
+	icon_state = "brigguardsuitw"
+	mutant_variants = NONE
 
 


### PR DESCRIPTION
title
anyway here's a good promo from during the invasion
https://www.youtube.com/watch?v=jva3T9N_iu0

## Changelog
:cl:
fix: the brig skirt works now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
