### PR TITLE
[FIX] prevents ghosts from un-flipping tables

### DIFF
--- a/modular_skyrat/modules/tableflip/code/flipped_table.dm
+++ b/modular_skyrat/modules/tableflip/code/flipped_table.dm
@@ -64,7 +64,7 @@
 
 /obj/structure/table/CtrlShiftClick(mob/living/user)
 	. = ..()
-	if(!istype(user) || !user.can_interact_with(src))
+	if(!istype(user) || !user.can_interact_with(src) || isobserver(user))
 		return
 	if(can_flip)
 		user.visible_message("<span class='danger'>[user] starts flipping [src]!</span>", "<span class='notice'>You start flipping over the [src]!</span>")

--- a/modular_skyrat/modules/tableflip/code/flipped_table.dm
+++ b/modular_skyrat/modules/tableflip/code/flipped_table.dm
@@ -48,7 +48,7 @@
 	if(get_dir(leaving.loc, new_location) == dir)
 		return COMPONENT_ATOM_BLOCK_EXIT
 
-/obj/structure/flippedtable/CtrlShiftClick(mob/living/user)
+/obj/structure/flippedtable/CtrlShiftClick(mob/user)
 	. = ..()
 	if(!istype(user) || !user.can_interact_with(src))
 		return FALSE

--- a/modular_skyrat/modules/tableflip/code/flipped_table.dm
+++ b/modular_skyrat/modules/tableflip/code/flipped_table.dm
@@ -48,7 +48,7 @@
 	if(get_dir(leaving.loc, new_location) == dir)
 		return COMPONENT_ATOM_BLOCK_EXIT
 
-/obj/structure/flippedtable/CtrlShiftClick(mob/user)
+/obj/structure/flippedtable/CtrlShiftClick(mob/living/user)
 	. = ..()
 	if(!istype(user) || !user.can_interact_with(src))
 		return FALSE


### PR DESCRIPTION
made only the living qualify for un-flipping tables

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ghosts were able to un-flip tables. I found what I think let them do it, and changed it. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ghosts had a narrow case where they could directly interact with the round, potentially in a combat situation.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: prevented ghosts from un-flipping tables
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
