### PR TITLE
[SEMI-MODULAR] Gives CMO, RD, and CE mini energy guns

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -48286,7 +48286,6 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/item/gun/energy/e_gun/mini,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "gsh" = (
@@ -49871,7 +49870,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/item/gun/energy/e_gun/mini,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
@@ -56609,7 +56607,6 @@
 "jZl" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/effect/turf_decal/delivery,
-/obj/item/gun/energy/e_gun/mini,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -27,6 +27,7 @@
 	new /obj/item/storage/photo_album/ce(src)
 	new /obj/item/storage/box/skillchips/engineering(src)
 	new /obj/item/clothing/suit/hooded/wintercoat/engineering/ce(src)
+	new /obj/item/gun/energy/e_gun/mini(src) //SKYRAT EDIT ADDITION
 	new /obj/item/construction/plumbing/engineering(src) //SKYRAT EDIT ADDITION
 	new /obj/item/circuitboard/machine/rodstopper(src) //SKYRAT EDIT ADDITION
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -99,6 +99,7 @@
 	new /obj/item/circuitboard/machine/techfab/department/medical(src)
 	new /obj/item/storage/photo_album/cmo(src)
 	new /obj/item/clothing/suit/hooded/wintercoat/medical/cmo(src)
+	new /obj/item/gun/energy/e_gun/mini(src) //SKYRAT EDIT ADDITION
 
 /obj/structure/closet/secure_closet/animal
 	name = "animal control"

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -29,6 +29,7 @@
 	new /obj/item/storage/photo_album/rd(src)
 	new /obj/item/storage/box/skillchips/science(src)
 	new /obj/item/clothing/suit/hooded/wintercoat/science/rd(src)
+	new /obj/item/gun/energy/e_gun/mini(src) //SKYRAT EDIT ADDITION
 
 
 /obj/structure/closet/secure_closet/cytology


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a mini e-gun to the lockers of the CMO, RD and CE, as well, removes them from the kilo map file so they aren't spawning with two energy guns round-start.

## Why It's Good For The Game

The telebaton is good for self-defence, but it's not.. great.. Having this, which is already on kilo gives heads more options to defend themselves. It's intentionally not amazing as well, so it's not used for hunting people down, it's to pepper people as you run away, not to be used as a killing weapon.

## Changelog
:cl:
add: Added mini e-guns to the lockers of the CMO, RD, and CE
del: Removed the mini e-guns from lockers in Kilo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->