### PR TITLE
[MODULAR][Balance] more Medigun Balance.

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -58,6 +58,13 @@
 		return
 	if(target.stat == DEAD)
 		return
+	//DISGUST 
+	if(target.getBruteLoss() > 49)
+		target.adjust_disgust(1.5) 
+	if(target.getBruteLoss() > 99)
+		target.adjust_disgust(1.5)
+	target.adjust_disgust(3)
+	//CLONE
 	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )
 		target.adjustCloneLoss(2.45)
 	if(target.getBruteLoss() > 99)
@@ -78,7 +85,14 @@
 		return
 	if(target.stat == DEAD)
 		return
-	if(target.getFireLoss() > 49 && target.geFireLoss() < 100 )
+	//DISGUST 
+	if(target.getFireLoss() > 49)
+		target.adjust_disgust(1.5) 
+	if(target.getFireLoss() > 99)
+		target.adjust_disgust(1.5)
+	target.adjust_disgust(3)
+	//CLONE
+	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )
 		target.adjustCloneLoss(2.45)
 	if(target.getFireLoss() > 99)
 		target.adjustCloneLoss(4.9)
@@ -118,6 +132,13 @@
 		return
 	if(target.stat == DEAD)
 		return
+	//DISGUST 
+	if(target.getBruteLoss() > 49)
+		target.adjust_disgust(1.5) 
+	if(target.getBruteLoss() > 99)
+		target.adjust_disgust(1.5)
+	target.adjust_disgust(2)
+	//CLONE
 	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )
 		target.adjustCloneLoss(1.9)
 	if(target.getBruteLoss() > 99)
@@ -138,6 +159,13 @@
 		return
 	if(target.stat == DEAD)
 		return
+	//DISGUST 
+	if(target.getFireLoss() > 49)
+		target.adjust_disgust(1.5) 
+	if(target.getFireLoss() > 99)
+		target.adjust_disgust(1.5)
+	target.adjust_disgust(2)
+	//CLONE
 	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )
 		target.adjustCloneLoss(1.9)
 	if(target.getFireLoss() > 99)
@@ -191,6 +219,13 @@
 		return
 	if(target.stat == DEAD)
 		return
+	//DISGUST 
+	if(target.getBruteLoss() > 49)
+		target.adjust_disgust(1.5) 
+	if(target.getBruteLoss() > 99)
+		target.adjust_disgust(1.5)
+	target.adjust_disgust(1)
+	//CLONE
 	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )
 		target.adjustCloneLoss(1.125)
 	if(target.getBruteLoss() > 99)
@@ -211,6 +246,13 @@
 		return
 	if(target.stat == DEAD)
 		return
+	//DISGUST 
+	if(target.getFireLoss() > 49)
+		target.adjust_disgust(1.5) 
+	if(target.getFireLoss() > 99)
+		target.adjust_disgust(1.5)
+	target.adjust_disgust(1)
+	//CLONE
 	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )
 		target.adjustCloneLoss(1.125)
 	if(target.getFireLoss() > 99)

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -58,6 +58,10 @@
 		return
 	if(target.stat == DEAD)
 		return
+	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )
+		target.adjustCloneLoss(2.45)
+	if(target.getBruteLoss() > 99)
+		target.adjustCloneLoss(4.9)
 	target.adjustBruteLoss(-7.5)
 //The Basic Burn Heal//
 /obj/item/ammo_casing/energy/medical/burn1
@@ -74,6 +78,10 @@
 		return
 	if(target.stat == DEAD)
 		return
+	if(target.getFireLoss() > 49 && target.geFireLoss() < 100 )
+		target.adjustCloneLoss(2.45)
+	if(target.getFireLoss() > 99)
+		target.adjustCloneLoss(4.9)
 	target.adjustFireLoss(-7.5)
 
 //Basic Toxin Heal//
@@ -110,6 +118,10 @@
 		return
 	if(target.stat == DEAD)
 		return
+	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )
+		target.adjustCloneLoss(1.9)
+	if(target.getBruteLoss() > 99)
+		target.adjustCloneLoss(3.8)
 	target.adjustBruteLoss(-11.25)
 //Tier II Burn Projectile//
 /obj/item/ammo_casing/energy/medical/burn2
@@ -126,6 +138,10 @@
 		return
 	if(target.stat == DEAD)
 		return
+	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )
+		target.adjustCloneLoss(1.9)
+	if(target.getFireLoss() > 99)
+		target.adjustCloneLoss(3.8)
 	target.adjustFireLoss(-11.25)
 //Tier II Oxy Projectile//
 /obj/item/ammo_casing/energy/medical/oxy2
@@ -175,6 +191,10 @@
 		return
 	if(target.stat == DEAD)
 		return
+	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )
+		target.adjustCloneLoss(1.125)
+	if(target.getBruteLoss() > 99)
+		target.adjustCloneLoss(2.25)
 	target.adjustBruteLoss(-15)
 //Tier III Burn Projectile//
 /obj/item/ammo_casing/energy/medical/burn3
@@ -191,6 +211,10 @@
 		return
 	if(target.stat == DEAD)
 		return
+	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )
+		target.adjustCloneLoss(1.125)
+	if(target.getFireLoss() > 99)
+		target.adjustCloneLoss(2.25)
 	target.adjustFireLoss(-15)
 //Tier III Oxy Projectile//
 /obj/item/ammo_casing/energy/medical/oxy3

--- a/modular_skyrat/modules/modular_weapons/code/modules/research/designs/mediguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/research/designs/mediguns.dm
@@ -5,6 +5,7 @@
 	id = "brute2medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000)
+	reagents_list = list(/datum/reagent/medicine/c2/libital = 10)
 	build_path = /obj/item/medicell/brute2
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
@@ -15,6 +16,7 @@
 	id = "burn2medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000)
+	reagents_list = list(/datum/reagent/medicine/c2/aiuri = 10)
 	build_path = /obj/item/medicell/burn2
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
@@ -25,6 +27,7 @@
 	id = "toxin2medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000)
+	reagents_list = list(/datum/reagent/medicine/c2/multiver = 10)
 	build_path = /obj/item/medicell/toxin2
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
@@ -35,6 +38,7 @@
 	id = "oxy2medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000)
+	reagents_list = list(/datum/reagent/medicine/c2/convermol = 10)
 	build_path = /obj/item/medicell/oxy2
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL

--- a/modular_skyrat/modules/modular_weapons/code/modules/research/designs/mediguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/research/designs/mediguns.dm
@@ -50,6 +50,7 @@
 	id = "brute3medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000, /datum/material/diamond = 500)
+	reagents_list = list(/datum/reagent/medicine/sal_acid = 10)
 	build_path = /obj/item/medicell/brute3
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
@@ -60,6 +61,7 @@
 	id = "burn3medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 3000, /datum/material/glass = 3000, /datum/material/plasma = 1000, /datum/material/diamond = 500)
+	reagents_list = list(/datum/reagent/medicine/oxandrolone = 10)
 	build_path = /obj/item/medicell/burn3
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
@@ -70,6 +72,7 @@
 	id = "toxin3medicell"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 3000, /datum/material/glass = 3000, /datum/material/plasma = 1000, /datum/material/diamond = 500)
+	reagents_list = list(/datum/reagent/medicine/pen_acid = 10)
 	build_path = /obj/item/medicell/toxin3
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
@@ -81,6 +84,7 @@
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 2000, /datum/material/glass = 2000, /datum/material/plasma = 1000, /datum/material/diamond = 500)
 	build_path = /obj/item/medicell/oxy3
+	reagents_list = list(/datum/reagent/medicine/salbutamol = 10)
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 //Upgrade Kit//


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**PLEASE TESTMERGE THIS BEFORE FULL MERGING** 

Balances the Brute and Burn cells on the medigun by giving them nausea and clone damage. All cells now also require healing chems to create. These changes should hopefully make the medigun into less of a magic healing gun, and more of an experimental medical tool.

Please leave feedback at the Medigun Discussion channel under the Sci-Med-Eng channel on discord, I am open to making changes.
## How the Clone damage works
If healing a patient over a certain damage type threshold, a percentage of that shot's healing is applied as clone damage. 
Here are the current values. These only apply to the brute/burn modes:

- Tier 1 cells 
  - 33% (2.45) done back as clone damage per shot when healing 50-99 damage
  - 66% (4.9) done back as clone damage per shot when healing 100+ damage

- Tier 2 cells 
  - 15% (1.9) done back as clone damage per shot when healing 50-99 damage
  - 33% (3.8) done back as clone damage per shot when healing 100+ damage

- Tier 3 cells 
  - 7.5% (1.125) done back as clone damage per shot when healing 50-99 damage
  - 15% (2.25) done back as clone damage per shot when healing 100+ damage
  
The idea behind this is to make bringing someone back from heavy brute/burn damage with the Medigun a temporary solution. Right now, only cryo treatment and rezadone can heal clone damage. If you are using the medigun to patch up minor wounds, this isn't going to affect you. 

## Nausea
Each shot does a default amount of nausea damage, this damage can increase if trying to heal someone with high damage (similar to how the clone function works.) The amount of nausea damage is decreased when using higher tier cells. I still need to test more to see how this affects people, and to see if I need to buff or nerf the effect.

This isn't supposed to be a major downside, but more of an RP reason to discourage Medical staff from randomly firing Mediguns at people. This also only applies to the brute/burn cells at the moment. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Chemicals to make cells

From now on, chemicals are going to be required to make cells. This should hopefully get chemistry involved with the medigun system to some extent. 
## Why It's Good For The Game
This should hopefully improve some of the balance problems that Mediguns have, while giving it more of it's own identity. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: see #7628
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
