### PR TITLE
[Map] Adds one sink to the NSS Journey medbay 💧

### DIFF
--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -23818,6 +23818,14 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"bES" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay)
 "bET" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -97007,7 +97015,7 @@ rYh
 sjV
 bmO
 lAN
-hjZ
+bES
 uGy
 pnW
 jsH


### PR DESCRIPTION
## About The Pull Request

It adds a sink.

## Why It's Good For The Game

It's the only medbay where I have to Journey (hah get it?) across the department for some water, the other medbays are full of sinks. Currently, the only sink is in the breakroom shower, which is scary to enter every time.

## Changelog
:cl:
add: A nice sink for doctors to get water from
/:cl:
