### PR TITLE
Fix the program at the cyborg tablet

### DIFF
--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -109,4 +109,4 @@
 	install_component(hard_drive) // SKYRAT EDIT -- ORIGINAL install_component(new /obj/item/computer_hardware/hard_drive/small/integrated/)
 	install_component(new /obj/item/computer_hardware/recharger/cyborg)
 	install_component(new /obj/item/computer_hardware/network_card/integrated)
-	hard_drive.store_file(/datum/computer_file/program/crew_manifest) // SKYRAT EDIT ADD
+	hard_drive.store_file(new /datum/computer_file/program/crew_manifest) // SKYRAT EDIT ADD


### PR DESCRIPTION
## About The Pull Request

Bug fix for missing manifest in cyborg tablet.

## Why It's Good For The Game

Cyborgs will no longer have to ride to the bridge every time to view the crew lineup on the Head of Personnel computer

## Changelog
:cl:
fix: Fix the program at the cyborg tablet
/:cl:
