### PR TITLE
Addition: Security Gun Vendor Circuit

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -138,6 +138,7 @@
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/clothing/gloves/krav_maga/sec/peacekeeper(src) //SKYRAT EDIT CHANGE - SEC_HAUL
 	new /obj/item/door_remote/head_of_security(src)
+	new /obj/item/circuitboard/machine/gun_vendor(src)
 
 /obj/structure/closet/secure_closet/security
 	name = "security officer's locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -138,7 +138,7 @@
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/clothing/gloves/krav_maga/sec/peacekeeper(src) //SKYRAT EDIT CHANGE - SEC_HAUL
 	new /obj/item/door_remote/head_of_security(src)
-	new /obj/item/circuitboard/machine/gun_vendor(src)
+	new /obj/item/circuitboard/machine/gun_vendor(src) // SKYRAT EDIT CHANGE
 
 /obj/structure/closet/secure_closet/security
 	name = "security officer's locker"

--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
@@ -9,8 +9,17 @@
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/gunsets.dmi'
 	icon_state = "gunvend"
 	use_power = NO_POWER_USE
+	circuit = /obj/item/circuitboard/machine/gun_vendor
 	max_integrity = 2000
 	density = TRUE
+
+/obj/item/circuitboard/machine/gun_vendor
+	name = "Weapons Dispenser (Machine Board)"
+	icon_state = "circuit_map"
+	build_path = /obj/machinery/gun_vendor
+	req_components = list(
+		/obj/item/stock_parts/manipulator = 2,
+		/obj/item/stock_parts/capacitor = 2)
 
 /obj/structure/gun_vendor/wrench_act(mob/living/user, obj/item/item)
 	default_unfasten_wrench(user, item, 120)


### PR DESCRIPTION
This adds a circuit for the Armadyne Weapons Dispenser.

## About The Pull Request

Adds a Weapons Dispenser (Machine Board) [circuitboard/machine/gun_vendor] into game.
Adds Weapons Dispenser circuit into the Warden's Locker.

## Why It's Good For The Game

People have noted it's been destroyed times before and there's no way to replace it. Strangely it does not have a circuit unlike the ammo machines next to it. Due to it being in an area that is highly prone to being bombed this would offer a backup option.
Due to the important nature of the machine, this would add one spare board(Much like departmental lathes) in the Warden's Locker.

## Changelog
:cl: Deek-Za
balance: Prevents security and their respective tokens from potentially being taken entirely out of the fight in the event of a bombing.
/:cl:
