### PR TITLE
Guns Galore now use their sounds.

### DIFF
--- a/modular_skyrat/modules/gunsgalore/code/guns/akm/akm.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/akm/akm.dm
@@ -14,6 +14,10 @@
 	worn_icon = 'modular_skyrat/modules/gunsgalore/icons/guns/akm/akm_back.dmi'
 	worn_icon_state = "akm"
 	fire_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/fire/akm/akm.ogg'
+	rack_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/ltrifle_cock.ogg'
+	load_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/ltrifle_magin.ogg'
+	load_empty_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/ltrifle_magin.ogg'
+	eject_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/ltrifle_magout.ogg'
 	alt_icons = TRUE
 	realistic = TRUE
 
@@ -26,7 +30,7 @@
 	caliber = "a762x39"
 	max_ammo = 30
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
-	
+
 /obj/item/ammo_box/magazine/akm/banana
 	name = "\improper RPK magazine"
 	desc = "a banana-shaped double-stack magazine able to hold 45 rounds of 7.62x39mm Soviet ammunition. It's meant to be used on a light machine gun, but it's just a longer AK magazine."

--- a/modular_skyrat/modules/gunsgalore/code/guns/m16/m16.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/m16/m16.dm
@@ -15,6 +15,10 @@
 	worn_icon_state = "m16"
 	fire_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/fire/m16/m16.ogg'
 	fire_sound_volume = 50
+	rack_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/sfrifle_cock.ogg'
+	load_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/sfrifle_magin.ogg'
+	load_empty_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/sfrifle_magin.ogg'
+	eject_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/sfrifle_magout.ogg'
 	alt_icons = TRUE
 	realistic = TRUE
 

--- a/modular_skyrat/modules/gunsgalore/code/guns/mp40/mp40.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/mp40/mp40.dm
@@ -15,6 +15,10 @@
 	worn_icon_state = "mp40"
 	fire_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/fire/mp40/mp40.ogg'
 	fire_sound_volume = 100
+	rack_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/smg_cock.ogg'
+	load_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/smg_magin.ogg'
+	load_empty_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/smg_magin.ogg'
+	eject_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/smg_magout.ogg'
 	alt_icons = TRUE
 	realistic = TRUE
 


### PR DESCRIPTION
M16, MP40 and AKM (most useable guns in the game) now actually use interacting sounds (magin, magout and cocking).

## About The Pull Request

Just how I said, M16, MP40 and AKM (including modern versions of course) now use sounds from 'interact' folder. 

## Why It's Good For The Game

Gun interaction now sounds cool.

## Changelog
:cl:
soundadd: M16, MP40 and AKM now have their interaction sounds.
/:cl:

