### PR TITLE
[Non-Modular]Buffs Minerborg's Kinetic Accelerator mod capacity.

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -76,7 +76,7 @@
 /obj/item/gun/energy/kinetic_accelerator/cyborg
 	holds_charge = TRUE
 	unique_frequency = TRUE
-	max_mod_capacity = 100
+	max_mod_capacity = 100 //SKYRAT EDIT//
 
 /obj/item/gun/energy/kinetic_accelerator/minebot
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -76,7 +76,7 @@
 /obj/item/gun/energy/kinetic_accelerator/cyborg
 	holds_charge = TRUE
 	unique_frequency = TRUE
-	max_mod_capacity = 80
+	max_mod_capacity = 100
 
 /obj/item/gun/energy/kinetic_accelerator/minebot
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL


### PR DESCRIPTION
## About The Pull Request

We all agree that the Minerborg's KA is shit, and that's not okay, so I have a minor solution to this and is: Increasing the mod capacity to 100%. Though, to keep this balanced, minerborgs still wont be able to modify their own KA's yet until someone else decides to code that because I'm still very new at coding.

## Why It's Good For The Game

Why not? Minerborgs don't deserve to suffer like this anymore in the current /tg/base.

## Changelog
:cl:
balance:Increases Minerborg's Kinetic Accelerator mod cap from 80 to 100.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
