### PR TITLE
Astrum Nanite Remover Remover

### DIFF
--- a/_maps/RandomZLevels/mothership_astrum.dmm
+++ b/_maps/RandomZLevels/mothership_astrum.dmm
@@ -3067,11 +3067,6 @@
 /obj/item/organ/cyberimp/arm/armblade,
 /turf/open/floor/mineral/abductor,
 /area/awaymission/mothership_astrum/halls)
-"OS" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/machinery/scanner_gate/anti_nanite,
-/turf/open/floor/mineral/abductor,
-/area/awaymission/mothership_astrum/halls)
 "Pb" = (
 /obj/item/melee/skateboard/hoverboard{
 	pixel_x = -16;
@@ -28223,9 +28218,9 @@ bV
 bV
 bV
 at
-OS
-OS
-OS
+Ei
+Ei
+Ei
 Es
 ca
 Ei


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Real quick fix, just removes the nanite removers at the start of the gateway. We don't need them anymore.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
![naniteremoverremover](https://user-images.githubusercontent.com/84593335/127718156-5d62c410-3f08-4b0e-9c6a-0aa0795ff156.PNG)

## Why It's Good For The Game
It stops from loading completely unused assets on roundstart. A very marginal change, yet a nice one to make.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

del: Removed the nanite removers from the start of the astrum gateway

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
