### PR TITLE
[s] Adds `discord_reported` column to the `ban` table in the SQL schema

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,18 +1,23 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.16; The query to update the schema revision table is:
+The latest database version is 5.18 (5.16 for /tg/); The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 16);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 18);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 16);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 18);
 
 In any query remember to add a prefix to the table names if you use one.
 
 -----------------------------------------------------
-<<<<<<< HEAD
-Version 5.16, 2 June 2021, by Mothblocks
-=======
-Version 5.16, 31 July 2021, by Atlanta-Ned
+Version 5.18, 23 August 2021, by GoldenAlpharex
+Added `discord_report` column to the `ban table`
+
+```
+`discord_reported` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0', /* SKYRAT EDIT - Labelling bans for ease of reporting them over Discord. */
+```
+
+-----------------------------------------------------
+Version 5.17, 31 July 2021, by Atlanta-Ned
 Added `library_action` table for tracking reported library books and actions taken on them.
 
 ```
@@ -31,8 +36,7 @@ CREATE TABLE `library_action` (
 
 
 -----------------------------------------------------
-Version 5.15, 2 June 2021, by Mothblocks
->>>>>>> ec2189370df (Adds the library_report table (#60599))
+Version 5.16, 2 June 2021, by Mothblocks
 Added verified admin connection log used for 2FA
 
 ```

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -93,6 +93,7 @@ CREATE TABLE `ban` (
   `unbanned_ip` INT(10) UNSIGNED NULL DEFAULT NULL,
   `unbanned_computerid` VARCHAR(32) NULL DEFAULT NULL,
   `unbanned_round_id` INT(11) UNSIGNED NULL DEFAULT NULL,
+  `discord_reported` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0', /* SKYRAT EDIT - Labelling bans for ease of reporting them over Discord. */
   PRIMARY KEY (`id`),
   KEY `idx_ban_isbanned` (`ckey`,`role`,`unbanned_datetime`,`expiration_time`),
   KEY `idx_ban_isbanned_details` (`ckey`,`ip`,`computerid`,`role`,`unbanned_datetime`,`expiration_time`),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is just to make my life easier in making an automated ban report system in a Discord channel.
I also updated the changelog and ensured that it was properly tracking the versions.

**Note for any downstream:** If you're getting this PR, please execute the following SQL query on your database prior to updating the schema on your database:
```sql
ALTER TABLE ban
ADD `discord_reported` TINYINT(1) UNSIGNED NOT NULL DEFAULT '1' AFTER `unbanned_round_id`;
```
This will ensure that all the previously existing bans are marked as reported on Discord, just so that, if you ever want to use this for your own needs, you won't have nulls in your table.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Easier time reporting bans that were made by admins in-game, by removing the need for admins to do it themselves. At least, that's what's coming.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex
server: SQL database schema updated to have a new `discord_reported` column in the `ban` table.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
