### PR TITLE
[MODULAR] Hypospray buffs

### DIFF
--- a/modular_skyrat/modules/hyposprays/code/game/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hyposprays_II.dm
@@ -1,8 +1,8 @@
 #define HYPO_SPRAY 0
 #define HYPO_INJECT 1
 
-#define WAIT_SPRAY 25
-#define WAIT_INJECT 25
+#define WAIT_SPRAY 15
+#define WAIT_INJECT 20
 #define SELF_SPRAY 15
 #define SELF_INJECT 15
 

--- a/modular_skyrat/modules/hyposprays/code/game/hypovials.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hypovials.dm
@@ -42,7 +42,7 @@
 	name = "hypovial"
 	desc = "A small, 60u capacity vial compatible with most hyposprays."
 	volume = 60
-	possible_transfer_amounts = list(1,2,5,10,20)
+	possible_transfer_amounts = list(1,2,5,10,20,30,40,50,60)
 
 //Fit in CMO hypo only
 /obj/item/reagent_containers/glass/bottle/vial/large


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Included in this PR are two different buffs.

First, the injection and spray speeds on the standard hypospray have been buffed. This is only for the standard Mk2 Hypospray, and not the CMO one.

- The injection time has been lowered from 2.5s to 2.0s
- The spray time has been lowered from 2.5s to 1.5s

Second, the standard hypovial can now inject it's entire storage (60u) instead of being able to inject only 20u max. It now also has more selection modes (30u, 40u, 50u, and 60u.)  

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The standard hypospray is slow and clunky to use and is also outclassed by pills and patches with nitrile gloves. This PR should make the standard hypospray feel more responsive to use, and give doctors more control while using it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Buffs the injection/spray speed on the standard Hypospray.
balance: Standard Hypovials can now inject their entire storage and have more selection modes 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
