### PR TITLE
Firelocks remastered

### DIFF
--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -91,7 +91,7 @@ again.
 /obj/effect/spawner/structure/window/reinforced
 	name = "reinforced window spawner"
 	icon_state = "rwindow_spawner"
-	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/fulltile)
+	spawn_list = list(/obj/machinery/door/firedoor/onetile, /obj/structure/grille, /obj/structure/window/reinforced/fulltile) //SKYRAT EDIT CHANGE
 
 /obj/effect/spawner/structure/window/hollow/reinforced
 	name = "hollow reinforced window spawner"

--- a/modular_skyrat/modules/aesthetics/firedoor/code/firedoor.dm
+++ b/modular_skyrat/modules/aesthetics/firedoor/code/firedoor.dm
@@ -1,3 +1,5 @@
+#define FIREDOOR_CLOSE_OVERRIDE_RESET_TIME 3 MINUTES
+
 /obj/machinery/door/firedoor
 	name = "Emergency Shutter"
 	desc = "Emergency air-tight shutter, capable of sealing off breached areas. This one has a glass panel. It has a mechanism to open it with just your hands."
@@ -79,9 +81,22 @@
 /obj/machinery/door/firedoor/attackby(obj/item/C, mob/user, params)
 	if(C.GetID())
 		if(allowed(user))
-			stay_open = !stay_open
-			balloon_alert(user, "close override [stay_open ? "engaged" : "disengaged"]")
+			toggle_close_override(user)
 	return ..()
+
+
+/obj/machinery/door/firedoor/CtrlClick(mob/user)
+	if(!user.canUseTopic(src, !issilicon(user)))
+		return
+	toggle_close_override()
+
+/obj/machinery/door/firedoor/proc/toggle_close_override(mob/user)
+	stay_open = !stay_open
+	balloon_alert(user, "close override [stay_open ? "engaged" : "disengaged"]")
+	addtimer(CALLBACK(src, .proc/close_override_reset), FIREDOOR_CLOSE_OVERRIDE_RESET_TIME)
+
+/obj/machinery/door/firedoor/proc/close_override_reset()
+	stay_open = FALSE
 
 /obj/machinery/door/firedoor/examine(mob/user)
 	. = ..()
@@ -90,3 +105,4 @@
 /obj/effect/spawner/structure/window/reinforced/no_firelock
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/fulltile)
 
+#undef FIREDOOR_CLOSE_OVERRIDE_RESET_TIME

--- a/modular_skyrat/modules/aesthetics/firedoor/code/firedoor.dm
+++ b/modular_skyrat/modules/aesthetics/firedoor/code/firedoor.dm
@@ -2,9 +2,14 @@
 	name = "Emergency Shutter"
 	desc = "Emergency air-tight shutter, capable of sealing off breached areas. This one has a glass panel. It has a mechanism to open it with just your hands."
 	icon = 'modular_skyrat/modules/aesthetics/firedoor/icons/firedoor_glass.dmi'
+
+	req_access = list(ACCESS_ATMOSPHERICS)
+
 	var/door_open_sound = 'modular_skyrat/modules/aesthetics/firedoor/sound/firedoor_open.ogg'
 	var/door_close_sound = 'modular_skyrat/modules/aesthetics/firedoor/sound/firedoor_open.ogg'
 	var/hot_or_cold = FALSE //True for hot, false for cold
+
+	var/stay_open = FALSE // Do we stay open? Triggered via atmos techs using their ID on it.
 
 /obj/machinery/door/firedoor/heavy
 	name = "Heavy Emergency Shutter"
@@ -17,9 +22,12 @@
 /obj/machinery/door/firedoor/open()
 	playsound(loc, door_open_sound, 90, TRUE)
 	. = ..()
+
 /obj/machinery/door/firedoor/close()
+	if(stay_open)
+		return
 	playsound(loc, door_close_sound, 90, TRUE)
-	. = ..()
+	return ..()
 
 /obj/machinery/door/firedoor/proc/atmos_changed(datum/source, datum/gas_mixture/air, exposed_temperature)
 	if(density)
@@ -66,7 +74,19 @@
 	var/my_area = get_area(src)
 
 	for(var/obj/machinery/firealarm/iterating_alarm in my_area)
-		iterating_alarm.RegisterSignal(src, COMSIG_FIREDOOR_CLOSED_FIRE, /obj/machinery/firealarm.proc/trigger_effects, FALSE) //We trigger the alarms automatically.
+		iterating_alarm.RegisterSignal(src, COMSIG_FIREDOOR_CLOSED_FIRE, /obj/machinery/firealarm.proc/trigger_effects, FALSE, override = TRUE) //We trigger the alarms automatically.
+
+/obj/machinery/door/firedoor/attackby(obj/item/C, mob/user, params)
+	if(C.GetID())
+		if(allowed(user))
+			stay_open = !stay_open
+			balloon_alert(user, "close override [stay_open ? "engaged" : "disengaged"]")
+	return ..()
+
+/obj/machinery/door/firedoor/examine(mob/user)
+	. = ..()
+	. += span_notice("It's close override mechanism is [stay_open ? "engaged" : "disengaged"].______qdel_list_wrapper")
 
 /obj/effect/spawner/structure/window/reinforced/no_firelock
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/fulltile)
+

