### PR TITLE
[NONMODULAR][FIX] Examine damage is now representitive of 130HP

### DIFF
--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -82,12 +82,12 @@
 	if(!source.override_notes)
 		// Make sure not to divide by 0 on accident
 		if(source.force > 0)
-			readout += "Our extensive research has shown that it takes a mere [span_warning("[round((100 / source.force), 0.1)]")] hit\s to beat down [victims[rand(1, victims.len)]] with no armor."
+			readout += "Our extensive research has shown that it takes a mere [span_warning("[round((130 / source.force), 0.1)]")] hit\s to beat down [victims[rand(1, victims.len)]] with no armor." //Skyrat Edit. Fixes examine.
 		else
 			readout += "Our extensive research found that you couldn't beat anyone to death with this if you tried."
 
 		if(source.throwforce > 0)
-			readout += "If you decide to throw this object instead, one will take [span_warning("[round((100 / source.throwforce), 0.1)]")] hit\s before collapsing."
+			readout += "If you decide to throw this object instead, one will take [span_warning("[round((130 / source.throwforce), 0.1)]")] hit\s before collapsing." //Skyrat edit - Fixes examine
 		else
 			readout += "If you decide to throw this object instead, then you will have trouble damaging anything."
 		if(source.armour_penetration > 0 || source.block_chance > 0)

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -73,9 +73,9 @@
 		var/list/readout = list("")
 		// No dividing by 0
 		if(loaded_projectile.damage > 0)
-			readout += "Most monkeys our legal team subjected to these rounds succumbed to their wounds after [span_warning("[round(100 / (loaded_projectile.damage * pellets), 0.1)]")] discharge\s at point-blank, taking [span_warning("[pellets]")] shot\s per round"
+			readout += "Most monkeys our legal team subjected to these rounds succumbed to their wounds after [span_warning("[round(130 / (loaded_projectile.damage * pellets), 0.1)]")] discharge\s at point-blank, taking [span_warning("[pellets]")] shot\s per round" //Skyrat Edit
 		if(loaded_projectile.stamina > 0)
-			readout += "[loaded_projectile.damage == 0 ? "Most Monkeys" : "More Fortunate Monkeys" ] collapsed from exhaustion after [span_warning("[round(100 / ((loaded_projectile.damage + loaded_projectile.stamina) * pellets), 0.1)]")] of these rounds"
+			readout += "[loaded_projectile.damage == 0 ? "Most Monkeys" : "More Fortunate Monkeys" ] collapsed from exhaustion after [span_warning("[round(130 / ((loaded_projectile.damage + loaded_projectile.stamina) * pellets), 0.1)]")] of these rounds" //Skyrat Edit
 		if(loaded_projectile.damage == 0 && loaded_projectile.stamina == 0)
 			return "Our legal team has determined the offensive nature of these rounds to be esoteric"
 		return readout.Join("\n") // Sending over a single string, rather than the whole list


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
/tg/ never decided to make this math non-static.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bruh

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: /tg/ math now has values changed to represent 130hp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
