### PR TITLE
[NON-MODULAR] Runtime Begone

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -639,7 +639,8 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	if(!LAZYACCESS(gone.important_recursive_contents, RECURSIVE_CONTENTS_AREA_SENSITIVE))
 		return
 	for(var/atom/movable/recipient as anything in gone.important_recursive_contents[RECURSIVE_CONTENTS_AREA_SENSITIVE])
-		SEND_SIGNAL(recipient, COMSIG_EXIT_AREA, src)
+		if(recipient) // SKYRAT EDIT -- PREVENT INVALID SIGNAL CALLS -- NEXT LINE INDENTED ALSO
+			SEND_SIGNAL(recipient, COMSIG_EXIT_AREA, src)
 
 
 /**


### PR DESCRIPTION
Something somewhere is adding null or qdel'd instances to an area's content list; because of the nature of how this code works I am unable to investigate this in any reasonably sane method, so instead we simply verify the target before sending a signal.

![image](https://user-images.githubusercontent.com/12817816/128075397-362513ff-c0ea-4c8c-96f4-6750c53d286b.png)
