### PR TITLE
[NON-MODULAR] Gives Cap and HoP seclites

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -31,6 +31,7 @@
 	new /obj/item/clothing/gloves/color/captain(src)
 	new /obj/item/storage/belt/sabre(src)
 	new /obj/item/storage/box/gunset/pdh_captain(src) //SKYRAT EDIT CHANGE - SEC_HAUL
+	new /obj/item/flashlight/seclite(src) //SKYRAT EDIT
 	new /obj/item/door_remote/captain(src)
 	new /obj/item/storage/photo_album/captain(src)
 
@@ -60,6 +61,7 @@
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/clothing/glasses/sunglasses(src)
 	new /obj/item/gun/energy/e_gun(src) //SKYRAT EDIT
+	new /obj/item/flashlight/seclite(src) //SKYRAT EDIT
 	new /obj/item/clothing/neck/petcollar(src)
 	new /obj/item/pet_carrier(src)
 	new /obj/item/door_remote/civilian(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title.

## Why It's Good For The Game

It's a flashlight, that's why it's good. Put it on your gun (so you can abuse it never running out of battery), put it in your pocket. Use it to light up maint tunnels, use it to actually see when the power goes out because the engie's inevitably screwed up the supermatter. DON'T use it to validhunt, but like, at the same time, it's a fucking flashlight, how are you going to validhunt with it.

It's a fucking flashlight, don't melodrama about how giving the HoP something as basic as that is going to make them Hopcurity. Don't nothingburger, I beg of you.

Also, you can literally already just print a seclite if you want. This is just saving you the hassle of not having to walk three minutes to do it. It really changes nothing besides save time.

## Changelog
:cl:
add: Seclite to HoP and Cap lockers.
/:cl: