### PR TITLE
Removes Vatbeasts/Slime nests, Snake Nests, and Toxic Bee nests from SSdecay

### DIFF
--- a/modular_skyrat/modules/decay_subsystem/code/decaySS.dm
+++ b/modular_skyrat/modules/decay_subsystem/code/decaySS.dm
@@ -29,11 +29,8 @@ SUBSYSTEM_DEF(decay)
 	var/list/possible_nests = list(
 		/obj/structure/mob_spawner/spiders,
 		/obj/structure/mob_spawner/bush,
-		/obj/structure/mob_spawner/grapes,
 		/obj/structure/mob_spawner/beehive,
-		/obj/structure/mob_spawner/rats,
-		/obj/structure/mob_spawner/snake,
-		/obj/structure/mob_spawner/beehive/toxic
+		/obj/structure/mob_spawner/rats
 		)
 
 /datum/controller/subsystem/decay/Initialize()

--- a/modular_skyrat/modules/decay_subsystem/code/nests.dm
+++ b/modular_skyrat/modules/decay_subsystem/code/nests.dm
@@ -8,7 +8,7 @@
 	density = FALSE
 	anchored = TRUE
 	layer = TABLE_LAYER
-	max_integrity = 150
+	max_integrity = 100
 	light_range = 2
 	light_power = 1
 	light_color = LIGHT_COLOR_LAVA


### PR DESCRIPTION
## About The Pull Request


**Host Note:** Removed impertinent portions of PR description.

Removes Vatbeasts/Slime nests, Snake Nests, and Toxic Bee nests from SSdecay
Alters the health of nests from 150 health to 100 health.


## Why It's Good For The Game

Some of the maint spawns consisted of xenobiology stuff that's insanely powerful to random loot spawns.

I removed beehives because it makes no sense for beehives to even occur in maint in the first place as the station is made out of metal. There are no flowers in maintenance either for bees to harvest hives, but regardless of that I'm still leaving the regular beehive in and keeping the "random toxic reagent" beehive out which usually contains very lethal or altering chemicals (Like unstable mutagen).

The vatbeast/slime one is also really not good. These are very powerful enemies exclusive to cryptology but are now somehow frequent in maintenance and are usually responsible for the high death count on station. It doesn't make much sense for a gameplay or logical perspective that when the nest is destroyed, it spawns "resurrection crystals" which give crewmembers extra lives, but turns them into a shadowling.

The snake one doesn't even function properly as the snakes are non-hostile, so I decided to remove that as well instead of altering the main snake type.

## Changelog
:cl: BurgerBB
del: Removes Vatbeast/Slime nests, snake nests, and toxic bee nests from maint.
balance: Reduces the health of nests from 150 to 100.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
