### PR TITLE
[MOSTLY NON-MODULAR] Hypovials can be printed from ChemMasters and pill presses. 

### DIFF
--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -3,6 +3,7 @@
 	name = "chemical press"
 	desc = "A press that makes pills, patches and bottles."
 	icon_state = "pill_press"
+	buffer = 60 //SKYRAT EDIT HYPOVIALS. This is needed so it can completely fill the vials up.
 
 	///maximum size of a pill
 	var/max_pill_volume = 50
@@ -10,6 +11,8 @@
 	var/max_patch_volume = 40
 	///maximum size of a bottle
 	var/max_bottle_volume = 30
+	//SKYRAT EDIT HYPOVIALS maximum size of a vial
+	var/max_vial_volume = 60
 	///current operating product (pills or patches)
 	var/product = "pill"
 	///the minimum size a pill or patch can be
@@ -72,6 +75,13 @@
 			reagents.trans_to(P, current_volume)
 			P.name = trim("[product_name] bottle")
 			stored_products += P
+		//SKYRAT EDIT HYPOVIALS
+		else if (product == "vial")
+			var/obj/item/reagent_containers/glass/bottle/vial/small/P = new(src)
+			reagents.trans_to(P, current_volume)
+			P.name = trim("[product_name] vial")
+			stored_products += P
+		//SKYRAT EDIT HYPOVIALS END 
 	if(stored_products.len)
 		var/pill_amount = 0
 		for(var/thing in loc)
@@ -128,4 +138,8 @@
 				max_volume = max_patch_volume
 			else if (product == "bottle")
 				max_volume = max_bottle_volume
+			//SKYRAT EDIT HYPOVIALS
+			else if (product == "vial")
+				max_volume = max_vial_volume
+			//SKYRAT EDIT HPYOVIALS END
 			current_volume = clamp(current_volume, min_volume, max_volume)

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -312,6 +312,10 @@
 			vol_each_max = min(40, vol_each_max)
 		else if (item_type == "bottle")
 			vol_each_max = min(30, vol_each_max)
+		//SKYRAT EDIT ADDITION START - HYPOVIALS
+		else if (item_type == "vial")
+			vol_each_max = min(60, vol_each_max)
+		//SKYRAT EDIT ADDITION END - HYPOVIALS
 		else if (item_type == "condimentPack")
 			vol_each_max = min(10, vol_each_max)
 		else if (item_type == "condimentBottle")
@@ -392,6 +396,15 @@
 				P.name = trim("[name] bottle")
 				adjust_item_drop_location(P)
 				reagents.trans_to(P, vol_each, transfered_by = usr)
+		//SKYRAT EDIT ADDTION HYPOVIALS START
+		if(item_type == "vial")
+			var/obj/item/reagent_containers/glass/bottle/vial/small/P
+			for(var/i = 0; i < amount; i++)
+				P = new/obj/item/reagent_containers/glass/bottle/vial/small(drop_location())
+				P.name = trim("[name] vial")
+				adjust_item_drop_location(P)
+				reagents.trans_to(P, vol_each, transfered_by = usr)
+		//SKYRAT EDIT ADDTION HYPOVIALS END
 			return TRUE
 		if(item_type == "condimentPack")
 			var/obj/item/reagent_containers/food/condiment/pack/P

--- a/modular_skyrat/modules/hyposprays/code/game/autolathe_designs.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/autolathe_designs.dm
@@ -1,12 +1,3 @@
-/datum/design/hypovialsmall
-	name = "Hypovial"
-	id = "hypovial"
-	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 500)
-	build_path = /obj/item/reagent_containers/glass/bottle/vial/small
-	category = list("initial","Medical","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-
 /datum/design/hypoviallarge
 	name = "Large Hypovial"
 	id = "large_hypovial"

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -230,12 +230,12 @@ const PackagingControls = (props, context) => {
     bottleAmount,
     setBottleAmount,
   ] = useSharedState(context, 'bottleAmount', 1);
-  //SKYRAT EDIT HYPOVIALS
+  // SKYRAT EDIT HYPOVIALS
   const [
     vialAmount,
     setVialAmount,
   ] = useSharedState(context, 'vialAmount', 1);
-  //SKYRAT EDIT END
+  // SKYRAT EDIT END
   const [
     packAmount,
     setPackAmount,
@@ -316,7 +316,7 @@ const PackagingControls = (props, context) => {
             type: 'vial',
             amount: vialAmount,
             volume: 'auto',
-          })} /> //SKYRAT EDIT HYPOVIALS END
+          })} /> // SKYRAT EDIT HYPOVIALS END
       )} 
       {!!condi && (
         <LabeledList.Item label="Bottle type">

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -230,6 +230,12 @@ const PackagingControls = (props, context) => {
     bottleAmount,
     setBottleAmount,
   ] = useSharedState(context, 'bottleAmount', 1);
+  //SKYRAT EDIT HYPOVIALS
+  const [
+    vialAmount,
+    setVialAmount,
+  ] = useSharedState(context, 'vialAmount', 1);
+  //SKYRAT EDIT END
   const [
     packAmount,
     setPackAmount,
@@ -299,6 +305,19 @@ const PackagingControls = (props, context) => {
             volume: 'auto',
           })} />
       )}
+      {!condi && ( // SKYRAT EDIT HYPOVIALS
+        <PackagingControlsItem 
+          label="Hypovials"
+          amount={vialAmount}
+          amountUnit="vials"
+          sideNote="max 60u"
+          onChangeAmount={(e, value) => setVialAmount(value)}
+          onCreate={() => act('create', {
+            type: 'vial',
+            amount: vialAmount,
+            volume: 'auto',
+          })} /> //SKYRAT EDIT HYPOVIALS END
+      )} 
       {!!condi && (
         <LabeledList.Item label="Bottle type">
           <Button.Checkbox

--- a/tgui/packages/tgui/interfaces/ChemPress.js
+++ b/tgui/packages/tgui/interfaces/ChemPress.js
@@ -42,6 +42,13 @@ export const ChemPress = (props, context) => {
                   product: "bottle",
                 })}
               />
+              <Button.Checkbox
+                content="Vials"
+                checked={product === "vial"}
+                onClick={() => act('change_product', {
+                  product: "vial",
+                })}
+              />
             </LabeledList.Item>
             <LabeledList.Item label="Volume">
               <NumberInput


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lets ChemMasters, along with pill presses, make small hypovials like they could on oldbase.
![image](https://user-images.githubusercontent.com/68373373/129627772-b49ac5c9-8005-45f7-bb98-5370fee8c30c.png)
![image](https://user-images.githubusercontent.com/68373373/129627857-839608dd-31f0-42a5-8f37-b21fd92cf29b.png)
 Because of this, small vials have been removed from the autolathe. In order to allow the pill press machines to make hypovials, the buffer capacity on them has been increased to 60 (from 50)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes hypovials function closer to how they did on oldbase and hopefully makes them easier to use.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed small hypovials from the autolathe
qol: Hypovials can now be produced by ChemMasters and pill presses, like on oldbase.
balance: Pill presses now have a buffer of 60 to accommodate for hypovials. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
