### PR TITLE
[MODULAR] Adds minimum players to several high-severity items and kits for traitors #2

### DIFF
--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -47,6 +47,7 @@
 	desc = "A fully-loaded Scarborough Arms bullpup submachine gun. The C-20r fires .45 rounds with a \
 			24-round magazine and is compatible with suppressors."
 	item = /obj/item/gun/ballistic/automatic/c20r/unrestricted
+	player_minimum = 25
 	cost = 14
 
 /datum/uplink_item/dangerous/shotgun_traitor
@@ -80,10 +81,13 @@
 	name = "CQC Manual"
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing."
 	item = /obj/item/book/granter/martial/cqc
+	player_minimum = 40
 	cost = 23
 	surplus = 17
+
 // Removed from the uplink for the time being.
-/*datum/uplink_item/stealthy_weapons/cqcplus
+/*
+/datum/uplink_item/stealthy_weapons/cqcplus
 	name = "CQC+ Manual"
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat and how to deflect projectiles before self-destructing."
 	item = /obj/item/book/granter/martial/cqc/plus
@@ -238,6 +242,7 @@
 	desc = "An upgraded, elite version of the Syndicate hardsuit. It features fireproofing, and also \
 			provides the user with superior armor and mobility compared to the standard Syndicate hardsuit."
 	item = /obj/item/clothing/suit/space/hardsuit/syndi/elite
+	player_minimum = 40
 	cost = 10
 
 /datum/uplink_item/suits/standard_armor
@@ -311,24 +316,28 @@
 	name = "Bulldog Operative bundle"
 	desc = "Fight the power with this frontline combatant kit, featuring armor and armaments commonly utilized by assault operative teams."
 	item = /obj/item/storage/backpack/duffelbag/syndie/loadout/metaops
+	player_minimum = 50
 	cost = 23
 
 /datum/uplink_item/loadout_skyrat/bond
 	name = "Classic Spy bundle"
 	desc = "Play the hero or the villain in a cheesy spy movie with this throwback kit to far less modern syndicate operatives."
 	item = /obj/item/storage/backpack/duffelbag/syndie/loadout/bond
+	player_minimum = 40
 	cost = 20
 
 /datum/uplink_item/loadout_skyrat/ninja
 	name = "Cyborg Ninja bundle"
 	desc = "Become a force of nature with this customized kit featuring next-generation syndicate technology in an efficient package."
 	item = /obj/item/storage/backpack/duffelbag/syndie/loadout/ninja
+	player_minimum = 50
 	cost = 20
 
 /datum/uplink_item/loadout_skyrat/darklord
 	name = "Dark Lord bundle"
 	desc = "Wield unlimited power with this extremely effective combative kit, guaranteed to give the user efficient staying potential in any confrontation."
 	item = /obj/item/storage/backpack/duffelbag/syndie/loadout/darklord
+	player_minimum = 50
 	cost = 20
 
 /datum/uplink_item/loadout_skyrat/hunter
@@ -359,6 +368,7 @@
 	name = "Laserman Bundle"
 	desc = "Themed after an infamous syndicate operative with a particular fighting style, this kit is both a fashionable throwback and a uniquely useful combative loadout."
 	item = /obj/item/storage/box/syndie_kit/loadout/lasermanbundle
+	player_minimum = 50
 	cost = 20
 
 //Badass section down here
@@ -367,6 +377,7 @@
 	desc = "Themed after the infamous terrorist(or not), Johnny Robohand. You have no reason to fail your objectives with this kit. The gun inside requires your arm to be robotic. \
 			It comes with a robotic replacement arm. Wake the fuck up, samurai."
 	item = /obj/item/storage/backpack/duffelbag/syndie/loadout/robohand
+	player_minimum = 50
 	cost = 35
 
 /datum/uplink_item/loadout_skyrat/robohand/purchase(mob/user, datum/component/uplink/U)


### PR DESCRIPTION
## About The Pull Request

Title

Remake of #6638 

This time, not on master branch!

## Why It's Good For The Game

No super high severity items on lowpop!

## Changelog
:cl:
balance: Puts high severity traitor items behind player minimum requirements.
/:cl:

