### PR TITLE
[MODULAR] Quick-Spawning other people is no longer awkward for the spawning admin

### DIFF
--- a/modular_skyrat/modules/icspawning/code/_onclick/observer.dm
+++ b/modular_skyrat/modules/icspawning/code/_onclick/observer.dm
@@ -11,13 +11,13 @@
 		outfits["Show All"] = "Show All"
 
 		var/dresscode
-		var/teleport_option = tgui_alert(user, "How would you like to be spawned in?", "IC Quick Spawn", list("Bluespace", "Pod", "Cancel"))
+		var/teleport_option = tgui_alert(usr, "How would you like to be spawned in?", "IC Quick Spawn", list("Bluespace", "Pod", "Cancel"))
 		if (teleport_option == "Cancel")
 			return
-		var/character_option = tgui_alert(user, "Which character?", "IC Quick Spawn", list("Selected Character", "Randomly Created", "Cancel"))
+		var/character_option = tgui_alert(usr, "Which character?", "IC Quick Spawn", list("Selected Character", "Randomly Created", "Cancel"))
 		if (character_option == "Cancel")
 			return
-		var/initial_outfits = tgui_alert(user, "Select outfit", "Quick Dress", list("Bluespace Tech", "Show All", "Cancel"))
+		var/initial_outfits = tgui_alert(usr, "Select outfit", "Quick Dress", list("Bluespace Tech", "Show All", "Cancel"))
 		if (initial_outfits == "Cancel")
 			return
 
@@ -32,7 +32,7 @@
 		// We're spawning someone else
 		var/give_return
 		if (user != usr)
-			give_return = tgui_alert(user, "Do you want to give them the power to return? Not recommended for non-admins.", "Give power?", list("Yes", "No"))
+			give_return = tgui_alert(usr, "Do you want to give them the power to return? Not recommended for non-admins.", "Give power?", list("Yes", "No"))
 			if(!give_return)
 				return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It's no longer a game of trust to see if you trust non-admins with spawning themselves in. YOU now have the control, as the spawning admin, of how they're going to spawn in.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't want to accidentally have someone in Bluespace Technician outfit when I meant to spawn them as an assistant.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex
fix: Admins are now the one that decide how you spawn when they quick-spawn you, instead of having to awkwardly wait for you to do it yourself.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
