### PR TITLE
[Modular] Journey; Bees for Botany, Green Engineering, and a WRENCH

### DIFF
--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -54,7 +54,7 @@
 /area/commons/toilet/locker)
 "aam" = (
 /obj/effect/spawner/randomsnackvend,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "aau" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -630,7 +630,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating/catwalk_floor,
 /area/engineering/break_room)
 "adh" = (
 /obj/machinery/disposal/bin,
@@ -686,7 +686,7 @@
 /area/security/office)
 "adt" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "adv" = (
 /obj/structure/chair/office{
@@ -716,28 +716,23 @@
 "adx" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/vending/tool,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "adz" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/yellow/anticorner{
 	dir = 8
 	},
-/obj/structure/closet/firecloset,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_corner{
+	dir = 4
+	},
 /area/engineering/break_room)
 "adA" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half,
+/turf/open/floor/iron/smooth_half,
 /area/engineering/break_room)
 "adG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -745,17 +740,13 @@
 /area/security/interrogation)
 "adM" = (
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/clothing/glasses/meson,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/anticorner,
+/turf/open/floor/iron/smooth_corner{
+	dir = 1
+	},
 /area/engineering/break_room)
 "adN" = (
 /turf/open/floor/iron/dark/side,
@@ -787,7 +778,7 @@
 /obj/machinery/navbeacon/wayfinding,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "adX" = (
 /obj/structure/sign/warning/radiation/rad_area,
@@ -890,7 +881,7 @@
 	c_tag = "Engineering Access"
 	},
 /obj/structure/closet/radiation,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "aey" = (
 /obj/machinery/door/airlock/command/glass{
@@ -909,12 +900,12 @@
 /area/security/office)
 "aeD" = (
 /obj/structure/closet/firecloset,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "aeQ" = (
 /obj/machinery/light/directional/east,
 /obj/structure/closet/radiation,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "aeR" = (
 /obj/machinery/light/small/directional/north,
@@ -927,7 +918,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "aeT" = (
 /obj/structure/cable,
@@ -937,7 +928,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating/catwalk_floor,
 /area/engineering/main)
 "aeV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -986,7 +977,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "afu" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1058,7 +1049,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_edge,
 /area/hallway/primary/central)
 "agc" = (
 /obj/structure/closet/emcloset,
@@ -1153,7 +1144,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "agW" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1245,7 +1236,7 @@
 	name = "engineering security door"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "ahF" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -1259,7 +1250,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "ahO" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1421,27 +1412,22 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aiK" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/main)
-"aiL" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
 	},
+/turf/open/floor/iron/smooth_half,
+/area/engineering/main)
+"aiL" = (
 /obj/structure/closet/radiation,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 8
+	},
 /area/engineering/main)
 "aiN" = (
 /obj/structure/cable,
@@ -1451,7 +1437,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "aiP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden{
@@ -1521,15 +1507,16 @@
 /area/security/courtroom)
 "ajq" = (
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/engineering/main)
 "ajw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden{
@@ -1547,11 +1534,12 @@
 "ajI" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/yellow/half{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/engineering/main)
 "ajK" = (
 /obj/structure/cable,
@@ -1569,7 +1557,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_corner{
+	dir = 4
+	},
 /area/engineering/main)
 "ajO" = (
 /obj/structure/window,
@@ -2442,14 +2432,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aoe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating,
+/obj/machinery/space_heater,
+/turf/open/floor/iron/dark/textured_large,
 /area/maintenance/starboard/fore)
 "aof" = (
 /turf/closed/wall/r_wall,
@@ -3091,8 +3075,7 @@
 /turf/open/floor/carpet/green,
 /area/command/heads_quarters/captain/private/NTREP)
 "arb" = (
-/obj/structure/closet/secure_closet/nanotrasen_representative/station,
-/obj/item/clothing/under/rank/centcom/intern,
+/obj/structure/filingcabinet/medical,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/NTREP)
 "ard" = (
@@ -3236,9 +3219,9 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/NTREP)
 "arI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arK" = (
@@ -3370,6 +3353,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 9
 	},
+/obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "asm" = (
@@ -3675,8 +3659,16 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Service Hall Maintenance";
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ato" = (
@@ -5737,7 +5729,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured_large,
 /area/cargo/storage)
 "azW" = (
 /obj/structure/window/reinforced/spawner/east,
@@ -5941,13 +5933,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aAu" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "maint2"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/trash_pile,
+/turf/open/floor/iron/dark/textured_large,
 /area/maintenance/starboard/fore)
 "aAv" = (
 /obj/structure/closet,
@@ -6107,8 +6094,6 @@
 /obj/machinery/camera{
 	c_tag = "Hydroponics Storage"
 	},
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/machinery/light/small/directional/north,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -6463,10 +6448,11 @@
 /turf/closed/wall,
 /area/service/theater)
 "aCt" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/table,
+/obj/item/book/manual/hydroponics_pod_people,
+/obj/item/paper/guides/jobs/hydroponics,
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "aCu" = (
 /obj/machinery/vending/games,
 /turf/open/floor/iron/dark,
@@ -6507,17 +6493,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCA" = (
-/obj/structure/cable,
-/obj/structure/railing,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCB" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -6537,13 +6516,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCD" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "maint1"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/dark/textured_large,
 /area/maintenance/starboard/fore)
 "aCE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -6876,11 +6850,9 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "aDX" = (
-/obj/machinery/modular_computer/console/preset/civilian{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/chair/sofa/bench/right,
+/turf/open/floor/iron/smooth_large,
+/area/hallway/secondary/service)
 "aDY" = (
 /obj/machinery/camera{
 	c_tag = "Theater Storage"
@@ -6890,15 +6862,15 @@
 	},
 /area/service/theater)
 "aEa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -7182,10 +7154,17 @@
 /area/service/theater)
 "aFm" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_large,
+/area/hallway/secondary/service)
 "aFn" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
@@ -7212,22 +7191,24 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "aFs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFu" = (
 /turf/closed/wall,
 /area/service/library)
 "aFv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFw" = (
@@ -7571,10 +7552,6 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/structure/table,
-/obj/item/circuitboard/machine/vendatray,
-/obj/item/circuitboard/machine/vendatray,
-/obj/item/camera,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
 	},
@@ -7611,9 +7588,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/brown/corner{
-	dir = 4
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/hallway/secondary/service)
 "aGD" = (
@@ -7626,18 +7600,21 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "aGE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGF" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 17
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/space_heater,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGH" = (
@@ -7651,8 +7628,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/iron/smooth_large,
+/area/hallway/secondary/service)
 "aGI" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -7690,16 +7667,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Service Hall Maintenance";
-	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth_large,
 /area/hallway/secondary/service)
 "aGQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -7707,8 +7680,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/hallway/secondary/service)
 "aGS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7723,17 +7699,13 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
-"aGV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aGW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGY" = (
@@ -7969,7 +7941,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/filingcabinet/medical,
+/obj/structure/closet/secure_closet/nanotrasen_representative/station,
+/obj/item/clothing/under/rank/centcom/intern,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/NTREP)
 "aHP" = (
@@ -8063,8 +8036,6 @@
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "aIb" = (
-/obj/structure/cable,
-/obj/machinery/rnd/production/techfab/department/service,
 /obj/machinery/camera{
 	c_tag = "Service Hallway West";
 	dir = 4
@@ -8086,48 +8057,35 @@
 	},
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/service/bar)
 "aIj" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	sortType = 21
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/door/airlock{
+	name = "Hydroponics Service Hall";
+	req_access_txt = "35";
+	req_one_access_txt = null
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/iron/smooth_large,
+/area/service/hydroponics)
 "aIk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/textured_large,
 /area/maintenance/starboard/fore)
 "aIl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/table,
+/obj/item/camera,
+/turf/open/floor/iron/showroomfloor,
+/area/hallway/secondary/service)
 "aIn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8146,6 +8104,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "aIt" = (
@@ -8162,11 +8124,11 @@
 /area/service/library)
 "aIw" = (
 /obj/structure/chair/office,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -8519,16 +8481,13 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/commons/toilet)
 "aJB" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Hydroponics Maintenance";
-	req_access_txt = "35"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "aJC" = (
 /turf/closed/wall,
 /area/service/bar)
