### PR TITLE
[NON-MODULAR] Alt title maintenance

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -527,8 +527,8 @@ SUBSYSTEM_DEF(job)
 	//SKYRAT EDIT ADDITION END
 
 	if(player_client)
-		to_chat(player_client, "<span class='infoplain'><b>As the [display_rank] you answer directly to [job.supervisors]. Special circumstances may change this. Your role is that of a [rank]. Regardless of what your job title may be, please work to fulfil that role.</b></span>") //SKYRAT EDIT -- ALT TITLES
-		// to_chat(player_client, "<span class='infoplain'><b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</span></b>" // SKYRAT EDIT ORIGINAL
+		to_chat(player_client, "<span class='infoplain'><b>As the [display_rank] you answer directly to [job.supervisors]. Special circumstances may change this. Your role is that of a [job.title]. Regardless of what your job title may be, please work to fulfil that role.</b></span>") //SKYRAT EDIT -- ALT TITLES
+		// to_chat(player_client, "<span class='infoplain'><b>As the [job.title] you answer directly to [job.supervisors]. Special circumstances may change this.</span></b>" // SKYRAT EDIT ORIGINAL
 
 	job.radio_help_message(equipping)
 

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -499,8 +499,8 @@ SUBSYSTEM_DEF(job)
 
 	equipping.mind?.set_assigned_role(job)
 
-	if(player_client)
-		to_chat(player_client, "<span class='infoplain'><b>You are the [job.title].</b></span>")
+	/* if(player_client)
+		to_chat(player_client, "<span class='infoplain'><b>You are the [job.title].</b></span>") */ // SKYRAT EDIT REMOVAL -- HANDLED BELOW WRT/ ALT TTILES
 
 	equipping.on_job_equipping(job)
 

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -526,7 +526,8 @@ SUBSYSTEM_DEF(job)
 	//SKYRAT EDIT ADDITION END
 
 	if(player_client)
-		to_chat(player_client, "<span class='infoplain'><b>As the [display_rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b></span>") //SKYRAT EDIT CHANGE
+		to_chat(player_client, "<span class='infoplain'><b>As the [display_rank] you answer directly to [job.supervisors]. Special circumstances may change this. Your role is that of a [rank]. Regardless of what your job title may be, please work to fulfil that role.</b></span>") //SKYRAT EDIT -- ALT TITLES
+		// to_chat(player_client, "<span class='infoplain'><b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</span></b>" // SKYRAT EDIT ORIGINAL
 
 	job.radio_help_message(equipping)
 

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -502,7 +502,8 @@ SUBSYSTEM_DEF(job)
 	var/display_rank = job.title
 	if(player_client && player_client.prefs && player_client.prefs.alt_titles_preferences[job.title])
 		display_rank = player_client.prefs.alt_titles_preferences[job.title]
-	to_chat(player_client, "<span class='infoplain'><b>You are the [display_rank].</b></span>")
+	if(player_client)
+		to_chat(player_client, "<span class='infoplain'><b>You are the [display_rank].</b></span>")
 	/* SKYRAT EDIT ORIGINAL
 	if(player_client)
 		to_chat(player_client, "<span class='infoplain'><b>You are the [job.title].</b></span>")

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -498,9 +498,15 @@ SUBSYSTEM_DEF(job)
 	SEND_SIGNAL(equipping, COMSIG_JOB_RECEIVED, job)
 
 	equipping.mind?.set_assigned_role(job)
-
-	/* if(player_client)
-		to_chat(player_client, "<span class='infoplain'><b>You are the [job.title].</b></span>") */ // SKYRAT EDIT REMOVAL -- HANDLED BELOW WRT/ ALT TTILES
+	//SKYRAT EDIT ADD - ALTERNATE JOB TITLES
+	var/display_rank = job.title
+	if(player_client && player_client.prefs && player_client.prefs.alt_titles_preferences[job.title])
+		display_rank = player_client.prefs.alt_titles_preferences[job.title]
+	to_chat(player_client, "<span class='infoplain'><b>You are the [display_rank].</b></span>")
+	/* SKYRAT EDIT ORIGINAL
+	if(player_client)
+		to_chat(player_client, "<span class='infoplain'><b>You are the [job.title].</b></span>")
+	*/ // SKYRAT EDIT END
 
 	equipping.on_job_equipping(job)
 
@@ -512,12 +518,8 @@ SUBSYSTEM_DEF(job)
 		else
 			handle_auto_deadmin_roles(player_client, job.title)
 
-	//SKYRAT EDIT ADD - ALTERNATE JOB TITLES
-	var/display_rank = job.title
-	if(player_client && player_client.prefs && player_client.prefs.alt_titles_preferences[job.title])
-		display_rank = player_client.prefs.alt_titles_preferences[job.title]
-	to_chat(equipping, "<span class='infoplain'><b>You are the [display_rank].</b></span>") // SKYRAT EDIT ADD END
-	var/list/packed_items
+
+	var/list/packed_items //SKYRAT EDIT ADD - CUSTOMISATION
 	if(job)
 		if (player_client && job.no_dresscode && job.loadout)
 			packed_items = player_client.prefs.equip_preference_loadout(equipping,FALSE,job,blacklist=job.blacklist_dresscode_slots,initial=TRUE)


### PR DESCRIPTION
Made some checks happen earlier to accommodate for code changes

Also just fixed some code that was lost :ihatemodularity:
## Changelog
:cl:
fix: Some alt title functionality
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
