### PR TITLE
[MODULAR] Fix Culture Defines

### DIFF
--- a/code/__DEFINES/~skyrat_defines/culture.dm
+++ b/code/__DEFINES/~skyrat_defines/culture.dm
@@ -13,7 +13,7 @@
 						/datum/cultural_info/culture/vatgrown, \
 						/datum/cultural_info/culture/spacer_core, \
 						/datum/cultural_info/culture/spacer_frontier, \
-						/datum/cultural_info/culture/zolmalchi, \
+						/datum/cultural_info/culture/zolmalchi
 
 #define CULTURES_XENO	/datum/cultural_info/culture/xenoknockoff
 
@@ -52,7 +52,7 @@
 						/datum/cultural_info/location/lordania, \
 						/datum/cultural_info/location/kingston, \
 						/datum/cultural_info/location/gaia, \
-						/datum/cultural_info/location/magnitka, \
+						/datum/cultural_info/location/magnitka
 
 
 #define FACTIONS_GENERIC	/datum/cultural_info/faction/none, \


### PR DESCRIPTION
Cultures were causing a runtime every time you tried to view them due to the defines being terminated incorrectly

:cl:
fix: Cultures no longer runtime
:/cl: