### PR TITLE
ashwalker changes

### DIFF
--- a/modular_skyrat/modules/ashwalker_change/code/ash_walker_den.dm
+++ b/modular_skyrat/modules/ashwalker_change/code/ash_walker_den.dm
@@ -1,0 +1,54 @@
+/obj/item/flashlight/lantern/ashwalker_variant
+	name = "ash-corrupted lantern"
+	uses_battery = FALSE
+	light_range = 8
+
+/obj/structure/lavaland/ash_walker/attackby(obj/item/I, mob/living/user, params)
+	if(istype(I, /obj/item/organ/regenerative_core) && user.mind.has_antag_datum(/datum/antagonist/ashwalker))
+		var/obj/item/organ/regenerative_core/regen_core = I
+		regen_core.preserved()
+		playsound(src, 'sound/magic/demon_consume.ogg', 50, TRUE)
+		to_chat(user, span_notice("The tendril revitalizes [regen_core]."))
+		return
+	if(istype(I, /obj/item/flashlight/lantern))
+		var/obj/item/flashlight/lantern/corrupted_lanter = I
+		new /obj/item/flashlight/lantern/ashwalker_variant(get_turf(user))
+		playsound(src, 'sound/magic/demon_consume.ogg', 50, TRUE)
+		to_chat(user, span_notice("The tendril corrupts [corrupted_lanter]."))
+		qdel(corrupted_lanter)
+		return
+	return ..()
+
+/obj/structure/lavaland/ash_walker/attack_hand(mob/living/user, list/modifiers)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/human_user = user
+	if(istype(human_user.dna.species, /datum/species/lizard/ashwalker))
+		return
+	var/allow_transform = 0
+	for(var/mob/living/carbon/human/count_human in range(1, src))
+		if(istype(count_human.dna.species, /datum/species/lizard/ashwalker))
+			allow_transform++
+	if(allow_transform < 2)
+		to_chat(human_user, span_warning("The tendril consumes a part of your flesh... you are not worthy!"))
+		playsound(src, 'sound/magic/demon_consume.ogg', 50, TRUE)
+		human_user.adjustBruteLoss(10)
+		return
+	else
+		to_chat(human_user, span_warning("The tendril consumes a part of your flesh... you have a chance!"))
+		var/choice = tgui_alert(human_user, "Become an Ashwalker? You will abandon your previous life and body.", "Major Choice", list("Yes", "No"))
+		if(choice != "Yes")
+			to_chat(human_user, span_warning("You will live long enough to regret this..."))
+			playsound(src, 'sound/magic/demon_consume.ogg', 50, TRUE)
+			human_user.adjustBruteLoss(10)
+			return
+		to_chat(human_user, span_notice("The tendril is pleased with your choice..."))
+		human_user.unequip_everything()
+		human_user.set_species(/datum/species/lizard/ashwalker)
+		human_user.underwear = "Nude"
+		human_user.update_body()
+		human_user.mind.add_antag_datum(/datum/antagonist/ashwalker)
+		ADD_TRAIT(human_user, TRAIT_PRIMITIVE, ROUNDSTART_TRAIT)
+		playsound(src, 'sound/magic/demon_dies.ogg', 50, TRUE)
+		meat_counter++
+	return ..()

--- a/modular_skyrat/modules/ashwalker_change/readme.md
+++ b/modular_skyrat/modules/ashwalker_change/readme.md
@@ -1,0 +1,29 @@
+https://github.com/Skyrat-SS13/Skyrat-tg/pull/3129
+
+## Title: Ashwalker Change
+
+MODULE ID: ASH_CHANGE
+
+### Description:
+
+When ashwalkers use regenerating cores on the tendril, it'll stablize the core.
+
+When ashwalkers use laterns on the tendril, it'll corrupt them, making them not require a battery.
+
+When a non-ashwalker touches the tendril with their bare hands when two ashwalkers are nearby, they will be prompted if they want to turn into an ashwalker.
+
+### TG Proc Changes:
+
+### Defines:
+
+### Master file additions
+
+- N/A
+
+### Included files that are not contained in this module:
+
+- N/A
+
+### Credits:
+
+Jake Park

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1_skyrat.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aK" = (
-/obj/structure/water_source/puddle,
+/obj/item/stack/sheet/mineral/coal/ten,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "bc" = (
@@ -37,7 +37,7 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "cP" = (
-/obj/structure/geyser/random,
+/obj/structure/water_source/puddle,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "dw" = (
@@ -45,8 +45,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "dG" = (
-/obj/effect/turf_decal/mining,
-/turf/closed/wall,
+/obj/item/pickaxe,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "dU" = (
 /obj/structure/stone_tile/block/cracked,
@@ -71,8 +71,7 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "eE" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "eO" = (
@@ -114,16 +113,13 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "fY" = (
-/turf/open/water,
-/area/ruin/unpowered/ash_walkers)
-"gJ" = (
-/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/structure/reagent_forge,
+/obj/structure/stone_tile/slab,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "hL" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/structure/reagent_anvil,
+/obj/structure/stone_tile/slab,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "hX" = (
@@ -203,11 +199,6 @@
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
-"jT" = (
-/obj/machinery/light/small/directional/south,
-/obj/item/stack/sheet/mineral/coal/ten,
-/turf/open/floor/plating,
-/area/ruin/unpowered/ash_walkers)
 "kx" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -220,10 +211,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
-"kB" = (
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/iron,
-/area/ruin/powered)
 "kE" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /obj/structure/stone_tile/center,
@@ -319,12 +306,13 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "ov" = (
-/turf/closed/wall,
+/obj/structure/bonfire/dense,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "pz" = (
-/obj/structure/table,
-/obj/item/card/id/advanced/mining,
-/turf/open/floor/plating,
+/obj/structure/reagent_water_basin,
+/obj/structure/stone_tile/slab,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "pD" = (
 /obj/structure/stone_tile/block{
@@ -490,8 +478,8 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "sC" = (
-/obj/effect/turf_decal/vg_decals/department/mining,
-/turf/closed/wall,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "sI" = (
 /obj/structure/stone_tile/block/burnt,
@@ -544,7 +532,7 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "tP" = (
-/obj/structure/girder,
+/obj/effect/mob_spawn/human/miner,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "ug" = (
@@ -583,7 +571,7 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "wm" = (
-/obj/item/stack/sheet/mineral/coal/ten,
+/obj/structure/geyser/random,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "wp" = (
@@ -644,9 +632,6 @@
 /obj/structure/railing/stone,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"wG" = (
-/turf/open/floor/plating,
-/area/ruin/unpowered/ash_walkers)
 "wM" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -691,10 +676,6 @@
 /obj/item/hatchet/wooden,
 /obj/item/hatchet/wooden,
 /turf/open/indestructible/boss,
-/area/ruin/unpowered/ash_walkers)
-"yl" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
 /area/ruin/unpowered/ash_walkers)
 "yJ" = (
 /turf/closed/mineral/volcanic/lava_land_surface,
@@ -807,9 +788,6 @@
 	dir = 4
 	},
 /turf/open/indestructible/boss,
-/area/ruin/unpowered/ash_walkers)
-"Du" = (
-/turf/open/floor/iron,
 /area/ruin/unpowered/ash_walkers)
 "DJ" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
@@ -953,10 +931,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
-"Kr" = (
-/obj/item/pickaxe,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "KS" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -1021,8 +995,7 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "LM" = (
-/obj/structure/bonfire/dense,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/water,
 /area/ruin/unpowered/ash_walkers)
 "LO" = (
 /obj/structure/stone_tile/cracked{
@@ -1058,7 +1031,8 @@
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "Mv" = (
-/obj/machinery/hydroponics/soil,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "MD" = (
@@ -1164,10 +1138,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/powered)
-"ON" = (
-/obj/effect/mob_spawn/human/miner,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "OR" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -1258,10 +1228,6 @@
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"RE" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/plating,
-/area/ruin/powered)
 "RG" = (
 /turf/closed/mineral/volcanic/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
@@ -1280,10 +1246,6 @@
 	},
 /obj/structure/fermenting_barrel,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
-"Ue" = (
-/obj/effect/mob_spawn/human/corpse/damaged,
-/turf/open/floor/plating,
 /area/ruin/unpowered/ash_walkers)
 "Ul" = (
 /obj/structure/necropolis_gate,
@@ -1320,8 +1282,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "VL" = (
-/obj/effect/mob_spawn/human/corpse/damaged,
-/turf/open/floor/iron,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "VX" = (
 /obj/structure/mineral_door/wood,
@@ -1449,7 +1411,7 @@
 /area/ruin/unpowered/ash_walkers)
 
 (1,1,1) = {"
-mv
+RG
 mv
 mv
 mv
@@ -1471,16 +1433,6 @@ RG
 iZ
 "}
 (2,1,1) = {"
-mv
-mv
-RG
-RG
-RG
-RG
-RG
-RG
-RG
-RG
 RG
 mv
 mv
@@ -1488,13 +1440,89 @@ mv
 mv
 mv
 mv
-RG
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
 RG
 iZ
 "}
 (3,1,1) = {"
 RG
 RG
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+RG
+iZ
+"}
+(4,1,1) = {"
+RG
+RG
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+mv
+RG
+iZ
+"}
+(5,1,1) = {"
+RG
+RG
+RG
+RG
+RG
+RG
+RG
+RG
+RG
+RG
+RG
+mv
+mv
+mv
+mv
+mv
+mv
+RG
+RG
+iZ
+"}
+(6,1,1) = {"
+RG
+RG
 RG
 RG
 RG
@@ -1514,82 +1542,11 @@ RG
 RG
 iZ
 "}
-(4,1,1) = {"
-RG
-RG
-RG
-RG
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-RG
-RG
-RG
-RG
-RG
-RG
-RG
-RG
-XV
-XV
-"}
-(5,1,1) = {"
-RG
-RG
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-RG
-RG
-RG
-RG
-RG
-RG
-RG
-XV
-XV
-"}
-(6,1,1) = {"
-RG
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-RG
-RG
-RG
-RG
-RG
-RG
-XV
-XV
-"}
 (7,1,1) = {"
-Ly
-mZ
-mZ
-fY
-fY
-mZ
-mZ
-mZ
-mZ
+RG
+RG
+RG
+RG
 mZ
 mZ
 mZ
@@ -1598,17 +1555,18 @@ mZ
 mZ
 RG
 RG
-Ly
+RG
+RG
+RG
+RG
+RG
+RG
 XV
 XV
 "}
 (8,1,1) = {"
-Ly
-mZ
-fY
-fY
-fY
-fY
+RG
+RG
 mZ
 mZ
 mZ
@@ -1617,20 +1575,19 @@ mZ
 mZ
 mZ
 mZ
-cP
 mZ
-mZ
-Ly
+RG
+RG
+RG
+RG
+RG
+RG
+RG
 XV
 XV
 "}
 (9,1,1) = {"
-Ly
-mZ
-fY
-fY
-fY
-fY
+RG
 mZ
 mZ
 mZ
@@ -1641,8 +1598,13 @@ mZ
 mZ
 mZ
 mZ
-cP
-Ly
+mZ
+RG
+RG
+RG
+RG
+RG
+RG
 XV
 XV
 "}
@@ -1650,10 +1612,76 @@ XV
 Ly
 mZ
 mZ
-fY
-fY
+mZ
+mZ
+mZ
+mZ
+mZ
 mZ
 aK
+mZ
+mZ
+mZ
+mZ
+mZ
+RG
+RG
+Ly
+XV
+XV
+"}
+(11,1,1) = {"
+Ly
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+wm
+mZ
+mZ
+Ly
+XV
+XV
+"}
+(12,1,1) = {"
+Ly
+mZ
+mZ
+LM
+LM
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+mZ
+wm
+Ly
+XV
+XV
+"}
+(13,1,1) = {"
+Ly
+mZ
+LM
+LM
+LM
+LM
+mZ
 mZ
 mZ
 mZ
@@ -1668,85 +1696,19 @@ Ly
 XV
 XV
 "}
-(11,1,1) = {"
-Ly
-mZ
-mZ
-mZ
-mZ
-hL
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-Ly
-XV
-XV
-"}
-(12,1,1) = {"
-Ly
-mZ
-mZ
-LM
-gJ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-Ly
-XV
-XV
-"}
-(13,1,1) = {"
-Ly
-Mv
-mZ
-gJ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-mZ
-Ly
-XV
-XV
-"}
 (14,1,1) = {"
 Ly
-Mv
-mZ
-mZ
-mZ
 mZ
 LM
+LM
+LM
+LM
+mZ
+aK
 mZ
 mZ
 mZ
-mZ
-mZ
+aK
 mZ
 mZ
 mZ
@@ -1760,14 +1722,14 @@ XV
 Ly
 mZ
 mZ
+LM
+LM
 mZ
 mZ
 mZ
 mZ
 mZ
-dw
-dw
-dw
+mZ
 dw
 mZ
 mZ
@@ -1780,18 +1742,18 @@ XV
 "}
 (16,1,1) = {"
 Ly
-aK
-eE
+mZ
+mZ
+mZ
+mZ
 Mv
-Mv
-Mv
-Mv
+mZ
 mZ
 mZ
 mZ
 mZ
 dw
-mZ
+Ra
 mZ
 mZ
 mZ
@@ -1809,8 +1771,8 @@ Ly
 Ly
 Ly
 mZ
-mZ
-mZ
+dG
+Ra
 mZ
 dw
 mZ
@@ -1830,13 +1792,13 @@ rQ
 wp
 LO
 Ly
-mZ
-mZ
-mZ
+cP
 mZ
 dw
-mZ
-mZ
+dw
+dw
+dw
+dw
 mZ
 mZ
 dw
@@ -1854,10 +1816,10 @@ MR
 Ly
 mZ
 mZ
+dw
 mZ
 mZ
-dw
-dw
+mZ
 dw
 dw
 dw
@@ -1877,10 +1839,10 @@ QG
 dw
 dw
 dw
-dw
-dw
 mZ
-mZ
+ov
+tP
+dw
 mZ
 mZ
 dw
@@ -1898,11 +1860,11 @@ xW
 Ly
 mZ
 mZ
-mZ
-mZ
 dw
 mZ
 mZ
+mZ
+dw
 mZ
 mZ
 Ly
@@ -1919,12 +1881,12 @@ KS
 OR
 Ly
 mZ
-mZ
-mZ
-mZ
+Ra
 dw
-mZ
-mZ
+dw
+dw
+dw
+dw
 mZ
 mZ
 Ly
@@ -1943,7 +1905,7 @@ Ly
 mZ
 mZ
 mZ
-mZ
+eE
 dw
 mZ
 mZ
@@ -1967,11 +1929,11 @@ mZ
 mZ
 mZ
 dw
-ov
-tP
-tP
-ov
-ov
+mZ
+mZ
+mZ
+mZ
+mZ
 Ly
 XV
 XV
@@ -1986,14 +1948,14 @@ pE
 NB
 NB
 mZ
-mZ
+eE
 mZ
 dw
-yl
+mZ
 VL
-kB
-wG
-RE
+VL
+VL
+VL
 Ly
 XV
 XV
@@ -2012,10 +1974,10 @@ mZ
 mZ
 dw
 sC
-Du
-wm
-wG
-ON
+mZ
+mZ
+mZ
+mZ
 Ly
 XV
 XV
@@ -2033,11 +1995,11 @@ Pr
 mZ
 mZ
 dw
-mZ
-mZ
-mZ
-mZ
-jT
+cP
+VL
+VL
+VL
+VL
 Ly
 XV
 XV
@@ -2055,9 +2017,9 @@ PB
 mZ
 mZ
 dw
-Du
-VL
-pz
+mZ
+mZ
+mZ
 mZ
 mZ
 Ly
@@ -2077,11 +2039,11 @@ pE
 mZ
 mZ
 dw
-dG
-Kr
-Du
-wG
-Ue
+mZ
+VL
+VL
+VL
+VL
 Ly
 XV
 XV
@@ -2272,9 +2234,9 @@ pE
 pE
 mZ
 mZ
-mZ
-mZ
-mZ
+dw
+dw
+dw
 Ly
 hY
 WW
@@ -2294,9 +2256,9 @@ pE
 mZ
 mZ
 mZ
-mZ
-mZ
-mZ
+fY
+hL
+pz
 Ly
 iJ
 PN

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4011,6 +4011,7 @@
 #include "modular_skyrat\modules\antagonists\code\gamemodes.dm"
 #include "modular_skyrat\modules\antagonists\eldritch_cult\knowledge\ash_lore_skyrat.dm"
 #include "modular_skyrat\modules\antagonists\eldritch_cult\knowledge\flesh_lore_skyrat.dm"
+#include "modular_skyrat\modules\ashwalker_change\code\ash_walker_den.dm"
 #include "modular_skyrat\modules\ashwalkers\Ashwalker\Ashwalkers.dm"
 #include "modular_skyrat\modules\ashwalkers\code\item\clothing\hands\hands.dm"
 #include "modular_skyrat\modules\ashwalkers\code\item\clothing\head\head.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When ashwalkers use regenerating cores on the tendril, it'll stablize the core.

When ashwalkers use laterns on the tendril, it'll corrupt them, making them not require a battery.

When a non-ashwalker touches the tendril with their bare hands when two ashwalkers are nearby, they will be prompted if they want to turn into an ashwalker.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
ashwalkers just a little stronger (by QoL)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: the ashwalker tendril can now stablize cores (ashwalker only)
add: the ashwalker tendril can now corrupt lanterns, making them a little better (ashwalker only)
add: the ashwalker tendril can now transform people into ashwalkers (2 ashwalkers required nearby, requires human consent)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
