### PR TITLE
fixes the arborlink vault floor until we get these catwalks in check.

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/vaulttango.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/vaulttango.dmm
@@ -513,11 +513,10 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/vaulttango)
 "ph" = (
-/obj/structure/lattice/catwalk/plated/dark,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/vaulttango)
 "pk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -847,12 +846,13 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/vaulttango)
 "CG" = (
-/obj/structure/lattice/catwalk/plated/dark,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
 /area/ruin/space/has_grav/vaulttango)
 "Dt" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -1434,13 +1434,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/vaulttango)
 "VX" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/delivery/blue,
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/grunge{
@@ -1449,12 +1447,12 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/vaulttango)
 "Wm" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
 /area/ruin/space/has_grav/vaulttango)
 "WB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -1563,7 +1561,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/vaulttango)
 "ZM" = (
@@ -2484,20 +2481,20 @@ ai
 mV
 oF
 pe
-ph
-ph
-ph
+Wm
+Wm
+Wm
 CG
-ph
-ph
-ph
-ph
-ph
-ph
+Wm
+Wm
+Wm
+Wm
+Wm
+Wm
 CG
-ph
-ph
-ph
+Wm
+Wm
+Wm
 pe
 rI
 WN
@@ -3232,20 +3229,20 @@ ai
 nO
 pD
 pe
-ph
-ph
-ph
+Wm
+Wm
+Wm
 CG
-ph
-ph
-ph
-ph
-ph
-ph
+Wm
+Wm
+Wm
+Wm
+Wm
+Wm
 CG
-ph
-ph
-ph
+Wm
+Wm
+Wm
 pe
 LC
 jY
@@ -3371,7 +3368,7 @@ ai
 ai
 PS
 cM
-Wm
+Tp
 Zl
 ai
 PK


### PR DESCRIPTION
## About The Pull Request

god i hate these new catwalks so much i hate them i hate them. replaces the arborlink vault catwalks with tile.

## Why It's Good For The Game

it'll get promptly reverted as soon as our ACTUAL catwalks come back. god i hate this.

## Changelog
:cl:
fix: replaced arborlink vault broken catwalks with tiles. also removed any trace of air tanks because apparently those are fucked.
/:cl: