### PR TITLE
Fixes access on meta sm alarm

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -38533,10 +38533,13 @@
 	dir = 8;
 	network = list("ss13","engine")
 	},
-/obj/machinery/airalarm/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
 	dir = 8
+	},
+/obj/machinery/airalarm/engine{
+	dir = 8;
+	pixel_x = 23
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

engineers being able to set up the SM is good

## Changelog
:cl:
fix: The Meta SM air alarm now starts unlocked
/:cl: