### PR TITLE
Exempts "Upstream PR Merged" from becoming stale.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,4 +17,4 @@ jobs:
         days-before-stale: 2
         days-before-close: 3
         stale-pr-label: 'Stale'
-        exempt-pr-label: 'RED LABEL'
+        exempt-pr-label: 'Upstream PR Merged'


### PR DESCRIPTION
Shouldn't ever happen.