### PR TITLE
[SEMI-MODULAR] Adds an override to allow the use of icon2html RARELY when we need it, fixing in the same swoop the in-game GAGS coloring screen

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1053,9 +1053,12 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 	dummySave = null
 	fdel("tmp/dummySave.sav") //if you get the idea to try and make this more optimized, make sure to still call unlock on the savefile after every write to unlock it.
 
-/proc/icon2html(thing, target, icon_state, dir = SOUTH, frame = 1, moving = FALSE, sourceonly = FALSE, extra_classes = null)
+/proc/icon2html(thing, target, icon_state, dir = SOUTH, frame = 1, moving = FALSE, sourceonly = FALSE, extra_classes = null, override_skyrat = FALSE) /// SKYRAT EDIT - icon2html override instead of fully disabling it - Original: /proc/icon2html(thing, target, icon_state, dir = SOUTH, frame = 1, moving = FALSE, sourceonly = FALSE, extra_classes = null)
+	// SKYRAT EDIT START - icon2html override instead of fully disabling it
+	if(!override_skyrat)
 		return "" //SKYRAT EDIT DISABLE - ICON2HTML
-/*
+	// SKYRAT EDIT END
+
 	if (!thing)
 		return
 	if(SSlag_switch.measures[DISABLE_USR_ICON2HTML] && usr && !HAS_TRAIT(usr, TRAIT_BYPASS_MEASURES))
@@ -1123,7 +1126,7 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 	if(sourceonly)
 		return SSassets.transport.get_asset_url(key)
 	return "<img class='[extra_classes] icon icon-[icon_state]' src='[SSassets.transport.get_asset_url(key)]'>"
-*/
+
 
 /proc/icon2base64html(thing)
 	if (!thing)

--- a/code/modules/admin/greyscale_modify_menu.dm
+++ b/code/modules/admin/greyscale_modify_menu.dm
@@ -240,6 +240,15 @@ This is highly likely to cause a lag spike for a few seconds."},
 			var/list/step_data = data["steps"][step]
 			var/image/layer = image(step)
 			var/image/result = step_data["result"]
+			// SKYRAT EDIT BEGIN - Bringing back the GAGS coloring menu - ORIGINAL:
+			/*
+			steps += list(
+				list(
+					"layer"=icon2html(layer, user, dir=sprite_dir, sourceonly=TRUE, override_skyrat = TRUE),
+					"result"=icon2html(result, user, dir=sprite_dir, sourceonly=TRUE, override_skyrat = TRUE),
+					"config_name"=step_data["config_name"]
+				)
+			)*/
 			steps += list(
 				list(
 					"layer"=icon2html(layer, user, dir=sprite_dir, sourceonly=TRUE, override_skyrat = TRUE),
@@ -247,6 +256,7 @@ This is highly likely to cause a lag spike for a few seconds."},
 					"config_name"=step_data["config_name"]
 				)
 			)
+			// SKYRAT EDIT END
 
 	sprite_data["time_spent"] = TICK_DELTA_TO_MS(time_spent)
 	sprite_data["finished"] = icon2html(finished, user, dir=sprite_dir, sourceonly=TRUE, override_skyrat = TRUE)

--- a/code/modules/admin/greyscale_modify_menu.dm
+++ b/code/modules/admin/greyscale_modify_menu.dm
@@ -242,14 +242,14 @@ This is highly likely to cause a lag spike for a few seconds."},
 			var/image/result = step_data["result"]
 			steps += list(
 				list(
-					"layer"=icon2html(layer, user, dir=sprite_dir, sourceonly=TRUE),
-					"result"=icon2html(result, user, dir=sprite_dir, sourceonly=TRUE),
+					"layer"=icon2html(layer, user, dir=sprite_dir, sourceonly=TRUE, override_skyrat = TRUE),
+					"result"=icon2html(result, user, dir=sprite_dir, sourceonly=TRUE, override_skyrat = TRUE),
 					"config_name"=step_data["config_name"]
 				)
 			)
 
 	sprite_data["time_spent"] = TICK_DELTA_TO_MS(time_spent)
-	sprite_data["finished"] = icon2html(finished, user, dir=sprite_dir, sourceonly=TRUE)
+	sprite_data["finished"] = icon2html(finished, user, dir=sprite_dir, sourceonly=TRUE, override_skyrat = TRUE)
 	refreshing = FALSE
 
 /datum/greyscale_modify_menu/proc/Unlock()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
icon2html is laggy, but in some cases, we might want to still use it regardless, because it would be at a very small scale.
For instance, a good example of that would be the GAGS coloring window in-game, which allows you to preview the color modifications that you're making to a greyscale item. Very cool and useful, and necessary if we want to add GAGS support to our loadout.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You'll now be able to use the GAGS coloring menu in-game again, hurray!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex
fix: Nanotrasen realized that not being able to preview color changes that were to be applied to the items they were hoping to sell in their vendors has drastically reduced interest in those items. They hope to bring back interest on them by enabling the preview once again.
code: icon2html now supports an override to use it even if it's meant to be disabled on here.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
