### PR TITLE
[MODULAR] Lets pens be constructed at autolathes.

### DIFF
--- a/modular_skyrat/modules/hyposprays/code/game/autolathe_designs.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/autolathe_designs.dm
@@ -16,7 +16,7 @@
 	category = list("initial","Medical","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/camera
+/datum/design/pen
 	name = "Pen"
 	id = "pen"
 	build_type = AUTOLATHE

--- a/modular_skyrat/modules/hyposprays/code/game/autolathe_designs.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/autolathe_designs.dm
@@ -15,3 +15,11 @@
 	build_path = /obj/item/reagent_containers/glass/bottle/vial/large
 	category = list("initial","Medical","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
+/datum/design/camera
+	name = "Pen"
+	id = "pen"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 32, /datum/material/glass = 8)
+	build_path = /obj/item/pen
+	category = list("initial", "Misc")


### PR DESCRIPTION
## About The Pull Request
Adds pens (standard) to the autolathe, for all your "assistants stole all my pens" needs.
also great credit to ambrosia#0117 for reminding me these weren't in there.
## Why It's Good For The Game

By adding pens to the autolathes, I have single-handedly saved the station, and ghostroles from the lack of writing utensils, despite the autolathe's supposed duty as the "general fabricator". (It was also kind of dumb you have to order an 800 cred crate to have a single pen)

## Changelog
:cl:
add: added pens to autolathes, so you can write with them, or form a book club or something.
/:cl:

