### PR TITLE
[semi-modular] medical holobarrier change

### DIFF
--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -145,7 +145,7 @@
 /obj/structure/holosign/barrier/medical/examine(mob/user)
 	. = ..()
 	. += span_notice("The biometric scanners are <b>[force_allaccess ? "off" : "on"]</b>.")
-
+/* SKYRAT EDIT ADDITION: Directional Barrier
 /obj/structure/holosign/barrier/medical/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
 	if(force_allaccess)
@@ -173,7 +173,7 @@
 	if(get_disease_severity_value(threat) > get_disease_severity_value(DISEASE_SEVERITY_MINOR))
 		return FALSE
 	return TRUE
-
+SKYRAT EDIT ADDITION END*/
 /obj/structure/holosign/barrier/medical/attack_hand(mob/living/user, list/modifiers)
 	if(!user.combat_mode && CanPass(user, get_dir(src, user)))
 		force_allaccess = !force_allaccess

--- a/modular_skyrat/modules/holosign_medical_change/code/game/objects/items/holosign_creator.dm
+++ b/modular_skyrat/modules/holosign_medical_change/code/game/objects/items/holosign_creator.dm
@@ -1,0 +1,38 @@
+/obj/item/holosign_creator/medical
+	max_signs = 6
+	var/directional_mode = FALSE
+	var/direction_locked
+
+/obj/item/holosign_creator/medical/examine(mob/user)
+	. = ..()
+	. += span_notice("CTRL + Click to switch between modes.")
+	. += span_notice("Current Mode: [directional_mode ? "Directional" : "Omni-Directional"]")
+
+/obj/item/holosign_creator/medical/CtrlClick(mob/user)
+	. = ..()
+	directional_mode = !directional_mode
+	direction_locked = null
+	if(directional_mode)
+		var/user_choice = input(user, "Choose which direction you wish for the medical holobarriers to restrict.", "Medical Holobarrier Direction Selection") as null|anything in list("NORTH", "EAST", "SOUTH", "WEST")
+		if(!user_choice)
+			directional_mode = FALSE
+			return
+		switch(user_choice)
+			if("NORTH")
+				direction_locked = NORTH
+			if("EAST")
+				direction_locked = EAST
+			if("SOUTH")
+				direction_locked = SOUTH
+			if("WEST")
+				direction_locked = WEST
+	to_chat(user, span_notice("New Mode: [directional_mode ? "Directional" : "Omni-Directional"]"))
+	playsound(src, 'sound/machines/click.ogg', 50, TRUE)
+
+/obj/item/holosign_creator/medical/afterattack(atom/target, mob/user, proximity_flag)
+	. = ..()
+	var/turf/target_turf = get_turf(target)
+	var/obj/structure/holosign/barrier/medical/target_holosign = locate(holosign_type) in target_turf
+	if(directional_mode && direction_locked && target_holosign)
+		target_holosign.directional_mode = TRUE
+		target_holosign.direction_locked = direction_locked

--- a/modular_skyrat/modules/holosign_medical_change/code/game/objects/structures/holosign.dm
+++ b/modular_skyrat/modules/holosign_medical_change/code/game/objects/structures/holosign.dm
@@ -1,0 +1,48 @@
+/obj/structure/holosign/barrier/medical
+	var/directional_mode = FALSE
+	var/direction_locked = null
+
+/obj/structure/holosign/barrier/medical/examine(mob/user)
+	. = ..()
+	if(directional_mode)
+		var/direction_name
+		switch(dir)
+			if(NORTH)
+				direction_name = "North"
+			if(EAST)
+				direction_name = "East"
+			if(SOUTH)
+				direction_name = "South"
+			if(WEST)
+				direction_name = "West"
+		. += span_notice("Blocked Direction: [direction_name]")
+
+/obj/structure/holosign/barrier/medical/CanAllowThrough(atom/movable/mover, border_dir)
+	. = ..()
+	if(force_allaccess)
+		return TRUE
+	if(istype(mover, /obj/vehicle/ridden))
+		for(var/M in mover.buckled_mobs)
+			if(ishuman(M))
+				if(!CheckHuman(M, border_dir))
+					return FALSE
+	if(ishuman(mover))
+		return CheckHuman(mover, border_dir)
+	return TRUE
+
+/obj/structure/holosign/barrier/medical/Bumped(atom/movable/AM, border_dir)
+	. = ..()
+	icon_state = "holo_medical"
+	if(ishuman(AM) && !CheckHuman(AM, border_dir))
+		if(buzzcd < world.time)
+			playsound(get_turf(src),'sound/machines/buzz-sigh.ogg',65,TRUE,4)
+			buzzcd = (world.time + 60)
+		icon_state = "holo_medical-deny"
+
+/obj/structure/holosign/barrier/medical/proc/CheckHuman(mob/living/carbon/human/sickboi, border_dir)
+	var/threat = sickboi.check_virus()
+	if(get_disease_severity_value(threat) > get_disease_severity_value(DISEASE_SEVERITY_MINOR))
+		if(directional_mode && border_dir != direction_locked)
+			return TRUE
+		return FALSE
+	return TRUE

--- a/modular_skyrat/modules/holosign_medical_change/readme.md
+++ b/modular_skyrat/modules/holosign_medical_change/readme.md
@@ -1,0 +1,27 @@
+## Title: Medical Holobarrier Change
+
+MODULE ID: MEDICAL_HOLOBARRIER_CHANGE
+
+### Description:
+
+Medical Holobarriers can now deploy 6, and there is a new mode: directional. Directional allows infected persons to enter but not leave a certain direction.
+
+### TG Proc Changes:
+
+- N/A
+
+### Defines:
+
+- N/A
+
+### Master file additions
+
+- N/A
+
+### Included files that are not contained in this module:
+
+- N/A
+
+### Credits:
+
+Jake Park

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4186,6 +4186,8 @@
 #include "modular_skyrat\modules\holdingfashion_port\code\game\objects\items\storage\backpack.dm"
 #include "modular_skyrat\modules\holdingfashion_port\code\research\designs\bluespace_design.dm"
 #include "modular_skyrat\modules\holdingfashion_port\code\research\techweb\bluespace_node.dm"
+#include "modular_skyrat\modules\holosign_medical_change\code\game\objects\items\holosign_creator.dm"
+#include "modular_skyrat\modules\holosign_medical_change\code\game\objects\structures\holosign.dm"
 #include "modular_skyrat\modules\horrorform\code\modules\antagonists\changeling\powers\horror_form.dm"
 #include "modular_skyrat\modules\horrorform\code\modules\mob\hostile\true_changeling.dm"
 #include "modular_skyrat\modules\huds\code\designs.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
medical holobarriers now have 6 instead of 3
medical holobarriers can either be omnidirectional (original) or directional (new).
directional means that infected persons can enter but not leave that direction.
ex: a north holobarrier means trying to enter from the turf north of the holobarrier blocks.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
suggestion: https://discord.com/channels/596783386295795713/640760802730835988/859505037718061066

## Changelog
:cl:
new: added an additional mode: directional for holobarrier
balance: medical holobarrier max amount 3 to 6
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
