### PR TITLE
[SEMI-MODULAR] Batons can once again apply stamina damage

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -237,13 +237,7 @@
 	L.Jitter(20)
 	//L.set_confusion(max(confusion_amt, L.get_confusion())) //SKYRAT EDIT REMOVAL
 	L.stuttering = max(8, L.stuttering)
-	L.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)
-	//SKYRAT EDIT CHANGE BEGIN
-	if(harmy) //Less extra stamina damage for harm batons
-		L.StaminaKnockdown(5)
-	else
-		L.StaminaKnockdown(stamina_loss_amt)
-		//SKYRAT EDIT CHANGE END
+	L.apply_damage(harmy ? 5 : stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)
 
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	//addtimer(CALLBACK(src, .proc/apply_stun_effect_end, L), apply_stun_delay) SKYRAT EDIT REMOVAL

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -237,7 +237,7 @@
 	L.Jitter(20)
 	//L.set_confusion(max(confusion_amt, L.get_confusion())) //SKYRAT EDIT REMOVAL
 	L.stuttering = max(8, L.stuttering)
-	//L.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST) - SKYRAT EDIT REMOVAL
+	L.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)
 	//SKYRAT EDIT CHANGE BEGIN
 	if(harmy) //Less extra stamina damage for harm batons
 		L.StaminaKnockdown(5)

--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_baton.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_baton.dm
@@ -11,6 +11,7 @@
 	force = 10
 	w_class = WEIGHT_CLASS_NORMAL
 	cooldown = 1.5 SECONDS
+	stamina_damage = 25 // its normally 55, this is less than half
 
 /obj/item/melee/baton/peacekeeper
 	name = "stunstick"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

During a previous PR someone commented out items dealing stamina damage.
This fixes that but also nerfs the stamina damage the peacekeeper baton actually deals.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

"Lets remove a game mechanic because I don't want to nerf it correctly"

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Stamina Damage works again
balance: Peacekeeper Batons deal less than a half of what they were originally supposed to
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
