### PR TITLE
Makes the russian language not be called, literally "Russian." It's 2561 why are we using 21st century Russian and not Neo-Russkya?

### DIFF
--- a/modular_skyrat/modules/customization/modules/language/russian.dm
+++ b/modular_skyrat/modules/customization/modules/language/russian.dm
@@ -1,5 +1,5 @@
 /datum/language/russian
-	name = "Russian"
+	name = "Neo-Russkya"
 	desc = "The official language of the Independent Colonial Confederation of Gilgamesh, originally established in 2122 by the short-lived United Slavic Confederation on Earth."
 	key = "r"
 	flags = TONGUELESS_SPEECH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the name of the russian language to Neo-Russkya
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Russian is a language that exists. We shouldn't really have it in game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
🆑 
qol: The name of the russian language, that is only seen in the selection menu, is now "Neo-Russkya"
:/cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
