### PR TITLE
[NON-MODULAR] Admin Marks

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -56,7 +56,7 @@
 			_mob.client.prefs.admin_mark_clear()
 			return
 		mark = sanitize(mark)
-		_mob.client.prefs.admin_mark_set()
+		_mob.client.prefs.admin_mark_set(mark)
 
 	else if(href_list["makeAntag"])
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -48,7 +48,16 @@
 			return
 		cmd_show_exp_panel(M.client)
 
-// SKYRAT EDIT BEGIN -- ONE CLICK ANTAG
+// SKYRAT EDIT BEGIN -- MORE ADMIN TOPICS
+	else if(href_list["setmark"])
+		var/mob/_mob = get_mob_by_key(href_list["setmark"])
+		var/mark = input("Enter new mark:", "Edit Mark ([href_list["setmark"]])") as text|null
+		if(!mark)
+			_mob.client.prefs.admin_mark_clear()
+			return
+		mark = sanitize(mark)
+		_mob.client.prefs.admin_mark_set()
+
 	else if(href_list["makeAntag"])
 
 		message_admins("[key_name_admin(usr)] is attempting to make [href_list["makeAntag"]]")
@@ -87,7 +96,7 @@
 		if(src.make_antag(href_list["makeAntag"], opt))
 			message_admins("[key_name_admin(usr)] created '[href_list["makeAntag"]]' with a parameter of '[opt]'.")
 		else message_admins("[key_name_admin(usr)] FAILED to create '[href_list["makeAntag"]]' with a parameter of '[opt]'.")
-// SKYRAT EDIT END -- ONE CLICK ANTAG
+// SKYRAT EDIT END -- MORE ADMIN TOPICS
 
 	else if(href_list["forceevent"])
 		if(!check_rights(R_FUN))

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -85,7 +85,7 @@
 		body += "(<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_ALL]'><font color='[(muted & MUTE_ALL)?"red":"blue"]'>toggle all</font></a>)"
 	// SKYRAT ADDITION - ADMIN MARKS
 	body += "<br><br>"
-	body += "<b>Admin Mark: <A href='?_src_=holder;[HrefToken()];setmark=[M.ckey]>[M.client.prefs.admin_mark || "None"]</A></b>"
+	body += "<b>Admin Mark: <A href='?_src_=holder;[HrefToken()];setmark=[M.ckey]'>[M.client.prefs.admin_mark || "None"]</A></b>"
 	// SKYRAT ADDITION END
 	body += "<br><br>"
 	body += "<A href='?_src_=holder;[HrefToken()];jumpto=[REF(M)]'><b>Jump to</b></A> | "

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -83,7 +83,10 @@
 		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_ADMINHELP]'><font color='[(muted & MUTE_ADMINHELP)?"red":"blue"]'>ADMINHELP</font></a> | "
 		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_DEADCHAT]'><font color='[(muted & MUTE_DEADCHAT)?"red":"blue"]'>DEADCHAT</font></a>\]"
 		body += "(<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_ALL]'><font color='[(muted & MUTE_ALL)?"red":"blue"]'>toggle all</font></a>)"
-
+	// SKYRAT ADDITION - ADMIN MARKS
+	body += "<br><br>"
+	body += "<b>Admin Mark: <A href='?_src_=holder;[HrefToken()];setmark=[M.ckey]>[M.client.prefs.admin_mark || "None"]</A></b>"
+	// SKYRAT ADDITION END
 	body += "<br><br>"
 	body += "<A href='?_src_=holder;[HrefToken()];jumpto=[REF(M)]'><b>Jump to</b></A> | "
 	body += "<A href='?_src_=holder;[HrefToken()];getmob=[REF(M)]'>Get</A> | "

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -16,7 +16,7 @@
 			if(!G.started_as_observer)//If you aghost to do this, KorPhaeron will deadmin you in your sleep.
 				log_admin("[key_name(usr)] checked advanced who in-round")
 			for(var/client/C in GLOB.clients)
-				var/entry = "\t[C.key]"
+				var/entry = "\t[C.prefs.admin_mark_stat_who()][C.key]" // SKYRAT EDIT - ADMIN MARK - original: "\t[C.key]"
 				if(C.holder && C.holder.fakekey)
 					entry += " <i>(as [C.holder.fakekey])</i>"
 				if (isnewplayer(C.mob))

--- a/modular_skyrat/modules/admin/code/player_alerts/preferences.dm
+++ b/modular_skyrat/modules/admin/code/player_alerts/preferences.dm
@@ -19,7 +19,7 @@
 /datum/preferences/proc/admin_mark_stat_who()
 	if(!admin_mark)
 		return ""
-	return emoji_parse(admin_mark)
+	return emoji_parse(":[admin_mark]:")
 
 /datum/preferences/save_preferences()
 	. = ..()

--- a/modular_skyrat/modules/admin/code/player_alerts/preferences.dm
+++ b/modular_skyrat/modules/admin/code/player_alerts/preferences.dm
@@ -1,0 +1,42 @@
+/datum/preferences
+	/// The mark applied to this client; usually to denote information for ease of use
+	var/admin_mark
+
+/datum/preferences/proc/admin_mark_set(admin_mark)
+	var/static/list/emoji
+	if(!emoji)
+		emoji = icon_states(icon(EMOJI_SET))
+	if(!(admin_mark in emoji))
+		tgui_alert(usr, "Invalid Mark")
+		return
+	src.admin_mark = admin_mark
+	save_preferences()
+
+/datum/preferences/proc/admin_mark_clear()
+	admin_mark = null
+	save_preferences()
+
+/datum/preferences/proc/admin_mark_stat_who()
+	if(!admin_mark)
+		return ""
+	return emoji_parse(admin_mark)
+
+/datum/preferences/save_preferences()
+	. = ..()
+	if(!. || !admin_mark || !path)
+		return
+	var/savefile/sfile = new /savefile(path)
+	if(!sfile)
+		return
+	sfile.cd = "/"
+	WRITE_FILE(sfile["admin_mark"], admin_mark)
+
+/datum/preferences/load_preferences()
+	. = ..()
+	if(!. || !path || !fexists(path))
+		return
+	var/savefile/sfile = new /savefile(path)
+	if(!sfile)
+		return
+	sfile.cd = "/"
+	READ_FILE(sfile["admin_mark"], admin_mark)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3905,6 +3905,7 @@
 #include "modular_skyrat\modules\admin\code\aooc.dm"
 #include "modular_skyrat\modules\admin\code\loud_say.dm"
 #include "modular_skyrat\modules\admin\code\sooc.dm"
+#include "modular_skyrat\modules\admin\code\player_alerts\preferences.dm"
 #include "modular_skyrat\modules\admin\code\smites\pie.dm"
 #include "modular_skyrat\modules\advanced_choice_beacons\code\advanced_choice_beacon.dm"
 #include "modular_skyrat\modules\advanced_shuttles\code\areas.dm"


### PR DESCRIPTION
Adds the ability for admins to assign special little icons to players to denote them.
![image](https://user-images.githubusercontent.com/12817816/128631694-81666420-d187-45b5-993f-b99a1c60d98a.png)

Host Approved.

:cl:
admin: Player Marks, accepts any emoji, find them in the Player Panel and the Who verb
:/cl: