### PR TITLE
[MODULAR]Traitor syndicate borgs (again)

### DIFF
--- a/modular_skyrat/modules/skyrat-uplinks/code/borgupgrades.dm
+++ b/modular_skyrat/modules/skyrat-uplinks/code/borgupgrades.dm
@@ -1,0 +1,6 @@
+/datum/uplink_item/device_tools/syndicateborg
+	name = "Syndicate Cyborg Upgrade"
+	desc = "A marvel of modern syndicate technology; a syndicate borg hijacker. Allowing for the use of extremely powerful repair nanites, building equipment and otherwise useful upgrades to the standard saboteur modules."
+	item = /obj/item/borg/upgrade/transform/syndicatejack
+	cost = 5 //Support item
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This was removed in rebase, and only added back for DS-1
These were balanced for traitors beforehand.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently emagging borgs SUCK for so many reasons, from instantly revealing your name to any smart scientist/roboticist/RD/Captain, to quite literally being able to be locked down across the map without consequence.

This adds a name-changing chameleon device, along with multiple other useful features for an aspiring traitor-hacked borg.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Syndiborgs to uplink
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
