### PR TITLE
SEVA properly protects clothes

### DIFF
--- a/modular_skyrat/modules/SEVA_suit/seva_obj.dm
+++ b/modular_skyrat/modules/SEVA_suit/seva_obj.dm
@@ -11,7 +11,7 @@
 	hoodtype = /obj/item/clothing/head/hooded/explorer/seva
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 50, RAD = 15, FIRE = 100, ACID = 25, WOUND = 2)
 	resistance_flags = FIRE_PROOF
-	transparent_protection = HIDEGLOVES|HIDESUITSTORAGE|HIDEJUMPSUIT|HIDESHOES
+	transparent_protection = HIDEJUMPSUIT
 
 /obj/item/clothing/head/hooded/explorer/seva
 	name = "SEVA Hood"

--- a/modular_skyrat/modules/SEVA_suit/seva_obj.dm
+++ b/modular_skyrat/modules/SEVA_suit/seva_obj.dm
@@ -11,6 +11,7 @@
 	hoodtype = /obj/item/clothing/head/hooded/explorer/seva
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 50, RAD = 15, FIRE = 100, ACID = 25, WOUND = 2)
 	resistance_flags = FIRE_PROOF
+	transparent_protection = HIDEGLOVES|HIDESUITSTORAGE|HIDEJUMPSUIT|HIDESHOES
 
 /obj/item/clothing/head/hooded/explorer/seva
 	name = "SEVA Hood"


### PR DESCRIPTION
## About The Pull Request
Adds a flag to prevent your jumpsuit burning off while wearing the SEVA suit, which is fireproof. Does not change visibility or functionality of clothes.

Doesn't protect your neck still so you will still seethe every time your pet collar burns off. Too bad!

On Citadel (from which this is ported) explorer suits fully cover jumpsuits and hides them from examine (thus offering protection from them being burnt off). On TG this is not the case, so I added a transparent protection flag to preserve functionality that normal explorer suits (don't) offer, while making them unburnable like they're supposed to with SEVA.

## Why It's Good For The Game

Bug fix
Suit advertised as being fire immune does not adequately protect your things from fire

## Changelog
:cl:
fix: being on fire wih a fireproof SEVA suit no longer somehow burns my jumpsuit off anyway
/:cl:
