### PR TITLE
[Modular] More language choices for specific species

### DIFF
--- a/modular_skyrat/master_files/code/modules/language/language_holders.dm
+++ b/modular_skyrat/master_files/code/modules/language/language_holders.dm
@@ -1,6 +1,0 @@
-/datum/language_holder/machine //SYNTHETIC LIZARD & CO LANGUAGE
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/machine = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/machine = list(LANGUAGE_ATOM))
-

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -294,6 +294,7 @@ GLOBAL_LIST_EMPTY(customizable_races)
 /datum/species/human
 	mutant_bodyparts = list()
 	default_mutant_bodyparts = list("ears" = "None", "tail" = "None", "wings" = "None")
+	learnable_languages = list(/datum/language/common, /datum/language/moffic, /datum/language/draconic)
 
 /datum/species/mush
 	mutant_bodyparts = list()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
@@ -28,3 +28,4 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	payday_modifier = 0.75
 	limbs_id = SPECIES_HUMAN
+	learnable_languages = list(/datum/language/common, /datum/language/nekomimetic, /datum/language/xenoknockoff, /datum/language/moffic, /datum/language/draconic)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
@@ -36,3 +36,4 @@
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/insect_parts_greyscale.dmi'
+	learnable_languages = list(/datum/language/common, /datum/language/moffic, /datum/language/buzzwords)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
@@ -36,7 +36,11 @@
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/mammal_parts_greyscale.dmi'
-	learnable_languages = list(/datum/language/common, /datum/language/nekomimetic, /datum/language/xenoknockoff, /datum/language/moffic)
+	learnable_languages = list(/datum/language/common,
+	/datum/language/monkey,
+	/datum/language/nekomimetic,
+	/datum/language/xenoknockoff,
+	/datum/language/moffic)
 
 /datum/species/mammal/get_random_features()
 	var/list/returned = MANDATORY_FEATURE_LIST

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
@@ -36,6 +36,7 @@
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/mammal_parts_greyscale.dmi'
+	learnable_languages = list(/datum/language/common, /datum/language/nekomimetic, /datum/language/xenoknockoff, /datum/language/moffic)
 
 /datum/species/mammal/get_random_features()
 	var/list/returned = MANDATORY_FEATURE_LIST

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/moth.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/moth.dm
@@ -18,7 +18,7 @@
 		TRAIT_CAN_STRIP
 	)
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/moth_parts_greyscale.dmi'
-	learnable_languages = list(/datum/language/common, /datum/language/moffic)
+	learnable_languages = list(/datum/language/common, /datum/language/moffic, /datum/language/buzzwords)
 	payday_modifier = 0.75
 
 /datum/species/moth/get_random_body_markings(list/passed_features)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic.dm
@@ -25,7 +25,6 @@
 	heatmod = 2
 	siemens_coeff = 1.4 //Not more because some shocks will outright crit you, which is very unfun
 	payday_modifier = 0.5 //Robots are cheep labor
-	species_language_holder = /datum/language_holder/machine
 	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
 	mutantbrain = /obj/item/organ/brain/ipc_positron
 	mutantstomach = /obj/item/organ/stomach/robot_ipc
@@ -36,7 +35,15 @@
 	mutantheart = /obj/item/organ/heart/robot_ipc
 	mutantliver = /obj/item/organ/liver/robot_ipc
 	exotic_blood = /datum/reagent/fuel/oil
-	learnable_languages = list(/datum/language/common, /datum/language/machine)
+	learnable_languages = list(/datum/language/common,
+	/datum/language/machine,
+	/datum/language/slime,
+	/datum/language/nekomimetic,
+	/datum/language/monkey,
+	/datum/language/xenoknockoff,
+	/datum/language/moffic,
+	/datum/language/buzzwords,
+	/datum/language/draconic)
 
 /datum/species/robotic/spec_life(mob/living/carbon/human/H)
 	if(H.stat == SOFT_CRIT || H.stat == HARD_CRIT)
@@ -282,5 +289,4 @@
 	use_skintones = TRUE
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	reagent_flags = PROCESS_SYNTHETIC
-	species_language_holder = /datum/language_holder/machine
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/synthhuman_parts_greyscale.dmi'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -4,8 +4,16 @@
 	mutant_bodyparts = list()
 	hair_color = "mutcolor"
 	hair_alpha = 160 //a notch brighter so it blends better.
-	learnable_languages = list(/datum/language/common, /datum/language/slime)
 	payday_modifier = 0.75
+	learnable_languages = list(/datum/language/common,
+	/datum/language/slime,
+	/datum/language/nekomimetic,
+	/datum/language/monkey,
+	/datum/language/xenoknockoff,
+	/datum/language/moffic,
+	/datum/language/buzzwords,
+	/datum/language/draconic)
+
 
 /datum/species/jelly/roundstartslime
 	name = "Xenobiological Slime Hybrid"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3875,7 +3875,6 @@
 #include "modular_skyrat\master_files\code\modules\events\spider_infestation.dm"
 #include "modular_skyrat\master_files\code\modules\jobs\departments\departments.dm"
 #include "modular_skyrat\master_files\code\modules\jobs\job_types\cyborg.dm"
-#include "modular_skyrat\master_files\code\modules\language\language_holders.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\emote_popup.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\carbon_say.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\dead\new_player\new_player.dm"


### PR DESCRIPTION
## About The Pull Request

Freeing up species restricted languages for species that could possibly speak them.

- Humans can learn moffic and draconic
- Synths of any kind can learn monkey, slime, nekomimetic, xenoknockoff, moffic, buzzwords and draconic.
- Slimes can learn monkey, nekomimetic, xenoknockoff, moffic, buzzwords and draconic.
- Moths can learn buzzwords.
- Anthro Insects can learn moffic and buzzwords.
- Anthro mammals can learn monkey, nekomimetic, xenoknockoff and moffic.
- Humanoids can learn nekomimetic, xenoknockoff, moffic and draconic.


## Why It's Good For The Game

My rationale for these species combined with these languages: If the species can wear the body-parts of another species, they can opt to learn the language. A humanoid who is practically a felinid should be able to speak or understand nekomimetic. A mammal who has moth wings should be able to speak or understand moffic, et cetera, et cetera.

It also makes the language points and linguist perk useful.

**Please leave recommendations for additions or changes in the comments,** this should be updated with a couple of commits, as I must have missed something.

## Changelog
:cl:
add: Humans can learn moffic and draconic
add: Synths of any kind can learn monkey, slime, nekomimetic, xenoknockoff, moffic, buzzwords and draconic.
add: Slimes can learn monkey, nekomimetic, xenoknockoff, moffic, buzzwords and draconic.
add: Moths can learn buzzwords.
add: Anthro Insects can learn moffic and buzzwords.
add: Anthro mammals can learn monkey, nekomimetic, xenoknockoff and moffic.
add: Humanoids can learn nekomimetic, xenoknockoff, moffic and draconic.
/:cl:
