### PR TITLE
venus changes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -107,7 +107,7 @@
 	icon_state = "venus_human_trap"
 	health_doll_icon = "venus_human_trap"
 	mob_biotypes = MOB_ORGANIC | MOB_PLANT
-	layer = SPACEVINE_MOB_LAYER
+	layer = ABOVE_ALL_MOB_LAYER //SKYRAT EDIT CHANGE Venus should be able to hide within the vines...
 	health = 60 //SKYRAT EDIT CHANGE
 	maxHealth = 60 //SKYRAT EDIT CHANGE
 	ranged = TRUE
@@ -142,10 +142,20 @@
 
 	ghost_controllable = TRUE //SKYRAT EDIT ADDITION
 
+	var/help_grow = 0 //SKYRAT EDIT CHANGE cooldown for helping plants grow
+
 
 /mob/living/simple_animal/hostile/venus_human_trap/Life(delta_time = SSMOBS_DT, times_fired)
 	. = ..()
 	pull_vines()
+	//SKYRAT EDIT CHANGE
+	var/turf/src_turf = get_turf(src)
+	var/obj/structure/spacevine/find_vine = locate() in src_turf.contents
+	if(!find_vine)
+		adjustHealth(maxHealth * 0.05)
+	else
+		adjustHealth(maxHealth * -0.05)
+	//SKYRAT EDIT CHANGE
 
 /mob/living/simple_animal/hostile/venus_human_trap/Moved(atom/OldLoc, Dir)
 	. = ..()
@@ -244,5 +254,44 @@
 /mob/living/simple_animal/hostile/venus_human_trap/death(gibbed)
 	for(var/i in vines)
 		qdel(i)
+	return ..()
+
+/mob/living/simple_animal/hostile/venus_human_trap/UnarmedAttack(atom/attack_target, proximity_flag, list/modifiers)
+	if(!istype(attack_target, /obj/structure/spacevine))
+		return ..()
+	if(!proximity_flag)
+		return
+	var/obj/structure/spacevine/attacked_spacevine = attack_target
+	if(help_grow <= world.time)
+		help_grow = world.time + 1 SECONDS
+		if(attacked_spacevine.energy >= 2)
+			attacked_spacevine.spread()
+			to_chat(src, span_notice("You help [attacked_spacevine] expand..."))
+		else
+			attacked_spacevine.grow()
+			to_chat(src, span_notice("You help [attacked_spacevine] grow..."))
+	var/turf/vine_turf = get_turf(attack_target)
+	var/break_list = list(
+		/obj/machinery/door,
+		/obj/structure/table,
+		/obj/structure/window,
+		/obj/structure/girder,
+		/obj/structure/grille,
+		/obj/structure/rack,
+		/obj/structure/door_assembly,
+		/obj/structure/closet,
+	)
+	for(var/check_contents in vine_turf.contents)
+		if(isliving(check_contents) && !istype(check_contents, /mob/living/simple_animal/hostile/venus_human_trap))
+			UnarmedAttack(check_contents)
+		for(var/check_break in break_list)
+			if(!istype(check_contents, check_break))
+				continue
+			UnarmedAttack(check_contents)
+
+/mob/living/simple_animal/hostile/venus_human_trap/start_pulling(atom/movable/AM, state, force, supress_message)
+	if(isliving(AM))
+		to_chat(src, span_warning("You are unable to pull living creatures, they are too heavy!"))
+		return FALSE
 	return ..()
 //SKYRAT EDIT END

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -271,7 +271,7 @@
 			attacked_spacevine.grow()
 			to_chat(src, span_notice("You help [attacked_spacevine] grow..."))
 	var/turf/vine_turf = get_turf(attack_target)
-	var/break_list = list(
+	var/list/break_list = list(
 		/obj/machinery/door,
 		/obj/structure/table,
 		/obj/structure/window,
@@ -284,9 +284,7 @@
 	for(var/check_contents in vine_turf.contents)
 		if(isliving(check_contents) && !istype(check_contents, /mob/living/simple_animal/hostile/venus_human_trap))
 			UnarmedAttack(check_contents)
-		for(var/check_break in break_list)
-			if(!istype(check_contents, check_break))
-				continue
+		if(is_type_in_list(check_contents, break_list))
 			UnarmedAttack(check_contents)
 
 /mob/living/simple_animal/hostile/venus_human_trap/start_pulling(atom/movable/AM, state, force, supress_message)

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -271,7 +271,7 @@
 			attacked_spacevine.grow()
 			to_chat(src, span_notice("You help [attacked_spacevine] grow..."))
 	var/turf/vine_turf = get_turf(attack_target)
-	var/static/list/break_list = list(
+	var/static/list/break_list = typecacheof(list(
 		/obj/machinery/door,
 		/obj/structure/table,
 		/obj/structure/window,
@@ -280,7 +280,7 @@
 		/obj/structure/rack,
 		/obj/structure/door_assembly,
 		/obj/structure/closet,
-	)
+	))
 	for(var/check_contents in vine_turf.contents)
 		if(isliving(check_contents) && !istype(check_contents, /mob/living/simple_animal/hostile/venus_human_trap))
 			UnarmedAttack(check_contents)

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -142,7 +142,7 @@
 
 	ghost_controllable = TRUE //SKYRAT EDIT ADDITION
 
-	var/help_grow = 0 //SKYRAT EDIT CHANGE cooldown for helping plants grow
+	COOLDOWN_DECLARE(help_grow)
 
 
 /mob/living/simple_animal/hostile/venus_human_trap/Life(delta_time = SSMOBS_DT, times_fired)
@@ -262,8 +262,8 @@
 	if(!proximity_flag)
 		return
 	var/obj/structure/spacevine/attacked_spacevine = attack_target
-	if(help_grow <= world.time)
-		help_grow = world.time + 1 SECONDS
+	if(COOLDOWN_FINISHED(src, help_grow))
+		COOLDOWN_START(src, help_grow, 1 SECONDS)
 		if(attacked_spacevine.energy >= 2)
 			attacked_spacevine.spread()
 			to_chat(src, span_notice("You help [attacked_spacevine] expand..."))
@@ -271,7 +271,7 @@
 			attacked_spacevine.grow()
 			to_chat(src, span_notice("You help [attacked_spacevine] grow..."))
 	var/turf/vine_turf = get_turf(attack_target)
-	var/list/break_list = list(
+	var/static/list/break_list = list(
 		/obj/machinery/door,
 		/obj/structure/table,
 		/obj/structure/window,
@@ -284,7 +284,7 @@
 	for(var/check_contents in vine_turf.contents)
 		if(isliving(check_contents) && !istype(check_contents, /mob/living/simple_animal/hostile/venus_human_trap))
 			UnarmedAttack(check_contents)
-		if(is_type_in_list(check_contents, break_list))
+		if(is_type_in_typecache(check_contents, break_list))
 			UnarmedAttack(check_contents)
 
 /mob/living/simple_animal/hostile/venus_human_trap/start_pulling(atom/movable/AM, state, force, supress_message)

--- a/modular_skyrat/master_files/code/modules/events/spacevine.dm
+++ b/modular_skyrat/master_files/code/modules/events/spacevine.dm
@@ -636,13 +636,6 @@
 		return
 	for(var/datum/spacevine_mutation/vine_mutation in mutations)
 		vine_mutation.on_cross(src, moving_atom)
-	if(istype(moving_atom, /mob/living/simple_animal/hostile/venus_human_trap))
-		var/mob/living/simple_animal/hostile/venus_human_trap/venus_trap = moving_atom
-		if(venus_trap.health >= venus_trap.maxHealth)
-			return
-		venus_trap.adjustHealth(-clamp(venus_trap.health += 2, 0, venus_trap.maxHealth), TRUE, TRUE)
-		to_chat(venus_trap, span_notice("The vines attempt to regenerate some of your wounds!"))
-		return
 
 // ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/structure/spacevine/attack_hand(mob/user, list/modifiers)
@@ -835,6 +828,13 @@
 	. = ..()
 	if(isvineimmune(mover))
 		return TRUE
+
+/obj/structure/spacevine/attack_ghost(mob/user)
+	var/turf/src_turf = get_turf(src)
+	var/mob/living/simple_animal/hostile/venus_human_trap/check_venus = locate() in src_turf.contents
+	if(!check_venus)
+		return ..()
+	check_venus.attack_ghost(user)
 
 /proc/isvineimmune(atom/checked_atom)
 	if(isliving(checked_atom))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
many changes to venus human traps:
they can hide under the vines now, rather than being right above them
they can help a singular vine grow a second
if they are not on vines, they lose health
if they are on vines, they slowly gain back health
they no longer gain health upon moving on turf with vines
they cannot pull living mobs
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
vines are getting absolutely decimated by the scythe changes
perhaps it could be attributed to the vines being discovered when they havent grown enough
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: venus human traps no longer heal upon moving on vines
balance: venus human traps will lose health if not on vines
balance: venus human traps will gain health slowly if on vines
balance: venus human traps cannot pull living mobs
balance: venus human traps are set down a layer, right below vines
balance: venus human traps can help vines grow every second
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