--- a/modular_skyrat/modules/aesthetics/firedoor/code/firedoor.dm
+++ b/modular_skyrat/modules/aesthetics/firedoor/code/firedoor.dm
@@ -61,7 +61,7 @@
 	var/my_area = get_area(src)
 
 	for(var/obj/machinery/firealarm/iterating_alarm in my_area)
-		iterating_alarm.RegisterSignal(src, COMSIG_FIREDOOR_CLOSED_FIRE, /obj/machinery/firealarm.proc/trigger_effects, FALSE) //We trigger the alarms automatically.
+		iterating_alarm.RegisterSignal(src, COMSIG_FIREDOOR_CLOSED_FIRE, /obj/machinery/firealarm.proc/trigger_effects, override = TRUE) //We trigger the alarms automatically.
 
 /obj/machinery/door/firedoor/update_icon_state()
 	. = ..()
@@ -71,12 +71,12 @@
 		icon_state = "[base_icon_state]_open"
 
 /obj/machinery/door/firedoor/onetile/CalculateAffectingAreas()
-	RegisterSignal(loc, COMSIG_TURF_EXPOSE, .proc/atmos_changed)
+	RegisterSignal(loc, COMSIG_TURF_EXPOSE, .proc/atmos_changed, override = TRUE)
 
 	var/my_area = get_area(src)
 
 	for(var/obj/machinery/firealarm/iterating_alarm in my_area)
-		iterating_alarm.RegisterSignal(src, COMSIG_FIREDOOR_CLOSED_FIRE, /obj/machinery/firealarm.proc/trigger_effects, FALSE, override = TRUE) //We trigger the alarms automatically.
+		iterating_alarm.RegisterSignal(src, COMSIG_FIREDOOR_CLOSED_FIRE, /obj/machinery/firealarm.proc/trigger_effects, override = TRUE) //We trigger the alarms automatically.
 
 /obj/machinery/door/firedoor/attackby(obj/item/C, mob/user, params)
 	if(C.GetID())
@@ -88,7 +88,7 @@
 /obj/machinery/door/firedoor/CtrlClick(mob/user)
 	if(!user.canUseTopic(src, !issilicon(user)))
 		return
-	toggle_close_override()
+	toggle_close_override(user)
 
 /obj/machinery/door/firedoor/proc/toggle_close_override(mob/user)
 	stay_open = !stay_open

--- a/modular_skyrat/modules/aesthetics/firedoor/code/firedoor.dm
+++ b/modular_skyrat/modules/aesthetics/firedoor/code/firedoor.dm
@@ -56,7 +56,7 @@
 
 /obj/machinery/door/firedoor/proc/CalculateAffectingAreas()
 	for(var/turf/adjacent_turf in range(1, src))
-		RegisterSignal(adjacent_turf, COMSIG_TURF_EXPOSE, .proc/atmos_changed)
+		RegisterSignal(adjacent_turf, COMSIG_TURF_EXPOSE, .proc/atmos_changed, override = TRUE)
 
 	var/my_area = get_area(src)
 

--- a/modular_skyrat/modules/aesthetics/firedoor/code/firedoor.dm
+++ b/modular_skyrat/modules/aesthetics/firedoor/code/firedoor.dm
@@ -59,3 +59,14 @@
 		icon_state = "[base_icon_state]_closed_[hot_or_cold ? "hot" : "cold"]"
 	else
 		icon_state = "[base_icon_state]_open"
+
+/obj/machinery/door/firedoor/onetile/CalculateAffectingAreas()
+	RegisterSignal(loc, COMSIG_TURF_EXPOSE, .proc/atmos_changed)
+
+	var/my_area = get_area(src)
+
+	for(var/obj/machinery/firealarm/iterating_alarm in my_area)
+		iterating_alarm.RegisterSignal(src, COMSIG_FIREDOOR_CLOSED_FIRE, /obj/machinery/firealarm.proc/trigger_effects, FALSE) //We trigger the alarms automatically.
+
+/obj/effect/spawner/structure/window/reinforced/no_firelock
+	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/fulltile)


### PR DESCRIPTION
Firelocks now come in two types, standard and onetile, and all reinforced windows now come with firelocks as standard!

Atmos techs can now force open a firelock for repairs.