### PR TITLE
[Modular] Disables cybersun codewise because the box people won't

### DIFF
--- a/modular_skyrat/modules/mapping/code/datums/ruins/space.dm
+++ b/modular_skyrat/modules/mapping/code/datums/ruins/space.dm
@@ -2,14 +2,14 @@
 /datum/map_template/ruin/space/skyrat/
 	prefix = "modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/"
 /*------*/
-
+/* //Disabled due to the existence of DS-2.
 /datum/map_template/ruin/space/skyrat/forgottenship
 	name = "CSBC-12"
 	id = "forgottenship"
 	description = "Cybersun would like to remind it's employees that any battle cruiser will be apropriately maintained, as will it's crew."
 	suffix = "forgottenship_skyrat.dmm"
 	always_place = TRUE
-
+*/
 /datum/map_template/ruin/space/skyrat/interdynefob
 	name = "DS-2"
 	id = "interdynefob"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As was original intended in #6487 , disables cybersun from spawning in the code rather than just on the box because despite me out and out saying it if I want something done I have to do it myself
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cybersun is entirely irrelevant and their comms key could be better used by some other faction or event anyways
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Cybersun has been disabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
