### PR TITLE
[MODULAR] Restricts 'Affection' module to one use and to dogborgs (and fixes an exploit)

### DIFF
--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -1,5 +1,6 @@
 /mob/living/silicon/robot
 	var/hasShrunk = FALSE
+	var/hasAffection = FALSE
 
 /obj/item/borg/upgrade/shrink
 	name = "borg shrinker"
@@ -17,6 +18,7 @@
 			to_chat(usr, "<span class='warning'>This unit's chassis cannot be shrunk any further.</span>")
 			return FALSE
 
+		borg.hasShrunk = TRUE
 		borg.notransform = TRUE
 		var/prev_lockcharge = borg.lockcharge
 		borg.SetLockdown(1)
@@ -33,7 +35,6 @@
 		borg.set_anchored(FALSE)
 		borg.notransform = FALSE
 		borg.resize = 0.75
-		borg.hasShrunk = TRUE
 		borg.update_transform()
 
 /obj/item/borg/upgrade/shrink/deactivate(mob/living/silicon/robot/borg, user = usr)
@@ -113,14 +114,23 @@
 	icon_state = "cyborg_upgrade3"
 
 /obj/item/borg/upgrade/affectionmodule/action(mob/living/silicon/robot/borg)
-	. = ..()
-	if(.)
-		var/obj/item/dogborg_tongue/dogtongue = new /obj/item/dogborg_tongue(borg.model)
-		borg.model.basic_modules += dogtongue
-		borg.model.add_module(dogtongue, FALSE, TRUE)
-		var/obj/item/dogborg_nose/dognose = new /obj/item/dogborg_nose(borg.model)
-		borg.model.basic_modules += dognose
-		borg.model.add_module(dognose, FALSE, TRUE)
+    . = ..()
+    if(!.)
+        return
+    if(borg.hasAffection)
+        to_chat(usr, "<span class='warning'>This unit already has a affection module installed!</span>")
+        return FALSE
+    if(!(R_TRAIT_WIDE in borg.model.model_features))
+        to_chat(usr, "<span class='warning'>This unit's chassis does not support this module.</span>")
+        return FALSE
+
+    var/obj/item/dogborg_tongue/dogtongue = new /obj/item/dogborg_tongue(borg.model)
+    borg.model.basic_modules += dogtongue
+    borg.model.add_module(dogtongue, FALSE, TRUE)
+    var/obj/item/dogborg_nose/dognose = new /obj/item/dogborg_nose(borg.model)
+    borg.model.basic_modules += dognose
+    borg.model.add_module(dognose, FALSE, TRUE)
+    borg.hasAffection = TRUE
 
 /obj/item/borg/upgrade/affectionmodule/deactivate(mob/living/silicon/robot/borg, user = usr)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/25504173/123203390-9e237080-d4f9-11eb-9b64-cb74c9da84df.png)
You guys hurt me so no more being cheeky

And exploit wise
![image](https://user-images.githubusercontent.com/25504173/123203418-aaa7c900-d4f9-11eb-9e41-e68d0ee92e8f.png)
Cant bypass the one shrink module use limit

## Why It's Good For The Game

Because people trying to be funny applying multiple upgrades of something I personally like to call 'wasted space' isn't.. funny or intended. Also I'll keep it to dogborgs only because I don't want the thought of a Roomba licking my feet to occupy my mental space

Also fixed an exploit I somehow managed to find in my random boredom of throwing. The shrink module, when it's doing it's magical fuckery, allows multiple shrink modules to be used which bypasses the limit of only being allowed to use it once

## Changelog
:cl:
fix: Fixed up 'Affection' module being abled to be added to a borg multiple times. Also restricted it to dogborgs only
fix: Fixed an exploit relating to the shrink module
/:cl: