### PR TITLE
Adds Noslip to Jackboots [I DONT KNOW THE DIFFERENCE BETWEEN MODULAR AND NONMODULAR]

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -152,6 +152,7 @@
 	permeability_coefficient = 0.05 //Thick soles, and covers the ankle
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes
 	can_be_tied = TRUE //SKYRAT EDIT
+	clothing_flags = NOSLIP
 
 /obj/item/clothing/shoes/jackboots/fast
 	slowdown = -1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds NOSLIP to security jackboots

## Why It's Good For The Game
Nobody can genuinely tell me that 5 security officers slipping over a bar of soap placed there by an elite assassin in a blood red hardsuit like some drop dead tonal mishmash cartoon is good rp.
the people who play sec hate being slipped by greytider antags who wanna test their "greytide-fu" out, and they hate being lead around by the nostrils for a 2-4 hour round chasing one greyshit who runs around maintenance dropping soap bars to slip and stun them. it's LRP as hell and it's literally only fun for the antag in that scenario.

It's not innovative or thinking outside the box it's just slipmeta. Oh how fun it is that sec officers dont even get to RP because they have to spend the entire round chasing some random assistant around maints and his bag is filled with soap and x4.

If you play like this, don't bother commenting on this PR, I'm already at your house fucking your mother so just knock on the door and tell me in person so I can give you the genuine swirly you deserve.

## Changelog
:cl:
add: Noslip to jackboots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
