### PR TITLE
[Modularr] Removes Downtown Special traitor bundle

### DIFF
--- a/modular_skyrat/modules/moretraitoritems/code/game/objects/items/storage/syndicate_loadout.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/game/objects/items/storage/syndicate_loadout.dm
@@ -89,7 +89,8 @@
 	new /obj/item/clothing/gloves/color/latex/nitrile(src)
 	new /obj/item/clothing/mask/gas/clown_hat(src)
 	new /obj/item/clothing/under/syndicate/sniper(src)
-	new /obj/item/kitchen/knife/combat/survival(src)*/
+	new /obj/item/kitchen/knife/combat/survival(src)
+*/
 
 /obj/item/storage/backpack/duffelbag/syndie/loadout/metaops/PopulateContents()
 	new /obj/item/clothing/suit/space/hardsuit/syndi(src)
@@ -209,7 +210,8 @@
 	new /obj/item/storage/fancy/candle_box(src)
 	new /obj/item/clothing/glasses/sunglasses(src)
 	new /obj/item/lighter(src)
-	new /obj/item/storage/fancy/cigarettes/cigars/cohiba(src)*/
+	new /obj/item/storage/fancy/cigarettes/cigars/cohiba(src)
+*/
 
 /obj/item/storage/box/syndie_kit/loadout/ocelotfoxtrot/PopulateContents()
 	new /obj/item/gun/ballistic/revolver/ocelot(src)

--- a/modular_skyrat/modules/moretraitoritems/code/game/objects/items/storage/syndicate_loadout.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/game/objects/items/storage/syndicate_loadout.dm
@@ -76,7 +76,7 @@
 	new /obj/item/camera_bug(src)
 	new /obj/item/clothing/glasses/thermal/syndi(src)
 	new /obj/item/card/id/advanced/chameleon(src)
-/*
+
 /obj/item/storage/backpack/duffelbag/syndie/loadout/sniper/PopulateContents()
 	new /obj/item/gun/ballistic/automatic/sniper_rifle/modular/blackmarket(src)
 	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
@@ -90,7 +90,6 @@
 	new /obj/item/clothing/mask/gas/clown_hat(src)
 	new /obj/item/clothing/under/syndicate/sniper(src)
 	new /obj/item/kitchen/knife/combat/survival(src)
-*/
 
 /obj/item/storage/backpack/duffelbag/syndie/loadout/metaops/PopulateContents()
 	new /obj/item/clothing/suit/space/hardsuit/syndi(src)
@@ -195,23 +194,6 @@
 	new /obj/item/toy/balloon/syndicate(src)
 	new /obj/item/storage/box/fakesyndiesuit(src)
 	new /obj/item/storage/box/donkpockets(src)
-/*
-/obj/item/storage/backpack/duffelbag/syndie/loadout/downtownspecial/PopulateContents()
-	new /obj/item/gun/ballistic/automatic/tommygun/therealtommy(src)
-	new /obj/item/ammo_box/magazine/tommygunm45(src)
-	new /obj/item/clothing/suit/det_suit/noir/mafioso(src)
-	new /obj/item/clothing/under/suit/blacktwopiece/armoured(src)
-	new /obj/item/clothing/mask/fakemoustache/italian(src)
-	new /obj/item/switchblade(src)
-	new /obj/item/clothing/shoes/laceup(src)
-	new /obj/item/virgin_mary(src)
-	new /obj/item/reagent_containers/food/drinks/bottle/whiskey(src)
-	new /obj/item/storage/box/drinkingglasses(src)
-	new /obj/item/storage/fancy/candle_box(src)
-	new /obj/item/clothing/glasses/sunglasses(src)
-	new /obj/item/lighter(src)
-	new /obj/item/storage/fancy/cigarettes/cigars/cohiba(src)
-*/
 
 /obj/item/storage/box/syndie_kit/loadout/ocelotfoxtrot/PopulateContents()
 	new /obj/item/gun/ballistic/revolver/ocelot(src)

--- a/modular_skyrat/modules/moretraitoritems/code/game/objects/items/storage/syndicate_loadout.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/game/objects/items/storage/syndicate_loadout.dm
@@ -76,7 +76,7 @@
 	new /obj/item/camera_bug(src)
 	new /obj/item/clothing/glasses/thermal/syndi(src)
 	new /obj/item/card/id/advanced/chameleon(src)
-
+/*
 /obj/item/storage/backpack/duffelbag/syndie/loadout/sniper/PopulateContents()
 	new /obj/item/gun/ballistic/automatic/sniper_rifle/modular/blackmarket(src)
 	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
@@ -89,7 +89,7 @@
 	new /obj/item/clothing/gloves/color/latex/nitrile(src)
 	new /obj/item/clothing/mask/gas/clown_hat(src)
 	new /obj/item/clothing/under/syndicate/sniper(src)
-	new /obj/item/kitchen/knife/combat/survival(src)
+	new /obj/item/kitchen/knife/combat/survival(src)*/
 
 /obj/item/storage/backpack/duffelbag/syndie/loadout/metaops/PopulateContents()
 	new /obj/item/clothing/suit/space/hardsuit/syndi(src)
@@ -194,7 +194,7 @@
 	new /obj/item/toy/balloon/syndicate(src)
 	new /obj/item/storage/box/fakesyndiesuit(src)
 	new /obj/item/storage/box/donkpockets(src)
-
+/*
 /obj/item/storage/backpack/duffelbag/syndie/loadout/downtownspecial/PopulateContents()
 	new /obj/item/gun/ballistic/automatic/tommygun/therealtommy(src)
 	new /obj/item/ammo_box/magazine/tommygunm45(src)
@@ -209,7 +209,7 @@
 	new /obj/item/storage/fancy/candle_box(src)
 	new /obj/item/clothing/glasses/sunglasses(src)
 	new /obj/item/lighter(src)
-	new /obj/item/storage/fancy/cigarettes/cigars/cohiba(src)
+	new /obj/item/storage/fancy/cigarettes/cigars/cohiba(src)*/
 
 /obj/item/storage/box/syndie_kit/loadout/ocelotfoxtrot/PopulateContents()
 	new /obj/item/gun/ballistic/revolver/ocelot(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tommy gun from the Downtown Special bundle is a lag-machine that will hard-lock and fuck up people's games, making it able to lag someone on a single hit and make them unable to react at all due to the way the bullets runtime. As such, this PR removes it completely

## Why It's Good For The Game
A gun that lags you to death isn't fun, fair, or interesting.

## Changelog
:cl:
balance: removes the Downtown Special traitor bundle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
