### PR TITLE
De-crapifies the sec taser - by replacing it with a disabler

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -196,7 +196,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	shoes = /obj/item/clothing/shoes/combat/peacekeeper //SKYRAT EDIT CHANGE - SEC_HAUL
 	l_pocket = /obj/item/restraints/handcuffs
 	r_pocket = /obj/item/assembly/flash/handheld
-	suit_store = /obj/item/gun/energy/taser/armadyne //SKYRAT EDIT CHANGE - SEC_HAUL
+	suit_store = /obj/item/gun/energy/disabler
 	backpack_contents = list(/obj/item/melee/classic_baton/peacekeeper, /obj/item/armament_token/sidearm) //SKYRAT EDIT CHANGE - SEC_HAUL - ORIGINAL: backpack_contents = list(/obj/item/melee/baton/loaded=1)
 
 	backpack = /obj/item/storage/backpack/security/peacekeeper //SKYRAT EDIT CHANGE - SEC_HAUL - ORIGINAL: backpack = /obj/item/storage/backpack/security

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -49,7 +49,7 @@
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/peacekeeper //SKYRAT EDIT CHANGE - SEC_HAUL - ORIGINAL: /obj/item/clothing/glasses/hud/security/sunglasses
 	r_pocket = /obj/item/assembly/flash/handheld
 	l_pocket = /obj/item/restraints/handcuffs
-	//suit_store = /obj/item/gun/energy/disabler //SKYRAT EDIT REMOVAL - SEC_HAUL
+	suit_store = /obj/item/gun/energy/disabler
 	backpack_contents = list(/obj/item/melee/classic_baton/peacekeeper, /obj/item/clothing/head/beret/sec/peacekeeper, /obj/item/armament_token/sidearm) //SKRYAT EDIT CHANGE - SEC_HAUL - ORIGINAL: backpack_contents = list(/obj/item/melee/baton/loaded=1)
 
 	backpack = /obj/item/storage/backpack/security/peacekeeper //SKYRAT EDIT CHANGE - SEC_HAUL - ORIGINAL: backpack = /obj/item/storage/backpack/security

--- a/modular_skyrat/modules/brigoff/code/modules/jobs/job_types/brigoff.dm
+++ b/modular_skyrat/modules/brigoff/code/modules/jobs/job_types/brigoff.dm
@@ -45,6 +45,9 @@
 	satchel = /obj/item/storage/backpack/satchel/sec/peacekeeper
 	duffelbag = /obj/item/storage/backpack/duffelbag/sec/peacekeeper
 	head = /obj/item/clothing/head/brigoff
+
+	suit_store = /obj/item/gun/energy/taser/armadyne
+
 	box = /obj/item/storage/box/survival/security
 	belt = /obj/item/pda/security
 

--- a/modular_skyrat/modules/brigoff/code/modules/jobs/job_types/brigoff.dm
+++ b/modular_skyrat/modules/brigoff/code/modules/jobs/job_types/brigoff.dm
@@ -39,18 +39,14 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	ears = /obj/item/radio/headset/headset_sec
 	glasses = /obj/item/clothing/glasses/sunglasses
-	backpack_contents = list(/obj/item/melee/classic_baton/peacekeeper, /obj/item/restraints/handcuffs = 2)
+	backpack_contents = list(/obj/item/gun/energy/taser/armadyne, /obj/item/melee/classic_baton/peacekeeper, /obj/item/restraints/handcuffs = 2)
 	implants = list(/obj/item/implant/mindshield)
 	backpack = /obj/item/storage/backpack/security/peacekeeper
 	satchel = /obj/item/storage/backpack/satchel/sec/peacekeeper
 	duffelbag = /obj/item/storage/backpack/duffelbag/sec/peacekeeper
 	head = /obj/item/clothing/head/brigoff
-
-	suit_store = /obj/item/gun/energy/taser/armadyne
-
 	box = /obj/item/storage/box/survival/security
 	belt = /obj/item/pda/security
-
 	id_trim = /datum/id_trim/job/brigoff
 
 

--- a/modular_skyrat/modules/sec_haul/code/security_sergeant/security_sergeant.dm
+++ b/modular_skyrat/modules/sec_haul/code/security_sergeant/security_sergeant.dm
@@ -38,7 +38,7 @@
 	suit = /obj/item/clothing/suit/armor/vest/peacekeeper/black
 	head = /obj/item/clothing/head/beret/sec/peacekeeper/sergeant
 
-	suit_store = /obj/item/gun/energy/taser/armadyne //SKYRAT EDIT CHANGE - SEC_HAUL
+	suit_store = /obj/item/gun/energy/disabler
 
 	backpack_contents = list(/obj/item/melee/classic_baton/telescopic, /obj/item/armament_token/sidearm, /obj/item/armament_token/primary)
 


### PR DESCRIPTION
_"Don't tase me bro!"_

## About The Pull Request

Made in conjunction with #6925, offering a different take on working this taser out. Replaces the Armadyne taser given both to the security officer and sergeant with the classic disabler, without removing the Armadyne taser from the code. Gives the warden his disabler back, the poor thing!

## Why It's Good For The Game

Tasers suck. Tasers really, _really_ suck. Even during testing, I found that tasers were wildly RNG when it came to how fast it would work, how many shots it would take, and so on. Giving disablers back gives security a perfectly non-lethal form of cracking down on criminals, and a little bit more.. _motivation_, to yoink that ablative trenchcoat from the armory.

We always need more motivation for that, right?

## Changelog
:cl:
balance: replaces security officer and sergeant's taser with a disabler. gives the warden a disabler, too.
/:cl: