### PR TITLE
Cyborgs have Late-join slots again (and spawn on-station when late-joining), and fixes linking to the AI properly on latejoin.

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -738,12 +738,15 @@ SUBSYSTEM_DEF(job)
 		destination = pick(GLOB.jobspawn_overrides[M.mind.assigned_role])
 		destination.JoinPlayerHere(M, FALSE)
 		return TRUE
-	//SKYRAT EDIT ADDITION
-	if(M.job)
-		if(M.job == "Prisoner")
-			destination = locate(/obj/effect/landmark/start/prisoner) in GLOB.landmarks_list
-			destination.JoinPlayerHere(M, buckle)
-			return TRUE
+	//SKYRAT EDIT ADDITION -- ONSTATION LATEJOINS
+	if(M.job && M.job == "Prisoner")
+		destination = locate(/obj/effect/landmark/start/prisoner) in GLOB.landmarks_list
+		destination.JoinPlayerHere(M, buckle)
+		return TRUE
+	if(M.job && M.job == "Cyborg")
+		destination = locate(/obj/effect/landmark/start/cyborg) in GLOB.landmarks_list
+		destination.JoinPlayerHere(M, buckle)
+		return TRUE
 	//SKYRAT EDIT END
 	if(latejoin_trackers.len)
 		destination = pick(latejoin_trackers)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -745,6 +745,7 @@ SUBSYSTEM_DEF(job)
 		return TRUE
 	if(M.job && M.job == "Cyborg")
 		destination = locate(/obj/effect/landmark/start/cyborg) in GLOB.landmarks_list
+		M.latejoin_find_parent_ai(destination.z)
 		destination.JoinPlayerHere(M, buckle)
 		return TRUE
 	//SKYRAT EDIT END

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -64,9 +64,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 /obj/effect/landmark/start/prisoner
 	name = "Prisoner"
 	icon_state = "Prisoner"
-
-/obj/effect/landmark/start/prisoner/after_round_start()
-	return
+	delete_after_roundstart = FALSE // SKYRAT EDIT ADD -- ONSTATION LATEJOINS
 
 /obj/effect/landmark/start/janitor
 	name = "Janitor"
@@ -195,6 +193,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 /obj/effect/landmark/start/cyborg
 	name = "Cyborg"
 	icon_state = "Cyborg"
+	delete_after_roundstart = FALSE // SKYRAT EDIT ADD -- ONSTATION LATEJOINS
 
 /obj/effect/landmark/start/ai
 	name = "AI"

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -2,7 +2,7 @@
 	title = "Cyborg"
 	auto_deadmin_role_flags = DEADMIN_POSITION_SILICON
 	faction = "Station"
-	total_positions = 0
+	total_positions = 3	// SKYRAT EDIT: Original value (0)
 	spawn_positions = 3	// SKYRAT EDIT: Original value (1)
 	supervisors = "your laws and the AI" //Nodrak
 	selection_color = "#ddffdd"

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -52,4 +52,4 @@ Security Medic=1,1
 Corrections Officer 1,1
 
 AI=1,1
-Cyborg=0,3
+Cyborg=3,3

--- a/modular_skyrat/master_files/code/modules/jobs/job_types/cyborg.dm
+++ b/modular_skyrat/master_files/code/modules/jobs/job_types/cyborg.dm
@@ -1,10 +1,12 @@
-/datum/job/cyborg/after_spawn(mob/living/silicon/robot/R, mob/M)
-	R.updatename(M.client)
-	R.gender = NEUTER
+/mob/proc/latejoin_find_parent_ai(target_z_level = 3)
+	var/mob/living/silicon/robot/cyborg = src
+	if(!istype(cyborg))
+		return
+	if(cyborg.connected_ai)
+		return
 	for(var/mob/living/silicon/ai/AI in GLOB.silicon_mobs)
-		if(AI.z == 3)
-			if(!(R.connected_ai))
-				R.set_connected_ai(AI)
-	R.lawsync()
-	R.show_laws()
-	
+		if(AI.z == target_z_level)
+			cyborg.set_connected_ai(AI)
+			break
+	cyborg.lawsync()
+	cyborg.show_laws()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This reverts #6451, while addressing the issue cited in the removal, namely 

> Currently if you late-join as a cyborg you won't be law-synced and linked with the current AI correctly. We have had a number of PRs that attempted to fix this issue, but it is still causing problems.

Has been fixed. When latejoining, a cyborg will be spawned on the AI satellite, the same way prisoners are spawned in their cells. They are then linked to the first located AI on the z level.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The reason I disagree with #6451 is as follows. Firstly, the issue that it was created to avoid has now been fixed, secondly, the changes make it difficult to play cyborg on low population shifts. You require at least one roboticist, let alone one who is working and doing their job, *and* at least one scientist who is actively doing RnD beyond what mining will yell at them for. Sometimes, science will just not research posibrains because they're running on a skeleton crew. Also, the topic of "It stifles RP to be able to skip the borging process," came up, but I would argue the opposite. If you possess a posibrain, you are shoehorned into one single RP path of being a posibrain cyborg. If you want to be an MMI cyborg, you either have to join at roundstart, or go up to the desk and get borged, neither of which are the easiest to RP out depending on the circumstances.

The only argument that I agree with is that "If you're a traitor doing something with a binary key, a latejoining borg can easily rumble you." But I would count that as such an edge case because a) Binary key is rarely used, B) that goes against validhunting rules in silicon policy and C) If you have subverted the AI and any unlinked borgs, chances are you've already gotten an upload terminal for both, and a new borg wouldn't matter all that much. Even then, I feel that an easy fix would be to make new borgs be announced over the binary channel, for instance, so when a traitor is using binary, they can know when to be quiet for a moment.

And as for spawning on station, the logic there, aside from it making the code easier, is to say "hey, why would a station asset that was presumably made on station, and presumably enters storage at the end of a shift. be shipped in from a transit hub and not the cargo shuttle, or just taken out of on-station storage."
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Latejoin Cyborg Slots, again.
add: Latejoin cyborgs now spawn on-station.
fix: Latejoin Cyborgs being linked to the AI, again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
