### PR TITLE
[MODULAR] The CentCom Formal Coat spawns in the NT Rep's locker again

### DIFF
--- a/modular_skyrat/modules/moretraitoritems/code/game/objects/items/storage/syndicate_loadout.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/game/objects/items/storage/syndicate_loadout.dm
@@ -166,7 +166,7 @@
 /obj/item/storage/box/syndie_kit/loadout/nt_impostor/PopulateContents()
 	new /obj/item/clothing/under/rank/centcom/officer(src)
 	new /obj/item/clothing/head/centcom_cap(src)
-	new /obj/item/clothing/suit/armor/vest/centcom_formal(src)
+	new /obj/item/clothing/suit/toggle/armor/vest/centcom_formal(src)
 	new /obj/item/clothing/shoes/combat(src)
 	new /obj/item/radio/headset/headset_cent/impostorsr(src)
 	new /obj/item/clothing/glasses/sunglasses(src)

--- a/modular_skyrat/modules/nanotrasen_rep/code/clothing.dm
+++ b/modular_skyrat/modules/nanotrasen_rep/code/clothing.dm
@@ -59,7 +59,7 @@
 /obj/item/clothing/head/beret/centcom_formal/ntrep
 	armor = list(MELEE = 15, BULLET = 5, LASER = 15, ENERGY = 25, BOMB = 10, BIO = 0, RAD = 0, FIRE = 30, ACID = 5, WOUND = 4)
 
-/obj/item/clothing/suit/armor/vest/centcom_formal/ntrep
+/obj/item/clothing/suit/toggle/armor/vest/centcom_formal/ntrep
 	armor = list(MELEE = 35, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, WOUND = 10)
 
 /obj/item/clothing/suit/hooded/wintercoat/centcom/ntrep

--- a/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_representative.dm
+++ b/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_representative.dm
@@ -153,7 +153,7 @@
 	new /obj/item/storage/box/gunset/nanotrasen_representative(src)
 	new /obj/item/storage/photo_album/personal(src)
 	new /obj/item/bedsheet/centcom(src)
-	new /obj/item/clothing/suit/armor/vest/centcom_formal/ntrep(src)
+	new /obj/item/clothing/suit/toggle/armor/vest/centcom_formal/ntrep(src)
 	new /obj/item/clothing/suit/hooded/wintercoat/centcom/ntrep(src)
 	new /obj/item/clothing/head/centhat(src)
 	new /obj/item/clothing/head/centcom_cap(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It's back, cooler than ever!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because it looks cool and is now toggleable thanks to Imaginos!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex
fix: Nanotrasen decided to fix the issue in its formal coat production line, resulting in the Nanotrasen Representative receiving their CentCom formal coat once again, now with some extra buttons to toggle its look on the go! 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
