### PR TITLE
[MODULAR] Stamina Update - Three Hops This Time

### DIFF
--- a/code/__DEFINES/~skyrat_defines/combat.dm
+++ b/code/__DEFINES/~skyrat_defines/combat.dm
@@ -28,16 +28,16 @@
 #define STAMINALOSS_REGEN_COEFF 50
 
 //Thresholds for detrimental effects from stamina
-#define STAMINA_THRESHOLD_WEAK 60
+#define STAMINA_THRESHOLD_WEAK 25
 
-#define STAMINA_THRESHOLD_KNOCKDOWN 120
+#define STAMINA_THRESHOLD_KNOCKDOWN 50
 
-#define STAMINA_THRESHOLD_SOFTCRIT 150
+#define STAMINA_THRESHOLD_SOFTCRIT 75
 
-#define STAMINA_THRESHOLD_HARDCRIT 150
+#define STAMINA_THRESHOLD_HARDCRIT 100
 
 //Stamina threshold from which resisting a grab becomes hard
-#define STAMINA_THRESHOLD_HARD_RESIST 80
+#define STAMINA_THRESHOLD_HARD_RESIST 30
 
 //A coefficient for doing the change of random CC's on a person (staminaloss/THIS)
 #define STAMINA_CROWD_CONTROL_COEFF 200


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates the defines for stamina flags.
Stamina damage is capped to MaxHP - (burn + brute); as such the maximum stamina damage you can ever have is MaxHP.
MaxHP is currently 135.
All limbs have a static stamina_modifier that changes how much stamina damage is converted to stamina loss.
This value defaults to 0.75 and is unchanged across most, if not all, boydparts.
This means the most stamina loss you can ever have is 101.25

Currently the only items that can actually put you into stam crit are items that directly set stamina damage instead of using the correct procs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Resolves an issue with stamina that has been present for five months due to myself and many others making bad assumptions about procs and how they work.
We apologize for the inconvenience.