### PR TITLE
[Modular] Fixes a wrong typepath that resulted in regular drink boxes to have syndicate shot glasses in them.

### DIFF
--- a/modular_skyrat/modules/moretraitoritems/code/game/objects/items/drinks/drinkingglass.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/game/objects/items/drinks/drinkingglass.dm
@@ -14,6 +14,6 @@
 	desc = "It has a picture of shot glasses on it."
 	illustration = "drinkglass"
 
-/obj/item/storage/box/drinkingglasses/PopulateContents()
+/obj/item/storage/box/syndieshotglasses/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass/syndicate(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This was intended to be for the Syndicate box, not the regular drinking glass box. Which meant the one you were buying with TC had nothing in them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because it's restoring proper behavior.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex
fix: Nanotrasen has seized control of their drinking glass factory once more, meaning that the Syndicate no longer manages to smuggle modified shot glasses in the station's standard-issue glass boxes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
