### PR TITLE
[NON-MODULAR] fixes simple mob emote spam in dchat

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -121,11 +121,12 @@
 		//SKYRAT EDIT CHANGE END
 
 	var/user_turf = get_turf(user)
-	for(var/mob/ghost in GLOB.dead_mob_list)
-		if(!ghost.client || isnewplayer(ghost))
-			continue
-		if(ghost.stat == DEAD && ghost.client && user.client && (ghost.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(ghost in viewers(user_turf, null)))
-			ghost.show_message("<span class='emote'>[FOLLOW_LINK(ghost, user)] [dchatmsg]</span>")
+	if(user.client)
+		for(var/mob/ghost in GLOB.dead_mob_list)
+			if(!ghost.client || isnewplayer(ghost))
+				continue
+			if(ghost.stat == DEAD && ghost.client && user.client && (ghost.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(ghost in viewers(user_turf, null)))
+				ghost.show_message("<span class='emote'>[FOLLOW_LINK(ghost, user)] [dchatmsg]</span>")
 
 	if(emote_type == EMOTE_AUDIBLE)
 		user.audible_message(msg, deaf_message = "<span class='emote'>You see how <b>[user]</b> [msg]</span>", audible_message_flags = EMOTE_MESSAGE)
@@ -301,10 +302,11 @@
 	var/ghost_text = "<b>[src]</b> [text]"
 
 	var/origin_turf = get_turf(src)
-	for(var/mob/ghost in GLOB.dead_mob_list)
-		if(!ghost.client || isnewplayer(ghost))
-			continue
-		if(ghost.stat == DEAD && ghost.client && (ghost.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(ghost in viewers(origin_turf, null)))
-			ghost.show_message("[FOLLOW_LINK(ghost, src)] [ghost_text]")
+	if (client)
+		for(var/mob/ghost in GLOB.dead_mob_list)
+			if(!ghost.client || isnewplayer(ghost))
+				continue
+			if(ghost.stat == DEAD && ghost.client && (ghost.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(ghost in viewers(origin_turf, null)))
+				ghost.show_message("[FOLLOW_LINK(ghost, src)] [ghost_text]")
 
 	visible_message(text, visible_message_flags = EMOTE_MESSAGE)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -121,7 +121,7 @@
 		//SKYRAT EDIT CHANGE END
 
 	var/user_turf = get_turf(user)
-	if(user.client)
+	if(user.client) //SKYRAT EDIT ADDITION - so that clientless mob emotes don't clog dchat
 		for(var/mob/ghost in GLOB.dead_mob_list)
 			if(!ghost.client || isnewplayer(ghost))
 				continue
@@ -302,7 +302,7 @@
 	var/ghost_text = "<b>[src]</b> [text]"
 
 	var/origin_turf = get_turf(src)
-	if (client)
+	if (client) //SKYRAT EDIT ADDITION - so that clientless mob emotes don't clog dchat
 		for(var/mob/ghost in GLOB.dead_mob_list)
 			if(!ghost.client || isnewplayer(ghost))
 				continue


### PR DESCRIPTION
## About The Pull Request

credits to azarak for the idea :3

approved by xyel, since it's a QoL

non-modular, because of the feature freeze upstream, and QoLs would get closed there

## Why It's Good For The Game

my chat won't be 40-50% simple mobs after this

## Changelog
:cl:
qol: no more simple mob emote spam in dchat
/:cl: