### PR TITLE
Heretics now get passive points over time (1 per 15 minutes after initially first creating a rune)

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_book.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_book.dm
@@ -68,7 +68,7 @@
 		if(has_passive_charge)
 			charge++
 			to_chat(user, span_danger("The new rune glows as eldritch knowledge is transfered to your tome!"))
-			addtimer(CALLBACK(src,.proc/alert_passive_charge),20 MINUTES)
+			addtimer(CALLBACK(src,.proc/alert_passive_charge),15 MINUTES)
 			has_passive_charge = FALSE
 		//SKYRAT ADDITION ENDS HERE
 		new /obj/effect/eldritch/big(A)

--- a/code/modules/antagonists/eldritch_cult/eldritch_book.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_book.dm
@@ -1,5 +1,5 @@
 /obj/item/forbidden_book
-	name = "Codex Cicatrix"
+	name = "\improper Codex Cicatrix" //SKYRAT CHANGE
 	desc = "This book describes the secrets of the veil between worlds."
 	icon = 'icons/obj/eldritch.dmi'
 	icon_state = "book"
@@ -8,13 +8,20 @@
 	///Last person that touched this
 	var/mob/living/last_user
 	///how many charges do we have?
-	var/charge = 2 //SKYRAT EDIT - ORIGINAL: 1
+	var/charge = 1
 	///Where we cannot create the rune?
 	var/static/list/blacklisted_turfs = typecacheof(list(/turf/closed,/turf/open/space,/turf/open/lava))
+	var/has_passive_charge = TRUE //SKYRAT ADDITION: PASSIVE CHARGES. GAINED EVERY 15 MINUTES AFTER YOU FIRST DRAW A RUIN.
 
 /obj/item/forbidden_book/Destroy()
 	last_user = null
 	. = ..()
+
+/obj/item/forbidden_book/proc/alert_passive_charge() //SKYRAT ADDITION
+	if(!last_user || !last_user.mind.has_antag_datum(/datum/antagonist/heretic))
+		return
+	to_chat(last_user, span_danger("You feel [src] calling to you... new knowledge has been found! Draw a new rune to transfer this knowledge."))
+	has_passive_charge = TRUE
 
 
 /obj/item/forbidden_book/examine(mob/user)
@@ -25,6 +32,7 @@
 	. += "Use it on the floor to create a transmutation rune, used to perform rituals."
 	. += "Hit an influence in the black part with it to gain a charge."
 	. += "Hit a transmutation rune to destroy it."
+	. += "You can gain a passive charge every 15 minutes after first drawing a rune." //SKYRAT ADDITION.
 
 /obj/item/forbidden_book/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
@@ -56,7 +64,13 @@
 	to_chat(user, span_danger("You start drawing a rune..."))
 
 	if(do_after(user,30 SECONDS,A))
-
+		//SKYRAT ADDITION STARTS HERE
+		if(has_passive_charge)
+			charge++
+			to_chat(user, span_danger("The new rune glows as eldritch knowledge is transfered to your tome!"))
+			addtimer(CALLBACK(src,.proc/alert_passive_charge),20 MINUTES)
+			has_passive_charge = FALSE
+		//SKYRAT ADDITION ENDS HERE
 		new /obj/effect/eldritch/big(A)
 
 ///Removes runes from the selected turf


### PR DESCRIPTION
## About The Pull Request

Heretics now get passive research points over time (1 per 15 minutes after initially first creating a rune).

## Why It's Good For The Game

Heretics is an undercooked gamemode for Skyrat. There are only two ways to gain points via heretic:
1. Finding arbitrary and very finite amount of magic crystals on station that cannot be shared.
2. Sacrificing very specific people who may or may not be in a dorm fucking or with a group of friends who don't ever move.

These are dumb ways to get points. 

A point every 15 minutes, assuming you're efficient means:
4 points every hour.
8 points every 2 hours.

Combine this with policy saying that unsanctioned religious ceremonies and summonings are against corporate regulations, and now you have a functional gamemode.


## Changelog
:cl:
balance: Heretics now get passive points over time (1 per 15 minutes after initially first creating a rune)
balance: Heretic starting points decreased from 2 to 1.
/:cl: