### PR TITLE
[Non-modular] Vatbeast and oozing grapes don't leave their corpse behind

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -284,6 +284,10 @@
 	speed = 1
 	health = 200
 	maxHealth = 200
+	//Skyrat add
+	loot = list(/obj/effect/decal/cleanable/greenglow, /obj/item/food/grown/grapes/ooze = 2)
+	del_on_death = 1
+	//
 	damage_coeff = list(BRUTE = 1, BURN = 0.8, TOX = 0.5, CLONE = 1.5, STAMINA = 0, OXY = 1)
 	melee_damage_lower = 12
 	melee_damage_upper = 12

--- a/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
@@ -14,6 +14,10 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	health = 250
 	maxHealth = 250
+	//Skyrat add
+	loot = list(/obj/effect/decal/cleanable/oil, /obj/item/food/octopusrings = 4)
+	del_on_death = 1
+	//
 	damage_coeff = list(BRUTE = 0.7, BURN = 0.7, TOX = 1, CLONE = 2, STAMINA = 0, OXY = 1)
 	melee_damage_lower = 25
 	melee_damage_upper = 25

--- a/modular_skyrat/modules/customization/modules/food_and_drinks/food/misc.dm
+++ b/modular_skyrat/modules/customization/modules/food_and_drinks/food/misc.dm
@@ -1,0 +1,21 @@
+//For miscellaneous foods
+
+//cytology mobs butcher results
+/obj/item/food/grown/grapes/ooze
+	seed = /obj/item/seeds/grape/green
+	name = "bunch of oozing grapes"
+	icon_state = "greengrapes"
+	bite_consumption_mod = 3
+	tastes = list("gelatinous grape" = 1)
+	distill_reagent = /datum/reagent/toxin/slimejelly
+
+/obj/item/food/octopusrings
+	name = "tentacle rings"
+	desc = "tentacle slices coated in batter."
+	icon_state = "onionrings"
+	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/virus_food = 1)
+	gender = PLURAL
+	tastes = list("batter" = 3, "viscous tentacle" = 1)
+	foodtypes = MEAT | TOXIC
+	w_class = WEIGHT_CLASS_SMALL
+//

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4046,6 +4046,7 @@
 #include "modular_skyrat\modules\customization\modules\culture\faction\faction_generic.dm"
 #include "modular_skyrat\modules\customization\modules\culture\location\_location.dm"
 #include "modular_skyrat\modules\customization\modules\culture\location\location_generic.dm"
+#include "modular_skyrat\modules\customization\modules\food_and_drinks\food\misc.dm"
 #include "modular_skyrat\modules\customization\modules\food_and_drinks\food\scottish.dm"
 #include "modular_skyrat\modules\customization\modules\food_and_drinks\recipes\drinks_recipes.dm"
 #include "modular_skyrat\modules\customization\modules\hydroponics\grown\tea_coffee.dm"


### PR DESCRIPTION
## About The Pull Request

Instead of having a bulky corpse that does nothing but sit in the hallways, they now drop 'unique' food items and instead leave a more fun mess to clean.

## Why It's Good For The Game

They just sat in the hallway, couldn't be disposal chuted, butchered, burned, juiced, or nothin'.

## Changelog
:cl:
expansion: Vatbeast mobs and the sholean grape type of ooze mobs now del their corpse upon death and drop loot.
/:cl:

