### PR TITLE
[NONMODULAR] [READY] Tweaks the cost of a few positive quirks

### DIFF
--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -30,7 +30,7 @@
 /datum/quirk/drunkhealing
 	name = "Drunken Resilience"
 	desc = "Nothing like a good drink to make you feel on top of the world. Whenever you're drunk, you slowly recover from injuries."
-	value = 6 /// SKYRAT EDIT - Quirk Rebalance - Original: value = 8
+	value = 8
 	mob_trait = TRAIT_DRUNK_HEALING
 	gain_text = "<span class='notice'>You feel like a drink would do you good.</span>"
 	lose_text = "<span class='danger'>You no longer feel like drinking would ease your pain.</span>"
@@ -53,7 +53,7 @@
 /datum/quirk/empath
 	name = "Empath"
 	desc = "Whether it's a sixth sense or careful study of body language, it only takes you a quick glance at someone to understand how they feel."
-	value = 4 /// SKYRAT EDIT - Quirk Rebalance - Original: value = 8
+	value = 6 /// SKYRAT EDIT - Quirk Rebalance - Original: value = 8
 	mob_trait = TRAIT_EMPATH
 	gain_text = "<span class='notice'>You feel in tune with those around you.</span>"
 	lose_text = "<span class='danger'>You feel isolated from others.</span>"

--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -53,7 +53,7 @@
 /datum/quirk/empath
 	name = "Empath"
 	desc = "Whether it's a sixth sense or careful study of body language, it only takes you a quick glance at someone to understand how they feel."
-	value = 4
+	value = 4 /// SKYRAT EDIT - Quirk Rebalance - Original: value = 8
 	mob_trait = TRAIT_EMPATH
 	gain_text = "<span class='notice'>You feel in tune with those around you.</span>"
 	lose_text = "<span class='danger'>You feel isolated from others.</span>"

--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -30,7 +30,7 @@
 /datum/quirk/drunkhealing
 	name = "Drunken Resilience"
 	desc = "Nothing like a good drink to make you feel on top of the world. Whenever you're drunk, you slowly recover from injuries."
-	value = 6
+	value = 6 /// SKYRAT EDIT - Quirk Rebalance - Original: value = 8
 	mob_trait = TRAIT_DRUNK_HEALING
 	gain_text = "<span class='notice'>You feel like a drink would do you good.</span>"
 	lose_text = "<span class='danger'>You no longer feel like drinking would ease your pain.</span>"

--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -30,7 +30,7 @@
 /datum/quirk/drunkhealing
 	name = "Drunken Resilience"
 	desc = "Nothing like a good drink to make you feel on top of the world. Whenever you're drunk, you slowly recover from injuries."
-	value = 8
+	value = 6
 	mob_trait = TRAIT_DRUNK_HEALING
 	gain_text = "<span class='notice'>You feel like a drink would do you good.</span>"
 	lose_text = "<span class='danger'>You no longer feel like drinking would ease your pain.</span>"
@@ -53,7 +53,7 @@
 /datum/quirk/empath
 	name = "Empath"
 	desc = "Whether it's a sixth sense or careful study of body language, it only takes you a quick glance at someone to understand how they feel."
-	value = 8
+	value = 4
 	mob_trait = TRAIT_EMPATH
 	gain_text = "<span class='notice'>You feel in tune with those around you.</span>"
 	lose_text = "<span class='danger'>You feel isolated from others.</span>"
@@ -179,7 +179,7 @@
 /datum/quirk/item_quirk/spiritual
 	name = "Spiritual"
 	desc = "You hold a spiritual belief, whether in God, nature or the arcane rules of the universe. You gain comfort from the presence of holy people, and believe that your prayers are more special than others. Being in the chapel makes you happy."
-	value = 4
+	value = 2
 	mob_trait = TRAIT_SPIRITUAL
 	gain_text = "<span class='notice'>You have faith in a higher power.</span>"
 	lose_text = "<span class='danger'>You lose faith!</span>"

--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -179,7 +179,7 @@
 /datum/quirk/item_quirk/spiritual
 	name = "Spiritual"
 	desc = "You hold a spiritual belief, whether in God, nature or the arcane rules of the universe. You gain comfort from the presence of holy people, and believe that your prayers are more special than others. Being in the chapel makes you happy."
-	value = 2
+	value = 2 /// SKYRAT EDIT - Quirk Rebalance - Original: value = 4
 	mob_trait = TRAIT_SPIRITUAL
 	gain_text = "<span class='notice'>You have faith in a higher power.</span>"
 	lose_text = "<span class='danger'>You lose faith!</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Read the title, tweaks Drunken Resilience from 8 to 6, Empath from 8 to 4, and Spiritual from 4 to 2.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Drunken Resilience's healing is just too bad to be worth 8 points.
Empath has to compete with Freerunning and Skittish which are both infinitely better mechanically.
Spiritual is essentially a flavour quirk, on par with the aspect emotes and this reflects that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Changes a few quirk's points
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
