### PR TITLE
mmi cryopod fix, battery tablet delete fix

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -330,6 +330,11 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 	handle_objectives()
 	QDEL_NULL(occupant)
+	//Skyrat Edit Start - No MMIs either
+	var/turf/src_turf = get_turf(src)
+	var/obj/item/mmi/mmi_item = locate() in src_turf.contents
+	qdel(mmi_item)
+	//Skyrat Edit Stop
 	open_machine()
 	name = initial(name)
 

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -59,7 +59,7 @@
 			user.put_in_hands(battery)
 			to_chat(user, span_notice("You detach \the [battery] from \the [src]."))
 		else
-			battery.forceMove(drop_location())
+			QDEL_NULL(battery) //Skyrat Edit Start - These batteries are outrageous
 		return TRUE
 
 /obj/item/stock_parts/cell/computer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
when a cyborg cryo's, the mmi wont be left behind
when a tablet is deleted, it wont drop a battery anymore
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
closes #1215
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: borgs wont drop a mmi on cryon
fix: tablets wont drop a battery on deletion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
