### PR TITLE
[SEMI-MODULAR] mentor chat filter

### DIFF
--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -63,6 +63,7 @@ h1.alert, h2.alert		{color: #000000;}
 
 .emote					{}
 .infoplain				{}
+.mentor					{}
 
 .userdanger				{color: #ff0000;	font-weight: bold;	font-size: 3;}
 .danger					{color: #ff0000;	font-weight: bold;}

--- a/modular_skyrat/master_files/code/__DEFINES/chat.dm
+++ b/modular_skyrat/master_files/code/__DEFINES/chat.dm
@@ -1,0 +1,2 @@
+
+#define MESSAGE_TYPE_MENTOR "mentor"

--- a/modular_skyrat/modules/mentor/code/dementor.dm
+++ b/modular_skyrat/modules/mentor/code/dementor.dm
@@ -6,6 +6,7 @@
 	remove_mentor_verbs()
 	if (/client/proc/mentor_unfollow in verbs)
 		mentor_unfollow()
+	to_chat(GLOB.mentors, "<span class='mentor'><b><font color ='#E236D8'><span class='prefix'>MENTOR:</span> [src] has dementored.</font></b></span>")
 	GLOB.mentors -= src
 	add_verb(src,/client/proc/cmd_mentor_rementor)
 
@@ -16,4 +17,5 @@
 		return
 	add_mentor_verbs()
 	GLOB.mentors[src] = TRUE
+	to_chat(GLOB.mentors, "<span class='mentor'><b><font color ='#E236D8'><span class='prefix'>MENTOR:</span> [src] has rementored.</font></b></span>")
 	remove_verb(src,/client/proc/cmd_mentor_rementor)

--- a/modular_skyrat/modules/mentor/code/mentorhelp.dm
+++ b/modular_skyrat/modules/mentor/code/mentorhelp.dm
@@ -15,7 +15,7 @@
 		return
 
 	var/show_char = CONFIG_GET(flag/mentors_mobname_only)
-	var/mentor_msg = "<span class='infoplain'><span class='mentornotice'><b><font color='purple'>MENTORHELP:</b> <b>[key_name_mentor(src, 1, 0, 1, show_char)]</b>: [msg]</font></span></span>"
+	var/mentor_msg = "<span class='mentornotice'><b><font color='purple'>MENTORHELP:</b> <b>[key_name_mentor(src, 1, 0, 1, show_char)]</b>: [msg]</font></span>"
 	log_mentor("MENTORHELP: [key_name_mentor(src, 0, 0, 0, 0)]: [msg]")
 
 	for(var/it in GLOB.mentors)
@@ -23,7 +23,7 @@
 		SEND_SOUND(X, 'sound/items/bikehorn.ogg')
 		to_chat(X, mentor_msg)
 
-	to_chat(src, "<span class='infoplain'><span class='mentornotice'><font color='purple'>PM to-<b>Mentors</b>: [msg]</font></span></span>")
+	to_chat(src, "<span class='mentornotice'><font color='purple'>PM to-<b>Mentors</b>: [msg]</font></span>")
 	return
 
 /proc/get_mentor_counts()

--- a/modular_skyrat/modules/mentor/code/mentorpm.dm
+++ b/modular_skyrat/modules/mentor/code/mentorpm.dm
@@ -32,7 +32,7 @@
 		return
 
 	if(is_mentor(whom))
-		to_chat(GLOB.mentors, "<span class='infoplain'><font color='purple'>[src] has started replying to [whom]'s mhelp.</font></span>")
+		to_chat(GLOB.mentors, "<span class='mentor'><font color='purple'>[src] has started replying to [whom]'s mhelp.</font></span>")
 
 	//get message text, limit it's length.and clean/escape html
 	if(!msg)
@@ -40,7 +40,7 @@
 
 		if(!msg)
 			if (is_mentor(whom))
-				to_chat(GLOB.mentors, "<span class='infoplain'><span class='purple'>[src] has stopped their reply to [whom]'s mhelp.</span></span>")
+				to_chat(GLOB.mentors, "<span class='mentor'><span class='purple'>[src] has stopped their reply to [whom]'s mhelp.</span></span>")
 			return
 
 		if(!C)
@@ -57,7 +57,7 @@
 	msg = sanitize(copytext_char(msg, 1, MAX_MESSAGE_LEN))
 	if(!msg)
 		if (is_mentor(whom))
-			to_chat(GLOB.mentors, "<span class='infoplain'><span class='purple'>[src] has stopped their reply to [whom]'s mhelp.</span></span>")
+			to_chat(GLOB.mentors, "<span class='mentor'><span class='purple'>[src] has stopped their reply to [whom]'s mhelp.</span></span>")
 		return
 	log_mentor("Mentor PM: [key_name(src)]->[key_name(C)]: [msg]")
 
@@ -66,17 +66,17 @@
 	var/show_char = CONFIG_GET(flag/mentors_mobname_only)
 	if(C.is_mentor())
 		if(is_mentor())//both are mentors
-			to_chat(C, "<span class='infoplain'><span class='purple'>Mentor PM from-<b>[key_name_mentor(src, C, 1, 0, 0)]</b>: [msg]</span></span>")
-			to_chat(src, "<span class='infoplain'><span class='blue'>Mentor PM to-<b>[key_name_mentor(C, C, 1, 0, 0)]</b>: [msg]</span></span>")
+			to_chat(C, "<span class='mentor'><span class='purple'>Mentor PM from-<b>[key_name_mentor(src, C, 1, 0, 0)]</b>: [msg]</span></span>")
+			to_chat(src, "<span class='mentor'><span class='blue'>Mentor PM to-<b>[key_name_mentor(C, C, 1, 0, 0)]</b>: [msg]</span></span>")
 
 		else		//recipient is a mentor but sender is not
-			to_chat(C, "<span class='infoplain'><span class='purple'>Reply PM from-<b>[key_name_mentor(src, C, 1, 0, show_char)]</b>: [msg]</span></span>")
-			to_chat(src, "<span class='infoplain'><span class='pink'>Mentor PM to-<b>[key_name_mentor(C, C, 1, 0, 0)]</b>: [msg]</span></span>")
+			to_chat(C, "<span class='mentor'><span class='purple'>Reply PM from-<b>[key_name_mentor(src, C, 1, 0, show_char)]</b>: [msg]</span></span>")
+			to_chat(src, "<span class='mentor'><span class='pink'>Mentor PM to-<b>[key_name_mentor(C, C, 1, 0, 0)]</b>: [msg]</span></span>")
 
 	else
 		if(is_mentor())	//sender is a mentor but recipient is not.
-			to_chat(C, "<span class='infoplain'><span class='purple'>Mentor PM from-<b>[key_name_mentor(src, C, 1, 0, 0)]</b>: [msg]</span></span>")
-			to_chat(src, "<span class='infoplain'><span class='pink'>Mentor PM to-<b>[key_name_mentor(C, C, 1, 0, show_char)]</b>: [msg]</span></span>")
+			to_chat(C, "<span class='mentor'><span class='purple'>Mentor PM from-<b>[key_name_mentor(src, C, 1, 0, 0)]</b>: [msg]</span></span>")
+			to_chat(src, "<span class='mentor'><span class='pink'>Mentor PM to-<b>[key_name_mentor(C, C, 1, 0, show_char)]</b>: [msg]</span></span>")
 
 	//we don't use message_Mentors here because the sender/receiver might get it too
 	var/show_char_sender = !is_mentor() && CONFIG_GET(flag/mentors_mobname_only)
@@ -84,4 +84,4 @@
 	for(var/it in GLOB.mentors)
 		var/client/X = it
 		if(X.key!=key && X.key!=C.key)	//check client/X is an Mentor and isn't the sender or recipient
-			to_chat(X, "<span class='infoplain'><B><span class='pink'>Mentor PM: [key_name_mentor(src, X, 0, 0, show_char_sender)]-&gt;[key_name_mentor(C, X, 0, 0, show_char_recip)]:</span></B> <span class='blue'>[msg]</span></span>") //inform X
+			to_chat(X, "<span class='mentor'><B><span class='pink'>Mentor PM: [key_name_mentor(src, X, 0, 0, show_char_sender)]-&gt;[key_name_mentor(C, X, 0, 0, show_char_recip)]:</span></B> <span class='blue'>[msg]</span></span>") //inform X

--- a/modular_skyrat/modules/mentor/code/mentorsay.dm
+++ b/modular_skyrat/modules/mentor/code/mentorsay.dm
@@ -13,7 +13,7 @@
 	log_mentor("MSAY: [key_name(src)] : [msg]")
 
 	if(check_rights_for(src, R_ADMIN,0))
-		msg = "<span class='infoplain'><b><font color ='#8A2BE2'><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message'>[msg]</span></font></b></span>"
+		msg = "<span class='mentor'><b><font color ='#8A2BE2'><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message'>[msg]</span></font></b></span>"
 	else
-		msg = "<span class='infoplain'><b><font color ='#E236D8'><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message'>[msg]</span></font></b></span>"
+		msg = "<span class='mentor'><b><font color ='#E236D8'><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message'>[msg]</span></font></b></span>"
 	to_chat(GLOB.admins | GLOB.mentors, msg)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3676,6 +3676,7 @@
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
+#include "modular_skyrat\master_files\code\__DEFINES\chat.dm"
 #include "modular_skyrat\master_files\code\_globalvars\configuration.dm"
 #include "modular_skyrat\master_files\code\_globalvars\maint_loot_common.dm"
 #include "modular_skyrat\master_files\code\_globalvars\maint_loot_oddity.dm"

--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -36,6 +36,7 @@ export const MESSAGE_TYPE_EVENTCHAT = 'eventchat';
 export const MESSAGE_TYPE_ADMINLOG = 'adminlog';
 export const MESSAGE_TYPE_ATTACKLOG = 'attacklog';
 export const MESSAGE_TYPE_DEBUG = 'debug';
+export const MESSAGE_TYPE_MENTOR = 'mentor'; // SKYRAT EDIT ADDITION
 
 // Metadata for each message type
 export const MESSAGE_TYPES = [
@@ -134,5 +135,11 @@ export const MESSAGE_TYPES = [
     name: 'Debug Log',
     description: 'DEBUG: SSPlanets subsystem Recover().',
     admin: true,
+  },
+  {
+    type: MESSAGE_TYPE_MENTOR, // SKYRAT EDIT
+    name: 'Mentor Log',
+    description: 'Mentor PMs and other mentor things.',
+    selector: '.mentor, .mentornotice',
   },
 ];

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -311,7 +311,7 @@ em {
   font-weight: bold;
 }
 
-.say, .emote, .infoplain, .oocplain, .warningplain {
+.say, .emote, .infoplain, .oocplain, .warningplain, .mentor {
 }
 
 .deadsay {

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -329,7 +329,7 @@ em {
   font-weight: bold;
 }
 
-.say, .emote, .infoplain, .oocplain, .warningplain {
+.say, .emote, .infoplain, .oocplain, .warningplain, .mentor {
 }
 
 .deadsay {


### PR DESCRIPTION
## About The Pull Request

Adds a chat filter to the mentor things. Beforehand all the mentor stuff was on info.

## Why It's Good For The Game

Because it's easier for mentors and players to be able to seperate out their things from other things. And to not have to scroll up a bunch if they want to re-read something.

## Changelog
:cl:
add: mentor chat filter
/:cl: