### PR TITLE
[BUG-FIX][SPEEDMERGE] Ambition auto approval actually fucking works now

### DIFF
--- a/modular_skyrat/modules/ambitions/code/ambition.dm
+++ b/modular_skyrat/modules/ambitions/code/ambition.dm
@@ -392,7 +392,8 @@
 	changed_after_approval = FALSE
 	last_requested_change = null
 	GLOB.ambitions_to_review -= src
-	log_action("APPROVED", FALSE)
+	submit();
+	log_action("AUTOMATICALLY APPROVED", FALSE)
 
 /datum/ambitions/proc/cancel_auto_approve()
 	if(auto_approve_timerid)

--- a/modular_skyrat/modules/ambitions/code/ambition.dm
+++ b/modular_skyrat/modules/ambitions/code/ambition.dm
@@ -324,7 +324,7 @@
 					if(I.prefs.toggles & SOUND_ADMINHELP)
 						SEND_SOUND(I, sound('modular_skyrat/modules/admin/sound/duckhonk.ogg'))
 					window_flash(I, ignorepref = TRUE)
-				auto_approve_timerid = _addtimer(CALLBACK(src, .proc/auto_approve), 5 MINUTES, TIMER_UNIQUE|TIMER_CLIENT_TIME)
+				auto_approve_timerid = _addtimer(CALLBACK(src, .proc/auto_approve), 10 MINUTES, TIMER_UNIQUE|TIMER_CLIENT_TIME)
 			if("spice")
 				var/new_intensity = text2num(href_list["amount"])
 				if(intensity == new_intensity)

--- a/modular_skyrat/modules/ambitions/code/ambition.dm
+++ b/modular_skyrat/modules/ambitions/code/ambition.dm
@@ -324,7 +324,7 @@
 					if(I.prefs.toggles & SOUND_ADMINHELP)
 						SEND_SOUND(I, sound('modular_skyrat/modules/admin/sound/duckhonk.ogg'))
 					window_flash(I, ignorepref = TRUE)
-				auto_approve_timerid = addtimer(CALLBACK(src, .proc/auto_approve), 5 MINUTES)
+				auto_approve_timerid = _addtimer(CALLBACK(src, .proc/auto_approve), 5 MINUTES, TIMER_UNIQUE|TIMER_CLIENT_TIME)
 			if("spice")
 				var/new_intensity = text2num(href_list["amount"])
 				if(intensity == new_intensity)


### PR DESCRIPTION
## Changelog
:cl:
fix: Use the correct timer flags for it to actually hash correctly
fix: Actually call submit when it auto approves so they get their gear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
