### PR TITLE
[Modular] Teleporter Beacons are no longer in the Maint Loottable.

### DIFF
--- a/modular_skyrat/master_files/code/_globalvars/maint_loot_common.dm
+++ b/modular_skyrat/master_files/code/_globalvars/maint_loot_common.dm
@@ -139,7 +139,6 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/wrench = 100
 	) = 200,
 	list( //Stuff you'd get elsewhere but they're not that good
-		/obj/item/beacon = 50,
 		/obj/item/binoculars = 50,
 		/obj/item/bodybag = 200,
 		/obj/item/clothing/gloves/radio = 25,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes teleporter beacons from the maintenance loot table, as a few spawned on DS-2 and the first question asked was, and I quote.
"Can we maxcap it?"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rather not get inverse cybersun'd, Thanks.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Maintenance's loottable is once again safe to use for ruins, gateways, etc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
