### PR TITLE
[MODULAR] Ghost Cafe QoL Map Tweaks

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -3329,7 +3329,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
@@ -4296,7 +4296,8 @@
 	},
 /area/centcom/holding/cafepark)
 "alC" = (
-/turf/open/water/overlay/hotspring/indestructible/outdoors,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
 /area/centcom/holding/cafepark)
 "alD" = (
 /obj/effect/turf_decal/tile/green,
@@ -4883,7 +4884,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
@@ -13180,6 +13181,8 @@
 /area/cruiser_dock/cargo)
 "aIt" = (
 /obj/structure/table/wood,
+/obj/item/gun/energy/floragun,
+/obj/item/geneshears,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
@@ -14660,10 +14663,13 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
@@ -16366,7 +16372,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
@@ -17277,7 +17283,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
@@ -19546,7 +19552,7 @@
 /turf/open/floor/wood,
 /area/cruiser_dock/heads/admiral)
 "aZs" = (
-/obj/structure/showcase/machinery/implanter,
+/obj/machinery/hypnochair,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
I was asked to open a PR on behalf of Dekunutkid#8855. This whole PR description and the map changes are done by them
## About The Pull Request
Adds a couple small, but nice things to the Ghost Cafe, including a Floral Somatoray, Botanogenetic Plant Shears and an Enhanced Interrogation Chamber.
Also updates the pool to use the Azarak liquid system and fixes the broken warning strip decals in botany.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Provides more opportunities to RP in the Ghost Cafe, as well as providing more opportunities to learn botany in a stress-free environment outside of the life-bringers. 
Map fixes and updates are good to improve mapping standards.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds advanced botany equipment to Ghost Cafe botany and an Enhanced Interrogation Chamber to the showroom.
add: Warning strips in Ghost Cafe botany are no longer annoying, and pool updated to the new liquids system.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
