### PR TITLE
the gas giant doesn't exist the gas giant doesn't exist the gas giant doesn't exist (deletes gas miners)

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -51955,7 +51955,7 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ikU" = (
-/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "ils" = (
@@ -58253,7 +58253,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jVx" = (
-/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "jVy" = (
@@ -64121,6 +64121,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/commons/dorms)
+"lvm" = (
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "lvo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 4
@@ -67789,7 +67793,7 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
 "mrK" = (
-/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "mrN" = (
@@ -109559,7 +109563,7 @@
 /turf/open/floor/plating,
 /area/cargo/sorting)
 "wYE" = (
-/obj/machinery/atmospherics/miner/n2o,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "wYI" = (
@@ -110881,6 +110885,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
+"xsu" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "xsP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -112050,7 +112058,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "xJA" = (
-/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "xJD" = (
@@ -135325,7 +135333,7 @@ wYE
 gmN
 vFd
 tDV
-tDV
+lvm
 wNz
 vFd
 mOB
@@ -142764,7 +142772,7 @@ aaa
 aad
 vFd
 gXk
-jQO
+xsu
 jQO
 vFd
 epE

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -8055,6 +8055,10 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit)
+"aXG" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "aXH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -20028,7 +20032,7 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "cKY" = (
-/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "cLc" = (
@@ -21535,7 +21539,7 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "dDh" = (
-/obj/machinery/atmospherics/miner/n2o,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "dDq" = (
@@ -29579,6 +29583,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
+"hXA" = (
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "hXG" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/iron/dark,
@@ -33191,7 +33199,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jVr" = (
-/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "jVG" = (
@@ -38126,7 +38134,7 @@
 /turf/open/floor/iron/dark,
 /area/commons/storage/mining)
 "mwT" = (
-/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "mxo" = (
@@ -59372,7 +59380,7 @@
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "xzf" = (
-/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "xzg" = (
@@ -95546,7 +95554,7 @@ vqw
 fSP
 riF
 jnK
-oUi
+aXG
 xdx
 ccm
 boP
@@ -97066,7 +97074,7 @@ bzs
 pjX
 ccm
 jkC
-uxp
+hXA
 uxp
 ccm
 kJV

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -62889,7 +62889,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "mGu" = (
-/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "mGw" = (
@@ -63209,7 +63209,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "mMV" = (
-/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "mNx" = (
@@ -65414,7 +65414,7 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
 "nQl" = (
-/obj/machinery/atmospherics/miner/n2o,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "nQy" = (
@@ -67154,7 +67154,7 @@
 /turf/open/floor/plating/rust,
 /area/security/prison)
 "oCa" = (
-/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "oCP" = (
@@ -74895,7 +74895,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "rPb" = (
-/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "rPt" = (
@@ -80392,6 +80392,7 @@
 /area/cargo/warehouse)
 "uhO" = (
 /obj/machinery/light/floor,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "uhS" = (
@@ -88422,6 +88423,10 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
+"xDe" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "xDG" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
 /obj/effect/turf_decal/bot,
@@ -115808,7 +115813,7 @@ rPb
 iTp
 idD
 xcO
-xcO
+xDe
 tkL
 idD
 agt

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -5288,6 +5288,10 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"aQX" = (
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "aRA" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
@@ -28442,7 +28446,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "hdc" = (
-/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "hdf" = (
@@ -32321,6 +32325,10 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"irG" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "irI" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -47908,7 +47916,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ntx" = (
-/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "ntC" = (
@@ -50970,7 +50978,7 @@
 /turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "opQ" = (
-/obj/machinery/atmospherics/miner/n2o,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "oqa" = (
@@ -67508,7 +67516,7 @@
 /turf/closed/wall,
 /area/command/heads_quarters/hop)
 "tGx" = (
-/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "tGz" = (
@@ -79350,7 +79358,7 @@
 	},
 /area/security/prison)
 "xuL" = (
-/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "xuW" = (
@@ -125755,7 +125763,7 @@ cor
 aaf
 scK
 hki
-iXC
+irG
 ewV
 deP
 aaf
@@ -127789,7 +127797,7 @@ aaa
 aaf
 deP
 jxI
-jxI
+aQX
 jxI
 deP
 beJ

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -3929,9 +3929,7 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/captain/private/NTREP)
 "auj" = (
-/obj/effect/turf_decal/vg_decals/atmos/mix{
-	dir = 8
-	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "auk" = (
@@ -27030,7 +27028,9 @@
 /area/engineering/atmos)
 "bQC" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/vg_decals/atmos/mix{
+	dir = 8
+	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "bQD" = (
@@ -28032,7 +28032,7 @@
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
 "bUU" = (
-/obj/machinery/atmospherics/miner/n2o,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bUV" = (
@@ -28041,7 +28041,9 @@
 /area/engineering/atmos)
 "bUW" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/effect/turf_decal/vg_decals/atmos/nitrous_oxide{
+	dir = 8
+	},
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bUY" = (
@@ -29182,7 +29184,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bYU" = (
-/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bYV" = (
@@ -29191,7 +29193,9 @@
 /area/engineering/atmos)
 "bYW" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/vg_decals/atmos/plasma{
+	dir = 8
+	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bYX" = (
@@ -30080,7 +30084,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ccB" = (
-/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "ccC" = (
@@ -30089,7 +30093,9 @@
 /area/engineering/atmos)
 "ccD" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide{
+	dir = 8
+	},
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "ccE" = (
@@ -31792,14 +31798,14 @@
 	},
 /area/engineering/main)
 "clT" = (
-/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "clU" = (
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "clV" = (
-/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "clW" = (
@@ -31894,17 +31900,23 @@
 /area/security/prison)
 "cmU" = (
 /obj/machinery/light/small/directional/south,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/vg_decals/atmos/nitrogen{
+	dir = 1
+	},
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "cmV" = (
 /obj/machinery/light/small/directional/south,
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/vg_decals/atmos/oxygen{
+	dir = 1
+	},
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "cmW" = (
 /obj/machinery/light/small/directional/south,
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/vg_decals/atmos/air{
+	dir = 1
+	},
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "cmX" = (
@@ -51256,9 +51268,7 @@
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/security/armory)
 "qXk" = (
-/obj/effect/turf_decal/vg_decals/atmos/air{
-	dir = 1
-	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "qXC" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
From maps only, they still exist in the code

IF YOU REALLY WANT TO DO A GAS INTENSIVE SOMETHING-SETUP, ENGIES, AHELP FOR ONE TO BE SPAWNED IN
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/80451102/127819554-102e10bc-6216-4281-bdd7-3c684715c10e.png)

![image](https://user-images.githubusercontent.com/80451102/127819610-51336ad3-ce3a-414d-9ae4-c3f99929c6eb.png)

They encourage bad habits, they take away the importance of atmos (especially compounded with OOC protections), and uh, they're bad.

They're still in the game so admins can spawn 'em in if someone wants 'em, but, yeah.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: the gas giant doesn't existthe gas giant doesn't existthe gas giant doesn't existthe gas giant doesn't existthe gas giant doesn't existthe gas giant doesn't existthe gas giant doesn't exist
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
