### PR TITLE
Japanese is a language for Earthlings

### DIFF
--- a/modular_skyrat/modules/customization/modules/culture/culture/culture_generic.dm
+++ b/modular_skyrat/modules/customization/modules/culture/culture/culture_generic.dm
@@ -1,12 +1,12 @@
 /datum/cultural_info/culture/generic
 	name = "Other Culture"
 	description = "You are from one of the many small, relatively unknown cultures scattered across the galaxy."
-	additional_langs = list(/datum/language/spacer, /datum/language/japanese)
+	additional_langs = /datum/language/spacer
 
 /datum/cultural_info/culture/vatgrown
 	name = "Vat Grown"
 	description = "You were not born like most of the people, instead grown and raised in laboratory conditions, either as clone, gene-adapt or some experiment. Your outlook diverges from baseline humanity accordingly."
-	additional_langs = list(/datum/language/spacer, /datum/language/japanese)
+	additional_langs = /datum/language/spacer
 
 /datum/cultural_info/culture/spacer_core
 	name = "Spacer, Core Systems"
@@ -23,7 +23,7 @@
 	vital goods, a lonely outpost on the edge of a dreary backwater, such people are raised in small, confined environments with few others, and tend to be most familiar with older, reliable but outdated \
 	technology. An independent sort, people on the frontier are more likely to be isolationist and self-driven."
 	economic_power = 0.9
-	additional_langs = list(/datum/language/spacer, /datum/language/japanese)
+	additional_langs = /datum/language/spacer
 
 /datum/cultural_info/culture/generic_human
 	name = "Humankind"
@@ -54,6 +54,7 @@
 	The long recovery period of Earth has resulted in much of the population being environmentally aware and heavily conservationist, eager to avoid past mistakes. Most Earthers are \
 	a content folk who see themselves as close to nature and keepers of the heritage of humanity."
 	economic_power = 1.1
+	additional_langs = /datum/language/japanese
 
 /datum/cultural_info/culture/luna_poor
 	name = "Luna, Lower Class"

--- a/modular_skyrat/modules/customization/modules/culture/culture/culture_generic.dm
+++ b/modular_skyrat/modules/customization/modules/culture/culture/culture_generic.dm
@@ -6,7 +6,7 @@
 /datum/cultural_info/culture/vatgrown
 	name = "Vat Grown"
 	description = "You were not born like most of the people, instead grown and raised in laboratory conditions, either as clone, gene-adapt or some experiment. Your outlook diverges from baseline humanity accordingly."
-	additional_langs = /datum/language/spacer
+	additional_langs = list(/datum/language/spacer)
 
 /datum/cultural_info/culture/spacer_core
 	name = "Spacer, Core Systems"
@@ -23,7 +23,7 @@
 	vital goods, a lonely outpost on the edge of a dreary backwater, such people are raised in small, confined environments with few others, and tend to be most familiar with older, reliable but outdated \
 	technology. An independent sort, people on the frontier are more likely to be isolationist and self-driven."
 	economic_power = 0.9
-	additional_langs = /datum/language/spacer
+	additional_langs = list(/datum/language/spacer)
 
 /datum/cultural_info/culture/generic_human
 	name = "Humankind"
@@ -54,7 +54,7 @@
 	The long recovery period of Earth has resulted in much of the population being environmentally aware and heavily conservationist, eager to avoid past mistakes. Most Earthers are \
 	a content folk who see themselves as close to nature and keepers of the heritage of humanity."
 	economic_power = 1.1
-	additional_langs = /datum/language/japanese
+	additional_langs = list(/datum/language/japanese)
 
 /datum/cultural_info/culture/luna_poor
 	name = "Luna, Lower Class"

--- a/modular_skyrat/modules/customization/modules/culture/culture/culture_generic.dm
+++ b/modular_skyrat/modules/customization/modules/culture/culture/culture_generic.dm
@@ -1,7 +1,7 @@
 /datum/cultural_info/culture/generic
 	name = "Other Culture"
 	description = "You are from one of the many small, relatively unknown cultures scattered across the galaxy."
-	additional_langs = /datum/language/spacer
+	additional_langs = list(/datum/language/spacer, /datum/language/japanese)
 
 /datum/cultural_info/culture/vatgrown
 	name = "Vat Grown"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

narrows down Japanese to be available to people who have cultures more likely to be from Earth. Earth is seemingly described as being "old cultures" and Japanese is described as a culturally old language. Whereas where Japanese is applied to now is mostly spacers who aren't anywhere near Earth to begin with.
Edit: On request Japanese was left in the generic default option, so you don't have to go out of your way to find it

## Why It's Good For The Game

it makes sense given the current selectable lore
Also people from Earth should be able to know Japanese
why do vat-grown people get to know an ancient language anyway

## Changelog
:cl:
qol: Japanese is for Earthlings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
