### PR TITLE
[NONMODULAR]Venus Humantrap Re-buffs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -108,13 +108,13 @@
 	health_doll_icon = "venus_human_trap"
 	mob_biotypes = MOB_ORGANIC | MOB_PLANT
 	layer = SPACEVINE_MOB_LAYER
-	health = 40 //SKYRAT EDIT CHANGE
-	maxHealth = 40 //SKYRAT EDIT CHANGE
+	health = 60 //SKYRAT EDIT CHANGE
+	maxHealth = 60 //SKYRAT EDIT CHANGE
 	ranged = TRUE
 	harm_intent_damage = 5
 	obj_damage = 60
-	melee_damage_lower = 20 //SKYRAT EDIT CHANGE - Original: 25
-	melee_damage_upper = 20 //SKYRAT EDIT CHANGE - Original: 25
+	melee_damage_lower = 25 //SKYRAT EDIT CHANGE - Original: 25
+	melee_damage_upper = 25 //SKYRAT EDIT CHANGE - Original: 25
 	combat_mode = TRUE
 	//del_on_death = TRUE //SKYRAT EDIT REMOVAL
 	flip_on_death = TRUE
@@ -136,7 +136,7 @@
 	/// The maximum amount of vines a plant can have at one time
 	var/max_vines = 4
 	/// How far away a plant can attach a vine to something
-	var/vine_grab_distance = 4 //SKYRAT EDIT - Original 5
+	var/vine_grab_distance = 5 //SKYRAT EDIT - Original 5
 	/// Whether or not this plant is ghost possessable
 	var/playable_plant = TRUE
 

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -113,8 +113,8 @@
 	ranged = TRUE
 	harm_intent_damage = 5
 	obj_damage = 60
-	melee_damage_lower = 25 //SKYRAT EDIT CHANGE - Original: 25
-	melee_damage_upper = 25 //SKYRAT EDIT CHANGE - Original: 25
+	melee_damage_lower = 25
+	melee_damage_upper = 25
 	combat_mode = TRUE
 	//del_on_death = TRUE //SKYRAT EDIT REMOVAL
 	flip_on_death = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -136,7 +136,7 @@
 	/// The maximum amount of vines a plant can have at one time
 	var/max_vines = 4
 	/// How far away a plant can attach a vine to something
-	var/vine_grab_distance = 5 //SKYRAT EDIT - Original 5
+	var/vine_grab_distance = 5
 	/// Whether or not this plant is ghost possessable
 	var/playable_plant = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fireaxes 1 hit killed them
10mm magnum 1 hit killed them
any form of projectile usually 1 hit killed them, or 2 hit in the rare instance of 10mm auto

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Venus humantraps are laughably easy to deal with unless one of two requirements are met

-They have seeding

At which point the round ends

Flowering is a close contender, but nowhere near as virulent as seeding. So uh. Yeah


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Venus humantraps are no longer incidentally far too weak due to a combination of our nerfs, buffs and /tg/'s changes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
