### PR TITLE
Minor beret fixes

### DIFF
--- a/code/modules/clothing/spacesuits/specialops.dm
+++ b/code/modules/clothing/spacesuits/specialops.dm
@@ -2,6 +2,8 @@
 	name = "officer's beret"
 	desc = "An armored beret commonly used by special operations officers. Uses advanced force field technology to protect the head from space."
 	icon_state = "beret_badge"
+	greyscale_config = /datum/greyscale_config/beret_badge
+	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
 	greyscale_colors = "#972A2A#F2F2F2"
 	dynamic_hair_suffix = "+generic"
 	dynamic_fhair_suffix = "+generic"

--- a/modular_skyrat/modules/berets/code/modules/clothing/head/jobs.dm
+++ b/modular_skyrat/modules/berets/code/modules/clothing/head/jobs.dm
@@ -92,7 +92,7 @@
 /obj/item/clothing/head/beret/medical/cmo
 	name = "chief medical officer's beret"
 	desc = "A beret custom-fit to the Chief Medical Officer, repaired once or twice after Runtime got a hold of it."
-	greyscale_colors = "#679CFE#34CCEE"
+	greyscale_colors = "#3299CC#34CCEE"
 
 /obj/item/clothing/head/beret/medical/cmo/alt
 	name = "chief medical officer's beret"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Before you ask, no, I didn't put the modular thing on the specialops.dm file, because I'll PR it upstream too, but I just didn't want this to just be changing the color, I want berets to be fully fixed.

Basically, the space beret actually has a sprite now, and the CMO beret has a more decent color.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less error sprites, better colors.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex, with some help from AlexPlayz for finding the bugs
fix: Space-proof beret now actually appears to have been made into a beret, instead of a reality-bending bunch of letters.
fix: CMO's beret received a new coat of paint, making it fit with the rest of their clothes a lot better.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
