### PR TITLE
Cyborg tablet software system

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -83,8 +83,31 @@
 	addtimer(CALLBACK(src, .proc/show_playstyle), 5)
 
 /mob/living/silicon/robot/proc/create_modularInterface()
-	if(!modularInterface)
+	// TG ORIGINAL BEGIN
+	//if(!modularInterface)
+	//	modularInterface = new /obj/item/modular_computer/tablet/integrated(src)
+	// TG ORIGINAL END
+	
+	//SKYRAT EDIT ADDITION BEGIN
+	//Creating a certain cyborg tablet depending on his species
+	if (model.name == "Default")
 		modularInterface = new /obj/item/modular_computer/tablet/integrated(src)
+	else if (model.name == "Engineering")
+		modularInterface = new /obj/item/modular_computer/tablet/integrated/enginer(src)
+	else if (model.name == "Security")
+		modularInterface = new /obj/item/modular_computer/tablet/integrated/security(src)
+	else if (model.name == "Medical")
+		modularInterface = new /obj/item/modular_computer/tablet/integrated/medical(src)
+	else if (model.name == "Service")
+		modularInterface = new /obj/item/modular_computer/tablet/integrated/service(src)
+	else if (model.name == "Peacekeeper")
+		modularInterface = new /obj/item/modular_computer/tablet/integrated/peacekeeper(src)
+	else if (model.name == "Clown")
+		modularInterface = new /obj/item/modular_computer/tablet/integrated/clown(src)
+	else
+		modularInterface = new /obj/item/modular_computer/tablet/integrated(src)
+	// SKYRAT EDIT ADDITION END
+	
 	modularInterface.layer = ABOVE_HUD_PLANE
 	modularInterface.plane = ABOVE_HUD_PLANE
 
@@ -166,8 +189,9 @@
 	var/input_model = show_radial_menu(src, src, model_icons, radius = 42)
 	if(!input_model || model.type != /obj/item/robot_model)
 		return
-
+	
 	model.transform_to(model_list[input_model])
+	create_modularInterface() // SKYRAT EDIT ADD
 
 
 /// Used to setup the a basic and (somewhat) unique name for the robot.
@@ -727,7 +751,8 @@
 
 	ionpulse = FALSE
 	revert_shell()
-
+	create_modularInterface() // SKYRAT EDIT ADD
+	
 	return TRUE
 
 /mob/living/silicon/robot/model/syndicate/ResetModel()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -83,33 +83,32 @@
 	addtimer(CALLBACK(src, .proc/show_playstyle), 5)
 
 /mob/living/silicon/robot/proc/create_modularInterface()
-	// TG ORIGINAL BEGIN
-	//if(!modularInterface)
-	//	modularInterface = new /obj/item/modular_computer/tablet/integrated(src)
-	// TG ORIGINAL END
-	
-	//SKYRAT EDIT ADDITION BEGIN
-	//Creating a certain cyborg tablet depending on his species
-	if (model.name == "Default")
+	if(!modularInterface)
 		modularInterface = new /obj/item/modular_computer/tablet/integrated(src)
-	else if (model.name == "Engineering")
-		modularInterface = new /obj/item/modular_computer/tablet/integrated/enginer(src)
-	else if (model.name == "Security")
-		modularInterface = new /obj/item/modular_computer/tablet/integrated/security(src)
-	else if (model.name == "Medical")
-		modularInterface = new /obj/item/modular_computer/tablet/integrated/medical(src)
-	else if (model.name == "Service")
-		modularInterface = new /obj/item/modular_computer/tablet/integrated/service(src)
-	else if (model.name == "Peacekeeper")
-		modularInterface = new /obj/item/modular_computer/tablet/integrated/peacekeeper(src)
-	else if (model.name == "Clown")
-		modularInterface = new /obj/item/modular_computer/tablet/integrated/clown(src)
-	else
-		modularInterface = new /obj/item/modular_computer/tablet/integrated(src)
-	// SKYRAT EDIT ADDITION END
-	
+		install_programs() // SKYRAT EDIT ADD
 	modularInterface.layer = ABOVE_HUD_PLANE
 	modularInterface.plane = ABOVE_HUD_PLANE
+	
+// SKYRAT EDIT ADDITION BEGIN
+// Program installation procedure depending on the selected module
+/mob/living/silicon/robot/proc/install_programs()
+	if (model.name == "Default")
+		modularInterface.default_programs_install()
+	else if (model.name == "Engineering")
+		modularInterface.enginering_programs_install()
+	else if (model.name == "Security")
+		modularInterface.security_programs_install()
+	else if (model.name == "Medical")
+		modularInterface.medical_programs_install()
+	else if (model.name == "Service")
+		modularInterface.service_programs_install()
+	else if (model.name == "Peacekeeper")
+		modularInterface.peacekeeper_programs_install()
+	else if (model.name == "Clown")
+		modularInterface.clown_programs_install()
+	else
+		modularInterface.default_programs_install()
+// SKYRAT EDIT ADDITION END
 
 /mob/living/silicon/robot/model/syndicate/create_modularInterface()
 	if(!modularInterface)
@@ -191,7 +190,7 @@
 		return
 	
 	model.transform_to(model_list[input_model])
-	create_modularInterface() // SKYRAT EDIT ADD
+	install_programs() // SKYRAT EDIT ADD
 
 
 /// Used to setup the a basic and (somewhat) unique name for the robot.
@@ -751,7 +750,8 @@
 
 	ionpulse = FALSE
 	revert_shell()
-	create_modularInterface() // SKYRAT EDIT ADD
+	modularInterface.remove_module_programs() // SKYRAT EDIT ADD
+	install_programs() // SKYRAT EDIT ADD
 	
 	return TRUE
 

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -110,3 +110,39 @@
 	install_component(new /obj/item/computer_hardware/recharger/cyborg)
 	install_component(new /obj/item/computer_hardware/network_card/integrated)
 	hard_drive.store_file(new /datum/computer_file/program/crew_manifest) // SKYRAT EDIT ADD
+
+//SKYRAT EDIT ADDITION BEGIN
+//Program presets for different types of cyborgs
+/obj/item/modular_computer/tablet/integrated/enginer/Initialize()
+	. = ..()
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
+	hard_drive.store_file(new /datum/computer_file/program/power_monitor/integrated)
+	hard_drive.store_file(new/datum/computer_file/program/alarm_monitor())
+	hard_drive.store_file(new /datum/computer_file/program/supermatter_monitor)
+	
+/obj/item/modular_computer/tablet/integrated/medical/Initialize()
+	. = ..()
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
+	hard_drive.store_file(new /datum/computer_file/program/radar/lifeline)
+
+/obj/item/modular_computer/tablet/integrated/security/Initialize()
+	. = ..()
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
+	hard_drive.store_file(new /datum/computer_file/program/secureye/integrated)
+	
+/obj/item/modular_computer/tablet/integrated/service/Initialize()
+	. = ..()
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive"
+	hard_drive.store_file(new /datum/computer_file/program/chatclient)
+
+/obj/item/modular_computer/tablet/integrated/peacekeeper/Initialize()
+	. = ..()
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
+	hard_drive.store_file(new /datum/computer_file/program/radar/lifeline)
+	hard_drive.store_file(new /datum/computer_file/program/secureye/integrated)
+
+/obj/item/modular_computer/tablet/integrated/clown/Initialize()
+	. = ..()
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive"
+	hard_drive.store_file(new /datum/computer_file/program/chatclient)
+// SKYRAT EDIT ADDITION END

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -117,7 +117,7 @@
 	. = ..()
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
 	hard_drive.store_file(new /datum/computer_file/program/power_monitor/integrated)
-	hard_drive.store_file(new/datum/computer_file/program/alarm_monitor())
+	hard_drive.store_file(new /datum/computer_file/program/alarm_monitor)
 	hard_drive.store_file(new /datum/computer_file/program/supermatter_monitor)
 	
 /obj/item/modular_computer/tablet/integrated/medical/Initialize()

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -113,36 +113,48 @@
 
 //SKYRAT EDIT ADDITION BEGIN
 //Program presets for different types of cyborgs
-/obj/item/modular_computer/tablet/integrated/enginer/Initialize()
-	. = ..()
+/obj/item/modular_computer/tablet/integrated/proc/default_programs_install()
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
+	hard_drive.store_file(new /datum/computer_file/program/crew_manifest)
+	return null
+
+/obj/item/modular_computer/tablet/integrated/proc/enginering_programs_install()
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
 	hard_drive.store_file(new /datum/computer_file/program/power_monitor/integrated)
 	hard_drive.store_file(new /datum/computer_file/program/alarm_monitor)
 	hard_drive.store_file(new /datum/computer_file/program/supermatter_monitor)
+	return null
 	
-/obj/item/modular_computer/tablet/integrated/medical/Initialize()
-	. = ..()
+/obj/item/modular_computer/tablet/integrated/proc/medical_programs_install()
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
 	hard_drive.store_file(new /datum/computer_file/program/radar/lifeline)
+	return null
 
-/obj/item/modular_computer/tablet/integrated/security/Initialize()
-	. = ..()
+/obj/item/modular_computer/tablet/integrated/proc/security_programs_install()
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
 	hard_drive.store_file(new /datum/computer_file/program/secureye/integrated)
+	return null
 	
-/obj/item/modular_computer/tablet/integrated/service/Initialize()
-	. = ..()
+/obj/item/modular_computer/tablet/integrated/proc/service_programs_install()
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
 	hard_drive.store_file(new /datum/computer_file/program/chatclient)
+	return null
 
-/obj/item/modular_computer/tablet/integrated/peacekeeper/Initialize()
-	. = ..()
+/obj/item/modular_computer/tablet/integrated/proc/peacekeeper_programs_install()
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
 	hard_drive.store_file(new /datum/computer_file/program/radar/lifeline)
 	hard_drive.store_file(new /datum/computer_file/program/secureye/integrated)
+	return null
 
-/obj/item/modular_computer/tablet/integrated/clown/Initialize()
-	. = ..()
+/obj/item/modular_computer/tablet/integrated/proc/clown_programs_install()
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
 	hard_drive.store_file(new /datum/computer_file/program/chatclient)
+	return null
+
+/obj/item/modular_computer/tablet/integrated/proc/remove_module_programs()
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
+	for (var/datum/computer_file/file in hard_drive.stored_files)
+		if (file.filename != "robotact" & file.filename != "filemanager" & file.filename != "compconfig" & file.filename != "plexagoncrew")
+			hard_drive.remove_file(file)
+	return null
 // SKYRAT EDIT ADDITION END

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -132,7 +132,7 @@
 	
 /obj/item/modular_computer/tablet/integrated/service/Initialize()
 	. = ..()
-	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive"
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
 	hard_drive.store_file(new /datum/computer_file/program/chatclient)
 
 /obj/item/modular_computer/tablet/integrated/peacekeeper/Initialize()

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -143,6 +143,6 @@
 
 /obj/item/modular_computer/tablet/integrated/clown/Initialize()
 	. = ..()
-	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive"
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
 	hard_drive.store_file(new /datum/computer_file/program/chatclient)
 // SKYRAT EDIT ADDITION END

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -101,3 +101,13 @@
 
 	return data
 
+//SKYRAT EDIT ADDITION BEGIN
+//Cyborg tablet software option
+/datum/computer_file/program/power_monitor/integrated
+	filename = "ampcheck_cyborg"
+	filedesc = "Cyborg AmpCheck"
+	requires_ntnet = TRUE
+	available_on_ntnet = FALSE
+	category = PROGRAM_CATEGORY_MISC
+	usage_flags = PROGRAM_TABLET
+// SKYRAT EDIT ADDITION END

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -194,3 +194,14 @@
 		if(tempnetwork.len)
 			camlist["[cam.c_tag]"] = cam
 	return camlist
+
+//SKYRAT EDIT ADDITION BEGIN
+//Cyborg tablet software option
+/datum/computer_file/program/secureye/integrated
+	filename = "secureye_cyborg"
+	filedesc = "Cyborg SecurEye"
+	requires_ntnet = TRUE
+	available_on_ntnet = FALSE
+	category = PROGRAM_CATEGORY_MISC
+	usage_flags = PROGRAM_TABLET
+// SKYRAT EDIT ADDITION END


### PR DESCRIPTION
## About The Pull Request

Adds a system for installing programs to cyborgs depending on their species.

## Why It's Good For The Game

It so happens that in the architecture of the tgstation build, every cyborg owns a tablet. In this form, these tablets are useless, because they are designed only for one program - **robotact**. At the same time, cyborgs have access to install and run any program on any station computer. And instead of using their tablet and station network, the cyborgs have to drive to the computers every time, which seems a little illogical.

I propose to use a system in which each cyborg is recorded a specific set of programs for remote use depending on its specialization.
For cyborgs at the moment I have made an installation of the following programs:

![image](https://user-images.githubusercontent.com/88540658/128999152-52fadf2e-942d-4cd1-9c03-d8183afba94e.png)

**Enginer** - _power_monitor, alarm_monitor, supermatter_monitor_;
**Medical** - _lifeline_;
**Security** - _secureye_;
**Service** - _chatclient_;
**Peacekeeper** - _lifeline, secureye_;
**Clown** - _chatclient_. (HONK in chat)

For the programs **secureye** and **power_monitor** I have created their variants for cyborgs, which are not available for installation on regular tablets and need a network. The regular versions of secureye and power_monitor are not available for installation on tablets.
This set of programs can easily be changed or added to in the future. I plan to do this if my changes are included in the main repository, porting variants of the conventional console interfaces for use in cyborg tablets. 


## Changelog
:cl:
add: Added system for loading programs to cyborgs when selecting a specific model
add: Added two special programs for cyborgs: power_monitor/integrated and secureye/integrated
code: The following files have been changed: robot.dm, tablet_presets.dm, powermonitor.dm, secureye.dm.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->