### PR TITLE
[Non-modular] Updates borg language, adds expanded language module

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -329,17 +329,37 @@ Key procs
 								/datum/language/machine = list(LANGUAGE_ATOM),
 								/datum/language/draconic = list(LANGUAGE_ATOM),
 								/datum/language/moffic = list(LANGUAGE_ATOM),
+								/*Skyrat remove - Moved to expanded language upgrade module
 								/datum/language/calcic = list(LANGUAGE_ATOM),
 								/datum/language/voltaic = list(LANGUAGE_ATOM),
-								/datum/language/nekomimetic = list(LANGUAGE_ATOM))
+								/datum/language/nekomimetic = list(LANGUAGE_ATOM),
+								Skyrat remove end*/
+								//Skyrat add - Adds our modular culture languages to borgs
+								/datum/language/spacer = list(LANGUAGE_ATOM),
+								/datum/language/japanese = list(LANGUAGE_ATOM),
+								/datum/language/gutter = list(LANGUAGE_ATOM),
+								/datum/language/russian = list(LANGUAGE_ATOM),
+								/datum/language/selenian = list(LANGUAGE_ATOM),
+								/datum/language/zolmach = list(LANGUAGE_ATOM))
+								//Skyrat add end
 	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 							/datum/language/uncommon = list(LANGUAGE_ATOM),
 							/datum/language/machine = list(LANGUAGE_ATOM),
 							/datum/language/draconic = list(LANGUAGE_ATOM),
 							/datum/language/moffic = list(LANGUAGE_ATOM),
+							/*Skyrat remove - Moved to expanded language upgrade module
 							/datum/language/calcic = list(LANGUAGE_ATOM),
 							/datum/language/voltaic = list(LANGUAGE_ATOM),
-							/datum/language/nekomimetic = list(LANGUAGE_ATOM))
+							/datum/language/nekomimetic = list(LANGUAGE_ATOM),
+							Skyrat remove end*/
+							//Skyrat add - Adds our modular culture languages to borgs
+							/datum/language/spacer = list(LANGUAGE_ATOM),
+							/datum/language/japanese = list(LANGUAGE_ATOM),
+							/datum/language/gutter = list(LANGUAGE_ATOM),
+							/datum/language/russian = list(LANGUAGE_ATOM),
+							/datum/language/selenian = list(LANGUAGE_ATOM),
+							/datum/language/zolmach = list(LANGUAGE_ATOM))
+							//Skyrat add end
 
 /datum/language_holder/moth
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -332,8 +332,8 @@ Key procs
 								/*Skyrat remove - Moved to expanded language upgrade module
 								/datum/language/calcic = list(LANGUAGE_ATOM),
 								/datum/language/voltaic = list(LANGUAGE_ATOM),
-								/datum/language/nekomimetic = list(LANGUAGE_ATOM),
 								Skyrat remove end*/
+								/datum/language/nekomimetic = list(LANGUAGE_ATOM),
 								//Skyrat add - Adds our modular culture languages to borgs
 								/datum/language/spacer = list(LANGUAGE_ATOM),
 								/datum/language/japanese = list(LANGUAGE_ATOM),
@@ -350,8 +350,8 @@ Key procs
 							/*Skyrat remove - Moved to expanded language upgrade module
 							/datum/language/calcic = list(LANGUAGE_ATOM),
 							/datum/language/voltaic = list(LANGUAGE_ATOM),
-							/datum/language/nekomimetic = list(LANGUAGE_ATOM),
 							Skyrat remove end*/
+							/datum/language/nekomimetic = list(LANGUAGE_ATOM),
 							//Skyrat add - Adds our modular culture languages to borgs
 							/datum/language/spacer = list(LANGUAGE_ATOM),
 							/datum/language/japanese = list(LANGUAGE_ATOM),

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -91,7 +91,6 @@
 
 		//SKYRAT EDIT START - RESEARCH DESIGNS
 		"affection_module",
-		"borg_upgrade_translator",
 		//SKYRAT EDIT END - RESEARCH DESIGNS
 	)
 
@@ -800,6 +799,18 @@
 		"skill_station",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+
+//Skyrat add - Language module
+/datum/techweb_node/linguistic_research
+	id = "linguistic_research"
+	display_name = "Linguistic Research"
+	description = "Technology allowing machines to imitate speech-patterns of nearly every recognized species."
+	prereq_ids = list("adv_robotics", "datatheory")
+	design_ids = list(
+		"borg_upgrade_translator"
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+//Skyrat add end
 
 /datum/techweb_node/cyborg_upg_util
 	id = "cyborg_upg_util"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -91,6 +91,7 @@
 
 		//SKYRAT EDIT START - RESEARCH DESIGNS
 		"affection_module",
+		"borg_upgrade_translator",
 		//SKYRAT EDIT END - RESEARCH DESIGNS
 	)
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -803,7 +803,7 @@
 //Skyrat add - Language module
 /datum/techweb_node/linguistic_research
 	id = "linguistic_research"
-	display_name = "Linguistic Research"
+	display_name = "Cyborg Upgrades: Linguistic Research"
 	description = "Technology allowing machines to imitate speech-patterns of nearly every recognized species."
 	prereq_ids = list("adv_robotics", "datatheory")
 	design_ids = list(

--- a/modular_skyrat/modules/cyborg/code/mechafabricator_designs.dm
+++ b/modular_skyrat/modules/cyborg/code/mechafabricator_designs.dm
@@ -30,8 +30,8 @@
 	id = "borg_upgrade_translator"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/translator
-	materials = list(/datum/material/iron = 5000, /datum/material/glass = 1000, /datum/material/silver = 2000, /datum/material/gold = 2000,  /datum/material/diamond = 200, /datum/material/plasma = 1000)
-	construction_time = 90
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500, /datum/material/silver = 1000, /datum/material/gold = 500,  /datum/material/diamond = 200, /datum/material/plasma = 1000)
+	construction_time = 40
 	category = list("Cyborg Upgrade Modules")
 
 /datum/design/advanced_materials

--- a/modular_skyrat/modules/cyborg/code/mechafabricator_designs.dm
+++ b/modular_skyrat/modules/cyborg/code/mechafabricator_designs.dm
@@ -25,6 +25,15 @@
 	construction_time = 40
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_translator
+	name = "Cyborg Upgrade (Expanded Translation Module)"
+	id = "borg_upgrade_translator"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/translator
+	materials = list(/datum/material/iron = 5000, /datum/material/glass = 1000, /datum/material/silver = 2000, /datum/material/gold = 2000,  /datum/material/diamond = 200, /datum/material/plasma = 1000)
+	construction_time = 90
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/advanced_materials
 	name = "Cyborg Upgrade (Advanced Materials)"
 	id = "advanced_materials"

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -172,7 +172,6 @@
 
 	borg.grant_language(/datum/language/calcic, TRUE, TRUE, LANGUAGE_ATOM)
 	borg.grant_language(/datum/language/voltaic, TRUE, TRUE, LANGUAGE_ATOM)
-	borg.grant_language(/datum/language/nekomimetic, TRUE, TRUE, LANGUAGE_ATOM)
 	borg.grant_language(/datum/language/buzzwords, TRUE, TRUE, LANGUAGE_ATOM)
 	borg.grant_language(/datum/language/sylvan, TRUE, TRUE, LANGUAGE_ATOM)
 	borg.grant_language(/datum/language/monkey, TRUE, TRUE, LANGUAGE_ATOM)
