### PR TITLE
[Modular] DS-2 Unfuck-date

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
@@ -155,11 +155,9 @@
 /turf/open/floor/iron/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
 "aB" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
 "aC" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
@@ -354,18 +352,20 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
 "bs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/trash_pile,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
+/obj/structure/chair/sofa/bench/right,
+/turf/open/floor/iron/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
 "bt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
+/obj/structure/window/reinforced/survival_pod{
 	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
@@ -431,7 +431,8 @@
 	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "bE" = (
 /obj/machinery/door/airlock/virology{
@@ -514,13 +515,15 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "bS" = (
-/obj/structure/chair/pew{
-	dir = 8;
-	pixel_x = 5
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/flora/rock,
+/turf/open/floor/grass,
+/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
 "bT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/trimline/brown/line,
@@ -541,6 +544,11 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"bW" = (
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
 "bY" = (
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
@@ -602,13 +610,8 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "ck" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/structure/table/glass,
+/obj/item/storage/bag/bio,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "cl" = (
@@ -677,10 +680,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "cx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_corner,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "cy" = (
 /obj/machinery/computer/monitor,
@@ -738,8 +738,8 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "cH" = (
 /obj/structure/table,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility/syndicate,
+/obj/item/storage/belt/utility/syndicate,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "cI" = (
@@ -967,7 +967,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "dB" = (
 /obj/structure/cable,
@@ -1052,10 +1052,9 @@
 /turf/open/floor/plating/catwalk_floor/plated,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "dP" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket/wooden,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
+/obj/item/stack/tile/iron,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "dQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1162,7 +1161,7 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "ei" = (
-/obj/machinery/mecha_part_fabricator/maint,
+/obj/machinery/mecha_part_fabricator,
 /turf/open/floor/iron/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "ej" = (
@@ -1307,11 +1306,12 @@
 /turf/open/floor/vault/rock,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "eG" = (
-/obj/structure/chair/pew{
-	dir = 8;
-	pixel_x = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/glass/bottle/thermite{
+	pixel_x = -8;
+	pixel_y = -5
 	},
-/turf/open/floor/wood,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "eH" = (
 /obj/structure/cable,
@@ -1388,9 +1388,12 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/mining_equipment)
 "eX" = (
-/obj/structure/chair/office{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
+/obj/item/pen/invisible,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/library)
 "eY" = (
@@ -1398,12 +1401,11 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "eZ" = (
-/obj/structure/chair/pew/left{
+/obj/structure/chair/office{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
+/area/ruin/space/has_grav/skyrat/interdynefob/service/library)
 "fa" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/computer/scan_consolenew,
@@ -1530,7 +1532,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "fw" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "fx" = (
 /turf/open/floor/iron/kitchen,
@@ -1617,7 +1619,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "fL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1783,7 +1785,7 @@
 /obj/machinery/light/small/broken/directional/east,
 /obj/machinery/conveyor{
 	dir = 1;
-	id = "garbage"
+	id = "ds2garbage"
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
@@ -1959,9 +1961,13 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "gK" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+/obj/structure/sauna_oven{
+	fuel_amount = -1;
+	water_amount = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "gL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -2090,8 +2096,9 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "hg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/pod/old/mass_driver_controller/trash{
-	pixel_y = 25
+/obj/machinery/computer/pod/old/mass_driver_controller{
+	id = "ds2disposals";
+	pixel_y = 32
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
@@ -2118,15 +2125,12 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "hl" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
+/obj/structure/sauna_oven{
+	fuel_amount = -1;
+	water_amount = -1
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/flora/rock,
-/turf/open/floor/grass,
-/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "hm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -2254,11 +2258,11 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
 "hK" = (
 /obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
@@ -2323,7 +2327,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
 	},
@@ -2520,10 +2526,12 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "iB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured_corner{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "iC" = (
 /obj/structure/table/wood,
@@ -2915,7 +2923,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "jT" = (
 /obj/effect/turf_decal/stripes/box,
@@ -3015,9 +3023,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "km" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/loot_site_spawner,
-/turf/open/floor/plating/catwalk_floor/plated,
+/obj/structure/chair/pew{
+	dir = 8;
+	pixel_x = 5
+	},
+/turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "kp" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3261,7 +3271,9 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "li" = (
-/obj/structure/closet/secure_closet/genpop,
+/obj/structure/closet/secure_closet/genpop{
+	req_access = list(151)
+	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
 	},
@@ -3409,7 +3421,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/frame/computer{
+/obj/machinery/computer/operating{
 	dir = 4
 	},
 /turf/open/floor/iron/textured,
@@ -3466,14 +3478,10 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "lZ" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/effect/mob_spawn/human/ds2/syndicate/researcher{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/skyrat/interdynefob/research)
+/obj/structure/trash_pile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "ma" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
@@ -3541,9 +3549,12 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "mr" = (
+/obj/structure/chair/pew{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/trash_pile,
-/turf/open/floor/plating/catwalk_floor/plated,
+/obj/machinery/light/broken/directional/south,
+/turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "ms" = (
 /obj/machinery/smartfridge/organ,
@@ -3560,10 +3571,11 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "mv" = (
-/obj/structure/chair/pew{
+/obj/structure/chair/pew/left{
 	dir = 4;
 	pixel_x = -5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "mw" = (
@@ -3613,6 +3625,9 @@
 /obj/item/slime_extract/grey{
 	pixel_x = 7;
 	pixel_y = 2
+	},
+/obj/item/paper{
+	info = "Hey, you, yes, you! Please be respectful to the bluespace powered monkey-cap of 64. There's potentially up to 4 xenobio labs at any time, don't use too much; and clean up after yourself!"
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
@@ -3701,12 +3716,18 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/northwest)
 "mQ" = (
-/obj/structure/chair/plastic{
-	dir = 8
+/obj/structure/chair/pew/right{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
+"mR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_edge,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/mining_equipment)
 "mS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/loot_site_spawner,
@@ -3734,7 +3755,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
-	id = "garbage";
+	id = "ds2garbage";
 	name = "disposal conveyor"
 	},
 /turf/open/floor/iron,
@@ -3744,7 +3765,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "mZ" = (
 /obj/effect/turf_decal/tile/bar,
@@ -3967,18 +3988,10 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/chapel)
 "nU" = (
-/obj/structure/table/wood,
-/obj/item/pen/blue{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/pen/red,
-/obj/item/pen/fourcolor{
-	pixel_x = -5;
-	pixel_y = -4
-	},
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/wood,
-/area/ruin/space/has_grav/skyrat/interdynefob/service/library)
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "nV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -4290,7 +4303,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
-/obj/machinery/vending/wardrobe/jani_wardrobe,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "oQ" = (
@@ -4331,6 +4344,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
+"oV" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
 "oX" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -4421,7 +4447,9 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/northeast)
 "pn" = (
 /obj/structure/table,
-/obj/item/storage/box/skillchips/science,
+/obj/item/storage/box/skillchips/science{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/textured,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "po" = (
@@ -4550,7 +4578,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "pI" = (
-/obj/machinery/vending/wardrobe/curator_wardrobe,
+/obj/machinery/modular_computer/console/preset/curator{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/library)
 "pL" = (
@@ -4616,7 +4646,6 @@
 "pT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "pU" = (
@@ -4643,18 +4672,20 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/grunge{
-	aiControlDisabled = 1;
 	name = "Planetary Access";
 	req_access_txt = "150"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "pY" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "pZ" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -4679,7 +4710,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "garbage"
+	id = "ds2garbage"
 	},
 /obj/machinery/door/window/westright,
 /turf/open/floor/iron,
@@ -4708,6 +4739,19 @@
 	dir = 1
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
+"qh" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
 "qi" = (
 /obj/machinery/shower{
 	dir = 4
@@ -4807,7 +4851,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/table,
+/obj/item/mop,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "qv" = (
@@ -4991,11 +5036,11 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "rb" = (
+/obj/machinery/recycler,
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "garbage"
+	id = "ds2garbage"
 	},
-/obj/machinery/recycler,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "rc" = (
@@ -5029,14 +5074,18 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "rj" = (
-/obj/structure/window{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	dir = 4
-	},
 /obj/machinery/shower{
 	dir = 1
+	},
+/obj/structure/drain,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/door/window/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 5
 	},
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
@@ -5068,8 +5117,16 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "rq" = (
-/obj/machinery/door/poddoor/massdriver_trash,
 /obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "ds2disposals"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "rr" = (
@@ -5124,6 +5181,10 @@
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "rz" = (
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "rB" = (
@@ -5133,7 +5194,10 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 9
+	},
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "rC" = (
 /obj/machinery/door/airlock/public/glass{
@@ -5219,22 +5283,13 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "rO" = (
 /obj/structure/table,
-/obj/item/storage/box/skillchips/engineering,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "rP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "150"
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/ruin/space/has_grav/skyrat/interdynefob/cargo/mining_equipment)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/iron/five,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "rR" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/smooth_large,
@@ -5463,7 +5518,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
 "sG" = (
-/obj/structure/chair/sofa/bench,
+/obj/structure/chair/sofa/bench/left,
 /turf/open/floor/iron/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
 "sI" = (
@@ -5558,8 +5613,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "tc" = (
-/obj/structure/window/reinforced,
 /obj/machinery/light/small/directional/north,
+/obj/structure/window/reinforced/survival_pod,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "td" = (
@@ -5819,10 +5874,10 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
 "tZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating/catwalk_floor/plated/dark,
-/area/ruin/space/has_grav/skyrat/interdynefob/cargo/mining_equipment)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/circuitboard/machine/mechfab,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "ub" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/smooth_half{
@@ -5900,8 +5955,9 @@
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
 "up" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/wardrobe/chaplain_black{
+	desc = "It's a storage unit for Interdyne-approved religious attire."
+	},
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/chapel)
 "uq" = (
@@ -5958,10 +6014,9 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "ux" = (
-/obj/structure/chair/sofa/bench,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/textured_large,
-/area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "uz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/robot_suit,
@@ -6065,7 +6120,6 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "uJ" = (
 /obj/structure/rack,
-/obj/item/clothing/shoes/magboots/syndie,
 /obj/effect/turf_decal/trimline/red/line{
 	color = "#fc0303";
 	dir = 8
@@ -6171,7 +6225,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "va" = (
 /turf/open/floor/iron/textured_large,
@@ -6239,6 +6293,13 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"vl" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
 "vm" = (
 /obj/machinery/door/morgue{
 	req_access_txt = "150"
@@ -6420,6 +6481,8 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "vP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating/catwalk_floor/plated,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "vQ" = (
@@ -6477,7 +6540,7 @@
 "vZ" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "wa" = (
 /obj/structure/table,
@@ -6954,12 +7017,8 @@
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "xx" = (
-/obj/structure/chair/pew{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "xB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -7202,9 +7261,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "yv" = (
-/obj/structure/sauna_oven{
-	fuel_amount = -1;
-	water_amount = -1
+/obj/structure/chair/pew/right{
+	dir = 8;
+	pixel_x = 5
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
@@ -7270,6 +7329,7 @@
 	},
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/item/reagent_containers/hypospray/medipen,
+/obj/item/weldingtool/hugetank,
 /obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron/kitchen{
 	dir = 1
@@ -7336,10 +7396,7 @@
 /turf/open/floor/carpet/blue,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
 "yQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/survival_pod,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "yR" = (
@@ -7641,7 +7698,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/survival_pod,
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "zO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -7771,9 +7828,13 @@
 /turf/open/floor/iron/dark/blue/side,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "At" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/iron/white,
-/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/loot_site_spawner,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "Au" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
@@ -7858,9 +7919,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
 "AF" = (
-/obj/machinery/modular_computer/console/preset/curator{
-	dir = 8
-	},
+/obj/structure/table/wood,
+/obj/machinery/computer/bookmanagement,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/library)
 "AG" = (
@@ -8118,15 +8178,13 @@
 /turf/open/floor/iron/dark/textured_edge,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "Bu" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
+/turf/open/floor/iron/dark/textured_corner,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "Bv" = (
 /obj/structure/chair/pew{
 	dir = 4;
 	pixel_x = -5
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "Bw" = (
@@ -8622,7 +8680,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/item/storage/backpack/duffelbag/syndie/surgery,
 /turf/open/floor/iron/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "CX" = (
@@ -8704,7 +8761,7 @@
 	},
 /obj/machinery/conveyor/inverted{
 	dir = 10;
-	id = "garbage"
+	id = "ds2garbage"
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
@@ -8826,7 +8883,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/survival_pod,
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Dy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8915,11 +8972,11 @@
 "DM" = (
 /obj/structure/window/reinforced/survival_pod,
 /obj/machinery/camera/xray{
-	c_tag = "Xenobio West";
+	c_tag = "DS-2 Xenobio West";
 	dir = 4;
 	network = list("fsci")
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "DN" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
@@ -8935,7 +8992,8 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/commissary)
 "DU" = (
 /obj/structure/table/wood,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "DV" = (
 /obj/effect/spawner/liquids_spawner,
@@ -8945,7 +9003,7 @@
 "DX" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/shaker,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "DY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -9001,19 +9059,26 @@
 	name = "server vent";
 	pressure_checks = 0
 	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 9
+	},
 /turf/open/floor/circuit/telecomms{
 	initial_gas_mix = "n2=100;TEMP=75"
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Eg" = (
 /obj/machinery/door/window/southleft,
-/obj/machinery/mass_driver/trash{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/mass_driver{
+	dir = 4;
+	id = "ds2disposals"
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "Eh" = (
@@ -9091,7 +9156,10 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "Es" = (
 /obj/structure/table/glass,
@@ -9346,10 +9414,10 @@
 /turf/open/floor/iron/white/corner,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "Fh" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "Fi" = (
 /obj/structure/chair{
 	dir = 8
@@ -9368,7 +9436,7 @@
 "Fk" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/rag,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "Fm" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -9899,7 +9967,6 @@
 	dir = 4
 	},
 /obj/structure/rack,
-/obj/item/autosurgeon/organ/syndicate,
 /turf/open/floor/iron/textured,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Hd" = (
@@ -9918,17 +9985,15 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/commissary)
 "Hh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
-"Hi" = (
-/obj/structure/sign/barsign{
-	req_access = null;
-	req_access_txt = "150"
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
+"Hi" = (
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "Hj" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/door/window/survival_pod{
@@ -10019,13 +10084,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "HA" = (
-/obj/structure/chair/pew{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken/directional/south,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "HB" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
 /turf/open/floor/iron/white,
@@ -10190,7 +10253,10 @@
 "Ic" = (
 /obj/machinery/light/directional/west,
 /obj/structure/railing,
-/obj/item/kirbyplants/random,
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/syndie/surgery{
+	pixel_y = 7
+	},
 /turf/open/floor/iron/textured,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Ie" = (
@@ -10358,6 +10424,7 @@
 /obj/structure/railing{
 	dir = 6
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "IC" = (
@@ -10380,10 +10447,13 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "IH" = (
 /obj/machinery/door/airlock/grunge{
-	aiControlDisabled = 1;
 	name = "Planetary Access";
 	req_access_txt = "150"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "II" = (
@@ -10545,7 +10615,9 @@
 /obj/structure/safe,
 /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
 /obj/item/card/emagfake,
-/obj/item/book/granter/martial/cqc/plus,
+/obj/item/paper{
+	info = "IOU - One 'gamer loot'"
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
 "Jj" = (
@@ -10597,14 +10669,11 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "Jt" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/item/pen/invisible,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/skyrat/interdynefob/service/library)
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "Ju" = (
 /obj/structure/table/wood,
 /obj/item/food/kebab/fiesta,
@@ -10687,7 +10756,8 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "JG" = (
 /turf/open/floor/iron/dark,
@@ -10705,13 +10775,10 @@
 /turf/open/floor/iron/dark/brown,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "JI" = (
-/obj/machinery/light/directional/south,
-/obj/structure/table/wood,
-/obj/item/taperecorder,
-/obj/item/camera,
-/obj/item/camera_film{
-	pixel_y = 9
+/obj/machinery/door/window/survival_pod{
+	dir = 8
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/library)
 "JJ" = (
@@ -10764,7 +10831,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
 "JT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/survival_pod,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "JV" = (
@@ -10978,11 +11045,7 @@
 /turf/template_noop,
 /area/template_noop)
 "KD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -11096,6 +11159,10 @@
 "KS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken/directional/south,
+/obj/item/clothing/shoes/magboots/syndie{
+	pixel_x = 4;
+	pixel_y = -3
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "KT" = (
@@ -11259,13 +11326,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "Lu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 8
 	},
@@ -11465,7 +11525,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor/inverted{
 	dir = 6;
-	id = "garbage"
+	id = "ds2garbage"
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
@@ -11530,13 +11590,16 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Ml" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "Mm" = (
 /obj/structure/chair/office/light{
@@ -11551,13 +11614,12 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "Mq" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lantern/syndicate,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "Mr" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "Ms" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -11650,7 +11712,9 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "MF" = (
-/obj/structure/closet/secure_closet/genpop,
+/obj/structure/closet/secure_closet/genpop{
+	req_access = list(151)
+	},
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
@@ -11813,17 +11877,22 @@
 "Ni" = (
 /obj/structure/window/reinforced/survival_pod,
 /obj/machinery/camera/xray{
-	c_tag = "Xenobio East";
+	c_tag = "DS-2 Xenobio East";
 	dir = 8;
-	network = list("dsci")
+	network = list("fsci")
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Nj" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"Nk" = (
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Nm" = (
 /obj/structure/table/wood,
 /obj/structure/sign/poster/contraband/energy_swords{
@@ -11891,7 +11960,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "Nv" = (
 /obj/item/storage/book/bible/syndicate,
-/obj/structure/altar_of_gods,
+/obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/chapel)
 "Nw" = (
@@ -11956,7 +12025,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "NG" = (
@@ -12103,6 +12171,9 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "NY" = (
 /obj/structure/rack/shelf,
+/obj/item/toy/beach_ball{
+	pixel_y = 6
+	},
 /turf/open/floor/iron/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
 "NZ" = (
@@ -12239,7 +12310,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Op" = (
 /obj/structure/chair/stool{
@@ -12463,7 +12534,10 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "150"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "Pf" = (
 /obj/structure/closet/secure_closet/personal/wall{
@@ -12518,9 +12592,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
 "Pp" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 8
 	},
@@ -12661,7 +12732,10 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
 "PO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "PP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12801,6 +12875,11 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
+"Qi" = (
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Qk" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -12851,7 +12930,8 @@
 	pixel_y = 32
 	},
 /obj/effect/mob_spawn/human/ds2/syndicate/researcher{
-	dir = 8
+	dir = 8;
+	uses = 2
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
@@ -13063,9 +13143,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/dark/textured_edge,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/mining_equipment)
 "QY" = (
@@ -13094,8 +13171,12 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
 "Rb" = (
-/obj/structure/window/reinforced/survival_pod,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 1
+	},
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Rc" = (
 /obj/effect/turf_decal/tile/bar,
@@ -13151,6 +13232,9 @@
 /obj/structure/trash_pile,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/nanotrasen_logo{
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "Rp" = (
@@ -13201,8 +13285,23 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "Rw" = (
-/obj/machinery/door/window/survival_pod{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/pen/blue{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/pen/red,
+/obj/item/pen/fourcolor{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 10
+	},
+/obj/item/taperecorder,
+/obj/item/camera,
+/obj/item/camera_film{
+	pixel_y = 9
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/library)
@@ -13485,7 +13584,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Sv" = (
@@ -13503,10 +13604,10 @@
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/northwest)
 "Sx" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "Sy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -13559,6 +13660,7 @@
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "SJ" = (
@@ -13694,6 +13796,15 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
+"Tm" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Tn" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
@@ -13745,12 +13856,10 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "Tu" = (
-/obj/structure/chair/pew/right{
-	dir = 8;
-	pixel_x = 5
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "Tw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -13787,12 +13896,13 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "TC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/textured_corner,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "TD" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -13802,7 +13912,6 @@
 	req_access = null;
 	req_access_txt = "150"
 	},
-/obj/item/autosurgeon/organ/syndicate,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay/chem)
 "TE" = (
@@ -13901,7 +14010,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "TU" = (
 /obj/effect/turf_decal/siding/wideplating{
@@ -13939,9 +14048,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "Ua" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured_edge,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/mining_equipment)
@@ -14049,13 +14157,11 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "Ux" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/skyrat/interdynefob/service/library)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "Uy" = (
 /obj/machinery/light/directional/east,
-/obj/structure/window/reinforced/survival_pod,
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer/on{
 	initialize_directions = 2;
 	name = "euthanization chamber freezer"
@@ -14087,10 +14193,8 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "UE" = (
-/obj/structure/chair/pew/left{
-	dir = 4;
-	pixel_x = -5
-	},
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket/wooden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
@@ -14220,7 +14324,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Vb" = (
 /obj/machinery/shower{
@@ -14276,7 +14380,7 @@
 /obj/machinery/light/directional/east{
 	pixel_y = 16
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Vm" = (
 /obj/structure/cable,
@@ -14286,19 +14390,12 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/chapel)
 "Vp" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Vr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/chair/office/light{
 	dir = 1;
 	pixel_y = 3
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
@@ -14465,6 +14562,15 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
+"VS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms{
+	initial_gas_mix = "n2=100;TEMP=75"
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/research)
 "VT" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
@@ -14508,17 +14614,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/chapel)
 "Wb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 1
-	},
-/area/ruin/space/has_grav/skyrat/interdynefob/cargo/mining_equipment)
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "Wd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -14550,7 +14650,6 @@
 	dir = 4
 	},
 /obj/structure/mopbucket,
-/obj/item/mop,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "Wh" = (
@@ -14731,6 +14830,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/mining_equipment)
 "WQ" = (
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "WS" = (
@@ -14960,7 +15060,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "XH" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "XI" = (
 /turf/open/floor/iron,
@@ -15056,7 +15156,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "XW" = (
 /obj/machinery/vending/boozeomat/syndicate_access,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "XX" = (
 /obj/structure/cable,
@@ -15167,7 +15267,7 @@
 /obj/structure/closet/secure_closet{
 	icon_state = "sec";
 	name = "brig officer's locker";
-	req_access_txt = "150"
+	req_access_txt = "151"
 	},
 /obj/item/storage/belt/security/full,
 /obj/item/radio/headset/headset_sec/alt/interdyne,
@@ -15317,7 +15417,7 @@
 /turf/open/floor/plating/catwalk_floor/plated/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "YL" = (
-/obj/machinery/vending/wardrobe/chap_wardrobe,
+/obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/chapel)
 "YM" = (
@@ -15330,13 +15430,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "YN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "YO" = (
@@ -15530,11 +15626,10 @@
 /turf/open/floor/holofloor/chapel,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/chapel)
 "Zt" = (
-/obj/structure/table,
-/obj/item/modular_computer/laptop/preset/syndicate,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/trash_pile,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "Zu" = (
 /obj/machinery/power/rtg/advanced,
 /obj/structure/cable,
@@ -15601,6 +15696,9 @@
 	name = "Research";
 	req_access_txt = "150"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "ZH" = (
@@ -15631,14 +15729,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor/plated/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "ZM" = (
-/obj/structure/sauna_oven{
-	fuel_amount = -1;
-	water_amount = -1
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "ZO" = (
@@ -17149,7 +17242,7 @@ nX
 nX
 nX
 nX
-nX
+Vt
 Vt
 Vt
 nX
@@ -17230,14 +17323,14 @@ Md
 bk
 XP
 WB
-WB
+Oe
 iS
 CU
 Bv
 mv
 UE
-dP
 nX
+mc
 mc
 mc
 nX
@@ -17321,17 +17414,17 @@ SO
 WB
 iS
 Rj
-Rj
+gK
 ZM
 rz
-eZ
 nX
+mc
 mc
 mc
 nX
 It
 yD
-CD
+rP
 oU
 XS
 nX
@@ -17409,11 +17502,11 @@ WB
 sz
 nX
 iL
-rz
 Rj
 Rj
-xx
+mr
 nX
+mc
 mc
 mc
 nX
@@ -17496,12 +17589,12 @@ Aq
 WB
 sz
 jQ
-Hh
 Rj
-Rj
-Rj
-HA
+hl
+ZM
+mQ
 nX
+Vt
 Vt
 Vt
 nX
@@ -17579,23 +17672,23 @@ GY
 eF
 yr
 Aq
-Zt
+mc
 nX
 WB
 sz
 nX
-Rj
-Rj
+gH
+km
 yv
-rz
-aB
+nU
 nX
+mc
 mc
 mc
 nX
 FR
 WB
-CD
+tZ
 WB
 Fp
 nX
@@ -17667,17 +17760,17 @@ Yz
 eF
 Yz
 Aq
-mQ
-nX
+mc
+iS
 WB
 WB
 iS
-gH
-bS
-eG
-Tu
-Sx
 nX
+nX
+nX
+nX
+nX
+mc
 mc
 mc
 nX
@@ -17755,15 +17848,15 @@ eF
 eF
 Kk
 Aq
+mc
+iS
+Oe
 WB
-jQ
+nX
+nX
+lZ
+Rn
 WB
-WB
-nX
-nX
-nX
-nX
-nX
 nX
 nX
 nX
@@ -17843,14 +17936,14 @@ Aq
 Aq
 Aq
 Aq
+mc
+iS
+WB
+WB
 WB
 nX
-WB
-WB
-WB
-nX
-mr
-km
+sz
+sz
 sz
 WB
 WB
@@ -17931,14 +18024,14 @@ Hp
 fE
 pP
 Aq
-Fh
+mc
 nX
 WB
 WB
 WB
 jQ
 WB
-WB
+Oe
 WB
 Oe
 Oe
@@ -17952,12 +18045,12 @@ WB
 WB
 WB
 uh
-Ag
+At
 HR
 fI
-if
-if
-if
+Bu
+Hh
+Sx
 AX
 HR
 Qs
@@ -18043,9 +18136,9 @@ np
 hi
 HR
 qT
-if
-if
-if
+Fh
+Hi
+Tu
 uc
 HR
 Tp
@@ -18109,9 +18202,9 @@ Dd
 Aq
 FU
 WB
-WB
-WB
-WB
+dP
+dP
+eG
 qU
 VD
 mh
@@ -18132,7 +18225,7 @@ HR
 HR
 cy
 if
-if
+HA
 PO
 Ml
 HR
@@ -18198,8 +18291,8 @@ sA
 sA
 sA
 Rn
-WB
-WB
+CD
+CD
 qU
 VD
 Ra
@@ -18220,9 +18313,9 @@ pj
 hc
 if
 if
-if
-PO
-Ml
+Jt
+Ux
+Wb
 HR
 zI
 Oz
@@ -18309,7 +18402,7 @@ Sg
 mI
 mI
 Er
-PO
+Ux
 HR
 nv
 nv
@@ -21047,7 +21140,7 @@ Oc
 lP
 BJ
 Ic
-lZ
+vp
 LD
 zu
 wk
@@ -21229,7 +21322,7 @@ zu
 qv
 iz
 ZE
-QW
+mR
 bG
 zu
 mc
@@ -21315,8 +21408,8 @@ vp
 LD
 zu
 qQ
-Wb
-tZ
+lF
+Xe
 Ua
 yW
 zu
@@ -21491,7 +21584,7 @@ JG
 WQ
 qj
 zu
-rP
+zu
 zu
 zu
 zu
@@ -21576,7 +21669,7 @@ ab
 OR
 cY
 JG
-JG
+LD
 qj
 vt
 ck
@@ -21669,7 +21762,7 @@ qj
 sa
 Vr
 cx
-JG
+bW
 JG
 eN
 dA
@@ -21752,17 +21845,17 @@ Lc
 By
 oz
 oz
-vp
+vl
 qj
 zo
 KD
-JG
-JG
+Qi
+Nk
 JW
 mA
-rB
+Tm
 zN
-rB
+Tm
 fK
 qj
 "}
@@ -21776,7 +21869,7 @@ zm
 zm
 ac
 zm
-zm
+aB
 yJ
 vV
 bV
@@ -21797,7 +21890,7 @@ WV
 ey
 Qv
 va
-hl
+BU
 ps
 gA
 my
@@ -21840,11 +21933,11 @@ hK
 vP
 vP
 vP
-vp
+oV
 qj
 NF
 TC
-JG
+bW
 ZB
 Py
 Hn
@@ -21860,7 +21953,7 @@ mc
 mc
 mc
 UW
-gK
+zm
 VW
 dK
 CH
@@ -21928,7 +22021,7 @@ Gz
 oz
 oz
 hC
-vp
+qh
 ZG
 YN
 iB
@@ -21973,7 +22066,7 @@ yJ
 va
 JM
 va
-BU
+bS
 ps
 gR
 my
@@ -22021,7 +22114,7 @@ qj
 Su
 ui
 Uy
-oe
+VS
 oe
 Mk
 Vk
@@ -22313,11 +22406,11 @@ va
 va
 Qa
 iw
-aA
-aA
-aA
-aA
-aA
+rH
+va
+va
+va
+iw
 rH
 Qa
 va
@@ -22447,7 +22540,7 @@ Wn
 Ny
 OW
 kw
-GF
+Zt
 PM
 wX
 wX
@@ -22509,7 +22602,7 @@ xj
 GP
 EP
 wi
-nU
+xj
 Rw
 JI
 Iq
@@ -22540,7 +22633,7 @@ PM
 wX
 wX
 wX
-wX
+GF
 xE
 UG
 LX
@@ -22597,9 +22690,9 @@ NK
 go
 Zj
 vW
-Jt
-eX
 xj
+eX
+eZ
 Iq
 QQ
 Rl
@@ -22685,7 +22778,7 @@ eH
 XB
 hy
 xj
-Ux
+xj
 AF
 pI
 Iq
@@ -22922,7 +23015,7 @@ NT
 cp
 HE
 yJ
-sG
+va
 JM
 Cc
 zj
@@ -22965,7 +23058,7 @@ YO
 fP
 Dv
 MB
-At
+MB
 kw
 kw
 kw
@@ -23010,7 +23103,7 @@ NT
 wU
 HE
 yJ
-ux
+UO
 JM
 Cc
 zj
@@ -23098,7 +23191,7 @@ NT
 wU
 HJ
 yJ
-sG
+bs
 JM
 Cc
 zj
@@ -23139,7 +23232,7 @@ Zw
 tQ
 Pg
 MC
-bs
+wX
 wX
 CP
 CP
@@ -23492,8 +23585,8 @@ zk
 ax
 Yh
 wX
-wX
-Hi
+TY
+xE
 cn
 Jo
 Tf
@@ -23756,7 +23849,7 @@ lg
 ZK
 MC
 DX
-Tf
+ux
 JF
 um
 Tf
@@ -23844,8 +23937,8 @@ lg
 Uu
 MC
 Mr
-Tf
-Jo
+ux
+pY
 um
 Tf
 EV
@@ -23932,7 +24025,7 @@ lg
 Zh
 MC
 Fk
-Tf
+ux
 pY
 aW
 nO
@@ -24020,11 +24113,11 @@ lg
 io
 MC
 vZ
-nO
+xx
 DU
 aW
 nO
-Bu
+nO
 Ge
 Ge
 mc

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
@@ -357,15 +357,20 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
 "bt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
 	},
 /obj/structure/window/reinforced/survival_pod,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "ds2garbage";
+	name = "disposal conveyor"
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
@@ -3753,11 +3758,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "mW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor_switch/oneway{
-	dir = 8;
-	id = "ds2garbage";
-	name = "disposal conveyor"
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "mX" = (
@@ -4712,7 +4713,10 @@
 	dir = 4;
 	id = "ds2garbage"
 	},
-/obj/machinery/door/window/westright,
+/obj/machinery/door/window/survival_pod{
+	dir = 8;
+	req_access_txt = "150"
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "qd" = (
@@ -8780,7 +8784,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Pool"
 	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
 "Dj" = (
 /obj/structure/lattice/catwalk,
@@ -9070,7 +9074,6 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "Eg" = (
-/obj/machinery/door/window/southleft,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -9078,6 +9081,9 @@
 /obj/machinery/mass_driver{
 	dir = 4;
 	id = "ds2disposals"
+	},
+/obj/machinery/door/window/survival_pod{
+	req_access_txt = "150"
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
@@ -10832,6 +10838,7 @@
 "JT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced/survival_pod,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "JV" = (
@@ -13748,6 +13755,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/chapel)
 "Tb" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/iron,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "Tc" = (
@@ -22556,7 +22564,7 @@ xE
 TA
 Tb
 wg
-mW
+wX
 xE
 mc
 mc
@@ -22643,7 +22651,7 @@ UG
 xE
 eU
 hg
-Tb
+mW
 AW
 xE
 mc
@@ -22818,7 +22826,7 @@ UG
 UG
 xE
 tc
-wX
+AW
 bt
 rb
 xE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Unfucks and beautifies some of the new DS-2 changes that were made in my abscense
This update includes:
### A paper reminding you of the fact the monkeycap exists and should be respected, and because **FIVE+** xenobio labs can exist concurrently.
Main Station, Interdyne, Free Golems, DS-2, and even more if someone sets up the maint one on journey or steals extracts for their own illicit labs, easily being able to hit the limit of 64 and staying there if someone isn't proactive about removing their monkies. Funnily enough I was quite proactive on why Interdyne only had one xenobio lab, though I guess that was ignored.

### The removal of the free **CQC+** manual, the autosurgeons, and engineering skillchips.
You may be surprised to hear this, but equipping a bunch of bored people with nothing to do with disablers and stun batons was _already_ a mistake. Free **CQC+** that any assistant with a stethoscope and half a brain could grab is just as horrible an idea. The engineering skillchips have been removed along a similar line, to prevent easy greytiding (Because EVERYONE on-site has access and could grab one.) The autosurgeons were removed because.. come on. Those were only on DS-1 because near nobody played there and it was an easy way to fuck around on the CC z-level. Just ask someone to implant you, because that's infinitely less mechanical and at least your funny gaming is timegated.

I also removed the syndicate lantern purely because it's the most powerful handheld light in the game and it was being handed out on a silver platter, in easy view of any passing spacetider.

### Disposals is no longer linked to the station's.
Yes, really. This is a serious thing that managed to happen. Did you know the hotel's disposals are also linked to the station? Did you know you can be round removed through this if your body gets disposaled by someone on an entirely different z-level? Because I know.

 ### No, DS-2 Chaplain, you can't interfere with the station's anymore.
Hey, fun fact. Did you know the armaments beacon is one-use? I found that out the hard way. The altar of the gods is also gone due to being dependent on.. y'know. Someone being the chaplain, and therefore entirely useless at best (and problematic to the station chaplain at worst.)

### Generic Map edits.
wood/large turf in maint bar, removal of the maint bar's sign in fear of it changing the area name (and also not being mounted properly) Xenobio and Engineering look a bit less fugly, and Mining is no longer connected to it via a maint door for.. some reason. Also the prison is a little easier to escape in terms of welding fuel, the pool is no longer.. `long bench territory`, and the second pair of maint magboots have moved.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
### I don't think I should need to explain why any of this is bad.
Also, I totally called this would happen if xenobio was added to DS-2.
![image](https://user-images.githubusercontent.com/50649185/124687614-3e3aab80-dea3-11eb-8e4d-34dcf2487d95.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: DS-2 no longer has free reusable autosurgeons, CQC+ (Which we DISABLED from the uplink, by the way!), and Engineering skillchips.
fix: DS-2 is no longer linked to the station's disposal network.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
