### PR TITLE
[MODULAR] Ghost Cafe Visitors will now always get their chameleon clothes box

### DIFF
--- a/modular_skyrat/modules/ghostcafe/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_skyrat/modules/ghostcafe/code/game/objects/structures/ghost_role_spawners.dm
@@ -64,7 +64,7 @@
 		to_chat(new_spawn,"<span class='warning'><b>Ghosting is free!</b></span>")
 		//to_chat(new_spawn,"<span class='narsiesmall'>Be warned: People who opt out of EORG will come here. Do not make the area uninhabitable and do NOT commit EORG. This is a safe-zone. If you attack people in EORG, you will be banned for griefing.</span>")
 		var/datum/action/toggle_dead_chat_mob/D = new(new_spawn)
-		new_spawn.put_in_hand(new /obj/item/storage/box/syndie_kit/chameleon/ghostcafe, RIGHT_HANDS, forced = TRUE)
+		new_spawn.put_in_hand(new /obj/item/storage/box/syndie_kit/chameleon/ghostcafe, LEFT_HANDS, forced = TRUE)
 		D.Grant(new_spawn)
 
 /datum/outfit/ghostcafe

--- a/modular_skyrat/modules/ghostcafe/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_skyrat/modules/ghostcafe/code/game/objects/structures/ghost_role_spawners.dm
@@ -64,13 +64,13 @@
 		to_chat(new_spawn,"<span class='warning'><b>Ghosting is free!</b></span>")
 		//to_chat(new_spawn,"<span class='narsiesmall'>Be warned: People who opt out of EORG will come here. Do not make the area uninhabitable and do NOT commit EORG. This is a safe-zone. If you attack people in EORG, you will be banned for griefing.</span>")
 		var/datum/action/toggle_dead_chat_mob/D = new(new_spawn)
+		new_spawn.put_in_hand(new /obj/item/storage/box/syndie_kit/chameleon/ghostcafe, RIGHT_HANDS, forced = TRUE)
 		D.Grant(new_spawn)
 
 /datum/outfit/ghostcafe
 	name = "ID, jumpsuit and shoes"
 	uniform = /obj/item/clothing/under/color/random
 	shoes = /obj/item/clothing/shoes/sneakers/black
-	r_hand = /obj/item/storage/box/syndie_kit/chameleon/ghostcafe
 	id = /obj/item/card/id/advanced/ghost_cafe
 
 /datum/action/toggle_dead_chat_mob


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Quirks would stop you from getting it, I say, screw you quirk, I want a box in my hand, I can pick up my instrument beacon later.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People with too many quirks were complaining they weren't getting their chameleon clothes box because their hands were full. They can't complain anymore.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex
fix: Ghost Cafe Visitors are now always eligible to a free box of chameleon clothes, and as such will always receive one in their left hand upon joining the Ghost Cafe!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