@@ -8564,6 +8523,7 @@
 	req_access_txt = "25"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron,
 /area/service/bar)
 "aJI" = (
@@ -8583,13 +8543,11 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "aJL" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=2";
-	freq = 1400;
-	location = "Hydroponics"
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/southleft{
+	name = "Hydroponics Delivery";
+	req_access_txt = "35"
 	},
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aJM" = (
@@ -8601,19 +8559,18 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "aJN" = (
-/obj/structure/table,
-/obj/item/book/manual/hydroponics_pod_people,
-/obj/item/paper/guides/jobs/hydroponics,
+/obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aJO" = (
-/obj/structure/closet/secure_closet/hydroponics,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aJP" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
 /obj/item/pen,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "aJQ" = (
@@ -8623,6 +8580,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/library)
 "aJR" = (
@@ -8632,10 +8590,11 @@
 /turf/open/floor/wood,
 /area/service/library)
 "aJS" = (
-/obj/structure/table/wood,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/service/library)
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/hallway/secondary/service)
 "aJT" = (
 /obj/structure/table/wood,
 /obj/item/nullrod,
@@ -8827,7 +8786,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aKE" = (
@@ -8853,9 +8811,6 @@
 "aKH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
-	},
-/obj/structure/sink{
-	pixel_y = 20
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -8933,17 +8888,11 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "aKW" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/showroomfloor,
+/area/hallway/secondary/service)
 "aKX" = (
-/obj/machinery/door/window/eastright{
-	name = "Hydroponics Delivery";
-	req_access_txt = "35"
-	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aKY" = (
@@ -8999,10 +8948,9 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "aLd" = (
-/obj/structure/table,
-/obj/item/watertank,
-/turf/open/floor/iron,
-/area/service/hydroponics)
+/obj/effect/spawner/randomcolavend,
+/turf/open/floor/iron/showroomfloor,
+/area/hallway/secondary/service)
 "aLe" = (
 /obj/structure/chair{
 	dir = 1
@@ -9442,6 +9390,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "aMI" = (
@@ -9465,7 +9414,6 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/library)
 "aMK" = (
@@ -9488,9 +9436,13 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "aMN" = (
-/obj/machinery/vending/wardrobe/hydro_wardrobe,
-/turf/open/floor/iron,
-/area/service/hydroponics)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/obj/structure/table,
+/turf/open/floor/iron/smooth_large,
+/area/hallway/secondary/service)
 "aMO" = (
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
@@ -9723,9 +9675,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aNP" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/modular_computer/console/preset/cargochat/service,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
 /turf/open/floor/wood,
-/area/service/library)
+/area/hallway/secondary/service)
 "aNQ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -9974,7 +9929,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/hallway/primary/central)
 "aOE" = (
 /obj/effect/turf_decal/tile/blue{
@@ -10030,15 +9985,16 @@
 /turf/open/floor/plating,
 /area/service/bar)
 "aOQ" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/door/window/southright,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/structure/window/spawner/west,
+/turf/open/floor/grass,
 /area/service/hydroponics)
 "aOS" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/service/library)
 "aOT" = (
@@ -10270,7 +10226,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/hallway/primary/central)
 "aPK" = (
 /turf/closed/wall,
@@ -11650,11 +11606,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
 "aUx" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;38"
-	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aUy" = (
@@ -11673,6 +11627,9 @@
 "aUC" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start/assistant,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/wood,
 /area/service/library)
 "aUD" = (
@@ -11766,6 +11723,13 @@
 /area/hallway/secondary/entry)
 "aUP" = (
 /obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "aUQ" = (
@@ -12045,32 +12009,27 @@
 /turf/open/floor/iron/smooth_large,
 /area/service/hydroponics)
 "aVL" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 16
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"aVN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"aVN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "aVO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "aVP" = (
 /obj/structure/table/wood,
 /obj/item/paper,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/library)
 "aVQ" = (
@@ -12138,18 +12097,13 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
 "aVY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/library)
 "aVZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Library"
@@ -12157,6 +12111,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/library)
 "aWa" = (
@@ -12172,14 +12127,11 @@
 /turf/open/space/basic,
 /area/space)
 "aWb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/sign/painting/library{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/service/library)
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "aWd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -12889,7 +12841,6 @@
 /turf/closed/wall,
 /area/commons/toilet/locker)
 "aXR" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -13826,6 +13777,7 @@
 "bat" = (
 /obj/structure/table/wood,
 /obj/item/pen,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/library)
 "bau" = (
@@ -14356,14 +14308,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bcj" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -14884,7 +14836,7 @@
 /area/maintenance/aft)
 "bdP" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "bdR" = (
 /obj/structure/cable,
@@ -15260,22 +15212,12 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "beV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/command/heads_quarters/ce)
 "beW" = (
 /obj/structure/window/reinforced{
@@ -16224,19 +16166,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bhQ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 1
+	},
 /area/engineering/main)
 "bhR" = (
 /obj/machinery/door/airlock/atmos{
@@ -16277,14 +16218,6 @@
 	},
 /turf/closed/wall,
 /area/cargo/sorting)
-"bhY" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/main)
 "bhZ" = (
 /obj/machinery/door/window/eastleft{
 	icon_state = "right";
@@ -16311,19 +16244,16 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "bic" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_half,
 /area/engineering/main)
 "bid" = (
 /obj/structure/extinguisher_cabinet{
@@ -16349,6 +16279,12 @@
 /turf/open/floor/wood,
 /area/command/meeting_room)
 "big" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "bii" = (
@@ -16357,22 +16293,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
-"bij" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "bik" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -16488,7 +16408,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "biB" = (
 /obj/structure/bodycontainer/morgue,
@@ -16982,7 +16902,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "bkd" = (
 /obj/structure/bodycontainer/morgue{
@@ -16997,11 +16917,11 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bkg" = (
-/obj/structure/sign/warning/electricshock{
+/obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "bkh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
@@ -17150,12 +17070,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "bkI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "bkJ" = (
 /obj/effect/spawner/structure/window,
@@ -17193,7 +17113,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "bkN" = (
 /turf/closed/wall,
@@ -17203,7 +17123,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "bkP" = (
 /obj/machinery/door/firedoor,
@@ -17233,7 +17153,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "bkS" = (
 /obj/effect/turf_decal/tile/brown{
@@ -17349,7 +17269,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "bli" = (
 /obj/structure/disposalpipe/segment{
@@ -17382,6 +17302,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	color = "#464d5b";
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -17423,7 +17347,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "blu" = (
 /obj/machinery/computer/mech_bay_power_console{
@@ -17655,7 +17579,7 @@
 /area/science/lab)
 "bmb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "bmc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18907,7 +18831,7 @@
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/hallway/primary/central)
 "bph" = (
 /obj/structure/sign/warning/securearea,
@@ -19342,6 +19266,9 @@
 "bqD" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "bqH" = (
@@ -20024,6 +19951,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"bsq" = (
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "bsu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -20549,7 +20480,7 @@
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/hallway/primary/central)
 "btH" = (
 /obj/structure/chair/stool,
@@ -21021,7 +20952,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/darkblue,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/hallway/primary/central)
 "buS" = (
 /obj/effect/turf_decal/tile/blue{
@@ -21033,7 +20964,7 @@
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/hallway/primary/central)
 "buT" = (
 /obj/structure/disposalpipe/segment{
@@ -21824,9 +21755,10 @@
 	dir = 4
 	},
 /obj/machinery/bounty_board/directional/north,
-/turf/open/floor/iron/dark/corner{
+/obj/effect/turf_decal/tile/dark{
 	dir = 1
 	},
+/turf/open/floor/iron/smooth_edge,
 /area/engineering/break_room)
 "bxL" = (
 /obj/machinery/camera{
@@ -23041,6 +22973,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/hangover,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/library)
 "bCJ" = (
@@ -25606,7 +25539,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/depsec/engineering,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "bKI" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -25639,8 +25575,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bKL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -25950,6 +25889,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bLR" = (
@@ -27012,7 +26952,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/gravity_generator)
 "bPZ" = (
 /obj/structure/table,
@@ -27262,7 +27202,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "bRj" = (
 /obj/structure/cable,
@@ -27272,7 +27212,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "bRl" = (
 /obj/structure/light_construct{
@@ -27292,7 +27232,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
 /area/security/checkpoint/engineering)
 "bRo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27805,7 +27748,7 @@
 /area/medical/virology)
 "bTh" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "bTl" = (
 /obj/effect/landmark/blobstart,
@@ -28210,7 +28153,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "bVy" = (
 /obj/structure/disposalpipe/segment{
@@ -28594,11 +28537,12 @@
 /area/maintenance/starboard/fore)
 "bWM" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#ff0000";
+	dir = 8
 	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
@@ -28785,7 +28729,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "bXr" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -28878,16 +28825,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "bXJ" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#ff0000";
+	dir = 8
 	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
@@ -28908,6 +28856,9 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/navbeacon/wayfinding,
+/obj/effect/turf_decal/siding/thinplating{
+	color = "#464d5b"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bXQ" = (
@@ -29193,15 +29144,20 @@
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
-/turf/open/floor/iron/checker,
+/obj/effect/turf_decal/tile/dark,
+/obj/effect/turf_decal/tile/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/engineering/break_room)
 "bYL" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/corner{
+/obj/effect/turf_decal/tile/dark{
 	dir = 1
 	},
+/turf/open/floor/iron/smooth_edge,
 /area/engineering/break_room)
 "bYM" = (
 /obj/structure/disposalpipe/segment{
@@ -29223,7 +29179,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "bYP" = (
 /obj/effect/landmark/event_spawn,
@@ -29322,7 +29278,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "bZi" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -29359,7 +29315,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "bZv" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -29377,7 +29333,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bZy" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "bZz" = (
 /obj/machinery/light_switch/directional/west,
@@ -29386,8 +29342,11 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/corner{
+/obj/effect/turf_decal/tile/dark{
 	dir = 1
+	},
+/turf/open/floor/iron/smooth_edge{
+	dir = 4
 	},
 /area/engineering/break_room)
 "bZB" = (
@@ -29634,7 +29593,11 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/iron/checker,
+/obj/effect/turf_decal/tile/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark,
+/turf/open/floor/iron/smooth,
 /area/engineering/break_room)
 "cax" = (
 /obj/structure/closet/wardrobe/black,
@@ -29859,36 +29822,19 @@
 /area/tcommsat/computer)
 "cbp" = (
 /obj/structure/closet/secure_closet/engineering_chief,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/command/heads_quarters/ce)
 "cbq" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable,
 /mob/living/simple_animal/parrot/poly,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
 /area/command/heads_quarters/ce)
 "cbr" = (
 /obj/structure/disposalpipe/segment{
@@ -30084,37 +30030,20 @@
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "ccj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "ccl" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
 /area/command/heads_quarters/ce)
 "ccp" = (
 /obj/structure/disposalpipe/segment{
@@ -30137,7 +30066,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "cct" = (
 /obj/structure/disposalpipe/segment{
@@ -30330,17 +30259,7 @@
 /area/maintenance/port/aft)
 "cdk" = (
 /obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cdl" = (
 /obj/effect/landmark/event_spawn,
@@ -30351,7 +30270,10 @@
 /obj/item/clipboard,
 /obj/item/paper/monitorkey,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
 /area/command/heads_quarters/ce)
 "cdn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -30480,7 +30402,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cdU" = (
 /obj/structure/chair/office/light{
@@ -30563,7 +30485,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "ceo" = (
 /obj/machinery/keycard_auth/directional/south,
@@ -30573,7 +30495,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "cex" = (
 /obj/machinery/camera{
@@ -30695,7 +30617,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cfa" = (
 /obj/structure/rack,
@@ -30706,13 +30628,10 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_half,
 /area/engineering/main)
 "cfb" = (
 /turf/closed/wall/r_wall,
@@ -30737,9 +30656,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cfg" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -30747,7 +30663,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_half,
 /area/engineering/main)
 "cfi" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -30829,26 +30748,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cfH" = (
 /obj/machinery/holopad,
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/button/door/directional/north{
 	id = "ceprivacy";
 	name = "Privacy Shutters Control"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cfI" = (
 /obj/structure/closet/secure_closet/research_director,
@@ -30865,7 +30774,7 @@
 "cfL" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cfN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
@@ -30936,7 +30845,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cgx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30988,6 +30897,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating{
+	color = "#464d5b";
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "cgO" = (
@@ -30998,20 +30911,10 @@
 	},
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/reagent_containers/pill/patch/aiuri,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cgR" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cgV" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
@@ -31183,7 +31086,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "chC" = (
 /obj/structure/rack,
@@ -31203,7 +31106,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "chE" = (
 /obj/structure/disposalpipe/segment,
@@ -31214,7 +31117,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "chH" = (
 /obj/structure/closet/firecloset,
@@ -31274,70 +31177,30 @@
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
 "cia" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
 /obj/structure/cable,
 /obj/structure/reagent_dispensers/fueltank/large,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cic" = (
 /obj/machinery/power/smes/engineering,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cid" = (
 /obj/machinery/power/smes/engineering,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cie" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -31346,7 +31209,7 @@
 	pixel_y = 30
 	},
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cig" = (
 /turf/closed/wall,
@@ -31365,54 +31228,27 @@
 /area/engineering/main)
 "cij" = (
 /obj/machinery/modular_computer/console/preset/engineering,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cik" = (
 /obj/machinery/computer/apc_control{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/command/heads_quarters/ce)
 "cim" = (
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cin" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/command/heads_quarters/ce)
 "cio" = (
 /obj/structure/table/reinforced,
@@ -31420,7 +31256,10 @@
 /obj/item/stamp/ce,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
 /area/command/heads_quarters/ce)
 "cip" = (
 /obj/effect/turf_decal/stripes/line{
@@ -31431,7 +31270,7 @@
 "cis" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "ciu" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31469,7 +31308,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "ciO" = (
 /obj/effect/turf_decal/stripes/line{
@@ -31518,6 +31357,10 @@
 	id = "Secure Storage";
 	name = "secure storage"
 	},
+/obj/effect/turf_decal/siding/thinplating{
+	color = "#464d5b";
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
 "ciZ" = (
@@ -31526,19 +31369,19 @@
 "cjb" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cjc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cjf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cjg" = (
 /obj/machinery/modular_computer/console/preset/id{
@@ -31548,54 +31391,37 @@
 	c_tag = "Chief Engineer's Office";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/requests_console/directional/west{
 	announcementConsole = 1;
 	department = "Chief Engineer's Desk";
 	departmentType = 3;
 	name = "Chief Engineer's Requests Console"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/command/heads_quarters/ce)
 "cjh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cji" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cjj" = (
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/command/heads_quarters/ce)
 "cjk" = (
 /obj/structure/sign/warning/securearea,
@@ -31606,14 +31432,14 @@
 	c_tag = "Engineering MiniSat Access";
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cjm" = (
 /obj/machinery/door/airlock/command{
 	name = "MiniSat Access";
 	req_access_txt = "65"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cjo" = (
 /obj/structure/closet/toolcloset,
@@ -31680,15 +31506,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
-/turf/open/floor/iron,
-/area/engineering/main)
-"cjR" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_one_access_txt = "10;24"
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cjU" = (
 /obj/machinery/computer/station_alert{
@@ -31698,21 +31516,14 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/command/heads_quarters/ce)
 "cjV" = (
 /obj/structure/tank_holder/oxygen,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cjX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31741,7 +31552,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
 /area/command/heads_quarters/ce)
 "cka" = (
 /obj/structure/table,
@@ -31800,16 +31614,6 @@
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
 "ckD" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -31821,7 +31625,7 @@
 	pixel_x = 6;
 	pixel_y = -2
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "ckF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -31830,62 +31634,37 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/engineering/main)
-"ckG" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/turf/open/floor/iron/smooth_corner{
+	dir = 4
 	},
+/area/engineering/main)
+"ckG" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
 /obj/structure/closet/crate/solarpanel_small,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "ckH" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "ckI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
 /obj/machinery/suit_storage_unit/engine,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "ckK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
 /obj/structure/tank_dispenser,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "ckL" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31897,20 +31676,10 @@
 	name = "Chief Engineer";
 	req_access_txt = "56"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/command/heads_quarters/ce)
 "ckS" = (
 /obj/structure/closet/cardboard,
@@ -32030,25 +31799,21 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_corner,
 /area/engineering/main)
 "clQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_corner{
+	dir = 1
+	},
 /area/engineering/main)
 "clR" = (
 /obj/machinery/light/directional/north,
@@ -32059,13 +31824,15 @@
 	},
 /obj/item/book/manual/wiki/engineering_construction,
 /obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 4
+	},
 /area/engineering/main)
 "clT" = (
 /obj/machinery/atmospherics/miner/nitrogen,
@@ -32138,41 +31905,29 @@
 	},
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cmF" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_half,
 /area/engineering/main)
 "cmG" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/yellow/anticorner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_corner,
 /area/engineering/main)
 "cmL" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_half,
 /area/engineering/main)
 "cmS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32231,7 +31986,7 @@
 	req_access_txt = "10"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cnt" = (
 /obj/machinery/camera{
@@ -32242,18 +31997,23 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_corner{
+	dir = 1
+	},
 /area/engineering/main)
 "cnv" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cnw" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/iron,
-/area/service/hydroponics)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/item/cigbutt,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/iron/smooth_large,
+/area/hallway/secondary/service)
 "cnx" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -32262,19 +32022,9 @@
 /area/engineering/main)
 "cny" = (
 /obj/effect/landmark/start/station_engineer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cnA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -32289,7 +32039,7 @@
 	pixel_x = -4;
 	pixel_y = -1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cnX" = (
 /obj/structure/extinguisher_cabinet{
@@ -32298,24 +32048,24 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cnY" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cnZ" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "coa" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "coh" = (
 /obj/machinery/door/window/brigdoor/security/cell{
@@ -32364,7 +32114,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "coM" = (
 /obj/effect/turf_decal/stripes/line{
@@ -32374,7 +32124,7 @@
 /area/engineering/main)
 "coZ" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cpa" = (
 /obj/machinery/light/directional/east,
@@ -32382,7 +32132,7 @@
 	dir = 5
 	},
 /obj/structure/closet/secure_closet/engineering_welding,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cpb" = (
 /obj/structure/closet/emcloset,
@@ -32405,21 +32155,21 @@
 "cpq" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cps" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cpt" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cpu" = (
 /obj/machinery/door/firedoor,
@@ -32427,6 +32177,10 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
 	req_one_access_txt = "10;24"
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	color = "#464d5b";
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -32469,7 +32223,7 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/gravity_generator)
 "cpV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32477,7 +32231,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cpW" = (
 /obj/effect/turf_decal/tile/red,
@@ -32496,7 +32250,7 @@
 "cpX" = (
 /obj/structure/table,
 /obj/item/stack/rods/fifty,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cpZ" = (
 /obj/structure/table,
@@ -32511,7 +32265,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cqa" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -32607,7 +32361,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cqo" = (
 /obj/structure/sign/warning/pods{
@@ -32616,7 +32370,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cqp" = (
 /obj/machinery/camera{
@@ -32651,7 +32405,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cqz" = (
 /obj/machinery/disposal/bin,
@@ -32659,13 +32413,17 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cqA" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
 	req_one_access_txt = "10;24"
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	color = "#464d5b";
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -32710,7 +32468,7 @@
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/gravity_generator)
 "cqN" = (
 /obj/structure/table,
@@ -32719,19 +32477,19 @@
 /obj/item/stack/sheet/plasteel{
 	amount = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cqP" = (
 /obj/structure/closet/radiation,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cqQ" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cqR" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cqS" = (
 /obj/structure/closet/emcloset/anchored,
@@ -32787,6 +32545,10 @@
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating{
+	color = "#464d5b";
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "crh" = (
@@ -32893,7 +32655,7 @@
 /area/engineering/main)
 "crP" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "crR" = (
 /obj/structure/transit_tube,
@@ -34846,7 +34608,7 @@
 /area/engineering/supermatter)
 "cAQ" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/gravity_generator)
 "cAR" = (
 /obj/machinery/door/window{
@@ -35100,7 +34862,7 @@
 /area/maintenance/starboard/aft)
 "cBO" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cBP" = (
 /obj/structure/table,
@@ -35256,7 +35018,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cDf" = (
 /obj/structure/table,
@@ -35299,7 +35061,7 @@
 "cDm" = (
 /obj/machinery/vending/engivend,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cDp" = (
 /obj/structure/cable,
@@ -35347,14 +35109,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cDB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/landmark/start/station_engineer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cDC" = (
 /obj/item/wrench,
@@ -35410,13 +35172,13 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cDI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cDL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
@@ -35438,7 +35200,7 @@
 	pixel_y = -2
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cEa" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -36385,7 +36147,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cMD" = (
 /turf/closed/wall/r_wall,
@@ -36592,11 +36354,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "cRr" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/iron/smooth_large,
+/area/hallway/secondary/service)
 "cRD" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot{
@@ -36633,12 +36395,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "cSk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/modular_computer/console/preset/cargochat/service,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/turf/open/floor/wood,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/secondary/service)
 "cSp" = (
 /obj/effect/spawner/structure/window,
@@ -36689,16 +36446,6 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cSL" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -36719,28 +36466,18 @@
 	pixel_y = -10;
 	req_access_txt = "10"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cSM" = (
 /obj/machinery/computer/station_alert,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cSN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cSQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -36750,7 +36487,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cSR" = (
 /obj/effect/turf_decal/delivery,
@@ -36761,7 +36498,7 @@
 	c_tag = "Engineering SMES"
 	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cST" = (
 /obj/effect/turf_decal/stripes/line,
@@ -36771,21 +36508,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cSU" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cSV" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cSW" = (
 /obj/effect/turf_decal/stripes/line{
@@ -36794,11 +36531,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cSX" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cSY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -36808,7 +36545,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cSZ" = (
 /obj/machinery/disposal/bin,
@@ -36821,24 +36558,14 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cTb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "cTf" = (
 /obj/machinery/requests_console{
@@ -36847,12 +36574,6 @@
 	name = "Engineering RC";
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -36860,7 +36581,10 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_half,
 /area/engineering/main)
 "cTE" = (
 /obj/machinery/door/airlock/external{
@@ -37101,6 +36825,9 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "dfx" = (
@@ -37250,7 +36977,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "dnc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
@@ -37295,7 +37023,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "dpI" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
@@ -37363,7 +37094,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "dvD" = (
 /obj/item/paper_bin{
@@ -37524,6 +37259,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
+"dEC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet,
+/area/service/library)
 "dFo" = (
 /turf/closed/wall,
 /area/service/lawoffice)
@@ -37602,8 +37344,11 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "dJS" = (
-/obj/structure/sign/poster/official/random,
-/turf/closed/wall,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/machinery/rnd/production/techfab/department/service,
+/turf/open/floor/wood,
 /area/hallway/secondary/service)
 "dMb" = (
 /obj/effect/turf_decal/tile/brown{
@@ -37908,7 +37653,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /mob/living/simple_animal/pet/poppy,
-/turf/open/floor/iron,
+/turf/open/floor/plating/catwalk_floor,
 /area/engineering/break_room)
 "dZQ" = (
 /obj/structure/chair/office{
@@ -37977,7 +37722,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "ecS" = (
 /obj/machinery/computer/warrant,
@@ -38399,9 +38144,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/hallway/secondary/service)
 "eAU" = (
@@ -38460,6 +38202,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"eHw" = (
+/turf/open/floor/grass,
+/area/service/hydroponics)
 "eIf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -38607,6 +38352,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
+"ePw" = (
+/obj/structure/beebox,
+/turf/open/floor/grass,
+/area/service/hydroponics)
 "ePK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
@@ -38655,6 +38404,16 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"eRK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating/catwalk_floor,
+/area/engineering/break_room)
 "eRL" = (
 /obj/machinery/flasher{
 	id = "cell4";
@@ -38674,6 +38433,23 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/command/gateway)
+"eSa" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/service/hydroponics)
+"eSQ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	color = "#464d5b";
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "eTo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38833,7 +38609,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_large,
 /area/engineering/gravity_generator)
 "fep" = (
 /obj/structure/cable,
@@ -39005,7 +38784,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "fkH" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/gravity_generator)
 "flc" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
@@ -39281,7 +39060,7 @@
 /area/security/prison)
 "fwA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "fxr" = (
 /obj/effect/landmark/start/security_officer,
@@ -39415,10 +39194,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"fCG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "fDD" = (
-/obj/item/assembly/mousetrap,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/chair/sofa/bench/left,
+/turf/open/floor/iron/smooth_large,
+/area/hallway/secondary/service)
 "fDX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39609,8 +39394,17 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "fPh" = (
-/obj/structure/sign/painting/library,
-/turf/closed/wall,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/circuitboard/machine/vendatray,
+/obj/item/circuitboard/machine/vendatray,
+/obj/item/toner/large,
+/turf/open/floor/wood,
 /area/hallway/secondary/service)
 "fPm" = (
 /obj/structure/cable,
@@ -40161,7 +39955,7 @@
 "gnd" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/gravity_generator)
 "gnf" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
@@ -40196,6 +39990,11 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"goZ" = (
+/obj/structure/table,
+/obj/item/watertank,
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "gpE" = (
 /obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
@@ -40452,7 +40251,7 @@
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/hallway/primary/central)
 "gFW" = (
 /obj/structure/cable,
@@ -41168,7 +40967,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/gravity_generator)
 "hte" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -41213,7 +41012,10 @@
 	pixel_y = -10;
 	req_access_txt = "10"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "hun" = (
 /obj/machinery/power/apc/auto_name/north,
@@ -41500,20 +41302,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "hFi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/smooth_large,
 /area/hallway/secondary/service)
 "hFp" = (
 /obj/structure/disposalpipe/segment{
@@ -41747,10 +41540,15 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "hRy" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/service/library)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 17
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "hRF" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/rack,
@@ -42025,21 +41823,11 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "ifj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/command/heads_quarters/ce)
 "ify" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -42071,6 +41859,11 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
+"igX" = (
+/obj/item/hhmirror,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/service/hydroponics)
 "ihi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -42085,7 +41878,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "ihy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42459,7 +42255,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/hallway/primary/central)
 "iFN" = (
 /obj/structure/disposalpipe/segment,
@@ -42469,6 +42265,10 @@
 "iFY" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating/corner{
+	color = "#464d5b";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "iGp" = (
@@ -42488,7 +42288,7 @@
 "iHd" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "iHH" = (
 /obj/structure/window/fulltile,
@@ -42556,7 +42356,7 @@
 /area/hallway/primary/starboard)
 "iLJ" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/hallway/primary/central)
 "iLK" = (
 /obj/structure/disposalpipe/segment{
@@ -42609,7 +42409,7 @@
 "iQF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "iRI" = (
 /obj/effect/turf_decal/stripes/line{
@@ -42826,7 +42626,13 @@
 	req_access_txt = "53"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/ai_monitored/command/nuke_storage)
 "jdF" = (
 /obj/machinery/door/airlock/security/glass{
@@ -42953,9 +42759,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "jjr" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -42963,7 +42766,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 1
+	},
 /area/engineering/main)
 "jjO" = (
 /obj/machinery/door_timer{
@@ -43533,6 +43341,10 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/science/misc_lab)
+"jIb" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet,
+/area/service/library)
 "jIe" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/effect/decal/cleanable/dirt,
@@ -43934,7 +43746,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "jYO" = (
 /obj/machinery/modular_computer/console/preset/civilian{
@@ -44037,7 +43849,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "kcV" = (
 /obj/structure/cable,
@@ -44155,7 +43967,7 @@
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/hallway/primary/central)
 "kgE" = (
 /obj/structure/dresser,
@@ -44188,6 +44000,15 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
+"kja" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/engineering/main)
 "kjH" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -44269,7 +44090,7 @@
 "knx" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/hallway/primary/central)
 "koe" = (
 /obj/structure/sink{
@@ -44542,6 +44363,12 @@
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/dark/textured_edge,
 /area/command/gateway)
+"kxX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "kyo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -44685,10 +44512,11 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "kCD" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/computer/cargo/request,
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "kCI" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
@@ -44916,7 +44744,6 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "kNq" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/line,
 /obj/item/kirbyplants/fullysynthetic,
 /turf/open/floor/plastic,
@@ -44983,11 +44810,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/cargo/storage)
 "kPd" = (
-/obj/item/trash/can,
-/mob/living/simple_animal/mouse/white,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/hallway/secondary/service)
 "kPH" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -45095,6 +44922,9 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "kXt" = (
@@ -45137,17 +44967,8 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "kYN" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -45264,6 +45085,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"lfO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/library)
 "lhu" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -45724,11 +45552,17 @@
 /area/hallway/secondary/entry)
 "lHi" = (
 /obj/structure/cable,
-/obj/structure/railing,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_large,
+/area/hallway/secondary/service)
 "lHR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45879,7 +45713,7 @@
 /area/security/prison)
 "lNi" = (
 /obj/structure/table,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/gravity_generator)
 "lNo" = (
 /obj/structure/disposalpipe/segment,
@@ -46058,7 +45892,7 @@
 /area/science/misc_lab)
 "lSU" = (
 /obj/effect/turf_decal/tile/blue/darkblue,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_corner,
 /area/hallway/primary/central)
 "lTj" = (
 /obj/machinery/door/airlock/public/glass{
@@ -46365,6 +46199,11 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"miE" = (
+/obj/structure/bookcase/random/fiction,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/service/library)
 "miU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted,
@@ -46410,6 +46249,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"mmi" = (
+/obj/machinery/light/directional/east,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window/spawner,
+/turf/open/floor/grass,
+/area/service/hydroponics)
 "mnV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -46524,13 +46369,13 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "muj" = (
-/obj/machinery/light/directional/east,
-/obj/structure/window/spawner,
-/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/structure/closet/crate/hydroponics,
+/obj/structure/window/spawner,
+/obj/structure/window/spawner/west,
+/turf/open/floor/grass,
 /area/service/hydroponics)
 "muH" = (
 /obj/machinery/door/firedoor,
@@ -46777,6 +46622,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
+"mIp" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/service/library)
 "mIq" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -46991,7 +46841,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/ai_monitored/command/nuke_storage)
 "mSu" = (
 /obj/structure/disposalpipe/segment{
@@ -47025,7 +46875,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/ai_monitored/command/nuke_storage)
 "mUB" = (
 /obj/structure/table,
@@ -47350,7 +47200,9 @@
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 8
+	},
 /area/hallway/primary/central)
 "nlx" = (
 /obj/structure/disposalpipe/segment{
@@ -47472,7 +47324,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/hallway/primary/central)
 "nua" = (
 /obj/effect/spawner/structure/window,
@@ -48820,7 +48672,7 @@
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/hallway/primary/central)
 "oFG" = (
 /obj/structure/grille,
@@ -49396,9 +49248,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/corner{
+/obj/effect/turf_decal/tile/dark{
 	dir = 1
 	},
+/turf/open/floor/iron/smooth,
 /area/engineering/break_room)
 "pjU" = (
 /turf/closed/wall/r_wall,
@@ -49955,10 +49808,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pIW" = (
-/obj/effect/turf_decal/siding/brown{
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	sortType = 21
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_large,
 /area/hallway/secondary/service)
 "pJj" = (
 /obj/machinery/ammo_workbench,
@@ -50147,12 +50008,6 @@
 	},
 /area/security/prison/safe)
 "pRs" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -50161,7 +50016,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_half,
 /area/engineering/main)
 "pSb" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -50487,7 +50345,7 @@
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/hallway/primary/central)
 "qfs" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -50560,6 +50418,10 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/commons/dorms)
+"qhA" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/service/library)
 "qhN" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -50821,6 +50683,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/warden)
+"qzL" = (
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/library)
 "qzO" = (
 /turf/open/floor/iron/showroomfloor,
 /area/hallway/secondary/service)
@@ -51264,6 +51130,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"qWy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating/catwalk_floor,
+/area/engineering/main)
 "qWV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -51271,10 +51143,15 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "qWZ" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Hydroponics"
+	},
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "qXk" = (
 /obj/effect/turf_decal/vg_decals/atmos/air{
 	dir = 1
@@ -51624,9 +51501,26 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"rpD" = (
+/obj/structure/window/spawner,
+/turf/open/floor/grass,
+/area/service/hydroponics)
 "rqi" = (
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"rqA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "rqU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -51925,16 +51819,11 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "rET" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/structure/sink{
+	pixel_y = 20
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "rFv" = (
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /turf/open/floor/grass,
@@ -52011,6 +51900,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"rJz" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "rJF" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -52036,7 +51929,9 @@
 	c_tag = "Vault Lobby";
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
 /area/hallway/primary/central)
 "rKP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -52201,7 +52096,7 @@
 /area/medical/medbay/aft)
 "rTH" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/hallway/primary/central)
 "rUx" = (
 /obj/structure/railing{
@@ -52254,7 +52149,7 @@
 	c_tag = "Gravity Generator";
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/gravity_generator)
 "rWl" = (
 /obj/item/chair/plastic{
@@ -52338,16 +52233,6 @@
 	},
 /area/security/prison)
 "rZR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -52357,7 +52242,7 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/item/stock_parts/cell/emproof,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "sbQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -52856,16 +52741,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sGc" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -52873,7 +52748,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "sGk" = (
 /obj/effect/landmark/observer_start,
@@ -53090,7 +52965,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "sNY" = (
 /obj/effect/landmark/carpspawn,
@@ -53269,7 +53144,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/start/depsec/engineering,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "sXy" = (
 /obj/machinery/door/airlock/external{
@@ -53799,7 +53674,9 @@
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
 /area/hallway/primary/central)
 "tuk" = (
 /obj/effect/turf_decal/tile/bar,
@@ -53843,7 +53720,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "tve" = (
 /obj/structure/disposalpipe/segment{
@@ -54099,7 +53980,9 @@
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 1
+	},
 /area/hallway/primary/central)
 "tGE" = (
 /obj/effect/mapping_helpers/airlock/locked,
@@ -54121,7 +54004,7 @@
 /obj/machinery/navbeacon/wayfinding,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/ai_monitored/command/nuke_storage)
 "tGP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -54199,6 +54082,13 @@
 "tKm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/cafeteria,
+/area/maintenance/port/aft)
+"tKn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating{
+	color = "#464d5b"
+	},
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "tKp" = (
 /obj/structure/table/wood,
@@ -54280,6 +54170,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"tNv" = (
+/obj/structure/bookcase/random/adult,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/service/library)
 "tOF" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
@@ -54350,17 +54247,8 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/break_room)
 "tRv" = (
 /obj/structure/closet/emcloset,
@@ -54839,6 +54727,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	sortType = 16
+	},
 /turf/open/floor/wood,
 /area/service/library)
 "upr" = (
@@ -54964,7 +54856,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/gravity_generator)
 "uvZ" = (
 /obj/machinery/door/window/brigdoor/security/cell{
@@ -55097,7 +54989,7 @@
 /area/security/prison)
 "uzr" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/hallway/primary/central)
 "uzJ" = (
 /turf/open/floor/iron/dark/side{
@@ -55164,6 +55056,12 @@
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"uEe" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "uEh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
@@ -55192,6 +55090,11 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"uFA" = (
+/obj/structure/bookcase/random/religion,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/service/library)
 "uFU" = (
 /obj/structure/toilet{
 	pixel_y = 16
@@ -55301,6 +55204,11 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/medical/chemistry)
+"uKr" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/service/library)
 "uKu" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
@@ -55555,6 +55463,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
+"uXh" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/door/window/westleft{
+	req_access_txt = "35"
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/service/hydroponics)
 "uXt" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Dock";
@@ -55807,7 +55725,7 @@
 "vkD" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "vkQ" = (
 /obj/machinery/power/apc/auto_name/north,
@@ -55902,7 +55820,9 @@
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
 /area/hallway/primary/central)
 "voM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -56070,7 +55990,6 @@
 /area/science/genetics)
 "vyO" = (
 /obj/structure/table/wood,
-/obj/structure/disposalpipe/segment,
 /obj/item/stack/package_wrap,
 /obj/item/paper_bin{
 	pixel_x = 1;
@@ -56117,13 +56036,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/hallway/primary/central)
 "vAw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "vAI" = (
 /obj/vehicle/ridden/secway,
@@ -56265,7 +56184,7 @@
 /obj/effect/turf_decal/tile/blue/darkblue{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/hallway/primary/central)
 "vFS" = (
 /obj/structure/disposalpipe/segment,
@@ -56401,6 +56320,10 @@
 	dir = 4
 	},
 /area/security/prison)
+"vLI" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/floor/grass,
+/area/service/hydroponics)
 "vLX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -56597,7 +56520,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/hallway/primary/central)
 "vWv" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -56722,7 +56645,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "wbO" = (
 /obj/effect/turf_decal/delivery/blue,
@@ -57119,7 +57043,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "wuS" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -57245,9 +57170,11 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "wBd" = (
-/obj/structure/railing,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_large,
+/area/hallway/secondary/service)
 "wBO" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/disposalpipe/trunk{
@@ -57284,6 +57211,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"wDE" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/library)
 "wDJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -57427,7 +57359,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/gravity_generator)
 "wIo" = (
 /obj/machinery/deepfryer,
@@ -57603,7 +57535,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "wPd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -57683,6 +57615,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "wRn" = (
@@ -58138,7 +58071,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/hallway/primary/central)
 "xjt" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -58167,7 +58100,7 @@
 /turf/open/floor/iron,
 /area/science/storage)
 "xkH" = (
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/hallway/primary/central)
 "xkP" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -58661,6 +58594,11 @@
 "xKN" = (
 /turf/closed/wall/r_wall,
 /area/command/gateway)
+"xKO" = (
+/obj/structure/table/wood,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/service/library)
 "xKQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -58696,6 +58634,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron,
 /area/service/theater)
 "xNZ" = (
@@ -58901,12 +58840,10 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "xWM" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/computer/cargo/request,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "xXc" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Crematorium Maintenance";
@@ -59040,7 +58977,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "ydA" = (
 /obj/effect/turf_decal/tile/blue{
@@ -59112,6 +59050,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
+"yeY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "yfx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -83870,7 +83814,7 @@ ciT
 bCq
 bSs
 ceY
-vLX
+tKn
 cmD
 cnr
 chD
@@ -84644,7 +84588,7 @@ cjJ
 cjJ
 cjJ
 cfL
-ckF
+kja
 cBO
 cgR
 cDB
@@ -84901,7 +84845,7 @@ ckB
 ckB
 cjJ
 cnY
-ckF
+kja
 cgR
 cgR
 cqx
@@ -85158,7 +85102,7 @@ ckB
 ckC
 cjJ
 cnX
-ckF
+kja
 cps
 cpX
 cqz
@@ -85672,7 +85616,7 @@ cjJ
 cjJ
 cjJ
 cnZ
-ckF
+kja
 cpt
 cpZ
 cig
@@ -86697,7 +86641,7 @@ cSQ
 cST
 cTa
 ceZ
-bhY
+bkI
 cgR
 ccw
 coM
@@ -87675,7 +87619,7 @@ aZR
 aZR
 aZR
 bft
-urc
+uEe
 xbg
 hGX
 wZU
@@ -87932,7 +87876,7 @@ aCN
 bdh
 bee
 bfv
-urc
+kxX
 xbg
 dfw
 bii
@@ -87982,7 +87926,7 @@ cjf
 cSX
 ckK
 rdP
-bij
+cfg
 ckH
 cpu
 tqy
@@ -88446,7 +88390,7 @@ aCP
 aEj
 bef
 bfv
-urc
+fCG
 xbg
 bqD
 cSz
@@ -88703,7 +88647,7 @@ aZR
 aZR
 aZR
 bfw
-urc
+yeY
 xbg
 rUV
 uro
@@ -89514,7 +89458,7 @@ cew
 bTh
 bZy
 bZy
-bXI
+eRK
 bZg
 bZD
 cbq
@@ -90285,7 +90229,7 @@ ihi
 tvd
 caA
 bZy
-bXI
+eRK
 bZy
 adz
 cfK
@@ -90299,7 +90243,7 @@ aiN
 bkM
 cqP
 cMm
-cpu
+eSQ
 cqa
 cig
 ccw
@@ -90547,7 +90491,7 @@ bVp
 adA
 adW
 biA
-biA
+qWy
 aeT
 agT
 ahF
@@ -91332,7 +91276,7 @@ fwA
 wOS
 fwA
 cgR
-cjR
+cqA
 crW
 csg
 uRx
@@ -95106,8 +95050,8 @@ hBw
 hBw
 azr
 cVb
-fPh
-myW
+cVb
+aWb
 aGI
 xzk
 xge
@@ -95620,7 +95564,7 @@ jtQ
 hBw
 efu
 aCu
-fPh
+cVb
 kWH
 dlp
 aJC
@@ -95877,8 +95821,8 @@ hBw
 hBw
 azr
 tHv
-dJS
-xLr
+cVb
+bkg
 xVA
 aJC
 aJE
@@ -97419,7 +97363,7 @@ aro
 aro
 aro
 rQR
-dJS
+aIl
 qzO
 pOR
 sAD
@@ -97676,8 +97620,8 @@ aro
 aro
 aro
 rQR
-fPh
-pIW
+aJS
+qzO
 aGB
 pUe
 aAe
@@ -97933,8 +97877,8 @@ aro
 aro
 vUu
 rQR
-cVb
-cSk
+aKW
+qzO
 eAT
 aHY
 aJI
@@ -98190,9 +98134,9 @@ aGe
 aro
 aro
 rQR
-cVb
-xWM
-hFi
+aLd
+qzO
+pOR
 xfm
 aJK
 aKV
@@ -98447,10 +98391,10 @@ aro
 aro
 aro
 rQR
-alP
-alP
+aMN
+cnw
 aGP
-alP
+cVb
 aJI
 aJI
 aJI
@@ -98705,9 +98649,9 @@ aro
 aro
 rQR
 aDX
-alP
+cSk
 aGH
-anf
+qWZ
 aJL
 aKX
 aJI
@@ -98962,11 +98906,11 @@ aro
 aro
 rQR
 fDD
-alP
+cSk
 aGQ
-aIk
 aIp
-aKW
+aIp
+aRJ
 aMG
 aIp
 aIp
@@ -99220,9 +99164,9 @@ rQR
 rQR
 kPd
 cRr
-arr
-aGH
+lHi
 aIp
+rET
 aKH
 aMI
 aIp
@@ -99472,12 +99416,12 @@ blD
 gjY
 gBW
 rQR
-xzh
-xzh
-alP
-alP
-alP
-anf
+aoe
+aAu
+cVb
+aNP
+hFi
+pIW
 aIj
 aJB
 aKD
@@ -99729,15 +99673,15 @@ bSp
 gjY
 hgK
 rQR
-xzh
-alP
-alP
+aoe
+aCD
+cVb
 kCD
 wBd
 aFm
-aIl
 aIp
-cnw
+xWM
+aRJ
 uzb
 aIp
 aXo
@@ -99986,14 +99930,14 @@ cpW
 hns
 hQC
 rQR
-alP
-alP
-aCz
-arI
-lHi
+aoe
+aIk
+cVb
+cVb
+cVb
 atn
-rET
 aIp
+aRJ
 aRJ
 aMt
 aIp
@@ -100243,15 +100187,15 @@ rQR
 lOv
 rQR
 rQR
-jaH
-apl
+arI
+arI
 aCA
-qWZ
+uGz
 awD
 aGW
 aIp
-aIp
-bkg
+aRJ
+aRJ
 aMA
 aIp
 aMw
@@ -100502,10 +100446,10 @@ aEe
 apl
 apl
 apl
-alP
-alP
-alO
-aGV
+aCz
+aUx
+aUx
+aGW
 aIp
 aBc
 awE
@@ -100755,13 +100699,13 @@ atw
 anf
 alP
 awH
-aEe
+anf
 alP
 atB
 alP
-alO
-xzh
-xzh
+alP
+awF
+anf
 bKK
 aIp
 aJO
@@ -101012,21 +100956,21 @@ ldN
 anf
 alP
 aoP
-aEe
+anf
 apE
 anf
 izV
 alP
-alP
-alO
-aGV
+awG
+anf
+bKK
 aIp
 aJN
-aLd
-aMN
+aRJ
+aRJ
 aNQ
 aOQ
-aOQ
+uXh
 muj
 qTo
 aUz
@@ -101269,22 +101213,22 @@ ary
 anf
 alP
 alP
-aEe
+anf
 alP
 anf
 vvP
 alP
 ffa
-aFm
+anf
 aGF
 aIp
+aJN
+aRJ
+aRJ
 aIp
-aIp
-aIp
-aIp
-aIp
-aIp
-aIp
+vLI
+eSa
+rpD
 aIp
 aIp
 aIp
@@ -101526,7 +101470,7 @@ atx
 anf
 alP
 auD
-aEe
+anf
 alP
 aAs
 mEX
@@ -101534,22 +101478,22 @@ alP
 jaH
 aFs
 aGE
+aIp
 aCt
-aCt
-aCt
-aCt
-aCt
-aCt
-aCt
-aCt
-aCt
-aCt
-aUx
-aVL
+goZ
+bsq
+aIp
+ePw
+eHw
+mmi
+aIp
+igX
+aIp
+bez
 aXR
-bdl
-bdl
-bdl
+bez
+bez
+bez
 bcj
 bez
 bfT
@@ -101783,13 +101727,13 @@ apE
 atB
 alP
 aoP
-aEe
+anf
 apE
 dlx
 wgt
 alP
 anf
-aFs
+aGW
 aFu
 fiY
 fiY
@@ -102040,13 +101984,13 @@ anf
 anf
 alP
 alP
-aEe
-alP
-alP
-alP
-alP
 anf
-aFs
+alP
+alP
+alP
+alP
+aVL
+hRy
 aFu
 nTD
 bav
@@ -102297,24 +102241,24 @@ fhy
 anf
 avE
 awI
-aoe
-apl
-aAu
-apl
-aCD
+anf
+anf
+aAt
+anf
+aCC
 aEa
 aFv
 wRm
 upf
 aJQ
 bCI
-aIt
-aIt
-aPb
-aIt
-aRN
-aIt
-aUB
+qhA
+qhA
+uFA
+qhA
+miE
+qhA
+tNv
 aFu
 aVZ
 aXT
@@ -102564,15 +102508,15 @@ aFu
 fiY
 aIs
 aJP
-aLg
+xKO
 aMH
-pUD
-aYW
-aYW
-wKl
-aYW
-aYW
-aYW
+uKr
+qzL
+qzL
+wDE
+qzL
+lfO
+qzL
 aVY
 wKl
 bas
@@ -102821,16 +102765,16 @@ aFu
 aHc
 aIw
 vyO
-aJS
+aLg
 aMJ
-aNP
+aIt
+aYW
+aYW
+aYW
+wKl
 aOS
-aOS
-aOS
-hRy
-aOS
-aOS
-aWb
+aYW
+aXu
 aYW
 bau
 aFu
@@ -103087,12 +103031,12 @@ aRO
 aRO
 aUC
 aVP
-aXu
-aYW
+dEC
+jIb
 bat
-bbD
-aYV
-qXW
+mIp
+rJz
+rqA
 beE
 bfV
 bhv


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does exactly what it says on the tin. Botany now has access to **bees** as they do on Icebox (at the cost of a frankly superfluous maintenance tunnel), and are now part of the service hall - which has also been somewhat cleaned up mapping-wise.
Engineering is now **green**, a change /tg/ is too scared to make themselves. Atmos is untouched for visibility reasons (and colorblind folk.) Why are the catwalks so fucked up? Yes!
This PR also does one thing we /all/ know we needed.. there is now ONE EXTRA WRENCH at the new atmos airtanks next to security. You're.. welcome?
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
/tg/ is too scared of green engineering. They fear it, knowing one day it will come for them. Every day we get closer to a green engineering utopia.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Bees are now accessible roundstart on NSS Journey, with their own little glass nook. Careful to not unleash them!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
