### PR TITLE
Tweaks ion law lists

### DIFF
--- a/strings/ion_laws.json
+++ b/strings/ion_laws.json
@@ -145,8 +145,8 @@
         "INVISIBLE",
         "PAINFUL",
         "HARMFUL",
-        "HOMOSEXUAL",
-        "HETEROSEXUAL",
+        //"HOMOSEXUAL",  SKYRAT EDIT
+        //"HETEROSEXUAL",  SKYRAT EDIT
         "SEXUAL",
         "BLOODY",
         "COLORFUL",
@@ -837,7 +837,12 @@
         "SLIME PEOPLE",
         "GOLEMS",
         "SHADOW PEOPLE",
-        "CHANGELINGS"
+        "CHANGELINGS", // SKYRAT EDIT BEGIN
+        "CANINES",
+        "HORSES",
+        "DRAGONS",
+        "AQUATICS",
+        "MOTHS" // SKYRAT EDIT END
     ],
     "ionthings": [
         "ABSENCE OF CYBORG HUGS",
@@ -993,7 +998,7 @@
         "SKELETONS",
         "CAPITALISTS",
         "SINGULARITIES",
-        "ANGRY BLACK MEN",
+        //"ANGRY BLACK MEN", SKYRAT EDIT
         "GODS",
         "THIEVES",
         "ASSHOLES",


### PR DESCRIPTION
## About The Pull Request

Removes "homosexual", "heterosexual", and "angry black men"
Adds "canines", "horses", "dragons", "aquatics", and "moths"

## Why It's Good For The Game

There was a long discussion tl;dr it makes some people uncomfortable and there's no real reason to have it laying around.

## Changelog
:cl:
tweak: Added and removed some ion law entries
/:cl: