### PR TITLE
fixes airlock names for icebox + nss

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -40965,6 +40965,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
+	name = "Mining Dock";
 	req_access_txt = "48"
 	},
 /obj/structure/cable,

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -21991,6 +21991,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
+	name = "Mining Dock";
 	req_access_txt = "48"
 	},
 /obj/structure/cable,


### PR DESCRIPTION
## About The Pull Request

self-explanatory! just changes the names of the airlocks in their respective place on both icebox and journey.

## Why It's Good For The Game

just some clean-up!

## Changelog
:cl:
fix: fixes the names of the cargo office to mining dock airlock on icebox and journey
/:cl: