### PR TITLE
[MODULAR] [READY] Fixes all the e_gun subtypes using the AC-2 worn sprite

### DIFF
--- a/modular_skyrat/modules/aesthetics/guns/code/guns.dm
+++ b/modular_skyrat/modules/aesthetics/guns/code/guns.dm
@@ -144,7 +144,6 @@
 	icon_state = "laser"
 
 /obj/item/gun/energy/e_gun/nuclear/emag_act(mob/user, obj/item/card/emag/E)
-//nuclear/emag_act(mob/user, obj/item/card/emag/E)
 	. = ..()
 	if(pin)
 		to_chat(user, "<span class='warning'>You probably want to do this on a new gun!")

--- a/modular_skyrat/modules/aesthetics/guns/code/guns.dm
+++ b/modular_skyrat/modules/aesthetics/guns/code/guns.dm
@@ -143,6 +143,7 @@
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/nucgun.dmi'
 	icon_state = "laser"
 
+/obj/item/gun/energy/e_gun/nuclear/emag_act(mob/user, obj/item/card/emag/E)
 //nuclear/emag_act(mob/user, obj/item/card/emag/E)
 	. = ..()
 	if(pin)

--- a/modular_skyrat/modules/aesthetics/guns/code/guns.dm
+++ b/modular_skyrat/modules/aesthetics/guns/code/guns.dm
@@ -6,6 +6,34 @@
 	worn_icon_state = "energy"
 	ammo_x_offset = 2
 
+/obj/item/gun/energy/e_gun/advtaser
+	worn_icon = null
+	worn_icon_state = "gun"
+
+/obj/item/gun/energy/e_gun/cfa_phalanx
+	worn_icon = null
+	worn_icon_state = "gun"
+
+/obj/item/gun/energy/e_gun/mini
+	worn_icon = null
+	worn_icon_state = "gun"
+
+/obj/item/gun/energy/e_gun/stun
+	worn_icon = null
+	worn_icon_state = "gun"
+
+/obj/item/gun/energy/e_gun/old
+	worn_icon = null
+	worn_icon_state = "gun"
+
+/obj/item/gun/energy/e_gun/hos
+	worn_icon = null
+	worn_icon_state = "gun"
+
+/obj/item/gun/energy/e_gun/dragnet
+	worn_icon = null
+	worn_icon_state = "gun"
+
 /obj/item/gun/energy/ionrifle
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/energy.dmi'
 	lefthand_file = 'modular_skyrat/modules/aesthetics/guns/icons/guns_lefthand.dmi'
@@ -80,6 +108,7 @@
 	ammo_x_offset = 2
 	lefthand_file = 'modular_skyrat/modules/aesthetics/guns/icons/guns_lefthand.dmi'
 	righthand_file = 'modular_skyrat/modules/aesthetics/guns/icons/guns_righthand.dmi'
+	worn_icon_state = "gun"
 
 /obj/item/gun/energy/lasercannon
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/energy.dmi'
@@ -94,6 +123,7 @@
 	name = "fantastic energy gun"
 	desc = "An energy gun with an experimental miniaturized nuclear reactor that automatically charges the internal power cell. This one seems quite fancy!"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/rainbow, /obj/item/ammo_casing/energy/disabler/rainbow)
+	worn_icon_state = "gun"
 
 /obj/item/ammo_casing/energy/laser/rainbow
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/nucgun.dmi'

--- a/modular_skyrat/modules/aesthetics/guns/code/guns.dm
+++ b/modular_skyrat/modules/aesthetics/guns/code/guns.dm
@@ -109,6 +109,7 @@
 	lefthand_file = 'modular_skyrat/modules/aesthetics/guns/icons/guns_lefthand.dmi'
 	righthand_file = 'modular_skyrat/modules/aesthetics/guns/icons/guns_righthand.dmi'
 	worn_icon_state = "gun"
+	worn_icon = null
 
 /obj/item/gun/energy/lasercannon
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/energy.dmi'
@@ -123,7 +124,6 @@
 	name = "fantastic energy gun"
 	desc = "An energy gun with an experimental miniaturized nuclear reactor that automatically charges the internal power cell. This one seems quite fancy!"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/rainbow, /obj/item/ammo_casing/energy/disabler/rainbow)
-	worn_icon_state = "gun"
 
 /obj/item/ammo_casing/energy/laser/rainbow
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/nucgun.dmi'
@@ -143,7 +143,7 @@
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/nucgun.dmi'
 	icon_state = "laser"
 
-/obj/item/gun/energy/e_gun/nuclear/emag_act(mob/user, obj/item/card/emag/E)
+//nuclear/emag_act(mob/user, obj/item/card/emag/E)
 	. = ..()
 	if(pin)
 		to_chat(user, "<span class='warning'>You probably want to do this on a new gun!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title.

## Why It's Good For The Game

uhh, they shouldn't be using it?

## Changelog
:cl:
fix: fixed e_gun subtypes using the AC-2 worn icon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
