### PR TITLE
[Modular] DS-2 Updates.

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/IceRuins/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/IceRuins/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -60,7 +60,7 @@
 "ar" = (
 /obj/machinery/door/airlock/command{
 	name = "Deck Officer";
-	req_access_txt = "150"
+	req_access_txt = "151"
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -970,31 +970,6 @@
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
-"jl" = (
-/obj/item/organ/tail/fluffy,
-/obj/item/organ/tail/fluffy,
-/obj/item/organ/tail/fluffy,
-/obj/item/organ/tail/fluffy/no_wag{
-	desc = "A severed tail. What did you cut this off of? Whatever it is, it doesn't seem like it wagged much.";
-	name = "fluffy tail (averse to wagging)"
-	},
-/obj/item/organ/tail/fluffy/no_wag{
-	desc = "A severed tail. What did you cut this off of? Whatever it is, it doesn't seem like it wagged much.";
-	name = "fluffy tail (averse to wagging)"
-	},
-/obj/item/organ/tail/fluffy/no_wag{
-	desc = "A severed tail. What did you cut this off of? Whatever it is, it doesn't seem like it wagged much.";
-	name = "fluffy tail (averse to wagging)"
-	},
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/structure/closet/crate/freezer,
-/turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
 "jm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -1685,16 +1660,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/mob/living/carbon/human/species/monkey{
-	faction = list("neutral","Syndicate")
-	},
-/obj/machinery/door/window/survival_pod{
-	dir = 8;
-	req_access_txt = "150"
-	},
-/obj/structure/window/reinforced/survival_pod,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/grass,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 10
+	},
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/virology)
 "rG" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -3011,15 +2983,17 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "Ij" = (
+/obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet{
 	icon_state = "qm";
 	name = "deck offficer's locker";
-	req_access = list(150)
+	req_access = list(151)
 	},
 /obj/item/clothing/neck/cloak/qm/syndie,
 /obj/item/clothing/under/rank/cargo/qm/syndie,
 /obj/item/circuitboard/computer/advanced_camera,
-/obj/machinery/light/directional/west,
+/obj/item/megaphone/cargo,
+/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "Im" = (
@@ -3367,6 +3341,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/mob/living/carbon/human/species/monkey{
+	ai_controller = null;
+	faction = list("neutral","Syndicate")
+	},
+/obj/structure/chair/office/light,
 /turf/open/floor/iron/white,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
 "Ny" = (
@@ -3570,17 +3549,13 @@
 /turf/open/floor/engine,
 /area/ruin/unpowered/syndicate_lava_base/testlab)
 "PQ" = (
+/obj/machinery/light/directional/north,
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/reagent_containers/dropper{
-	pixel_y = -7
+	pixel_y = -6
 	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 10
-	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/virology)
 "PW" = (
@@ -6772,7 +6747,7 @@ ab
 ab
 dJ
 jg
-jl
+EU
 yQ
 Vk
 jR

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -96,11 +96,13 @@
 /obj/structure/closet/secure_closet{
 	icon_state = "qm";
 	name = "deck offficer's locker";
-	req_access = list(150)
+	req_access = list(151)
 	},
 /obj/item/clothing/neck/cloak/qm/syndie,
 /obj/item/clothing/under/rank/cargo/qm/syndie,
 /obj/item/circuitboard/computer/advanced_camera,
+/obj/item/megaphone/cargo,
+/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "br" = (
@@ -118,16 +120,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/mob/living/carbon/human/species/monkey{
-	faction = list("neutral","Syndicate")
-	},
-/obj/machinery/door/window/survival_pod{
-	dir = 8;
-	req_access_txt = "150"
-	},
-/obj/structure/window/reinforced/survival_pod,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/grass,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 10
+	},
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/virology)
 "bv" = (
 /obj/effect/turf_decal/stripes/line,
@@ -327,7 +326,7 @@
 "dA" = (
 /obj/machinery/door/airlock/command{
 	name = "Deck Officer";
-	req_access_txt = "150"
+	req_access_txt = "151"
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2005,6 +2004,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/mob/living/carbon/human/species/monkey{
+	ai_controller = null;
+	faction = list("neutral","Syndicate")
+	},
+/obj/structure/chair/office/light,
 /turf/open/floor/iron/white,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
 "zt" = (
@@ -3199,31 +3203,6 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"Na" = (
-/obj/item/organ/tail/fluffy,
-/obj/item/organ/tail/fluffy,
-/obj/item/organ/tail/fluffy,
-/obj/item/organ/tail/fluffy/no_wag{
-	desc = "A severed tail. What did you cut this off of? Whatever it is, it doesn't seem like it wagged much.";
-	name = "fluffy tail (averse to wagging)"
-	},
-/obj/item/organ/tail/fluffy/no_wag{
-	desc = "A severed tail. What did you cut this off of? Whatever it is, it doesn't seem like it wagged much.";
-	name = "fluffy tail (averse to wagging)"
-	},
-/obj/item/organ/tail/fluffy/no_wag{
-	desc = "A severed tail. What did you cut this off of? Whatever it is, it doesn't seem like it wagged much.";
-	name = "fluffy tail (averse to wagging)"
-	},
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/structure/closet/crate/freezer,
-/turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
 "Nc" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -4043,13 +4022,9 @@
 /obj/machinery/light/directional/north,
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/reagent_containers/dropper{
-	pixel_y = -7
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 10
+	pixel_y = -6
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/virology)
@@ -6774,7 +6749,7 @@ ab
 ab
 kD
 Wr
-Na
+pI
 ZX
 NH
 Yp

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/RockplanetRuins/rockplanet_surface_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/RockplanetRuins/rockplanet_surface_syndicate_base1_skyrat.dmm
@@ -96,11 +96,13 @@
 /obj/structure/closet/secure_closet{
 	icon_state = "qm";
 	name = "deck offficer's locker";
-	req_access = list(150)
+	req_access = list(151)
 	},
 /obj/item/clothing/neck/cloak/qm/syndie,
 /obj/item/clothing/under/rank/cargo/qm/syndie,
 /obj/item/circuitboard/computer/advanced_camera,
+/obj/item/megaphone/cargo,
+/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "br" = (
@@ -118,16 +120,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/mob/living/carbon/human/species/monkey{
-	faction = list("neutral","Syndicate")
-	},
-/obj/machinery/door/window/survival_pod{
-	dir = 8;
-	req_access_txt = "150"
-	},
-/obj/structure/window/reinforced/survival_pod,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/grass,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 10
+	},
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/virology)
 "bv" = (
 /obj/effect/turf_decal/stripes/line,
@@ -327,7 +326,7 @@
 "dA" = (
 /obj/machinery/door/airlock/command{
 	name = "Deck Officer";
-	req_access_txt = "150"
+	req_access_txt = "151"
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2005,6 +2004,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/mob/living/carbon/human/species/monkey{
+	ai_controller = null;
+	faction = list("neutral","Syndicate")
+	},
+/obj/structure/chair/office/light,
 /turf/open/floor/iron/white,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
 "zt" = (
@@ -3199,31 +3203,6 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"Na" = (
-/obj/item/organ/tail/fluffy,
-/obj/item/organ/tail/fluffy,
-/obj/item/organ/tail/fluffy,
-/obj/item/organ/tail/fluffy/no_wag{
-	desc = "A severed tail. What did you cut this off of? Whatever it is, it doesn't seem like it wagged much.";
-	name = "fluffy tail (averse to wagging)"
-	},
-/obj/item/organ/tail/fluffy/no_wag{
-	desc = "A severed tail. What did you cut this off of? Whatever it is, it doesn't seem like it wagged much.";
-	name = "fluffy tail (averse to wagging)"
-	},
-/obj/item/organ/tail/fluffy/no_wag{
-	desc = "A severed tail. What did you cut this off of? Whatever it is, it doesn't seem like it wagged much.";
-	name = "fluffy tail (averse to wagging)"
-	},
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/item/organ/ears/mutant,
-/obj/structure/closet/crate/freezer,
-/turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
 "Nc" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -4043,13 +4022,9 @@
 /obj/machinery/light/directional/north,
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/reagent_containers/dropper{
-	pixel_y = -7
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 10
+	pixel_y = -6
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/virology)
@@ -6774,7 +6749,7 @@ ab
 ab
 kD
 Wr
-Na
+pI
 ZX
 NH
 Yp

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
@@ -78,6 +78,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
 "am" = (
@@ -353,6 +354,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "br" = (
@@ -776,6 +778,14 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
+"cU" = (
+/obj/machinery/camera/xray{
+	c_tag = "DS-2 Port Quarter Maintenance Airlock - North";
+	dir = 8;
+	network = list("fsci")
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "cW" = (
 /obj/structure/drain/big,
 /turf/open/floor/iron/textured_large,
@@ -1177,6 +1187,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
 "eo" = (
@@ -1896,6 +1907,15 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
+"gQ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/xray{
+	c_tag = "DS-2 Port Quarter Solars";
+	network = list("fsci")
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/solars/southwest)
 "gR" = (
 /obj/structure/rack/shelf,
 /obj/item/storage/box/papersack,
@@ -2869,6 +2889,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
 "kr" = (
@@ -3113,6 +3134,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
 "lq" = (
@@ -3384,6 +3407,13 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"mq" = (
+/obj/machinery/camera/xray{
+	c_tag = "DS-2 Port Fore Maintenance Airlock";
+	network = list("fsci")
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/northwest)
 "mr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/trash_pile,
@@ -3560,6 +3590,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/red/side{
 	dir = 1
 	},
@@ -3939,6 +3970,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
 "oy" = (
@@ -4605,6 +4637,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "qt" = (
@@ -5065,6 +5098,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/red/side{
 	dir = 1
 	},
@@ -5320,6 +5354,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
 "sQ" = (
@@ -5467,6 +5502,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "ts" = (
@@ -5661,6 +5697,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+"ui" = (
+/obj/machinery/camera/xray{
+	c_tag = "DS-2 Port Quarter Maintenance Airlock - Middle";
+	network = list("fsci")
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "uj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -6549,6 +6592,7 @@
 	req_access_txt = "151"
 	},
 /obj/effect/turf_decal/siding/wideplating,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "wZ" = (
@@ -6750,7 +6794,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "xO" = (
-/obj/effect/spawner/structure/window/survival_pod,
+/obj/structure/window/shuttle/spaceship,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "xQ" = (
@@ -6783,6 +6828,11 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
 "xV" = (
+/obj/machinery/camera/xray{
+	c_tag = "DS-2 Starboard Bow Maintenance Airlock";
+	dir = 4;
+	network = list("fsci")
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/northeast)
 "xW" = (
@@ -6852,6 +6902,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
 "yk" = (
@@ -7239,6 +7290,10 @@
 "zt" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/machinery/camera/xray{
+	c_tag = "DS-2 Starboard Bow Solars";
+	network = list("fsci")
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/solars/northeast)
 "zu" = (
@@ -8211,6 +8266,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
 "CS" = (
@@ -8945,6 +9001,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "Fx" = (
@@ -9102,6 +9159,7 @@
 	name = "Long-Term Brig";
 	req_access_txt = "151"
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "Gc" = (
@@ -10371,7 +10429,7 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "Kt" = (
-/turf/closed/wall/mineral/titanium/survival,
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "Ku" = (
 /obj/effect/loot_site_spawner,
@@ -10636,6 +10694,7 @@
 	req_access_txt = "151"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/red/side{
 	dir = 1
 	},
@@ -11050,6 +11109,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "MH" = (
@@ -11386,6 +11446,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/red/side{
 	dir = 4
 	},
@@ -12349,10 +12410,10 @@
 	},
 /obj/item/storage/belt/security/full,
 /obj/item/radio/headset/headset_sec/alt/interdyne,
-/obj/item/clothing/head/warden/syndicate,
 /obj/item/clothing/suit/armor/vest/warden/syndicate,
 /obj/item/clothing/under/utility/sec/old/syndicate,
 /obj/structure/cable,
+/obj/item/clothing/head/sec/navywarden/syndicate,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
@@ -12530,6 +12591,11 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "Rz" = (
+/obj/machinery/camera/xray{
+	c_tag = "DS-2 Port Maintenance Airlock";
+	dir = 8;
+	network = list("fsci")
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/northwest)
 "RB" = (
@@ -12924,6 +12990,7 @@
 	req_access_txt = "151"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/lawyer)
 "SV" = (
@@ -13086,6 +13153,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/template_noop)
+"TA" = (
+/obj/structure/sign/warning/firingrange{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark/red/side{
+	dir = 6
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/security)
 "TB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral,
@@ -13359,6 +13434,9 @@
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Uy" = (
+/turf/closed/wall/mineral/titanium/spaceship,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "Uz" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -13503,6 +13581,14 @@
 "UX" = (
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/northwest)
+"Va" = (
+/obj/machinery/camera/xray{
+	c_tag = "DS-2 Hangar Airlock";
+	dir = 4;
+	network = list("fsci")
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "Vb" = (
 /obj/machinery/shower{
 	dir = 8
@@ -14222,6 +14308,7 @@
 	name = "Equipment";
 	req_access_txt = "151"
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/red/side{
 	dir = 4
 	},
@@ -14823,6 +14910,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "ZA" = (
@@ -16485,7 +16573,7 @@ mc
 mc
 mc
 Md
-bk
+cU
 XP
 WB
 WB
@@ -16526,7 +16614,7 @@ qu
 BK
 oP
 Yk
-RT
+gQ
 RT
 vv
 Yk
@@ -16684,7 +16772,7 @@ nX
 mc
 mc
 nX
-bk
+ui
 nX
 XR
 TB
@@ -18393,7 +18481,7 @@ mc
 Vt
 mc
 ay
-Rz
+mq
 Aq
 Aq
 Aq
@@ -18519,7 +18607,7 @@ ix
 Vu
 ix
 ix
-gS
+TA
 sA
 md
 yb
@@ -19170,7 +19258,7 @@ nA
 ZX
 ZX
 rn
-rE
+Va
 QI
 vQ
 vQ
@@ -19335,14 +19423,14 @@ NE
 RC
 Kt
 Kt
-Kt
-Kt
+Uy
+Uy
 nY
-Kt
+Uy
 nY
-Kt
-Kt
-Kt
+Uy
+Uy
+Uy
 rE
 Js
 tJ
@@ -19430,8 +19518,8 @@ nd
 vd
 lA
 tt
-Kt
-Kt
+Uy
+Uy
 rE
 LM
 mc
@@ -19782,8 +19870,8 @@ Kc
 vd
 fY
 tt
-Kt
-Kt
+Uy
+Uy
 rE
 LM
 mc
@@ -19863,14 +19951,14 @@ NE
 RC
 Kt
 Kt
-Kt
-Kt
+Uy
+Uy
 nY
-Kt
+Uy
 nY
-Kt
-Kt
-Kt
+Uy
+Uy
+Uy
 rE
 Mf
 tJ

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
@@ -14,6 +14,7 @@
 	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "ac" = (
@@ -2427,6 +2428,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
+"iH" = (
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/blue/corner,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "iI" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_edge{
@@ -2503,6 +2512,7 @@
 	dir = 9
 	},
 /obj/item/aicard,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "iU" = (
@@ -2635,6 +2645,7 @@
 "js" = (
 /obj/structure/table/reinforced,
 /obj/machinery/defibrillator_mount/loaded/directional/west,
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "jt" = (
@@ -2921,6 +2932,13 @@
 	dir = 1
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
+"ku" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/ultra{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "kw" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
@@ -4353,10 +4371,9 @@
 /turf/open/floor/iron/textured,
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "pE" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/south,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/skyrat/interdynefob/bridge)
+/obj/structure/table/glass,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "pF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/textured_edge{
@@ -4419,6 +4436,9 @@
 /obj/effect/turf_decal/trimline/red/line{
 	color = "#fc0303";
 	dir = 8
+	},
+/obj/structure/sign/poster/contraband/shipstation{
+	pixel_x = 32
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
@@ -6753,6 +6773,16 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
+"xH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/blue/arrow_ccw{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/mid_joiner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "xI" = (
 /obj/structure/flora/tree/jungle/small{
 	pixel_x = -23
@@ -7420,6 +7450,9 @@
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/melee/baton/cattleprod,
+/obj/structure/sign/poster/contraband/secborg_vale{
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "Ae" = (
@@ -7863,6 +7896,7 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "BG" = (
@@ -8175,6 +8209,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "CC" = (
@@ -9119,6 +9154,10 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
+"FT" = (
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor/plated,
+/area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southeast)
 "FU" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
@@ -9879,6 +9918,8 @@
 "Iz" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/brown/line,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "IA" = (
@@ -10062,6 +10103,12 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/template_noop)
 "Jh" = (
+/obj/effect/turf_decal/trimline/blue/arrow_ccw{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/mid_joiner{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "Ji" = (
@@ -10635,6 +10682,14 @@
 	dir = 4
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
+"Lc" = (
+/obj/structure/sign/poster/contraband/syndicate_medical{
+	pixel_y = 32
+	},
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron/white,
+/area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "Ld" = (
 /obj/effect/turf_decal/vg_decals/numbers/zero,
 /turf/open/floor/plating,
@@ -10822,6 +10877,9 @@
 "LJ" = (
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
+/obj/structure/sign/poster/contraband/icebox_moment{
+	pixel_x = -32
+	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "LK" = (
@@ -10932,6 +10990,9 @@
 "LZ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
@@ -11974,6 +12035,16 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
+"Py" = (
+/obj/effect/turf_decal/trimline/blue/arrow_ccw{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/mid_joiner,
+/obj/effect/turf_decal/trimline/blue/mid_joiner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "Pz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
@@ -12562,6 +12633,15 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/mining_equipment)
 "Rv" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/blue/arrow_ccw{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/mid_joiner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "Rw" = (
@@ -19059,7 +19139,7 @@ Gi
 Gi
 Gi
 Gi
-LZ
+iH
 oC
 pH
 HF
@@ -19144,10 +19224,10 @@ oC
 vU
 Rv
 Jh
-Rv
+xH
 Jh
 Jh
-Jh
+Py
 oC
 FH
 gy
@@ -19225,9 +19305,9 @@ tO
 Gi
 mc
 EL
-wK
+Vv
 qs
-wK
+Vv
 Yl
 Yl
 hU
@@ -20723,7 +20803,7 @@ mc
 EL
 XU
 ne
-pE
+Vj
 wq
 uo
 dY
@@ -20809,9 +20889,9 @@ fb
 Gi
 mc
 EL
-wK
+Vv
 bq
-wK
+Vv
 wq
 MX
 ed
@@ -21177,8 +21257,8 @@ Na
 vw
 CB
 ab
-UG
-PM
+vt
+xK
 wX
 qj
 JG
@@ -21266,7 +21346,7 @@ uw
 QQ
 oC
 wX
-PM
+xK
 wX
 qj
 JG
@@ -21354,7 +21434,7 @@ Gi
 Gi
 oC
 UG
-CP
+FT
 wX
 qj
 Qp
@@ -21442,7 +21522,7 @@ mc
 mc
 xE
 wX
-wX
+Ct
 UG
 qj
 qj
@@ -21530,10 +21610,10 @@ mc
 mc
 xE
 UG
-UG
-wX
-wX
-UG
+vt
+Ct
+Ct
+vt
 DG
 Ct
 xK
@@ -21775,7 +21855,7 @@ cs
 Rl
 tP
 kw
-MB
+pE
 MB
 Zn
 MB
@@ -21863,7 +21943,7 @@ fb
 Rl
 fb
 kw
-MB
+Lc
 MB
 Zn
 ML
@@ -22146,7 +22226,7 @@ SV
 FI
 zl
 kw
-wX
+ku
 pv
 xE
 Mh


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I've become acutely aware _someone_, or _someone**s**_, is actively breaking the policy on DS-2 and repeatedly tiding it for the elite hardsuit. This update is designed (partly) to make raiding both the armory and the admiral's office much, **much** harder - and also some QOL, and the deck officer's office being properly restricted to commsec only.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't know what it is about assistants seeing absolute unit sized enemy installations and going "Hmm yes today I will attempt to steal from the syndicate" but frankly someone's going to get shot if this keeps up
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The DS-2 Admiral's office now starts bolted and unhackable, to curb tiding.
fix: The Interdyne Virology monkey has been made to stay in a constant state of euphoria so it may not harm the masses.
fix: The Interdyne Deck Officer's office now is command only - but has some extra goodies for the DO when they wake up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
