### PR TITLE
[NON-MODULAR] Immovable Rods are nicer to people laying down

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -7,6 +7,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 --NEOFite
 */
 
+#define MAXHP_RESTING 0.80 // SKYRAT ADDITION - SEE BELOW
 /datum/round_event_control/immovable_rod
 	name = "Immovable Rod"
 	typepath = /datum/round_event/immovable_rod
@@ -74,7 +75,9 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/loopy_rod = FALSE
 	//SKYRAT ADDITION - RODS DEAL LESS DAMAGE TO MOBS LAYING DOWN
 	/// The percentage of maxhp to apply as damage to a mob laying down on Bump
-	var/maxhp_damage_resting = 0.80
+	var/maxhp_damage_resting = MAXHP_RESTING
+	///Who have we already hit so far
+	var/list/client/already_hit = list()
 	//SKYRAT ADDITION - END
 
 /obj/effect/immovablerod/New(atom/start, atom/end, aimed_at, force_looping)
@@ -258,7 +261,14 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	if(iscarbon(smeared_mob))
 		var/mob/living/carbon/smeared_carbon = smeared_mob
 		//SKYRAT ADDITION - RODS DEAL LESS DAMAGE TO MOBS LAYING DOWN
-		if(smeared_carbon.resting)
+		var/first_time_around = TRUE
+		if(smeared_carbon.client)
+			var/client/cli = smeared_carbon.client
+			if(cli in already_hit)
+				first_time_around = FALSE
+			else
+				already_hit |= cli
+		if(smeared_carbon.resting && first_time_around)
 			var/cur_damage = smeared_carbon.getBruteLoss() + smeared_carbon.getFireLoss()
 			var/damage = (smeared_carbon.maxHealth * maxhp_damage_resting) - cur_damage
 			if(damage > 0)
@@ -340,3 +350,5 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/proc/walk_in_direction(direction)
 	destination = get_edge_target_turf(src, direction)
 	walk_towards(src, destination, 1)
+
+#undef MAXHP_RESTING //SKYRAT ADDITION - SEE ABOVE

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -101,7 +101,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	UnregisterSignal(src, COMSIG_ATOM_ENTERING)
 	RemoveElement(/datum/element/point_of_interest)
 	SSaugury.unregister_doom(src)
-
+	already_hit = null
 	return ..()
 
 /obj/effect/immovablerod/examine(mob/user)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -101,7 +101,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	UnregisterSignal(src, COMSIG_ATOM_ENTERING)
 	RemoveElement(/datum/element/point_of_interest)
 	SSaugury.unregister_doom(src)
-	already_hit = null
+	already_hit = null //Skyrat Addition
 	return ..()
 
 /obj/effect/immovablerod/examine(mob/user)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -72,6 +72,10 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/dnd_style_level_up = TRUE
 	/// Whether the rod can loop across other z-levels. The rod will still loop when the z-level is self-looping even if this is FALSE.
 	var/loopy_rod = FALSE
+	//SKYRAT ADDITION - RODS DEAL LESS DAMAGE TO MOBS LAYING DOWN
+	/// The percentage of maxhp to apply as damage to a mob laying down on Bump
+	var/maxhp_damage_resting = 0.80
+	//SKYRAT ADDITION - END
 
 /obj/effect/immovablerod/New(atom/start, atom/end, aimed_at, force_looping)
 	. = ..()
@@ -253,6 +257,17 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 	if(iscarbon(smeared_mob))
 		var/mob/living/carbon/smeared_carbon = smeared_mob
+		//SKYRAT ADDITION - RODS DEAL LESS DAMAGE TO MOBS LAYING DOWN
+		if(smeared_carbon.resting)
+			var/cur_damage = smeared_carbon.getBruteLoss() + smeared_carbon.getFireLoss()
+			var/damage = (smeared_carbon.maxHealth * maxhp_damage_resting) - cur_damage
+			if(damage > 0)
+				smeared_carbon.adjustBruteLoss(damage)
+			// This copies functionality from below, essentially a 10% chance you just get fucked big time
+			if(smeared_mob.density || prob(10))
+				smeared_mob.ex_act(EXPLODE_HEAVY)
+			return
+		//SKYRAT ADDITION - END
 		smeared_carbon.adjustBruteLoss(100)
 		var/obj/item/bodypart/penetrated_chest = smeared_carbon.get_bodypart(BODY_ZONE_CHEST)
 		penetrated_chest?.receive_damage(60, wound_bonus = 20, sharpness=SHARP_POINTY)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Host Request.

If you are hit by an immovable rod while laying down it will only deal enough damage to take you to 20% hp and no lower.
If you are standing you will still get railed; maybe dont stand in the way of an immovable rod

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You can do something other than pray against immovable rods

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Immovable rods are nicer to people who are resting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
