### PR TITLE
Buffs the everlasting shit out of Atmos devices

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -264,9 +264,9 @@
 //PIPES
 //Atmos pipe limits
 /// (kPa) What pressure pumps and powered equipment max out at.
-#define MAX_OUTPUT_PRESSURE 4500
+#define MAX_OUTPUT_PRESSURE 15000 //SKYRAT CHANGE: TRIPLES MAX OUTPUT PRESSURE
 /// (L/s) Maximum speed powered equipment can work at.
-#define MAX_TRANSFER_RATE 200
+#define MAX_TRANSFER_RATE 500 //SKYRAT CHANGE: TRIPLES MAX TRANSFER RATE.
 /// How many percent of the contents that an overclocked volume pumps leak into the air
 #define VOLUME_PUMP_LEAK_AMOUNT 0.1
 //used for device_type vars

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -28,7 +28,7 @@
 	///The temperature we trying to get to
 	var/target_temperature = T20C
 	///How much heat/cold we can deliver
-	var/heating_power = 40000
+	var/heating_power = 80000 //SKRAT CHANGE: DOUBLES THIS.
 	///How efficiently we can deliver that heat/cold (higher indicates less cell consumption)
 	var/efficiency = 20000
 	///The amount of degrees above and below the target temperature for us to change mode to heater or cooler

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -517,7 +517,7 @@ get_true_breath_pressure(pp) --> gas_pp = pp/breath_pp*total_moles()
 **/
 
 /// Pumps gas from src to output_air. Amount depends on target_pressure
-/datum/gas_mixture/proc/pump_gas_to(datum/gas_mixture/output_air, target_pressure, specific_gas = null)
+/datum/gas_mixture/proc/pump_gas_to(datum/gas_mixture/output_air, target_pressure, specific_gas = null, rate=1) //SKYRAT CHANGE, ADDS RATE.
 	var/output_starting_pressure = output_air.return_pressure()
 
 	if((target_pressure - output_starting_pressure) < 0.01)
@@ -531,10 +531,10 @@ get_true_breath_pressure(pp) --> gas_pp = pp/breath_pp*total_moles()
 
 		//Actually transfer the gas
 		if(specific_gas)
-			var/datum/gas_mixture/removed = remove_specific(specific_gas, transfer_moles)
+			var/datum/gas_mixture/removed = remove_specific(specific_gas, transfer_moles*rate) //SKYRAT CHANGE, ADDS RATE.
 			output_air.merge(removed)
 			return TRUE
-		var/datum/gas_mixture/removed = remove(transfer_moles)
+		var/datum/gas_mixture/removed = remove(transfer_moles*rate) //SKYRAT CHANGE, ADDS RATE.
 		output_air.merge(removed)
 		return TRUE
 	return FALSE

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -59,7 +59,7 @@
 	var/datum/gas_mixture/air1 = airs[1]
 	var/datum/gas_mixture/air2 = airs[2]
 
-	if(air1.pump_gas_to(air2, target_pressure))
+	if(air1.pump_gas_to(air2, target_pressure, rate=2)) //SKYRAT CHANGE: ADDS RATE.
 		update_parents()
 
 /**

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -12,7 +12,7 @@
 	///Is the machine on?
 	var/on = FALSE
 	///the rate the machine will scrub air
-	var/volume_rate = 1000
+	var/volume_rate = 2000 //SKYRAT CHANGE: DOUBLES VOLUME RATE.
 	///Multiplier with ONE_ATMOSPHERE, if the enviroment pressure is higher than that, the scrubber won't work
 	var/overpressure_m = 80
 	///Should the machine use overlay in update_overlays() when open/close?
@@ -177,7 +177,7 @@
 	idle_power_usage = 10
 
 	overpressure_m = 200
-	volume_rate = 1500
+	volume_rate = 3000 //SKYRAT CHANGE: DOUBLES VOLUME RATE.
 	volume = 50000
 
 	var/movable = FALSE


### PR DESCRIPTION
## About The Pull Request

Increases max pressure for gas pumps from 4500 to 15000.
Doubles the strength of gas pumps.
Increases max volume transfer amount from 200 to 500.
Increases the heating power for portable space heaters from 40000 to 80000.
Increases the volume rate of portable scrubbers from 1000 to 2000.
Increases the volume rate of large portable scrubbers from 1500 to 3000.

## Why It's Good For The Game

Atmos is currently dogshit thanks to Icebox and Deltastation existing as well as /tg/ nerfs from above. It usually takes an entire 1 hour to fix any resulting "atmospheric damage" from breaches on large stations. It also takes a massive amount of time to clear any accidental contamination issues in pipes via pumps alone because of how gas transfer works.  This PR effectively takes that amount of time and then cuts it into quarters.

## Changelog
:cl: BurgerBB
balance: Buffs the everlasting shit out of gas pumps, volume pumps, portable heaters, and portable scrubbers.
/:cl: