### PR TITLE
Ronin Curator bundle

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -273,6 +273,17 @@
 	new /obj/item/clothing/mask/gas/carp(src)
 	new /obj/item/kitchen/knife/hunting(src)
 	new /obj/item/storage/box/papersack/meat(src)
+	
+	
+/obj/item/storage/box/hero/ronin
+    name = "Sword Saint, Wandering Vagabond - 1600's."
+    desc = "Anyone can give up, it's the easiest thing in the world to do. But to hold it together when everyone else would understand if you fell apart, that's true strength. Become the wandering swordsman you were always meant to be!"
+    
+/obj/item/storage/box/hero/ronin/PopulateContents()
+    new /obj/item/clothing/under/costume/kamishimo
+    new /obj/item/clothing/head/rice_hat
+    new /obj/item/katana/weak/curator
+    new /obj/item/clothing/shoes/sandal(src)
 
 /obj/item/choice_beacon/augments
 	name = "augment beacon"

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -270,6 +270,12 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	user.visible_message(span_suicide("[user] is slitting [user.p_their()] stomach open with [src]! It looks like [user.p_theyre()] trying to commit seppuku!"))
 	return(BRUTELOSS)
 
+/obj/item/katana/weak/curator //This has the same stats as the curator's claymore
+	desc = "An ancient Katana. Forged by... Well, it doesn't really say, but surely it's authentic! And sharp to boot!"
+	force = 15
+	block_chance = 30
+	armour_penetration = 5
+
 /obj/item/katana/cursed
 	slot_flags = null
 	item_flags = DROPDEL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a weakened katana with the same stats as the curator's claymore, so that one kit isn't necessarily better than the other. Please note that this may need tweaking as I'm not quite sure if I added it right.

Also adds a new kit to the heroic beacon, that of the Sword Saint. It gives curators the aforementioned katana, a kashimono, a rice hat, and some sandles. It's prettymuch the same as the Scottsman kit, but without the spraypaint.

## Why It's Good For The Game

It's just a neat thing, and I feel like the curator needs some love. I thought this would be cool, and if all goes well I might try adding some more out of the box kits for the curator. Like if we added a UFC or a boxing kit, it'd give curators an excuse to turn the library into a gym, and I think that'd be cool. Or a magical girl kit but i'll level with you if anyone wants that they can code it themselves cos I know shit all about coding and even less about magical girls.

Also, in the absence of a real mechanical job for the curator to do (bring back devils please), please just let them have this small scrap. You already knew half the playerbase are weebs anyway.

## Changelog
:cl:
add: Added weak curator katana
add: Added ronin kit to curator's heroic beacon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
