### PR TITLE
[MODULAR] Adds Manage Player Ranks verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -209,7 +209,12 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	)
 GLOBAL_LIST_INIT(admin_verbs_possess, list(/proc/possess, /proc/release))
 GLOBAL_PROTECT(admin_verbs_possess)
-GLOBAL_LIST_INIT(admin_verbs_permissions, list(/client/proc/edit_admin_permissions))
+/// SKYRAT EDIT BEGIN - Player Rank Manager - ORIGINAL: GLOBAL_LIST_INIT(admin_verbs_permissions, list(/client/proc/edit_admin_permissions))
+GLOBAL_LIST_INIT(admin_verbs_permissions, list(
+	/client/proc/edit_admin_permissions,
+	/client/proc/manage_player_ranks
+	))
+/// SKYRAT EDIT END
 GLOBAL_PROTECT(admin_verbs_permissions)
 GLOBAL_LIST_INIT(admin_verbs_poll, list(/client/proc/poll_panel))
 GLOBAL_PROTECT(admin_verbs_poll)

--- a/modular_skyrat/modules/admin/code/manage_player_ranks.dm
+++ b/modular_skyrat/modules/admin/code/manage_player_ranks.dm
@@ -19,7 +19,7 @@
 	if(!check_rights(R_PERMISSIONS))
 		return
 
-	var/choice = tgui_alert(usr, "Which rank would you like to manage?", "Manage Player Ranks", SKYRAT_PLAYER_RANKS)
+	var/choice = tgui_alert(usr, "Which rank would you like to manage?", "Manage Player Ranks", SKYRAT_PLAYER_RANKS+"Cancel")
 	if(!choice || !(choice in SKYRAT_PLAYER_RANKS))
 		return
 

--- a/modular_skyrat/modules/admin/code/manage_player_ranks.dm
+++ b/modular_skyrat/modules/admin/code/manage_player_ranks.dm
@@ -1,0 +1,135 @@
+/// The defines for the appropriate config files
+#define SKYRAT_DONATOR_CONFIG_FILE "[global.config.directory]/skyrat/donators.txt"
+#define SKYRAT_MENTOR_CONFIG_FILE "[global.config.directory]/skyrat/mentors.txt"
+#define SKYRAT_VETERAN_CONFIG_FILE "[global.config.directory]/skyrat/veteran_players.txt"
+
+/// The list of the available special player ranks
+#define SKYRAT_PLAYER_RANKS list("Donator", "Mentor", "Veteran")
+
+/client/proc/manage_player_ranks()
+	set category = "Admin"
+	set name = "Manage Player Ranks"
+	set desc = "Manage who has the special player ranks while the server is running."
+	if(!check_rights(R_PERMISSIONS))
+		return
+	usr.client.holder.manage_player_ranks()
+
+/// Proc for admins to change people's "player" ranks (donator, mentor, veteran, etc.)
+/datum/admins/proc/manage_player_ranks()
+	if(!check_rights(R_PERMISSIONS))
+		return
+
+	var/choice = tgui_alert(usr, "Which rank would you like to manage?", "Manage Player Ranks", SKYRAT_PLAYER_RANKS)
+	if(!choice || !(choice in SKYRAT_PLAYER_RANKS))
+		return
+
+	manage_player_rank_in_group(choice)
+
+/// Proc that helps a bit with repetition, basically an extension of `manage_player_ranks()`
+/datum/admins/proc/manage_player_rank_in_group(group)
+	if(!(group in SKYRAT_PLAYER_RANKS))
+		CRASH("[key_name(usr)] attempted to add someone to an invalid \"[group]\" group.")
+
+	var/group_title = lowertext(group)
+
+	var/list/choices = list("Add", "Remove")
+	switch(tgui_alert(usr, "What would you like to do?", "Manage [group]s", choices))
+		if("Add")
+			var/name = input(usr, "Please enter the CKEY (case-insensitive) of the person you would like to make a [group_title]:", "Add a [group_title]") as null|text
+			if(!name)
+				return
+
+			var/player_to_be = ckey(name)
+			if(!player_to_be)
+				to_chat(usr, span_warning("\"[name]\" is not a valid CKEY."))
+				return
+
+			switch(group)
+				if ("Donator")
+					for(var/a_donator as anything in GLOB.donator_list)
+						if(player_to_be == a_donator)
+							to_chat(usr, span_warning("\"[player_to_be]\" is already a [group_title]!"))
+							return
+					// Now that we know that the ckey is valid and they're not already apart of that group, let's add them to it!
+					GLOB.donator_list[player_to_be] = TRUE
+					text2file(player_to_be, SKYRAT_DONATOR_CONFIG_FILE)
+
+				if("Mentor")
+					for(var/a_mentor as anything in GLOB.mentor_datums)
+						if(player_to_be == a_mentor)
+							to_chat(usr, span_warning("\"[player_to_be]\" is already a [group_title]!"))
+							return
+					// Now that we know that the ckey is valid and they're not already apart of that group, let's add them to it!
+					new /datum/mentors(player_to_be)
+					text2file(player_to_be, SKYRAT_MENTOR_CONFIG_FILE)
+
+				if ("Veteran")
+					for(var/a_veteran as anything in GLOB.veteran_players)
+						if(player_to_be == a_veteran)
+							to_chat(usr, span_warning("\"[player_to_be]\" is already a [group_title]!"))
+							return
+					// Now that we know that the ckey is valid and they're not already apart of that group, let's add them to it!
+					GLOB.veteran_players[player_to_be] = TRUE
+					text2file(player_to_be, SKYRAT_VETERAN_CONFIG_FILE)
+
+				else
+					return
+
+			message_admins("[key_name(usr)] has granted [group_title] status to [player_to_be].")
+			log_admin_private("[key_name(usr)] has granted [group_title] status to [player_to_be].")
+
+
+		if("Remove")
+			var/name = input(usr, "Please enter the CKEY (case-insensitive) of the person you would like to no longer be a [group_title]:", "Remove a [group_title]") as null|text
+			if(!name)
+				return
+
+			var/player_that_was = ckey(name)
+			if(!player_that_was)
+				to_chat(usr, span_warning("\"[name]\" is not a valid CKEY."))
+				return
+
+			var/changes = FALSE
+			switch(group)
+				if ("Donator")
+					for(var/a_donator as anything in GLOB.donator_list)
+						if(player_that_was == a_donator)
+							GLOB.donator_list -= player_that_was
+							changes = TRUE
+					if(!changes)
+						to_chat(usr, span_warning("\"[player_that_was]\" was already not a [group_title]."))
+						return
+					save_donators()
+
+				if("Mentor")
+					for(var/a_mentor as anything in GLOB.mentor_datums)
+						if(player_that_was == a_mentor)
+							var/datum/mentors/mentor_datum = GLOB.mentor_datums[a_mentor]
+							mentor_datum.remove_mentor()
+							changes = TRUE
+					if(!changes)
+						to_chat(usr, span_warning("\"[player_that_was]\" was already not a [group_title]."))
+					save_mentors()
+
+				if("Veteran")
+					for(var/a_veteran as anything in GLOB.veteran_players)
+						if(player_that_was == a_veteran)
+							GLOB.veteran_players -= player_that_was
+							changes = TRUE
+					if(!changes)
+						to_chat(usr, span_warning("\"[player_that_was]\" was already not a [group_title]."))
+						return
+					save_veteran_players()
+
+				else
+					return
+			message_admins("[key_name(usr)] has revoked [group_title] status from [player_that_was].")
+			log_admin_private("[key_name(usr)] has revoked [group_title] status from [player_that_was].")
+
+		else
+			return
+
+#undef SKYRAT_DONATOR_CONFIG_FILE
+#undef SKYRAT_MENTOR_CONFIG_FILE
+#undef SKYRAT_VETERAN_CONFIG_FILE
+#undef SKYRAT_PLAYER_RANKS

--- a/modular_skyrat/modules/customization/modules/admin/donator_list.dm
+++ b/modular_skyrat/modules/customization/modules/admin/donator_list.dm
@@ -11,4 +11,11 @@ GLOBAL_LIST(donator_list)
 			continue
 		GLOB.donator_list[ckey(line)] = TRUE //Associative so we can check it much faster
 
+/proc/save_donators()
+	/// Yes, this is incredibly long, deal with it. It's to keep that cute little comment at the top.
+	var/donators = "###############################################################################################\n# List for people who support us! They get cool loadout items                                 #\n# Case is not important for ckey.                                                             #\n###############################################################################################\n"
+	for(var/veteran in GLOB.donator_list)
+		donators += veteran + "\n"
+	rustg_file_write(donators, DONATORLISTFILE)
+
 #undef DONATORLISTFILE

--- a/modular_skyrat/modules/customization/modules/admin/donator_list.dm
+++ b/modular_skyrat/modules/customization/modules/admin/donator_list.dm
@@ -14,8 +14,8 @@ GLOBAL_LIST(donator_list)
 /proc/save_donators()
 	/// Yes, this is incredibly long, deal with it. It's to keep that cute little comment at the top.
 	var/donators = "###############################################################################################\n# List for people who support us! They get cool loadout items                                 #\n# Case is not important for ckey.                                                             #\n###############################################################################################\n"
-	for(var/veteran in GLOB.donator_list)
-		donators += veteran + "\n"
+	for(var/donator in GLOB.donator_list)
+		donators += donator + "\n"
 	rustg_file_write(donators, DONATORLISTFILE)
 
 #undef DONATORLISTFILE

--- a/modular_skyrat/modules/veteran_players/code/veteran_players.dm
+++ b/modular_skyrat/modules/veteran_players/code/veteran_players.dm
@@ -11,6 +11,12 @@ GLOBAL_LIST(veteran_players)
 			continue
 		GLOB.veteran_players[ckey(line)] = TRUE //Associative so we can check it much faster
 
+/proc/save_veteran_players()
+	var/veteran_list = ""
+	for(var/veteran in GLOB.veteran_players)
+		veteran_list += veteran + "\n"
+	rustg_file_write(veteran_list, VETERANPLAYERS)
+
 /proc/is_veteran_player(client/user)
 	if(GLOB.veteran_players[user.ckey])
 		return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3912,6 +3912,7 @@
 #include "modular_skyrat\modules\admin\code\adminhelp.dm"
 #include "modular_skyrat\modules\admin\code\aooc.dm"
 #include "modular_skyrat\modules\admin\code\loud_say.dm"
+#include "modular_skyrat\modules\admin\code\manage_player_ranks.dm"
 #include "modular_skyrat\modules\admin\code\sooc.dm"
 #include "modular_skyrat\modules\admin\code\smites\pie.dm"
 #include "modular_skyrat\modules\advanced_choice_beacons\code\advanced_choice_beacon.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is a new verb to allow those with the `+PERMISSIONS` to edit "player" ranks (not to be confused with admin ranks, they're all unique and separate from one another) on the server, with changes that should take effect instantly.

It works for Donators, Mentors and Veterans so far, and it shouldn't be too hard to add some more.

**Test-merge this first, to be sure that it doesn't accidentally nuke the donator, mentor and veteran lists. Making a backup is _highly_ suggested too. I did a lot of testing, but you never know. Better be safe than sorry.**

Here's what it looks like, and then there's another window to choose betting `Add` and `Remove`, and then it's a text field to enter the ckey.
![image](https://user-images.githubusercontent.com/58045821/129493593-1b06a2fb-0166-431c-ba94-b6403165cf14.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more need to wait a couple of days for someone with machine access to add your name to a file to get the benefits in-game, it can now be done easily by Staff Managers and above!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex
admin: Added a Manage Player Ranks verb for those with the +PERMISSIONS flag, to allow for easy in-game editing of the donator, mentor and veteran members.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
