### PR TITLE
[Semi-Modular] Allows Xenohybrids to speak Xenocommon

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -38,7 +38,8 @@
 		/datum/language/spacer,  //SKYRAT EDIT - customization - extra languages
 		/datum/language/selenian,  //SKYRAT EDIT - customization - extra languages
 		/datum/language/gutter,  //SKYRAT EDIT - customization - extra languages
-		/datum/language/zolmach // SKYRAT EDIT - customization - extra languages
+		/datum/language/zolmach, // SKYRAT EDIT - customization - extra languages
+		/datum/language/xenocommon // SKYRAT EDIT - Gives Xenohybrids the ability to speak Xenomorph again.
 	))
 
 /obj/item/organ/tongue/Initialize(mapload)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
@@ -28,6 +28,7 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	liked_food = MEAT
+	learnable_languages = list(/datum/language/common, /datum/language/xenocommon)
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/xeno_parts_greyscale.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives the Xenomorph language to the Xenohybrid race as a racial language selectable from the character menu.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It gives the species more identity beyond being reskinned humans.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Xenohybrids can now choose to start the round knowing or speaking Xenomorph.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
