### PR TITLE
[MODULAR] Limit advanced modules to 1 and to engineering borg

### DIFF
--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -1,6 +1,7 @@
 /mob/living/silicon/robot
 	var/hasShrunk = FALSE
 	var/hasAffection = FALSE
+	var/hasAdvanced = FALSE
 
 /obj/item/borg/upgrade/shrink
 	name = "borg shrinker"
@@ -180,23 +181,31 @@
 	name = "engineering advanced materials processor"
 	desc = "allows a cyborg to synthesize and store advanced materials"
 	icon_state = "cyborg_upgrade3"
+	model_type = list(/obj/item/robot_model/engineering)
 	model_flags = BORG_MODEL_ENGINEERING
 
 /obj/item/borg/upgrade/advanced_materials/action(mob/living/silicon/robot/borgo, user)
 	. = ..()
 	if(!.)
 		return
+	if(borgo.hasAdvanced)
+		to_chat(usr, span_warning("This unit already has advanced materials installed!"))
+		to_chat(usr, "There's no room for more materials!")
+		return FALSE;
+
 	var/obj/item/stack/sheet/plasteel/cyborg/plasteel_holder = new(borgo.model)
 	var/obj/item/stack/sheet/titaniumglass/cyborg/titanium_holder = new(borgo.model)
 	borgo.model.basic_modules += plasteel_holder
 	borgo.model.basic_modules += titanium_holder
-	borgo.model.add_module(plasteel_holder)
-	borgo.model.add_module(titanium_holder)
+	borgo.model.add_module(plasteel_holder, FALSE, TRUE)
+	borgo.model.add_module(titanium_holder, FALSE, TRUE)
+	borgo.hasAdvanced = TRUE
 
 /obj/item/borg/upgrade/advanced_materials/deactivate(mob/living/silicon/robot/borgo, user)
 	. = ..()
 	if(!.)
 		return
+	borgo.hasAdvanced = FALSE
 	for(var/obj/item/stack/sheet/plasteel/cyborg/plasteel_holder in borgo.model.modules)
 		borgo.model.remove_module(plasteel_holder, TRUE)
 	for(var/obj/item/stack/sheet/titaniumglass/cyborg/titanium_holder in borgo.model.modules)

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -189,8 +189,8 @@
 	if(!.)
 		return
 	if(borgo.hasAdvanced)
-		to_chat(usr, span_warning("This unit already has advanced materials installed!"))
-		to_chat(usr, "There's no room for more materials!")
+		to_chat(user, span_warning("This unit already has advanced materials installed!"))
+		to_chat(user, "There's no room for more materials!")
 		return FALSE;
 
 	var/obj/item/stack/sheet/plasteel/cyborg/plasteel_holder = new(borgo.model)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the issue of engineering borgs having more than 1 advanced modules installed and being able to be installed in other modules beside engineering borgs
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stops the spam of advanced materials inside the borg items and limits to just engineering borgs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Limits advanced modules to 1 for borgs
fix: Advanced materials, exclusive for engi borgs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
