### PR TITLE
[MODULAR] Lets users change the case design for hypospray kits

### DIFF
--- a/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
@@ -24,7 +24,11 @@
 	case_designs = list(
 		"firstaid" = image(icon = src.icon, icon_state = "firstaid-mini"),
 		"brute" = image(icon = src.icon, icon_state = "brute-mini"),
-		"burn" = image(icon = src.icon, icon_state = "burn-mini"))
+		"burn" = image(icon = src.icon, icon_state = "burn-mini"),
+		"toxin" = image(icon = src.icon, icon_state = "toxin-mini"),
+		"rad" = image(icon = src.icon, icon_state = "rad-mini"),
+		"bpurple" = image(icon = src.icon, icon_state = "purple-mini"),
+		"oxy" = image(icon = src.icon, icon_state = "oxy-mini"))
 
 /obj/item/storage/hypospraykit/update_icon_state()
 	. = ..()

--- a/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
@@ -8,6 +8,48 @@
 	throw_speed = 3
 	throw_range = 7
 	var/empty = FALSE
+	var/current_case = "firstaid"
+	var/static/list/case_designs
+
+//Code to give hypospray kits selectable paterns.
+
+/obj/item/storage/hypospraykit/Initialize()
+	..()
+	if(!length(case_designs))
+		populate_case_designs()
+	update_icon_state()
+	update_icon()
+
+/obj/item/storage/hypospraykit/proc/populate_case_designs()
+	case_designs = list(
+		"firstaid" = image(icon = src.icon, icon_state = "firstaid-mini"),
+		"brute" = image(icon = src.icon, icon_state = "brute-mini"),
+		"burn" = image(icon = src.icon, icon_state = "burn-mini"))
+
+/obj/item/storage/hypospraykit/update_icon_state()
+	. = ..()
+	icon_state = icon_state = "[current_case]-mini"
+
+/obj/item/storage/hypospraykit/proc/case_menu(mob/user)
+	if(.)
+		return
+	var/choice = show_radial_menu(user, src , case_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 42, require_near = TRUE)
+	if(!choice)
+		return FALSE
+	current_case = choice
+	update_icon()
+
+/obj/item/storage/hypospraykit/proc/check_menu(mob/user)
+	if(!istype(user))
+		return FALSE
+	if(user.incapacitated() || !user.is_holding(src))
+		return FALSE
+	return TRUE
+
+
+/obj/item/storage/hypospraykit/CtrlShiftClick(mob/user, obj/item/I)
+	case_menu(user)
+
 
 /obj/item/storage/hypospraykit/ComponentInitialize()
 	. = ..()
@@ -16,6 +58,7 @@
 	stored.can_hold = typecacheof(list(
 	/obj/item/hypospray/mkii,
 	/obj/item/reagent_containers/glass/bottle/vial))
+
 
 /obj/item/storage/hypospraykit/empty
 	desc = "A hypospray kit with general use vials."

--- a/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
@@ -61,7 +61,7 @@
 
 /obj/item/storage/hypospraykit/CtrlShiftClick(mob/user, obj/item/I)
 	case_menu(user)
-
+//END OF HYPOSPRAY CASE MENU CODE
 
 /obj/item/storage/hypospraykit/ComponentInitialize()
 	. = ..()

--- a/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
@@ -10,6 +10,8 @@
 	var/empty = FALSE
 	var/current_case = "firstaid"
 	var/static/list/case_designs
+	var/static/list/cmo_case_designs
+	var/cmo_case = FALSE
 
 //Code to give hypospray kits selectable paterns.
 
@@ -29,6 +31,9 @@
 		"rad" = image(icon = src.icon, icon_state = "rad-mini"),
 		"bpurple" = image(icon = src.icon, icon_state = "purple-mini"),
 		"oxy" = image(icon = src.icon, icon_state = "oxy-mini"))
+	cmo_case_designs = list(
+		"tactical" = image(icon= src.icon, icon_state = "tactical-mini"))
+	cmo_case_designs += case_designs
 
 /obj/item/storage/hypospraykit/update_icon_state()
 	. = ..()
@@ -37,7 +42,10 @@
 /obj/item/storage/hypospraykit/proc/case_menu(mob/user)
 	if(.)
 		return
-	var/choice = show_radial_menu(user, src , case_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 42, require_near = TRUE)
+	var/casetype = cmo_case_designs
+	if(!src.cmo_case)
+		casetype = case_designs
+	var/choice = show_radial_menu(user, src , casetype, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 42, require_near = TRUE)
 	if(!choice)
 		return FALSE
 	current_case = choice
@@ -79,6 +87,8 @@
 	name = "deluxe hypospray kit"
 	desc = "A kit containing a deluxe hypospray and vials."
 	icon_state = "tactical-mini"
+	current_case = "tactical"
+	cmo_case = TRUE
 
 /obj/item/storage/hypospraykit/cmo/PopulateContents()
 	if(empty)

--- a/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
@@ -29,7 +29,7 @@
 		"burn" = image(icon = src.icon, icon_state = "burn-mini"),
 		"toxin" = image(icon = src.icon, icon_state = "toxin-mini"),
 		"rad" = image(icon = src.icon, icon_state = "rad-mini"),
-		"bpurple" = image(icon = src.icon, icon_state = "purple-mini"),
+		"purple" = image(icon = src.icon, icon_state = "purple-mini"),
 		"oxy" = image(icon = src.icon, icon_state = "oxy-mini"))
 	cmo_case_designs = list(
 		"tactical" = image(icon= src.icon, icon_state = "tactical-mini"))

--- a/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
@@ -61,6 +61,7 @@
 
 /obj/item/storage/hypospraykit/CtrlShiftClick(mob/user, obj/item/I)
 	case_menu(user)
+
 //END OF HYPOSPRAY CASE MENU CODE
 
 /obj/item/storage/hypospraykit/ComponentInitialize()

--- a/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
@@ -37,7 +37,7 @@
 
 /obj/item/storage/hypospraykit/update_icon_state()
 	. = ..()
-	icon_state = icon_state = "[current_case]-mini"
+	icon_state = "[current_case]-mini"
 
 /obj/item/storage/hypospraykit/proc/case_menu(mob/user)
 	if(.)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Users can now Ctrl+Shift Click on a Hypospray kit to change the case design on it through a radial menu. 
![image](https://user-images.githubusercontent.com/68373373/130381471-f086c348-f323-49b5-a029-f5515befa10c.png)
The CMO kit can also do this and can change back to the default texture.
![image](https://user-images.githubusercontent.com/68373373/130381491-383ad9a2-61b2-48ba-8c23-a54d899fa84a.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should give chemists and doctors a way to visibly label hypospray kits based on their contents. Currently the only hypospray kit textures used in the game are the default and cmo ones, despite the rest still being in the files.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Hypospray kits can be now be Ctrl+Shift clicked to change the design. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
