### PR TITLE
[Non-Modular]Temporarily Reduces Bubblegum's base melee damage but increases armor penetration.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -43,9 +43,9 @@ Difficulty: Hard
 	friendly_verb_simple = "stare down"
 	icon = 'icons/mob/lavaland/96x96megafauna.dmi'
 	speak_emote = list("gurgles")
-	armour_penetration = 40
-	melee_damage_lower = 40
-	melee_damage_upper = 40
+	armour_penetration = 45
+	melee_damage_lower = 35
+	melee_damage_upper = 35
 	speed = 5
 	move_to_delay = 5
 	retreat_distance = 5

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -262,7 +262,7 @@ Difficulty: Hard
 			to_chat(L, span_userdanger("[src] rends you!"))
 			playsound(T, attack_sound, 100, TRUE, -1)
 			var/limb_to_hit = L.get_bodypart(pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
-			L.apply_damage(10, BRUTE, limb_to_hit, L.run_armor_check(limb_to_hit, MELEE, null, null, armour_penetration), wound_bonus = CANT_WOUND)
+			L.apply_damage(8, BRUTE, limb_to_hit, L.run_armor_check(limb_to_hit, MELEE, null, null, armour_penetration), wound_bonus = CANT_WOUND) //Skyrat Edit, from 10 to 8 damage.
 	SLEEP_CHECK_DEATH(3)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/bloodgrab(turf/T, handedness)
@@ -486,7 +486,7 @@ Difficulty: Hard
 			var/mob/living/L = A
 			L.visible_message(span_danger("[src] slams into [L]!"), span_userdanger("[src] tramples you into the ground!"))
 			src.forceMove(get_turf(L))
-			L.apply_damage(istype(src, /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination) ? 15 : 30, BRUTE, wound_bonus = CANT_WOUND)
+			L.apply_damage(istype(src, /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination) ? 12 : 25, BRUTE, wound_bonus = CANT_WOUND) // Skyrat Edit: from 15 : 30 to 12 : 30
 			playsound(get_turf(L), 'sound/effects/meteorimpact.ogg', 100, TRUE)
 			shake_camera(L, 4, 3)
 			shake_camera(src, 2, 3)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -43,9 +43,9 @@ Difficulty: Hard
 	friendly_verb_simple = "stare down"
 	icon = 'icons/mob/lavaland/96x96megafauna.dmi'
 	speak_emote = list("gurgles")
-	armour_penetration = 45
-	melee_damage_lower = 35
-	melee_damage_upper = 35
+	armour_penetration = 45 //Skyrat Edit
+	melee_damage_lower = 35 //Skyrat Edit
+	melee_damage_upper = 35 //Skyrat Edit
 	speed = 5
 	move_to_delay = 5
 	retreat_distance = 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Spacelag turned this Necropolis Monarch into a too strong megafauna for the average spessmen, and killing enough of them with his enormous claws caused his claws sharpen them, but turned the King into a lazier megafauna for relying more of the power of his claws than using his brute force as he always used to do to continue killing defenseless creatures or fools who dared to challenge him. 

## Why It's Good For The Game

So my suggestion in this PR is slightly nerf the Bubblegum's base damage for balance him while the spacelag persists in the server. But in exchange, his armor penetration has been increased to still be a challenging megafauna for the miners who enjoy hunting megafaunas. I hope this change doesn't turn the Bubblegum into a weaker megafauna, or an even much stronger megafauna than he already is.

## Changelog
:cl:
balance: Bubblegum's melee reduced to 35, Armor Penetration increased to 45.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
