### PR TITLE
Adds the option to go without a working tongue at roundstart!

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -485,20 +485,3 @@
 		signer.visible_message(span_notice("[signer] raises [signer.p_their()] eyebrows."))
 	else if(question_found)
 		signer.visible_message(span_notice("[signer] lowers [signer.p_their()] eyebrows."))
-
-/obj/item/organ/tongue/stump
-	name = "Tongue stump"
-	desc = "What remains of a tongue."
-	icon_state = "tonguenormal"
-	sense_of_taste = FALSE
-	attack_verb_continuous = list("drools", "spits", "gurgles")
-	attack_verb_simple = list("drool", "spit", "gurgle")
-	modifies_speech = FALSE
-
-/obj/item/organ/tongue/stump/Insert(mob/living/carbon/tongue_owner, special = 0)
-	. = ..()
-	ADD_TRAIT(tongue_owner, TRAIT_MUTE, ORGAN_TRAIT)
-
-/obj/item/organ/tongue/stump/Remove(mob/living/carbon/tongue_owner, special = 0)
-	..()
-	REMOVE_TRAIT(tongue_owner, TRAIT_MUTE, ORGAN_TRAIT)

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -485,3 +485,20 @@
 		signer.visible_message(span_notice("[signer] raises [signer.p_their()] eyebrows."))
 	else if(question_found)
 		signer.visible_message(span_notice("[signer] lowers [signer.p_their()] eyebrows."))
+
+/obj/item/organ/tongue/stump
+	name = "Tongue stump"
+	desc = "What remains of a tongue."
+	icon_state = "tonguenormal"
+	sense_of_taste = FALSE
+	attack_verb_continuous = list("drools", "spits", "gurgles")
+	attack_verb_simple = list("drool", "spit", "gurgle")
+	modifies_speech = FALSE
+
+/obj/item/organ/tongue/stump/Insert(mob/living/carbon/tongue_owner, special = 0)
+	. = ..()
+	ADD_TRAIT(tongue_owner, TRAIT_MUTE, ORGAN_TRAIT)
+
+/obj/item/organ/tongue/stump/Remove(mob/living/carbon/tongue_owner, special = 0)
+	..()
+	REMOVE_TRAIT(tongue_owner, TRAIT_MUTE, ORGAN_TRAIT)

--- a/modular_skyrat/modules/customization/modules/client/augment/organs.dm
+++ b/modular_skyrat/modules/customization/modules/client/augment/organs.dm
@@ -101,8 +101,8 @@
 	attack_verb_simple = list("drool", "spit", "gurgle")
 	modifies_speech = FALSE
 
-/obj/item/organ/tongue/stump/Insert(mob/living/carbon/tongue_owner, special = 0)
-	. = ..()
+/obj/item/organ/tongue/stump/Insert(mob/living/carbon/tongue_owner)
+	..()
 	ADD_TRAIT(tongue_owner, TRAIT_MUTE, ORGAN_TRAIT)
 
 /obj/item/organ/tongue/stump/Remove(mob/living/carbon/tongue_owner, special = 0)

--- a/modular_skyrat/modules/customization/modules/client/augment/organs.dm
+++ b/modular_skyrat/modules/customization/modules/client/augment/organs.dm
@@ -90,6 +90,25 @@
 	name = "Forked tongue"
 	path = /obj/item/organ/tongue/lizard
 
+/* Code for the tongue, no better place to put it!*/
+
+/obj/item/organ/tongue/stump
+	name = "Tongue stump"
+	desc = "What remains of a tongue."
+	icon_state = "tonguenormal"
+	sense_of_taste = FALSE
+	attack_verb_continuous = list("drools", "spits", "gurgles")
+	attack_verb_simple = list("drool", "spit", "gurgle")
+	modifies_speech = FALSE
+
+/obj/item/organ/tongue/stump/Insert(mob/living/carbon/tongue_owner, special = 0)
+	. = ..()
+	ADD_TRAIT(tongue_owner, TRAIT_MUTE, ORGAN_TRAIT)
+
+/obj/item/organ/tongue/stump/Remove(mob/living/carbon/tongue_owner, special = 0)
+	..()
+	REMOVE_TRAIT(tongue_owner, TRAIT_MUTE, ORGAN_TRAIT)
+
 /datum/augment_item/organ/tongue/stump
 	name = "Tongue stump"
 	path = /obj/item/organ/tongue/stump

--- a/modular_skyrat/modules/customization/modules/client/augment/organs.dm
+++ b/modular_skyrat/modules/customization/modules/client/augment/organs.dm
@@ -89,3 +89,8 @@
 /datum/augment_item/organ/tongue/forked
 	name = "Forked tongue"
 	path = /obj/item/organ/tongue/lizard
+
+/datum/augment_item/organ/tongue/stump
+	name = "Tongue stump"
+	path = /obj/item/organ/tongue/stump
+	cost = -2

--- a/modular_skyrat/modules/customization/modules/client/augment/organs.dm
+++ b/modular_skyrat/modules/customization/modules/client/augment/organs.dm
@@ -93,4 +93,3 @@
 /datum/augment_item/organ/tongue/stump
 	name = "Tongue stump"
 	path = /obj/item/organ/tongue/stump
-	cost = -2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simply adds the option to have your tongue replaced with a stump. Why it's this way is completely up to you, I'm just giving you the option to do it.

## Why It's Good For The Game

Because it's a cool character concept that isn't currently possible in the game. Having a character who can't talk will always be interesting!

## Changelog
:cl:
add: Added tongue stump to the augmentation menu.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
