### PR TITLE
[NON-MODULAR] Organized runtime viewer now shows number of each runtime

### DIFF
--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -86,7 +86,7 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 		var/datum/error_viewer/error_source/error_source
 		for (var/erroruid in error_sources)
 			error_source = error_sources[erroruid]
-			html += "[error_source.make_link(null, src)]<br>"
+			html += "[error_source.make_link(null, src)] x [error_source.errors.len]<br>" //SKYRAT EDIT - RUNTIME TRANSPARENCY
 
 	else
 		html += "[make_link("organized", null)] | linear<hr>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fever request from Cobalt, sounded good
Should probably PR this upstream.
![image](https://user-images.githubusercontent.com/14105827/129447032-1a43f3f3-f206-406a-9f3a-239db983777e.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Easier to see the problem runtimes in the less box-intensive runtime viewer
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Foxtrot (Funce)
admin: Runtime viewer now shows the number of "organized" runtimes when you're in organized view mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
