### PR TITLE
Removes HOS parade jackets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -81,7 +81,6 @@
 	new /obj/item/clothing/suit/toggle/armor/hos/hos_formal(src)
 	new /obj/item/cartridge/hos(src)
 	new /obj/item/radio/headset/heads/hos(src)
-	// new /obj/item/clothing/suit/armor/hos/parade/female(src) // SKYRAT EDIT CHANGE - ORIGINAL: new /obj/item/clothing/under/rank/security/head_of_security/parade/female(src) // SKYRAT EDIT REMOVAL - OVERRIDDEN BY https://github.com/tgstation/tgstation/pull/60414
 	new /obj/item/clothing/under/rank/security/head_of_security/parade(src)
 	// new /obj/item/clothing/suit/armor/hos/parade(src) // SKYRAT EDIT ADDITION // SKYRAT EDIT REMOVAL - OVERRIDDEN BY https://github.com/tgstation/tgstation/pull/60414
 	new /obj/item/clothing/suit/armor/vest/leather(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -81,9 +81,9 @@
 	new /obj/item/clothing/suit/toggle/armor/hos/hos_formal(src)
 	new /obj/item/cartridge/hos(src)
 	new /obj/item/radio/headset/heads/hos(src)
-	new /obj/item/clothing/suit/armor/hos/parade/female(src) // SKYRAT EDIT CHANGE - ORIGINAL: new /obj/item/clothing/under/rank/security/head_of_security/parade/female(src)
+	// new /obj/item/clothing/suit/armor/hos/parade/female(src) // SKYRAT EDIT CHANGE - ORIGINAL: new /obj/item/clothing/under/rank/security/head_of_security/parade/female(src) // SKYRAT EDIT REMOVAL - OVERRIDDEN BY https://github.com/tgstation/tgstation/pull/60414
 	new /obj/item/clothing/under/rank/security/head_of_security/parade(src)
-	new /obj/item/clothing/suit/armor/hos/parade(src) // SKYRAT EDIT ADDITION
+	// new /obj/item/clothing/suit/armor/hos/parade(src) // SKYRAT EDIT ADDITION // SKYRAT EDIT REMOVAL - OVERRIDDEN BY https://github.com/tgstation/tgstation/pull/60414
 	new /obj/item/clothing/suit/armor/vest/leather(src)
 	new /obj/item/clothing/suit/armor/hos(src)
 	new /obj/item/clothing/under/rank/security/head_of_security/skirt(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -82,7 +82,6 @@
 	new /obj/item/cartridge/hos(src)
 	new /obj/item/radio/headset/heads/hos(src)
 	new /obj/item/clothing/under/rank/security/head_of_security/parade(src)
-	// new /obj/item/clothing/suit/armor/hos/parade(src) // SKYRAT EDIT ADDITION // SKYRAT EDIT REMOVAL - OVERRIDDEN BY https://github.com/tgstation/tgstation/pull/60414
 	new /obj/item/clothing/suit/armor/vest/leather(src)
 	new /obj/item/clothing/suit/armor/hos(src)
 	new /obj/item/clothing/under/rank/security/head_of_security/skirt(src)

--- a/modular_skyrat/modules/customization/modules/clothing/suits/armor.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/suits/armor.dm
@@ -32,6 +32,8 @@
 	mutant_variants = NONE
 	body_parts_covered = CHEST|ARMS|LEGS
 
+// SKYRAT EDIT REMOVAL - OVERRIDDEN BY https://github.com/tgstation/tgstation/pull/60414
+/*
 /obj/item/clothing/suit/armor/hos/parade/female
 	name = "head of security's female parade jacket"
 	desc = "A luxurious jacket for the head of security, woven in a deep red. This one comes with white trousers. On the lapel is a small pin in the shape of a deer's head."
@@ -39,6 +41,7 @@
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
 	icon_state = "hos_parade_fem"
 	inhand_icon_state = "hos_parade_fem"
+*/
 
 // WARDEN
 

--- a/modular_skyrat/modules/customization/modules/clothing/suits/armor.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/suits/armor.dm
@@ -32,16 +32,6 @@
 	mutant_variants = NONE
 	body_parts_covered = CHEST|ARMS|LEGS
 
-// SKYRAT EDIT REMOVAL - OVERRIDDEN BY https://github.com/tgstation/tgstation/pull/60414
-/*
-/obj/item/clothing/suit/armor/hos/parade/female
-	name = "head of security's female parade jacket"
-	desc = "A luxurious jacket for the head of security, woven in a deep red. This one comes with white trousers. On the lapel is a small pin in the shape of a deer's head."
-	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'
-	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
-	icon_state = "hos_parade_fem"
-	inhand_icon_state = "hos_parade_fem"
-*/
 
 // WARDEN
 

--- a/modular_skyrat/modules/customization/modules/clothing/under/security.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/under/security.dm
@@ -11,20 +11,6 @@
 	inhand_icon_state = "hos_parade_male"
 	can_adjust = FALSE
 
-// SKYRAT EDIT REMOVAL - OVERRIDDEN BY https://github.com/tgstation/tgstation/pull/60414
-/*
-/obj/item/clothing/suit/armor/hos/parade
-	name = "head of security's parade jacket"
-	desc = "A luxurious deep red jacket for the head of security, woven with a golden trim. It smells of gunpowder and authority."
-	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'
-	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
-	icon_state = "hos_parade"
-	inhand_icon_state = "hos_parade"
-	body_parts_covered = CHEST|GROIN|ARMS
-	cold_protection = CHEST|GROIN|ARMS
-	heat_protection = CHEST|GROIN|ARMS
-*/
-
 /obj/item/clothing/under/rank/security/head_of_security/peacekeeper/sol
 	name = "sol chief of police uniform"
 	desc = "A white satin shirt with a leather belt, the belt buckle is a large NT."

--- a/modular_skyrat/modules/customization/modules/clothing/under/security.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/under/security.dm
@@ -11,6 +11,8 @@
 	inhand_icon_state = "hos_parade_male"
 	can_adjust = FALSE
 
+// SKYRAT EDIT REMOVAL - OVERRIDDEN BY https://github.com/tgstation/tgstation/pull/60414
+/*
 /obj/item/clothing/suit/armor/hos/parade
 	name = "head of security's parade jacket"
 	desc = "A luxurious deep red jacket for the head of security, woven with a golden trim. It smells of gunpowder and authority."
@@ -21,6 +23,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS
 	heat_protection = CHEST|GROIN|ARMS
+*/
 
 /obj/item/clothing/under/rank/security/head_of_security/peacekeeper/sol
 	name = "sol chief of police uniform"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nukes the old HOS parade jackets, because of tgstation/tgstation#60414

## Why It's Good For The Game

Unnecessary to have.

## Changelog
:cl:
del: Removed HOS Parade jackets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
