### PR TITLE
[Modular] DO is a head once again.

### DIFF
--- a/modular_skyrat/master_files/code/datums/id_trim/syndicate.dm
+++ b/modular_skyrat/master_files/code/datums/id_trim/syndicate.dm
@@ -77,6 +77,7 @@
 /datum/id_trim/syndicom/skyrat/interdyne/deckofficer
 	assignment = "Deck Officer"
 	trim_state = "trim_deckofficer"
+	access = list(ACCESS_SYNDICATE,ACCESS_ROBOTICS,ACCESS_SYNDICATE_LEADER)
 
 ///Misc
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
~~Lightly parodying #1972, since I forgot to update the Deck Officer to have command access. Honk!~~
All hail cargo. DO while not having a console mapped yet, they can use their tablet to change access of people.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cargo is often their own thing, with CL getting involved not too often, so it's a good thing to relegate the power to the DO, which already kind of resides and rules over cargo.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: DO is now a head of cargo, instead of the CL. And while being a head he's also command and all that stuff.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