@@ -182,6 +181,7 @@
 	borg.grant_language(/datum/language/terrum, TRUE, TRUE, LANGUAGE_ATOM)
 	borg.grant_language(/datum/language/vox, TRUE, TRUE, LANGUAGE_ATOM)
 	borg.grant_language(/datum/language/xenoknockoff, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.grant_language(/datum/language/xenocommon, TRUE, TRUE, LANGUAGE_ATOM)
 
 /obj/item/borg/upgrade/translator/deactivate(mob/living/silicon/robot/borg, user = usr)
 	. = ..()
@@ -191,7 +191,6 @@
 
 	borg.remove_language(/datum/language/calcic, TRUE, TRUE, LANGUAGE_ATOM)
 	borg.remove_language(/datum/language/voltaic, TRUE, TRUE, LANGUAGE_ATOM)
-	borg.remove_language(/datum/language/nekomimetic, TRUE, TRUE, LANGUAGE_ATOM)
 	borg.remove_language(/datum/language/buzzwords, TRUE, TRUE, LANGUAGE_ATOM)
 	borg.remove_language(/datum/language/sylvan, TRUE, TRUE, LANGUAGE_ATOM)
 	borg.remove_language(/datum/language/monkey, TRUE, TRUE, LANGUAGE_ATOM)
@@ -201,6 +200,7 @@
 	borg.remove_language(/datum/language/terrum, TRUE, TRUE, LANGUAGE_ATOM)
 	borg.remove_language(/datum/language/vox, TRUE, TRUE, LANGUAGE_ATOM)
 	borg.remove_language(/datum/language/xenoknockoff, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.grant_language(/datum/language/xenocommon, TRUE, TRUE, LANGUAGE_ATOM)
 
 /////////////////////////////////////////////
 /// Advanced Engineering Cyborg Materials ///

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -2,6 +2,7 @@
 	var/hasShrunk = FALSE
 	var/hasAffection = FALSE
 	var/hasAdvanced = FALSE
+	var/hasExpLang = FALSE
 
 /obj/item/borg/upgrade/shrink
 	name = "borg shrinker"
@@ -152,6 +153,54 @@
 		borg.model.remove_module(dogtongue, TRUE)
 	for(var/obj/item/dogborg_nose/dognose in borg.model.modules)
 		borg.model.remove_module(dognose, TRUE)
+
+
+/obj/item/borg/upgrade/translator
+	name = "expanded translation module"
+	desc = "A module which allows the borgs to understand and speak additional languages."
+	icon_state = "component"
+
+/obj/item/borg/upgrade/translator/action(mob/living/silicon/robot/borg)
+	. = ..()
+	if(!.)
+		return
+	if(borg.hasExpLang)
+		to_chat(usr, "<span class='warning'>This unit already has an expanded translation module installed!</span>")
+		return FALSE
+
+	borg.hasExpLang = TRUE
+
+	borg.grant_language(/datum/language/calcic, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.grant_language(/datum/language/voltaic, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.grant_language(/datum/language/nekomimetic, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.grant_language(/datum/language/buzzwords, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.grant_language(/datum/language/sylvan, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.grant_language(/datum/language/monkey, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.grant_language(/datum/language/slime, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.grant_language(/datum/language/shadowtongue, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.grant_language(/datum/language/piratespeak, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.grant_language(/datum/language/terrum, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.grant_language(/datum/language/vox, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.grant_language(/datum/language/xenoknockoff, TRUE, TRUE, LANGUAGE_ATOM)
+
+/obj/item/borg/upgrade/translator/deactivate(mob/living/silicon/robot/borg, user = usr)
+	. = ..()
+	if(.)
+		return
+	borg.hasExpLang = FALSE
+
+	borg.remove_language(/datum/language/calcic, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.remove_language(/datum/language/voltaic, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.remove_language(/datum/language/nekomimetic, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.remove_language(/datum/language/buzzwords, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.remove_language(/datum/language/sylvan, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.remove_language(/datum/language/monkey, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.remove_language(/datum/language/slime, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.remove_language(/datum/language/shadowtongue, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.remove_language(/datum/language/piratespeak, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.remove_language(/datum/language/terrum, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.remove_language(/datum/language/vox, TRUE, TRUE, LANGUAGE_ATOM)
+	borg.remove_language(/datum/language/xenoknockoff, TRUE, TRUE, LANGUAGE_ATOM)
 
 /////////////////////////////////////////////
 /// Advanced Engineering Cyborg Materials ///


### PR DESCRIPTION
## About The Pull Request

What borgs used to be able to speak and understand:
Common, uncommon, encoded audio, draconic, moffic, nekomimetic, calcic and coltaic.

What borgs are able to speak and understand now:
Common, uncommon, encoded audio, draconic, moffic, nekomimetic, **spacer, japanese, gutter, russian, selenian, zolmach.**

Borgs can have their language module upgraded by installing a Expanded Translation Module, they can then **also** speak and understand:
Calcic, voltaic, nekomimetic, buzzwords, sylvan, monkey, slime, shadowtongue, piratespeak, terrum, vox, xenoknockoff, xenocommon.

The language module is locked behind Advanced Robotics and Big Data, (In space).
![LnZvGl2q4h](https://user-images.githubusercontent.com/77534246/130293306-0b06c86b-8a57-471d-be2a-4c6e122489b6.jpg)

## Why It's Good For The Game

Updating old content to include our new content and make it on-par.

## Changelog
:cl:
add: Borgs can speak and understand Spacer, Japanese, Gutter, Russian, Selenian and Zolmach
add: An expanded language module to allow Borgs to speak and understand Calcic, Voltaic, Buzzwords, Sylvan, Monkey, Slime, Shadowtongue, Piratespeak, Terrum, Vox, Xenoknockoff and Xenocommon.
del: Borgs can no longer speak or understand Calcic and Voltaic.
/:cl:
