### PR TITLE
[NON-MODULAR] fixes things so that classic (including peacekeeper) batons can stamcrit again

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -333,7 +333,7 @@
 			playsound(get_turf(src), 'sound/effects/bang.ogg', 10, TRUE) //bonk
 	else
 		target.Knockdown(knockdown_time)
-		target.apply_damage(stamina_damage, STAMINA)
+		target.apply_damage(stamina_damage, STAMINA) //SKYRAT EDIT CHANGE (original is target.apply_damage(stamina_damage, STAMINA, BODY_ZONE_CHEST))
 		additional_effects_non_cyborg(target, user)
 
 		playsound(get_turf(src), on_stun_sound, 75, TRUE, -1)

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -333,7 +333,7 @@
 			playsound(get_turf(src), 'sound/effects/bang.ogg', 10, TRUE) //bonk
 	else
 		target.Knockdown(knockdown_time)
-		target.apply_damage(stamina_damage, STAMINA, BODY_ZONE_CHEST)
+		target.apply_damage(stamina_damage, STAMINA)
 		additional_effects_non_cyborg(target, user)
 
 		playsound(get_turf(src), on_stun_sound, 75, TRUE, -1)


### PR DESCRIPTION
## About The Pull Request

Not sure if it was a bug or intentional but here's your fix, batons can stamcrit again.

## Why It's Good For The Game

BECAUSE I SHOULDN'T HAVE TO FUCKIN BASH SOMEONE TO STAMCRIT THEM, SINCE THREE PEOPLE GOING AT SOMEONE WITH BATONS FOR FIVE MINUTES DOES ABSOLUTELY NOTHING

## Changelog
:cl:
fix: batons stamcrit again
/:cl: