### PR TITLE
[MODULAR][FIX/QoL] Mediguns eject Medicells into hands before the floor.

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -198,6 +198,7 @@
 		to_chat(user, span_notice("You remove a cell"))
 		var/obj/item/last_cell = installedcells[installedcells.len]
 		if(last_cell)
+			last_cell.forceMove(drop_location())
 			user.put_in_hands(last_cell)
 		installedcells -= last_cell
 		ammo_type.len--

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -198,7 +198,7 @@
 		to_chat(user, span_notice("You remove a cell"))
 		var/obj/item/last_cell = installedcells[installedcells.len]
 		if(last_cell)
-			last_cell.forceMove(drop_location())
+			user.put_in_hands(last_cell)
 		installedcells -= last_cell
 		ammo_type.len--
 		cellcount -= 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the proc used to remove the medicells so that they dispense into the users hands first. It was originally intended to work like this, I just didn't know this proc existed. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes Mediguns less cumbersome to use.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Mediguns now eject Medicells into the user's hands instead of always on the floor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
