### PR TITLE
[QOL] Atmos Tablet Update

### DIFF
--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -54,7 +54,9 @@
 
 /obj/item/modular_computer/tablet/preset/advanced/atmos/Initialize() //This will be defunct and will be replaced when NtOS PDAs are done
 	. = ..()
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive") //SKYRAT EDIT ADD
 	install_component(new /obj/item/computer_hardware/sensorpackage)
+	hard_drive.store_file(new /datum/computer_file/program/alarm_monitor) //SKYRAT EDIT ADD
 
 /obj/item/modular_computer/tablet/preset/advanced/engineering/Initialize()
 	. = ..()


### PR DESCRIPTION
Have the Canary Application pre-installed on the atmospherics tablet.

## About The Pull Request

Just makes some simple tweaks to the Atmospherics Tablet to have Canary[alarm_monitor] pre-installed

## Why It's Good For The Game

As an atmospherics tech, this is one of your most important tools since it monitors atmospherics alarms and fire alarms.
It's pretty much required to download it at the beginning of every shift as an Atmos Tech. This would alleviate that little chore you have to do every round(A double annoyance if your coming in from interlink since you can't download while on the interlink shuttle)
Engineers already get their job app, CIMS, pre-installed onto theirs, so why not?

## Changelog
:cl: Deek-Za
qol: Make Atmos have a more time efficient round start.
/:cl: