### PR TITLE
You must now opt into antag, and be antag now actually works.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -370,8 +370,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		var/mob/dead/new_player/player = i
 		if(player.ready == PLAYER_READY_TO_PLAY && player.mind && player.check_preferences())
 			roundstart_pop_ready++
-			if(player.client.prefs.be_antag) //SKYRAT EDIT CHANGE
-				candidates.Add(player)
+			candidates.Add(player)
 	log_game("DYNAMIC: Listing [roundstart_rules.len] round start rulesets, and [candidates.len] players ready.")
 	if (candidates.len <= 0)
 		log_game("DYNAMIC: [candidates.len] candidates.")

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -200,6 +200,12 @@
 			candidates.Remove(candidate_player)
 			continue
 
+		//SKYRAT EDIT ADDITION
+		if(!candidate_client.prefs?.be_antag)
+			candidates.Remove(candidate_player)
+			continue
+		//SKYRAT EDIT END
+
 		if(candidate_client.get_remaining_days(minimum_required_age) > 0)
 			candidates.Remove(candidate_player)
 			continue

--- a/modular_skyrat/modules/customization/modules/client/preferences.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_INIT(food, list(
 	var/tmp/old_be_special = 0 //Bitflag version of be_special, used to update old savefiles and nothing more
 										//If it's 0, that's good, if it's anything but 0, the owner of this prefs file's antag choices were,
 										//autocorrected this round, not that you'd need to check that.
-	var/be_antag = TRUE //Does this player wish to be an antag this round?
+	var/be_antag = FALSE //Does this player wish to be an antag this round?
 
 	var/UI_style = null
 	var/buttons_locked = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically what this does is inverts the current state of be_antag to FALSE, meaning when you join, you are set to have antagonist off.

And now the game actually respects if you have this on or off, if you have it off, you will not get it.

If no one opts in, the game will not start, and you will be notified. This means you can opt in and have a near 100% chance of getting antag.

## Changelog
:cl:
balance: Be antag now starts set to off.
fix: Be antag now actually works.
/:cl:

