### PR TITLE
[Important] Raising the PR standards for sprites PRs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -812,11 +812,15 @@ There is no strict process when it comes to merging pull requests. Pull requests
 
 * After leaving reviews on an open pull request, maintainers may convert it to a draft. Once you have addressed all their comments to the best of your ability, feel free to mark the pull as `Ready for Review` again.
 
+* **Pull requests that include sprites must have in-game screenshots that were taken on your own test-server in the PR body**, to ensure they were tested properly. For instance, if you're adding new clothes, a screenshot of those clothes being worn is expected in the PR body. Not every single direction needs to be displayed, but each icon that's actually being used in-game should be showcased.
+
 ## Porting features/sprites/sounds/tools from other codebases
 
 If you are porting features/tools from other codebases, you must give them credit where it's due. Typically, crediting them in your pull request and the changelog is the recommended way of doing it. Take note of what license they use though, porting stuff from AGPLv3 and GPLv3 codebases are allowed.
 
 Regarding sprites & sounds, you must credit the artist and possibly the codebase. All /tg/station assets including icons and sound are under a [Creative Commons 3.0 BY-SA license](https://creativecommons.org/licenses/by-sa/3.0/) unless otherwise indicated. However if you are porting assets from GoonStation or usually any assets under the [Creative Commons 3.0 BY-NC-SA license](https://creativecommons.org/licenses/by-nc-sa/3.0/) are to go into the 'goon' folder of the /tg/station codebase.
+
+Regarding sprites in particular, you still need to take your own screenshots of the sprites in-game on your Skyrat code in your PR body, not just re-use the screenshots provided in the original PR.
 
 ## Banned content
 Do not add any of the following in a Pull Request or risk getting the PR closed:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -812,7 +812,7 @@ There is no strict process when it comes to merging pull requests. Pull requests
 
 * After leaving reviews on an open pull request, maintainers may convert it to a draft. Once you have addressed all their comments to the best of your ability, feel free to mark the pull as `Ready for Review` again.
 
-* **Pull requests that include sprites must have in-game screenshots that were taken on your own test-server in the PR body**, to ensure they were tested properly. For instance, if you're adding new clothes, a screenshot of those clothes being worn is expected in the PR body. Not every single direction needs to be displayed, but each icon that's actually being used in-game should be showcased.
+* **Pull requests that include sprites must have in-game screenshots that were taken on your own test-server in the PR body.** For instance, if you're adding new clothes, a screenshot of those clothes being worn is expected in the PR body. Not every single direction needs to be displayed, but each icon that's actually being used in-game should be showcased.
 
 ## Porting features/sprites/sounds/tools from other codebases
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It's sad that we must come to this point, but for the sake of the sanity of our maintainers, we've decided that, from this point on, PRs with sprites must show screenshots of the sprites used in-game, on a test-server running your Skyrat code, in the PR body.

Why do that, you might ask?
Well, the reasoning is quite simple: There's been many cases where some people make tiny mistakes when it comes to sprite changes on the server, be it because the size of the PR was quite massive, or because the testing wasn't thorough enough. We as maintainer can't be expected to know for a fact that you named every single one of your icon_states correctly in your .dmi files, and using the icon diff bot to figure out how the sprite will look in-game is simply just not enough.
Having to ask people if they tested their PR just feels awkward, and so we want to avoid conflicts, and want to uphold a certain standard on the codebase.

Yes, I'm aware that this will require more efforts to make a sprite PR, but it was always good practice to include screenshots of your sprites in your PR body anyway. It's just enforcing good practices.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's going to be a lot easier to review sprites PRs, and will reduce the chances that sprite changes create issues once merged.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
Not player-facing.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
