### PR TITLE
[MODULAR] Lavaland Samples to Purchase

### DIFF
--- a/modular_skyrat/modules/cargo/code/bloat.dm
+++ b/modular_skyrat/modules/cargo/code/bloat.dm
@@ -56,6 +56,20 @@
 /////////////////////////////// Service //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
+/datum/supply_pack/organic/lavalandsamples
+	name = "Planetary Flora Samples"
+	desc = "A box of samples taken from the surface of Lavaland. Requires Hydroponics access to open."
+	cost = CARGO_CRATE_VALUE * 2
+	access_view = ACCESS_HYDROPONICS
+	contains = list(/obj/item/seeds/lavaland/polypore,
+					/obj/item/seeds/lavaland/porcini,
+					/obj/item/seeds/lavaland/inocybe,
+					/obj/item/seeds/lavaland/ember,
+					/obj/item/seeds/lavaland/seraka,
+					/obj/item/seeds/star_cactus,
+					/obj/item/seeds/star_cactus)
+	crate_name = "planetary seeds crate"
+	crate_type = /obj/structure/closet/crate/hydroponics
 
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Goodies //////////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can buy all the lavaland seeds from cargo now, costs the same as the exotic seeds crate

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Now that we have random mining, sometimes botanists have 0 access to a bunch of cool plants with unique traits. This just gives them the option if no miners are available to harvest samples / they can't go down themselves / Lavaland doesn't roll.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Lavaland flora seeds can be purchased from cargo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
