### PR TITLE
Temporarily removes the Asteroid from possible lavaland replacements.

### DIFF
--- a/config/skyrat/mining_levels.txt
+++ b/config/skyrat/mining_levels.txt
@@ -1,4 +1,3 @@
 Lavaland.dmm+lavaland
-Rockplanet.dmm+rockplanet
 Icemoon.dmm+icemoon
 TidalLock.dmm+tidallock


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables the Rockplanet from rolling in lavaland by removing it from the skyrat config option.

## Why It's Good For The Game

Legitimately one of the worst designed thing on this server.

- Atmosphere is only suitable for mining HARDSUITS. Only 3 spawn yet there are more shaft mining slots than that.
- Mining a wall causes a void, causing it to create a temporary void that moves you into it due to spacewind.
- Fauna consists of absolutely random previously-used assets from xenobiology/space ruins that have no theme or color coordination.
- Fauna itself are incredibly fast and attack hard, compared to lavaland's attack slow and attack hard. This effect is amplified due to the fact that the mining hardsuit slows you down significantly.
- There are zero tendrils or geysers or anything absolutely interesting.
- Megafauna spawns are incredibly limited. Only 1 spawn of each type and that's it.
- Ambient sounds consist of annoying vocal sounds shamelessly stolen from the HL2 source game "The Hidden" because the creator clearly didn't bother to implement any interesting ambient sounds.
- No rhyme or reason when it comes to ore generation: Just everything is clustered in together and super concentrated at the initial area. Zero sense of progression, unlike lavaland where everything is generated farther north.
- Zero ghost roles, as far as I am aware of.

I legitimately don't care who made this. It's infuriating that this exists when lavaland is actively maintained and worked on and actually has interesting sprites/loot/design/roleplay/ect.


## Changelog
:cl:
config: Removes the Rockplanet from Lavaland replacement rotation.
/:cl: