### PR TITLE
[MODULAR][QoL] Hyposprays can now quick swap vials.

### DIFF
--- a/modular_skyrat/modules/hyposprays/code/game/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hyposprays_II.dm
@@ -39,7 +39,7 @@
 	var/spray_self = SELF_SPRAY
 
 	//Can you hotswap vials? - Currently no hyposprays allow this for some reason
-	var/quickload = FALSE
+	var/quickload = TRUE
 	//Does it go through hardsuits?
 	var/penetrates = FALSE
 

--- a/modular_skyrat/modules/hyposprays/code/game/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hyposprays_II.dm
@@ -102,13 +102,13 @@
 			var/obj/item/reagent_containers/glass/bottle/vial/container = used_item
 			var/obj/item/reagent_containers/glass/bottle/vial/old_container = vial
 			if(!is_type_in_list(container, allowed_containers))
-				to_chat(user, "<span class='notice'>[src] doesn't accept this type of vial.</span>")
+				to_chat(user, span_notice("[src] doesn't accept this type of vial."))
 				return FALSE
 			old_container.forceMove(drop_location())
 			if(!user.transferItemToLoc(container, src))
 				return FALSE
 			vial = container
-			user.visible_message("<span class='notice'>[user] has swapped a vial into [src].</span>","<span class='notice'>You have swapped [vial] into [src].</span>")
+			user.visible_message(span_notice("[user] has swapped a vial into [src]."), span_notice("You have swapped [vial] into [src]."))
 			playsound(loc, 'sound/weapons/autoguninsert.ogg', 35, 1)
 			user.put_in_hands(old_container)
 			return TRUE

--- a/modular_skyrat/modules/hyposprays/code/game/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hyposprays_II.dm
@@ -38,7 +38,7 @@
 	//Time taken to spray self
 	var/spray_self = SELF_SPRAY
 
-	//Can you hotswap vials? - Currently no hyposprays allow this for some reason
+	//Can you hotswap vials? - now all hyposprays can!
 	var/quickload = TRUE
 	//Does it go through hardsuits?
 	var/penetrates = FALSE
@@ -98,7 +98,20 @@
 		if(!quickload)
 			to_chat(user, "<span class='warning'>[src] can not hold more than one vial!</span>")
 			return FALSE
-		unload_hypo(vial, user)
+		else
+			var/obj/item/reagent_containers/glass/bottle/vial/container = used_item
+			var/obj/item/reagent_containers/glass/bottle/vial/old_container = vial
+			if(!is_type_in_list(container, allowed_containers))
+				to_chat(user, "<span class='notice'>[src] doesn't accept this type of vial.</span>")
+				return FALSE
+			old_container.forceMove(drop_location())
+			if(!user.transferItemToLoc(container, src))
+				return FALSE
+			vial = container
+			user.visible_message("<span class='notice'>[user] has swapped a vial into [src].</span>","<span class='notice'>You have swapped [vial] into [src].</span>")
+			playsound(loc, 'sound/weapons/autoguninsert.ogg', 35, 1)
+			user.put_in_hands(old_container)
+			return TRUE
 	if((istype(used_item, /obj/item/reagent_containers/glass/bottle/vial)))
 		var/obj/item/reagent_containers/glass/bottle/vial/container = used_item
 		if(!is_type_in_list(container, allowed_containers))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so that you can swap out a loaded hypospray by clicking on it with a vial, sort of like tactical reloading on guns or swapping out beakers.

https://user-images.githubusercontent.com/68373373/128710103-63bc6eff-7b19-4d25-90be-cef03b11a4b3.mp4


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should make hyposprays feel less cumbersome to use, while also making them fall more in line with the functionality of other container based equipment. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: hypovials inside of a hypospray can be swapped out more easily.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
