### PR TITLE
[Modular] Adds nympho quirk to headrole, security restricted quirk lists.

### DIFF
--- a/code/__DEFINES/~skyrat_defines/jobs.dm
+++ b/code/__DEFINES/~skyrat_defines/jobs.dm
@@ -3,6 +3,6 @@
 #define JOB_UNAVAILABLE_LANGUAGE 7
 #define JOB_NOT_VETERAN 8
 
-#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE, "Nymphomania" = TRUE, "Masochism" = TRUE, "Sadism" = TRUE
-#define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE, "Nymphomania" = TRUE, "Masochism" = TRUE, "Sadism" = TRUE
+#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE, "Nymphomania" = TRUE
+#define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE, "Nymphomania" = TRUE
 #define TECH_RESTRICTED_QUIRKS "Chunky Fingers" = TRUE

--- a/code/__DEFINES/~skyrat_defines/jobs.dm
+++ b/code/__DEFINES/~skyrat_defines/jobs.dm
@@ -3,6 +3,6 @@
 #define JOB_UNAVAILABLE_LANGUAGE 7
 #define JOB_NOT_VETERAN 8
 
-#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE
-#define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE
+#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE, "Nymphomania" = TRUE, "Masochism" = TRUE, "Sadism" = TRUE
+#define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE, "Nymphomania" = TRUE, "Masochism" = TRUE, "Sadism" = TRUE
 #define TECH_RESTRICTED_QUIRKS "Chunky Fingers" = TRUE

--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -128,3 +128,16 @@
 		if(!pref.languages[lang] || pref.languages[lang] < required_languages[lang])
 			return FALSE
 	return TRUE
+
+// Nanotrasen Fleet
+/datum/job/fleetmaster
+	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
+
+/datum/job/operations_inspector
+	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
+
+/datum/job/deck_crew
+	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
+
+/datum/job/bridge_officer
+	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds nymphomania to the HEAD_RESTRICTED_QUIRKS and SEC_RESTRICTED_QUIRKS lists. NT Fleet staff now have to abide by the head bad quirks list as well.

## Why It's Good For The Game

Reduces the chance of heads of staff and security going, "It's a medical condition!~" and ignoring their duties.

## Changelog
:cl:
balance: Head roles and security cannot have nymphomania. NT fleet now under same head role quirk restrictions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
