### PR TITLE
Temporarily disables rot pending better implementation

### DIFF
--- a/code/datums/components/food/decomposition.dm
+++ b/code/datums/components/food/decomposition.dm
@@ -72,8 +72,10 @@
 			remove_timer()
 			return
 
+	/* SKYRAT EDIT REMOVAL BEGINS - Temporary disabling rot
 	// If all other checks fail, then begin decomposition.
 	timerid = addtimer(CALLBACK(src, .proc/decompose), time_remaining, TIMER_STOPPABLE | TIMER_UNIQUE)
+	*/ /// SKYRAT EDIT REMOVAL ENDS
 
 /datum/component/decomposition/Destroy()
 	remove_timer()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Rot as it currently stands doesn't match the pace of Skyrat, and until better mechanics are implemented to address its inherent issues, it's better to temporarily prevent rot from applying to anything.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's too quick right now, and really unforgiving, and while it works fine for a cook, it doesn't work as well for botany and the likes.
It's not meant to be permanent, it's just that I'm sick of hearing the complaints, and anyone is free to uncomment this tiny bit of code whenever there's a better way to get around the whole decomposition.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex
del: Nanotrasen has decided to invest in researching a non-harmful ant repellant. The results so far are quite satisfying, and as such, food doesn't appear to have the time to rot in the span of a shift anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
