### PR TITLE
[MODULAR] Medicell Safety

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -18,7 +18,7 @@
 //End of cells
 
 /obj/item/ammo_casing/energy/medical
-	projectile_type = /obj/projectile/energy/medical/default
+	projectile_type = /obj/projectile/energy/medical/oxygen
 	select_name = "oxygen"
 	fire_sound = 'sound/effects/stealthoff.ogg'
 	e_cost = 120
@@ -29,17 +29,15 @@
 	name = "medical heal shot"
 	icon_state = "blue_laser"
 	damage = 0
-
-/obj/projectile/energy/medical/upgraded
-	pass_flags = UPGRADED_MEDICELL_PASSFLAGS
-/obj/item/ammo_casing/energy/medical/default
+/obj/projectile/energy/medical/oxygen
 	name = "oxygen heal shot"
+	var/amount_healed = 10
 
-/obj/projectile/energy/medical/default/on_hit(mob/living/target)
+/obj/projectile/energy/medical/oxygen/on_hit(mob/living/target)
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	target.adjustOxyLoss(-10)
+	target.adjustOxyLoss(-amount_healed)
 
 //PROCS//
 //Applies digust by damage thresholds.
@@ -191,17 +189,13 @@
 
 //Tier II Oxy Projectile//
 /obj/item/ammo_casing/energy/medical/oxy2
-	projectile_type = /obj/projectile/energy/medical/upgraded/oxy2
+	projectile_type = /obj/projectile/energy/medical/oxygen/better
 	select_name = "oxygen II"
 
-/obj/projectile/energy/medical/upgraded/oxy2
+/obj/projectile/energy/medical/oxygen/better
 	name = "strong oxygen heal shot"
+	amount_healed = 20
 
-/obj/projectile/energy/medical/upgraded/oxy2/on_hit(mob/living/target)
-	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	target.adjustOxyLoss(-20)
 //Tier II Toxin Projectile//
 /obj/item/ammo_casing/energy/medical/toxin2
 	projectile_type = /obj/projectile/energy/medical/upgraded/toxin2
@@ -272,17 +266,13 @@
 
 //Tier III Oxy Projectile//
 /obj/item/ammo_casing/energy/medical/oxy3
-	projectile_type = /obj/projectile/energy/medical/upgraded/oxy3
+	projectile_type = /obj/projectile/energy/medical/oxygen/better/best
 	select_name = "oxygen III"
 
-/obj/projectile/energy/medical/upgraded/oxy3
+/obj/projectile/energy/medical/oxygen/better/best
 	name = "powerful oxygen heal shot"
+	amount_healed = 30
 
-/obj/projectile/energy/medical/upgraded/oxy3/on_hit(mob/living/target)
-	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	target.adjustOxyLoss(-30)
 //Tier III Toxin Projectile//
 /obj/item/ammo_casing/energy/medical/toxin3
 	projectile_type = /obj/projectile/energy/medical/upgraded/toxin3

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -115,6 +115,7 @@
 //SAFE MODES
 /obj/item/ammo_casing/energy/medical/brute1/safe
 	projectile_type = /obj/projectile/energy/medical/safe/brute1
+
 /obj/projectile/energy/medical/safe/brute1
 	name = "safe brute heal shot"
 	icon_state = "red_laser"
@@ -123,7 +124,6 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	//Stops healing from 50 or over
 	if(target.getBruteLoss() >= 50)
 		return
 	target.adjustBruteLoss(-7.5)
@@ -131,6 +131,7 @@
 
 /obj/item/ammo_casing/energy/medical/burn1/safe
 	projectile_type = /obj/projectile/energy/medical/safe/burn1
+
 /obj/projectile/energy/medical/safe/burn1
 	name = "safe burn heal shot"
 	icon_state = "yellow_laser"
@@ -139,7 +140,6 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	//Stops healing from 50 or over
 	if(target.getFireLoss() >= 50)
 		return
 	target.adjustFireLoss(-7.5)
@@ -160,7 +160,6 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	//DISGUST
 	DamageDisgust(target, target.getBruteLoss())
 	target.adjust_disgust(2)
 	DamageClone(target, target.getBruteLoss(), 11.25, 0.33)
@@ -213,6 +212,7 @@
 //SAFE MODES
 /obj/item/ammo_casing/energy/medical/brute2/safe
 	projectile_type = /obj/projectile/energy/medical/upgraded/safe/brute2
+
 /obj/projectile/energy/medical/upgraded/safe/brute2
 	name = "safe brute heal shot"
 	icon_state = "red_laser"
@@ -221,7 +221,6 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	//Stops healing from 50 or over
 	if(target.getBruteLoss() > 49)
 		return
 	target.adjustBruteLoss(-11.25)
@@ -229,6 +228,7 @@
 
 /obj/item/ammo_casing/energy/medical/burn2/safe
 	projectile_type = /obj/projectile/energy/medical/upgraded/safe/burn2
+
 /obj/projectile/energy/medical/upgraded/safe/burn2
 	name = "safe burn heal shot"
 	icon_state = "yellow_laser"
@@ -237,7 +237,6 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	//Stops healing from 50 or over
 	if(target.getFireLoss() > 49)
 		return
 	target.adjustFireLoss(-11.25)
@@ -308,6 +307,7 @@
 //SAFE MODES
 /obj/item/ammo_casing/energy/medical/brute3/safe
 	projectile_type = /obj/projectile/energy/medical/upgraded/safe/brute3
+
 /obj/projectile/energy/medical/upgraded/safe/brute3
 	name = "safe brute heal shot"
 	icon_state = "red_laser"
@@ -316,7 +316,6 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	//Stops healing from 50 or over
 	if(target.getBruteLoss() > 49)
 		return
 	target.adjustBruteLoss(-15)
@@ -324,6 +323,7 @@
 
 /obj/item/ammo_casing/energy/medical/burn3/safe
 	projectile_type = /obj/projectile/energy/medical/upgraded/safe/burn3
+
 /obj/projectile/energy/medical/upgraded/safe/burn3
 	name = "safe burn heal shot"
 	icon_state = "yellow_laser"
@@ -332,7 +332,6 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	//Stops healing from 50 or over
 	if(target.getFireLoss() > 49)
 		return
 	target.adjustFireLoss(-15)

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -162,21 +162,17 @@
 	safeBrute(target, amount_healed, base_disgust)
 
 /obj/item/ammo_casing/energy/medical/burn1/safe
-	projectile_type = /obj/projectile/energy/medical/safe/burn1
+	projectile_type = /obj/projectile/energy/medical/safe/burn
 
-/obj/projectile/energy/medical/safe/burn1
+/obj/projectile/energy/medical/safe/burn
 	name = "safe burn heal shot"
 	icon_state = "yellow_laser"
+	var/amount_healed = 7.5
+	var/base_disgust = 3
 
-/obj/projectile/energy/medical/safe/burn1/on_hit(mob/living/target)
+/obj/projectile/energy/medical/safe/burn/on_hit(mob/living/target)
 	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	if(target.getFireLoss() >= 50)
-		return
-	target.adjustFireLoss(-7.5)
-	target.adjust_disgust(3)
-
+	safeBurn(target, amount_healed, base_disgust)
 //T2 Healing Projectiles//
 //Tier II Brute Projectile//
 /obj/item/ammo_casing/energy/medical/brute2
@@ -233,20 +229,14 @@
 	base_disgust = 2
 
 /obj/item/ammo_casing/energy/medical/burn2/safe
-	projectile_type = /obj/projectile/energy/medical/upgraded/safe/burn2
+	projectile_type = /obj/projectile/energy/medical/safe/burn/better
 
-/obj/projectile/energy/medical/upgraded/safe/burn2
-	name = "safe burn heal shot"
-	icon_state = "yellow_laser"
+/obj/projectile/energy/medical/safe/burn/better
+	name = "safe strong burn heal shot"
+	pass_flags =  UPGRADED_MEDICELL_PASSFLAGS
+	amount_healed = 11.25
+	base_disgust = 2
 
-/obj/projectile/energy/medical/upgraded/safe/burn2/on_hit(mob/living/target)
-	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	if(target.getFireLoss() >= 50)
-		return
-	target.adjustFireLoss(-11.25)
-	target.adjust_disgust(2)
 //T3 Healing Projectiles//
 //Tier III Brute Projectile//
 /obj/item/ammo_casing/energy/medical/brute3
@@ -300,20 +290,11 @@
 	amount_healed = 15
 	base_disgust = 1
 /obj/item/ammo_casing/energy/medical/burn3/safe
-	projectile_type = /obj/projectile/energy/medical/upgraded/safe/burn3
-
-/obj/projectile/energy/medical/upgraded/safe/burn3
-	name = "safe burn heal shot"
-	icon_state = "yellow_laser"
-
-/obj/projectile/energy/medical/upgraded/safe/burn3/on_hit(mob/living/target)
-	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	if(target.getFireLoss() >= 50)
-		return
-	target.adjustFireLoss(-15)
-	target.adjust_disgust(1)
+	projectile_type = /obj/projectile/energy/medical/safe/burn/better/best
+/obj/projectile/energy/medical/safe/burn/better/best
+	name = "safe powerful burn heal shot"
+	amount_healed = 15
+	base_disgust = 1
 
 //End of Basic Tiers of cells.//
 

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -118,16 +118,17 @@
 
 //Basic Toxin Heal//
 /obj/item/ammo_casing/energy/medical/toxin1
-	projectile_type = /obj/projectile/energy/medical/toxin1
+	projectile_type = /obj/projectile/energy/medical/toxin
 	select_name = "toxin"
 
-/obj/projectile/energy/medical/toxin1
+/obj/projectile/energy/medical/toxin
 	name = "toxin heal shot"
 	icon_state = "green_laser"
+	var/amount_healed = 5
 
-/obj/projectile/energy/medical/toxin1/on_hit(mob/living/target)
+/obj/projectile/energy/medical/toxin/on_hit(mob/living/target)
 	. = ..()
-	healTox(target, 5)
+	healTox(target, amount_healed)
 
 //SAFE MODES
 /obj/item/ammo_casing/energy/medical/brute1/safe
@@ -198,16 +199,12 @@
 
 //Tier II Toxin Projectile//
 /obj/item/ammo_casing/energy/medical/toxin2
-	projectile_type = /obj/projectile/energy/medical/upgraded/toxin2
+	projectile_type = /obj/projectile/energy/medical/toxin/better
 	select_name = "toxin II"
 
-/obj/projectile/energy/medical/upgraded/toxin2
+/obj/projectile/energy/medical/toxin/better
 	name = "strong toxin heal shot"
-	icon_state = "green_laser"
-
-/obj/projectile/energy/medical/upgraded/toxin2/on_hit(mob/living/target)
-	. = ..()
-	healTox(target, 7.5)
+	amount_healed = 7.5
 
 //SAFE MODES
 /obj/item/ammo_casing/energy/medical/brute2/safe
@@ -275,12 +272,12 @@
 
 //Tier III Toxin Projectile//
 /obj/item/ammo_casing/energy/medical/toxin3
-	projectile_type = /obj/projectile/energy/medical/upgraded/toxin3
+	projectile_type = /obj/projectile/energy/medical/toxin/better/best
 	select_name = "toxin III"
 
-/obj/projectile/energy/medical/upgraded/toxin3
+/obj/projectile/energy/medical/toxin/better/best
 	name = "powerful toxin heal shot"
-	icon_state = "green_laser"
+	amount_healed = 10
 
 /obj/projectile/energy/medical/upgraded/toxin3/on_hit(mob/living/target)
 	. = ..()

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -99,7 +99,10 @@
 	if(target.stat == DEAD)
 		return
 	//DISGUST
-	BurnDisgust(target)
+	if(target.getFireLoss() > 49)
+		target.adjust_disgust(1.5)
+	if(target.getFireLoss() > 99)
+		target.adjust_disgust(1.5)
 	target.adjust_disgust(3)
 	//CLONE
 	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )
@@ -181,7 +184,10 @@
 	if(target.stat == DEAD)
 		return
 	//DISGUST
-	BruteDisgust(target)
+	if(target.getBruteLoss() >= 50)
+		target.adjust_disgust(1.5)
+	if(target.getBruteLoss() >= 100)
+		target.adjust_disgust(1.5)
 	target.adjust_disgust(2)
 	//CLONE
 	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )
@@ -205,7 +211,10 @@
 	if(target.stat == DEAD)
 		return
 	//DISGUST
-	BurnDisgust(target)
+	if(target.getFireLoss() > 49)
+		target.adjust_disgust(1.5)
+	if(target.getFireLoss() > 99)
+		target.adjust_disgust(1.5)
 	target.adjust_disgust(2)
 	//CLONE
 	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )
@@ -299,7 +308,10 @@
 	if(target.stat == DEAD)
 		return
 	//DISGUST
-	BruteDisgust(target)
+	if(target.getBruteLoss() > 49)
+		target.adjust_disgust(1.5)
+	if(target.getBruteLoss() > 99)
+		target.adjust_disgust(1.5)
 	target.adjust_disgust(1)
 	//CLONE
 	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )
@@ -323,7 +335,10 @@
 	if(target.stat == DEAD)
 		return
 	//DISGUST
-	BurnDisgust(target)
+	if(target.getFireLoss() > 49)
+		target.adjust_disgust(1.5)
+	if(target.getFireLoss() > 99)
+		target.adjust_disgust(1.5)
 	target.adjust_disgust(1)
 	//CLONE
 	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -58,9 +58,9 @@
 		return
 	if(target.stat == DEAD)
 		return
-	//DISGUST 
+	//DISGUST
 	if(target.getBruteLoss() > 49)
-		target.adjust_disgust(1.5) 
+		target.adjust_disgust(1.5)
 	if(target.getBruteLoss() > 99)
 		target.adjust_disgust(1.5)
 	target.adjust_disgust(3)
@@ -85,9 +85,9 @@
 		return
 	if(target.stat == DEAD)
 		return
-	//DISGUST 
+	//DISGUST
 	if(target.getFireLoss() > 49)
-		target.adjust_disgust(1.5) 
+		target.adjust_disgust(1.5)
 	if(target.getFireLoss() > 99)
 		target.adjust_disgust(1.5)
 	target.adjust_disgust(3)
@@ -115,6 +115,25 @@
 		return
 	target.adjustToxLoss(-5)
 	target.radiation = max(target.radiation - 40, 0)//Toxin is treatable, but inefficent//
+
+//SAFE MODES
+/obj/item/ammo_casing/energy/medical/brute1/safe
+	projectile_type = /obj/projectile/energy/medical/safe/brute1
+/obj/projectile/energy/medical/safe/brute1
+	name = "safe brute heal shot"
+	icon_state = "red_laser"
+
+/obj/projectile/energy/medical/safe/brute1/on_hit(mob/living/target)
+	. = ..()
+	if(!istype(target, /mob/living/carbon/human))
+		return
+	if(target.stat == DEAD)
+		return
+	//Stops healing from 50 or over
+	if(target.getBruteLoss() > 49)
+		return
+	target.adjustBruteLoss(-7.5)
+
 //T2 Healing Projectiles//
 //Tier II Brute Projectile//
 /obj/item/ammo_casing/energy/medical/brute2
@@ -132,9 +151,9 @@
 		return
 	if(target.stat == DEAD)
 		return
-	//DISGUST 
+	//DISGUST
 	if(target.getBruteLoss() > 49)
-		target.adjust_disgust(1.5) 
+		target.adjust_disgust(1.5)
 	if(target.getBruteLoss() > 99)
 		target.adjust_disgust(1.5)
 	target.adjust_disgust(2)
@@ -159,9 +178,9 @@
 		return
 	if(target.stat == DEAD)
 		return
-	//DISGUST 
+	//DISGUST
 	if(target.getFireLoss() > 49)
-		target.adjust_disgust(1.5) 
+		target.adjust_disgust(1.5)
 	if(target.getFireLoss() > 99)
 		target.adjust_disgust(1.5)
 	target.adjust_disgust(2)
@@ -219,9 +238,9 @@
 		return
 	if(target.stat == DEAD)
 		return
-	//DISGUST 
+	//DISGUST
 	if(target.getBruteLoss() > 49)
-		target.adjust_disgust(1.5) 
+		target.adjust_disgust(1.5)
 	if(target.getBruteLoss() > 99)
 		target.adjust_disgust(1.5)
 	target.adjust_disgust(1)
@@ -246,9 +265,9 @@
 		return
 	if(target.stat == DEAD)
 		return
-	//DISGUST 
+	//DISGUST
 	if(target.getFireLoss() > 49)
-		target.adjust_disgust(1.5) 
+		target.adjust_disgust(1.5)
 	if(target.getFireLoss() > 99)
 		target.adjust_disgust(1.5)
 	target.adjust_disgust(1)

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -43,16 +43,10 @@
 
 //PROCS//
 //DIGUST
-/obj/projectile/energy/medical/proc/BruteDisgust(mob/living/target)
-	if(target.getBruteLoss() > 49)
-		target.adjust_disgust(1.5)
-	if(target.getBruteLoss() > 99)
-		target.adjust_disgust(1.5)
-
-/obj/projectile/energy/medical/proc/BurnDisgust(mob/living/target)
-	if(target.getFireLoss() > 49)
-		target.adjust_disgust(1.5)
-	if(target.getFireLoss() > 99)
+/obj/projectile/energy/medical/proc/DamageDisgust(mob/living/target, type_damage)
+	if(type_damage >= 100)
+		target.adjust_disgust(3)
+	if(type_damage >=  50 && type_damage < 100)
 		target.adjust_disgust(1.5)
 
 /obj/projectile/energy/medical/proc/IsLivingHuman(mob/living/target)
@@ -60,6 +54,8 @@
 		return FALSE
 	if(target.stat == DEAD)
 		return FALSE
+	else
+		return TRUE
 //T1 Healing Projectiles//
 //The Basic Brute Heal Projectile//
 /obj/item/ammo_casing/energy/medical/brute1
@@ -73,9 +69,9 @@
 /obj/projectile/energy/medical/brute1/on_hit(mob/living/target)
 	. = ..()
 	if(!IsLivingHuman(target))
-		return
+		return FALSE
 	//DISGUST
-	BruteDisgust(target)
+	DamageDisgust(target, target.getBruteLoss())
 	target.adjust_disgust(3)
 	//CLONE
 	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -239,6 +239,41 @@
 		return
 	target.adjustToxLoss(-7.5)
 	target.radiation = max(target.radiation - 60, 0)
+
+//SAFE MODES
+/obj/item/ammo_casing/energy/medical/brute2/safe
+	projectile_type = /obj/projectile/energy/medical/upgraded/safe/brute2
+/obj/projectile/energy/medical/upgraded/safe/brute2
+	name = "safe brute heal shot"
+	icon_state = "red_laser"
+
+/obj/projectile/energy/medical/upgraded/safe/brute2/on_hit(mob/living/target)
+	. = ..()
+	if(!istype(target, /mob/living/carbon/human))
+		return
+	if(target.stat == DEAD)
+		return
+	//Stops healing from 50 or over
+	if(target.getBruteLoss() > 49)
+		return
+	target.adjustBruteLoss(-11.25)
+
+/obj/item/ammo_casing/energy/medical/burn2/safe
+	projectile_type = /obj/projectile/energy/medical/upgraded/safe/burn2
+/obj/projectile/energy/medical/upgraded/safe/burn2
+	name = "safe burn heal shot"
+	icon_state = "yellow_laser"
+
+/obj/projectile/energy/medical/upgraded/safe/burn2/on_hit(mob/living/target)
+	. = ..()
+	if(!istype(target, /mob/living/carbon/human))
+		return
+	if(target.stat == DEAD)
+		return
+	//Stops healing from 50 or over
+	if(target.getFireLoss() > 49)
+		return
+	target.adjustFireLoss(-11.25)
 //T3 Healing Projectiles//
 //Tier III Brute Projectile//
 /obj/item/ammo_casing/energy/medical/brute3
@@ -326,5 +361,39 @@
 		return
 	target.adjustToxLoss(-5)
 	target.radiation = max(target.radiation - 80, 0)
+//SAFE MODES
+/obj/item/ammo_casing/energy/medical/brute3/safe
+	projectile_type = /obj/projectile/energy/medical/upgraded/safe/brute3
+/obj/projectile/energy/medical/upgraded/safe/brute3
+	name = "safe brute heal shot"
+	icon_state = "red_laser"
+
+/obj/projectile/energy/medical/upgraded/safe/brute3/on_hit(mob/living/target)
+	. = ..()
+	if(!istype(target, /mob/living/carbon/human))
+		return
+	if(target.stat == DEAD)
+		return
+	//Stops healing from 50 or over
+	if(target.getBruteLoss() > 49)
+		return
+	target.adjustBruteLoss(-15)
+
+/obj/item/ammo_casing/energy/medical/burn3/safe
+	projectile_type = /obj/projectile/energy/medical/upgraded/safe/burn3
+/obj/projectile/energy/medical/upgraded/safe/burn3
+	name = "safe burn heal shot"
+	icon_state = "yellow_laser"
+
+/obj/projectile/energy/medical/upgraded/safe/burn3/on_hit(mob/living/target)
+	. = ..()
+	if(!istype(target, /mob/living/carbon/human))
+		return
+	if(target.stat == DEAD)
+		return
+	//Stops healing from 50 or over
+	if(target.getFireLoss() > 49)
+		return
+	target.adjustFireLoss(-15)
 
 //End of Basic Tiers of cells.//

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -95,10 +95,7 @@
 	if(target.stat == DEAD)
 		return
 	//DISGUST
-	if(target.getFireLoss() > 49)
-		target.adjust_disgust(1.5)
-	if(target.getFireLoss() > 99)
-		target.adjust_disgust(1.5)
+	BurnDisgust(target)
 	target.adjust_disgust(3)
 	//CLONE
 	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )
@@ -180,10 +177,7 @@
 	if(target.stat == DEAD)
 		return
 	//DISGUST
-	if(target.getBruteLoss() >= 50)
-		target.adjust_disgust(1.5)
-	if(target.getBruteLoss() >= 100)
-		target.adjust_disgust(1.5)
+	BruteDisgust(target)
 	target.adjust_disgust(2)
 	//CLONE
 	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )
@@ -207,10 +201,7 @@
 	if(target.stat == DEAD)
 		return
 	//DISGUST
-	if(target.getFireLoss() > 49)
-		target.adjust_disgust(1.5)
-	if(target.getFireLoss() > 99)
-		target.adjust_disgust(1.5)
+	BurnDisgust(target)
 	target.adjust_disgust(2)
 	//CLONE
 	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )
@@ -304,10 +295,7 @@
 	if(target.stat == DEAD)
 		return
 	//DISGUST
-	if(target.getBruteLoss() > 49)
-		target.adjust_disgust(1.5)
-	if(target.getBruteLoss() > 99)
-		target.adjust_disgust(1.5)
+	BruteDisgust(target)
 	target.adjust_disgust(1)
 	//CLONE
 	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )
@@ -331,10 +319,7 @@
 	if(target.stat == DEAD)
 		return
 	//DISGUST
-	if(target.getFireLoss() > 49)
-		target.adjust_disgust(1.5)
-	if(target.getFireLoss() > 99)
-		target.adjust_disgust(1.5)
+	BurnDisgust(target)
 	target.adjust_disgust(1)
 	//CLONE
 	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -79,6 +79,14 @@
 	DamageClone(target, target.getFireLoss(), amount_healed, max_clone)
 	target.adjustFireLoss(-amount_healed)
 
+//Heal Toxin damage
+/obj/projectile/energy/medical/proc/healTox(mob/living/target, amount_healed)
+	. = ..()
+	if(!IsLivingHuman(target))
+		return FALSE
+	target.adjustToxLoss(-amount_healed)
+	target.radiation = max(target.radiation - (amount_healed * 8), 0)//Rads are treatable, but inefficent//
+
 //T1 Healing Projectiles//
 //The Basic Brute Heal Projectile//
 /obj/item/ammo_casing/energy/medical/brute1
@@ -116,10 +124,7 @@
 
 /obj/projectile/energy/medical/toxin1/on_hit(mob/living/target)
 	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	target.adjustToxLoss(-5)
-	target.radiation = max(target.radiation - 40, 0)//Toxin is treatable, but inefficent//
+	healTox(target, 5)
 
 //SAFE MODES
 /obj/item/ammo_casing/energy/medical/brute1/safe

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -30,7 +30,6 @@
 
 /obj/projectile/energy/medical/upgraded
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-
 /obj/item/ammo_casing/energy/medical/default
 	name = "oxygen heal shot"
 
@@ -42,6 +41,19 @@
 		return
 	target.adjustOxyLoss(-10)
 
+//PROCS//
+//DIGUST
+/obj/projectile/energy/medical/proc/BruteDisgust(mob/living/target)
+	if(target.getBruteLoss() > 49)
+		target.adjust_disgust(1.5)
+	if(target.getBruteLoss() > 99)
+		target.adjust_disgust(1.5)
+
+/obj/projectile/energy/medical/proc/BurnDisgust(mob/living/target)
+	if(target.getFireLoss() > 49)
+		target.adjust_disgust(1.5)
+	if(target.getFireLoss() > 99)
+		target.adjust_disgust(1.5)
 //T1 Healing Projectiles//
 //The Basic Brute Heal Projectile//
 /obj/item/ammo_casing/energy/medical/brute1
@@ -59,10 +71,7 @@
 	if(target.stat == DEAD)
 		return
 	//DISGUST
-	if(target.getBruteLoss() > 49)
-		target.adjust_disgust(1.5)
-	if(target.getBruteLoss() > 99)
-		target.adjust_disgust(1.5)
+	BruteDisgust(target)
 	target.adjust_disgust(3)
 	//CLONE
 	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -60,7 +60,7 @@
 		return FALSE
 	else
 		return TRUE
-
+//Heals Brute without safety
 /obj/projectile/energy/medical/proc/healBrute(mob/living/target, amount_healed, max_clone)
 	. = ..()
 	if(!IsLivingHuman(target))
@@ -69,6 +69,15 @@
 	target.adjust_disgust(3)
 	DamageClone(target, target.getBruteLoss(), amount_healed, max_clone)
 	target.adjustBruteLoss(-amount_healed)
+//Heals Burn damage without safety
+/obj/projectile/energy/medical/proc/healBurn(mob/living/target, amount_healed, max_clone)
+	. = ..()
+	if(!IsLivingHuman(target))
+		return FALSE
+	DamageDisgust(target, target.getFireLoss())
+	target.adjust_disgust(3)
+	DamageClone(target, target.getFireLoss(), amount_healed, max_clone)
+	target.adjustFireLoss(-amount_healed)
 
 //T1 Healing Projectiles//
 //The Basic Brute Heal Projectile//
@@ -81,6 +90,7 @@
 	icon_state = "red_laser"
 
 /obj/projectile/energy/medical/brute1/on_hit(mob/living/target)
+	. = ..()
 	healBrute(target, 7.5, 2/3)
 //The Basic Burn Heal//
 /obj/item/ammo_casing/energy/medical/burn1
@@ -93,12 +103,7 @@
 
 /obj/projectile/energy/medical/burn1/on_hit(mob/living/target)
 	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	DamageDisgust(target, target.getFireLoss())
-	target.adjust_disgust(3)
-	DamageClone(target, target.getFireLoss(), 7.5, 2/3)
-	target.adjustFireLoss(-7.5)
+	healBurn(target, 7.5, 2/3)
 
 //Basic Toxin Heal//
 /obj/item/ammo_casing/energy/medical/toxin1

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -161,16 +161,9 @@
 	if(!IsLivingHuman(target))
 		return FALSE
 	//DISGUST
-	if(target.getBruteLoss() >= 50)
-		target.adjust_disgust(1.5)
-	if(target.getBruteLoss() >= 100)
-		target.adjust_disgust(1.5)
+	DamageDisgust(target, target.getBruteLoss())
 	target.adjust_disgust(2)
-	//CLONE
-	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )
-		target.adjustCloneLoss(1.9)
-	if(target.getBruteLoss() > 99)
-		target.adjustCloneLoss(3.8)
+	DamageClone(target, target.getBruteLoss(), 11.25, 0.33)
 	target.adjustBruteLoss(-11.25)
 //Tier II Burn Projectile//
 /obj/item/ammo_casing/energy/medical/burn2
@@ -185,17 +178,9 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	//DISGUST
-	if(target.getFireLoss() > 49)
-		target.adjust_disgust(1.5)
-	if(target.getFireLoss() > 99)
-		target.adjust_disgust(1.5)
+	DamageDisgust(target, target.getFireLoss())
 	target.adjust_disgust(2)
-	//CLONE
-	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )
-		target.adjustCloneLoss(1.9)
-	if(target.getFireLoss() > 99)
-		target.adjustCloneLoss(3.8)
+	DamageClone(target, target.getFireLoss(), 11.25, 0.33)
 	target.adjustFireLoss(-11.25)
 //Tier II Oxy Projectile//
 /obj/item/ammo_casing/energy/medical/oxy2
@@ -271,17 +256,9 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	//DISGUST
-	if(target.getBruteLoss() > 49)
-		target.adjust_disgust(1.5)
-	if(target.getBruteLoss() > 99)
-		target.adjust_disgust(1.5)
+	DamageDisgust(target, target.getBruteLoss())
 	target.adjust_disgust(1)
-	//CLONE
-	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )
-		target.adjustCloneLoss(1.125)
-	if(target.getBruteLoss() > 99)
-		target.adjustCloneLoss(2.25)
+	DamageClone(target, target.getBruteLoss(), 15, 0.11)
 	target.adjustBruteLoss(-15)
 //Tier III Burn Projectile//
 /obj/item/ammo_casing/energy/medical/burn3
@@ -296,17 +273,9 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	//DISGUST
-	if(target.getFireLoss() > 49)
-		target.adjust_disgust(1.5)
-	if(target.getFireLoss() > 99)
-		target.adjust_disgust(1.5)
+	DamageDisgust(target, target.getFireLoss())
 	target.adjust_disgust(1)
-	//CLONE
-	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )
-		target.adjustCloneLoss(1.125)
-	if(target.getFireLoss() > 99)
-		target.adjustCloneLoss(2.25)
+	DamageClone(target, target.getFireLoss(), 15, 0.11)
 	target.adjustFireLoss(-15)
 //Tier III Oxy Projectile//
 /obj/item/ammo_casing/energy/medical/oxy3

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -1,3 +1,5 @@
+#define UPGRADED_MEDICELL_PASSFLAGS PASSTABLE | PASSGLASS | PASSGRILLE
+
 //Medigun Cells/
 /obj/item/stock_parts/cell/medigun/ //This is the cell that mediguns from cargo will come with//
 	name = "Basic Medigun Cell"
@@ -29,7 +31,7 @@
 	damage = 0
 
 /obj/projectile/energy/medical/upgraded
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	pass_flags = UPGRADED_MEDICELL_PASSFLAGS
 /obj/item/ammo_casing/energy/medical/default
 	name = "oxygen heal shot"
 
@@ -87,16 +89,19 @@
 //T1 Healing Projectiles//
 //The Basic Brute Heal Projectile//
 /obj/item/ammo_casing/energy/medical/brute1
-	projectile_type = /obj/projectile/energy/medical/brute1
+	projectile_type = /obj/projectile/energy/medical/brute
 	select_name = "brute"
 
-/obj/projectile/energy/medical/brute1
+/obj/projectile/energy/medical/brute
 	name = "brute heal shot"
 	icon_state = "red_laser"
+	var/amount_healed = 7.5
+	var/max_clone = 2/3
+	var/base_disgust = 3
 
-/obj/projectile/energy/medical/brute1/on_hit(mob/living/target)
+/obj/projectile/energy/medical/brute/on_hit(mob/living/target)
 	. = ..()
-	healBrute(target, 7.5, 2/3, 3)
+	healBrute(target, amount_healed, max_clone, base_disgust)
 //The Basic Burn Heal//
 /obj/item/ammo_casing/energy/medical/burn1
 	projectile_type = /obj/projectile/energy/medical/burn1
@@ -159,17 +164,16 @@
 //T2 Healing Projectiles//
 //Tier II Brute Projectile//
 /obj/item/ammo_casing/energy/medical/brute2
-	projectile_type = /obj/projectile/energy/medical/upgraded/brute2
+	projectile_type = /obj/projectile/energy/medical/brute/better
 	select_name = "brute II"
 
-/obj/projectile/energy/medical/upgraded/brute2
+/obj/projectile/energy/medical/brute/better
 	name = "strong brute heal shot"
-	icon_state = "red_laser"
+	pass_flags =  UPGRADED_MEDICELL_PASSFLAGS
+	amount_healed = 11.25
+	max_clone = 1/3
+	base_disgust = 2
 
-
-/obj/projectile/energy/medical/upgraded/brute2/on_hit(mob/living/target)
-	. = ..()
-	healBrute(target, 11.25, 1/3, 2)
 //Tier II Burn Projectile//
 /obj/item/ammo_casing/energy/medical/burn2
 	projectile_type = /obj/projectile/energy/medical/upgraded/burn2
@@ -243,16 +247,15 @@
 //T3 Healing Projectiles//
 //Tier III Brute Projectile//
 /obj/item/ammo_casing/energy/medical/brute3
-	projectile_type = /obj/projectile/energy/medical/upgraded/brute3
+	projectile_type = /obj/projectile/energy/medical/brute/better/best
 	select_name = "brute III"
 
-/obj/projectile/energy/medical/upgraded/brute3
+/obj/projectile/energy/medical/brute/better/best
 	name = "powerful brute heal shot"
-	icon_state = "red_laser"
+	amount_healed = 15
+	max_clone = 1/9
+	base_disgust = 1
 
-/obj/projectile/energy/medical/upgraded/brute3/on_hit(mob/living/target)
-	. = ..()
-	healBrute(target, 15, 1/9, 1)
 //Tier III Burn Projectile//
 /obj/item/ammo_casing/energy/medical/burn3
 	projectile_type = /obj/projectile/energy/medical/upgraded/burn3
@@ -324,3 +327,5 @@
 	target.adjust_disgust(1)
 
 //End of Basic Tiers of cells.//
+
+#undef UPGRADED_MEDICELL_PASSFLAGS

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -133,6 +133,7 @@
 	if(target.getBruteLoss() > 49)
 		return
 	target.adjustBruteLoss(-7.5)
+	target.adjust_disgust(3)
 
 /obj/item/ammo_casing/energy/medical/burn1/safe
 	projectile_type = /obj/projectile/energy/medical/safe/burn1
@@ -150,6 +151,7 @@
 	if(target.getFireLoss() > 49)
 		return
 	target.adjustFireLoss(-7.5)
+	target.adjust_disgust(3)
 
 //T2 Healing Projectiles//
 //Tier II Brute Projectile//
@@ -257,6 +259,7 @@
 	if(target.getBruteLoss() > 49)
 		return
 	target.adjustBruteLoss(-11.25)
+	target.adjust_disgust(2)
 
 /obj/item/ammo_casing/energy/medical/burn2/safe
 	projectile_type = /obj/projectile/energy/medical/upgraded/safe/burn2
@@ -274,6 +277,7 @@
 	if(target.getFireLoss() > 49)
 		return
 	target.adjustFireLoss(-11.25)
+	target.adjust_disgust(2)
 //T3 Healing Projectiles//
 //Tier III Brute Projectile//
 /obj/item/ammo_casing/energy/medical/brute3
@@ -378,6 +382,7 @@
 	if(target.getBruteLoss() > 49)
 		return
 	target.adjustBruteLoss(-15)
+	target.adjust_disgust(1)
 
 /obj/item/ammo_casing/energy/medical/burn3/safe
 	projectile_type = /obj/projectile/energy/medical/upgraded/safe/burn3
@@ -395,5 +400,6 @@
 	if(target.getFireLoss() > 49)
 		return
 	target.adjustFireLoss(-15)
+	target.adjust_disgust(1)
 
 //End of Basic Tiers of cells.//

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -42,13 +42,19 @@
 	target.adjustOxyLoss(-10)
 
 //PROCS//
-//DIGUST
+//Applies digust by damage thresholds.
 /obj/projectile/energy/medical/proc/DamageDisgust(mob/living/target, type_damage)
 	if(type_damage >= 100)
 		target.adjust_disgust(3)
 	if(type_damage >=  50 && type_damage < 100)
 		target.adjust_disgust(1.5)
-
+//Applies clone damage by thresholds
+/obj/projectile/energy/medical/proc/DamageClone(mob/living/target, type_damage, ammount_healed, max_clone)
+	if(type_damage > 49 && type_damage < 100 )
+		target.adjustCloneLoss((ammount_healed * (max_clone * 0.5)))
+	if(type_damage > 99)
+		target.adjustCloneLoss((ammount_healed * max_clone))
+//Checks to see if the patient is living.
 /obj/projectile/energy/medical/proc/IsLivingHuman(mob/living/target)
 	if(!istype(target, /mob/living/carbon/human))
 		return FALSE
@@ -74,10 +80,7 @@
 	DamageDisgust(target, target.getBruteLoss())
 	target.adjust_disgust(3)
 	//CLONE
-	if(target.getBruteLoss() > 49 && target.getBruteLoss() < 100 )
-		target.adjustCloneLoss(2.45)
-	if(target.getBruteLoss() > 99)
-		target.adjustCloneLoss(4.9)
+	DamageClone(target, target.getBruteLoss(), 7.5, 0.66)
 	target.adjustBruteLoss(-7.5)
 //The Basic Burn Heal//
 /obj/item/ammo_casing/energy/medical/burn1

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -60,6 +60,16 @@
 		return FALSE
 	else
 		return TRUE
+
+/obj/projectile/energy/medical/proc/healBrute(mob/living/target, amount_healed, max_clone)
+	. = ..()
+	if(!IsLivingHuman(target))
+		return FALSE
+	DamageDisgust(target, target.getBruteLoss())
+	target.adjust_disgust(3)
+	DamageClone(target, target.getBruteLoss(), amount_healed, max_clone)
+	target.adjustBruteLoss(-amount_healed)
+
 //T1 Healing Projectiles//
 //The Basic Brute Heal Projectile//
 /obj/item/ammo_casing/energy/medical/brute1
@@ -71,13 +81,7 @@
 	icon_state = "red_laser"
 
 /obj/projectile/energy/medical/brute1/on_hit(mob/living/target)
-	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	DamageDisgust(target, target.getBruteLoss())
-	target.adjust_disgust(3)
-	DamageClone(target, target.getBruteLoss(), 7.5, 2/3)
-	target.adjustBruteLoss(-7.5)
+	healBrute(target, 7.5, 2/3)
 //The Basic Burn Heal//
 /obj/item/ammo_casing/energy/medical/burn1
 	projectile_type = /obj/projectile/energy/medical/burn1

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -61,27 +61,24 @@
 	else
 		return TRUE
 //Heals Brute without safety
-/obj/projectile/energy/medical/proc/healBrute(mob/living/target, amount_healed, max_clone)
-	. = ..()
+/obj/projectile/energy/medical/proc/healBrute(mob/living/target, amount_healed, max_clone, base_disgust)
 	if(!IsLivingHuman(target))
 		return FALSE
 	DamageDisgust(target, target.getBruteLoss())
-	target.adjust_disgust(3)
+	target.adjust_disgust(base_disgust)
 	DamageClone(target, target.getBruteLoss(), amount_healed, max_clone)
 	target.adjustBruteLoss(-amount_healed)
 //Heals Burn damage without safety
-/obj/projectile/energy/medical/proc/healBurn(mob/living/target, amount_healed, max_clone)
-	. = ..()
+/obj/projectile/energy/medical/proc/healBurn(mob/living/target, amount_healed, max_clone, base_disgust)
 	if(!IsLivingHuman(target))
 		return FALSE
 	DamageDisgust(target, target.getFireLoss())
-	target.adjust_disgust(3)
+	target.adjust_disgust(base_disgust)
 	DamageClone(target, target.getFireLoss(), amount_healed, max_clone)
 	target.adjustFireLoss(-amount_healed)
 
 //Heal Toxin damage
 /obj/projectile/energy/medical/proc/healTox(mob/living/target, amount_healed)
-	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
 	target.adjustToxLoss(-amount_healed)
@@ -99,7 +96,7 @@
 
 /obj/projectile/energy/medical/brute1/on_hit(mob/living/target)
 	. = ..()
-	healBrute(target, 7.5, 2/3)
+	healBrute(target, 7.5, 2/3, 3)
 //The Basic Burn Heal//
 /obj/item/ammo_casing/energy/medical/burn1
 	projectile_type = /obj/projectile/energy/medical/burn1
@@ -111,7 +108,7 @@
 
 /obj/projectile/energy/medical/burn1/on_hit(mob/living/target)
 	. = ..()
-	healBurn(target, 7.5, 2/3)
+	healBurn(target, 7.5, 2/3, 3)
 
 //Basic Toxin Heal//
 /obj/item/ammo_casing/energy/medical/toxin1
@@ -172,12 +169,7 @@
 
 /obj/projectile/energy/medical/upgraded/brute2/on_hit(mob/living/target)
 	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	DamageDisgust(target, target.getBruteLoss())
-	target.adjust_disgust(2)
-	DamageClone(target, target.getBruteLoss(), 11.25, 1/3)
-	target.adjustBruteLoss(-11.25)
+	healBrute(target, 11.25, 1/3, 2)
 //Tier II Burn Projectile//
 /obj/item/ammo_casing/energy/medical/burn2
 	projectile_type = /obj/projectile/energy/medical/upgraded/burn2
@@ -189,12 +181,7 @@
 
 /obj/projectile/energy/medical/upgraded/burn2/on_hit(mob/living/target)
 	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	DamageDisgust(target, target.getFireLoss())
-	target.adjust_disgust(2)
-	DamageClone(target, target.getFireLoss(), 11.25, 1/3)
-	target.adjustFireLoss(-11.25)
+	healBurn(target, 11.25, 1/3, 2)
 //Tier II Oxy Projectile//
 /obj/item/ammo_casing/energy/medical/oxy2
 	projectile_type = /obj/projectile/energy/medical/upgraded/oxy2
@@ -218,10 +205,8 @@
 	icon_state = "green_laser"
 
 /obj/projectile/energy/medical/upgraded/toxin2/on_hit(mob/living/target)
-	if(!IsLivingHuman(target))
-		return FALSE
-	target.adjustToxLoss(-7.5)
-	target.radiation = max(target.radiation - 60, 0)
+	. = ..()
+	healTox(target, 7.5)
 
 //SAFE MODES
 /obj/item/ammo_casing/energy/medical/brute2/safe
@@ -267,12 +252,7 @@
 
 /obj/projectile/energy/medical/upgraded/brute3/on_hit(mob/living/target)
 	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	DamageDisgust(target, target.getBruteLoss())
-	target.adjust_disgust(1)
-	DamageClone(target, target.getBruteLoss(), 15, 1/9)
-	target.adjustBruteLoss(-15)
+	healBrute(target, 15, 1/9, 1)
 //Tier III Burn Projectile//
 /obj/item/ammo_casing/energy/medical/burn3
 	projectile_type = /obj/projectile/energy/medical/upgraded/burn3
@@ -284,12 +264,7 @@
 
 /obj/projectile/energy/medical/upgraded/burn3/on_hit(mob/living/target)
 	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	DamageDisgust(target, target.getFireLoss())
-	target.adjust_disgust(1)
-	DamageClone(target, target.getFireLoss(), 15, 1/9)
-	target.adjustFireLoss(-15)
+	healBurn(target, 15, 1/9, 1)
 //Tier III Oxy Projectile//
 /obj/item/ammo_casing/energy/medical/oxy3
 	projectile_type = /obj/projectile/energy/medical/upgraded/oxy3
@@ -314,10 +289,7 @@
 
 /obj/projectile/energy/medical/upgraded/toxin3/on_hit(mob/living/target)
 	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	target.adjustToxLoss(-5)
-	target.radiation = max(target.radiation - 80, 0)
+	healTox(target, 10)
 //SAFE MODES
 /obj/item/ammo_casing/energy/medical/brute3/safe
 	projectile_type = /obj/projectile/energy/medical/upgraded/safe/brute3

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -47,11 +47,11 @@
 	if(type_damage >=  50 && type_damage < 100)
 		target.adjust_disgust(1.5)
 //Applies clone damage by thresholds
-/obj/projectile/energy/medical/proc/DamageClone(mob/living/target, type_damage, ammount_healed, max_clone)
-	if(type_damage > 49 && type_damage < 100 )
-		target.adjustCloneLoss((ammount_healed * (max_clone * 0.5)))
-	if(type_damage > 99)
-		target.adjustCloneLoss((ammount_healed * max_clone))
+/obj/projectile/energy/medical/proc/DamageClone(mob/living/target, type_damage, amount_healed, max_clone)
+	if(type_damage >= 50 && type_damage < 100 )
+		target.adjustCloneLoss((amount_healed * (max_clone * 0.5)))
+	if(type_damage >= 100)
+		target.adjustCloneLoss((amount_healed * max_clone))
 //Checks to see if the patient is living.
 /obj/projectile/energy/medical/proc/IsLivingHuman(mob/living/target)
 	if(!istype(target, /mob/living/carbon/human))
@@ -76,7 +76,7 @@
 		return FALSE
 	DamageDisgust(target, target.getBruteLoss())
 	target.adjust_disgust(3)
-	DamageClone(target, target.getBruteLoss(), 7.5, 0.66)
+	DamageClone(target, target.getBruteLoss(), 7.5, 2/3)
 	target.adjustBruteLoss(-7.5)
 //The Basic Burn Heal//
 /obj/item/ammo_casing/energy/medical/burn1
@@ -93,7 +93,7 @@
 		return FALSE
 	DamageDisgust(target, target.getFireLoss())
 	target.adjust_disgust(3)
-	DamageClone(target, target.getFireLoss(), 7.5, 0.66)
+	DamageClone(target, target.getFireLoss(), 7.5, 2/3)
 	target.adjustFireLoss(-7.5)
 
 //Basic Toxin Heal//
@@ -162,7 +162,7 @@
 		return FALSE
 	DamageDisgust(target, target.getBruteLoss())
 	target.adjust_disgust(2)
-	DamageClone(target, target.getBruteLoss(), 11.25, 0.33)
+	DamageClone(target, target.getBruteLoss(), 11.25, 1/3)
 	target.adjustBruteLoss(-11.25)
 //Tier II Burn Projectile//
 /obj/item/ammo_casing/energy/medical/burn2
@@ -179,7 +179,7 @@
 		return FALSE
 	DamageDisgust(target, target.getFireLoss())
 	target.adjust_disgust(2)
-	DamageClone(target, target.getFireLoss(), 11.25, 0.33)
+	DamageClone(target, target.getFireLoss(), 11.25, 1/3)
 	target.adjustFireLoss(-11.25)
 //Tier II Oxy Projectile//
 /obj/item/ammo_casing/energy/medical/oxy2
@@ -221,7 +221,7 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	if(target.getBruteLoss() > 49)
+	if(target.getBruteLoss() >= 50)
 		return
 	target.adjustBruteLoss(-11.25)
 	target.adjust_disgust(2)
@@ -237,7 +237,7 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	if(target.getFireLoss() > 49)
+	if(target.getFireLoss() >= 50)
 		return
 	target.adjustFireLoss(-11.25)
 	target.adjust_disgust(2)
@@ -257,7 +257,7 @@
 		return FALSE
 	DamageDisgust(target, target.getBruteLoss())
 	target.adjust_disgust(1)
-	DamageClone(target, target.getBruteLoss(), 15, 0.11)
+	DamageClone(target, target.getBruteLoss(), 15, 1/9)
 	target.adjustBruteLoss(-15)
 //Tier III Burn Projectile//
 /obj/item/ammo_casing/energy/medical/burn3
@@ -274,7 +274,7 @@
 		return FALSE
 	DamageDisgust(target, target.getFireLoss())
 	target.adjust_disgust(1)
-	DamageClone(target, target.getFireLoss(), 15, 0.11)
+	DamageClone(target, target.getFireLoss(), 15, 1/9)
 	target.adjustFireLoss(-15)
 //Tier III Oxy Projectile//
 /obj/item/ammo_casing/energy/medical/oxy3
@@ -316,7 +316,7 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	if(target.getBruteLoss() > 49)
+	if(target.getBruteLoss() >= 50)
 		return
 	target.adjustBruteLoss(-15)
 	target.adjust_disgust(1)
@@ -332,7 +332,7 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	if(target.getFireLoss() > 49)
+	if(target.getFireLoss() >= 50)
 		return
 	target.adjustFireLoss(-15)
 	target.adjust_disgust(1)

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -35,10 +35,8 @@
 
 /obj/projectile/energy/medical/default/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	target.adjustOxyLoss(-10)
 
 //PROCS//
@@ -91,10 +89,8 @@
 
 /obj/projectile/energy/medical/burn1/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	//DISGUST
 	if(target.getFireLoss() > 49)
 		target.adjust_disgust(1.5)
@@ -119,10 +115,8 @@
 
 /obj/projectile/energy/medical/toxin1/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	target.adjustToxLoss(-5)
 	target.radiation = max(target.radiation - 40, 0)//Toxin is treatable, but inefficent//
 
@@ -135,10 +129,8 @@
 
 /obj/projectile/energy/medical/safe/brute1/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	//Stops healing from 50 or over
 	if(target.getBruteLoss() >= 50)
 		return
@@ -153,10 +145,8 @@
 
 /obj/projectile/energy/medical/safe/burn1/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	//Stops healing from 50 or over
 	if(target.getFireLoss() >= 50)
 		return
@@ -176,10 +166,8 @@
 
 /obj/projectile/energy/medical/upgraded/brute2/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	//DISGUST
 	if(target.getBruteLoss() >= 50)
 		target.adjust_disgust(1.5)
@@ -203,10 +191,8 @@
 
 /obj/projectile/energy/medical/upgraded/burn2/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	//DISGUST
 	if(target.getFireLoss() > 49)
 		target.adjust_disgust(1.5)
@@ -229,10 +215,8 @@
 
 /obj/projectile/energy/medical/upgraded/oxy2/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	target.adjustOxyLoss(-20)
 //Tier II Toxin Projectile//
 /obj/item/ammo_casing/energy/medical/toxin2
@@ -244,11 +228,8 @@
 	icon_state = "green_laser"
 
 /obj/projectile/energy/medical/upgraded/toxin2/on_hit(mob/living/target)
-	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	target.adjustToxLoss(-7.5)
 	target.radiation = max(target.radiation - 60, 0)
 
@@ -261,10 +242,8 @@
 
 /obj/projectile/energy/medical/upgraded/safe/brute2/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	//Stops healing from 50 or over
 	if(target.getBruteLoss() > 49)
 		return
@@ -279,10 +258,8 @@
 
 /obj/projectile/energy/medical/upgraded/safe/burn2/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	//Stops healing from 50 or over
 	if(target.getFireLoss() > 49)
 		return
@@ -300,10 +277,8 @@
 
 /obj/projectile/energy/medical/upgraded/brute3/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	//DISGUST
 	if(target.getBruteLoss() > 49)
 		target.adjust_disgust(1.5)
@@ -327,10 +302,8 @@
 
 /obj/projectile/energy/medical/upgraded/burn3/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	//DISGUST
 	if(target.getFireLoss() > 49)
 		target.adjust_disgust(1.5)
@@ -353,10 +326,8 @@
 
 /obj/projectile/energy/medical/upgraded/oxy3/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	target.adjustOxyLoss(-30)
 //Tier III Toxin Projectile//
 /obj/item/ammo_casing/energy/medical/toxin3
@@ -369,10 +340,8 @@
 
 /obj/projectile/energy/medical/upgraded/toxin3/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	target.adjustToxLoss(-5)
 	target.radiation = max(target.radiation - 80, 0)
 //SAFE MODES
@@ -384,10 +353,8 @@
 
 /obj/projectile/energy/medical/upgraded/safe/brute3/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	//Stops healing from 50 or over
 	if(target.getBruteLoss() > 49)
 		return
@@ -402,10 +369,8 @@
 
 /obj/projectile/energy/medical/upgraded/safe/burn3/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
-		return
+	if(!IsLivingHuman(target))
+		return FALSE
 	//Stops healing from 50 or over
 	if(target.getFireLoss() > 49)
 		return

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -77,6 +77,22 @@
 	DamageClone(target, target.getFireLoss(), amount_healed, max_clone)
 	target.adjustFireLoss(-amount_healed)
 
+/obj/projectile/energy/medical/proc/safeBrute(mob/living/target, amount_healed, base_disgust)
+	if(!IsLivingHuman(target))
+		return FALSE
+	if(target.getBruteLoss() >= 50 )
+		return FALSE
+	target.adjust_disgust(base_disgust)
+	target.adjustBruteLoss(-amount_healed)
+
+/obj/projectile/energy/medical/proc/safeBurn(mob/living/target, amount_healed, base_disgust)
+	if(!IsLivingHuman(target))
+		return FALSE
+	if(target.getFireLoss() >= 50 )
+		return FALSE
+	target.adjust_disgust(base_disgust)
+	target.adjustFireLoss(-amount_healed)
+
 //Heal Toxin damage
 /obj/projectile/energy/medical/proc/healTox(mob/living/target, amount_healed)
 	if(!IsLivingHuman(target))
@@ -132,20 +148,18 @@
 
 //SAFE MODES
 /obj/item/ammo_casing/energy/medical/brute1/safe
-	projectile_type = /obj/projectile/energy/medical/safe/brute1
+	projectile_type = /obj/projectile/energy/medical/safe/brute
 
-/obj/projectile/energy/medical/safe/brute1
+/obj/projectile/energy/medical/safe/brute
 	name = "safe brute heal shot"
 	icon_state = "red_laser"
+	var/amount_healed = 7.5
+	var/base_disgust = 3
 
-/obj/projectile/energy/medical/safe/brute1/on_hit(mob/living/target)
+
+/obj/projectile/energy/medical/safe/brute/on_hit(mob/living/target)
 	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	if(target.getBruteLoss() >= 50)
-		return
-	target.adjustBruteLoss(-7.5)
-	target.adjust_disgust(3)
+	safeBrute(target, amount_healed, base_disgust)
 
 /obj/item/ammo_casing/energy/medical/burn1/safe
 	projectile_type = /obj/projectile/energy/medical/safe/burn1
@@ -195,6 +209,7 @@
 
 /obj/projectile/energy/medical/oxygen/better
 	name = "strong oxygen heal shot"
+	pass_flags =  UPGRADED_MEDICELL_PASSFLAGS
 	amount_healed = 20
 
 //Tier II Toxin Projectile//
@@ -204,24 +219,18 @@
 
 /obj/projectile/energy/medical/toxin/better
 	name = "strong toxin heal shot"
+	pass_flags =  UPGRADED_MEDICELL_PASSFLAGS
 	amount_healed = 7.5
 
 //SAFE MODES
 /obj/item/ammo_casing/energy/medical/brute2/safe
-	projectile_type = /obj/projectile/energy/medical/upgraded/safe/brute2
+	projectile_type = /obj/projectile/energy/medical/safe/brute/better
 
-/obj/projectile/energy/medical/upgraded/safe/brute2
-	name = "safe brute heal shot"
-	icon_state = "red_laser"
-
-/obj/projectile/energy/medical/upgraded/safe/brute2/on_hit(mob/living/target)
-	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	if(target.getBruteLoss() >= 50)
-		return
-	target.adjustBruteLoss(-11.25)
-	target.adjust_disgust(2)
+/obj/projectile/energy/medical/safe/brute/better
+	name = "safe strong brute heal shot"
+	pass_flags =  UPGRADED_MEDICELL_PASSFLAGS
+	amount_healed = 11.25
+	base_disgust = 2
 
 /obj/item/ammo_casing/energy/medical/burn2/safe
 	projectile_type = /obj/projectile/energy/medical/upgraded/safe/burn2
@@ -284,21 +293,12 @@
 	healTox(target, 10)
 //SAFE MODES
 /obj/item/ammo_casing/energy/medical/brute3/safe
-	projectile_type = /obj/projectile/energy/medical/upgraded/safe/brute3
+	projectile_type = /obj/projectile/energy/medical/safe/brute/better/best
 
-/obj/projectile/energy/medical/upgraded/safe/brute3
-	name = "safe brute heal shot"
-	icon_state = "red_laser"
-
-/obj/projectile/energy/medical/upgraded/safe/brute3/on_hit(mob/living/target)
-	. = ..()
-	if(!IsLivingHuman(target))
-		return FALSE
-	if(target.getBruteLoss() >= 50)
-		return
-	target.adjustBruteLoss(-15)
-	target.adjust_disgust(1)
-
+/obj/projectile/energy/medical/safe/brute/better/best
+	name = "safe powerful brute heal shot"
+	amount_healed = 15
+	base_disgust = 1
 /obj/item/ammo_casing/energy/medical/burn3/safe
 	projectile_type = /obj/projectile/energy/medical/upgraded/safe/burn3
 

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -54,6 +54,12 @@
 		target.adjust_disgust(1.5)
 	if(target.getFireLoss() > 99)
 		target.adjust_disgust(1.5)
+
+/obj/projectile/energy/medical/proc/IsLivingHuman(mob/living/target)
+	if(!istype(target, /mob/living/carbon/human))
+		return FALSE
+	if(target.stat == DEAD)
+		return FALSE
 //T1 Healing Projectiles//
 //The Basic Brute Heal Projectile//
 /obj/item/ammo_casing/energy/medical/brute1
@@ -66,9 +72,7 @@
 
 /obj/projectile/energy/medical/brute1/on_hit(mob/living/target)
 	. = ..()
-	if(!istype(target, /mob/living/carbon/human))
-		return
-	if(target.stat == DEAD)
+	if(!IsLivingHuman(target))
 		return
 	//DISGUST
 	BruteDisgust(target)

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -76,10 +76,8 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	//DISGUST
 	DamageDisgust(target, target.getBruteLoss())
 	target.adjust_disgust(3)
-	//CLONE
 	DamageClone(target, target.getBruteLoss(), 7.5, 0.66)
 	target.adjustBruteLoss(-7.5)
 //The Basic Burn Heal//

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -91,17 +91,9 @@
 	. = ..()
 	if(!IsLivingHuman(target))
 		return FALSE
-	//DISGUST
-	if(target.getFireLoss() > 49)
-		target.adjust_disgust(1.5)
-	if(target.getFireLoss() > 99)
-		target.adjust_disgust(1.5)
+	DamageDisgust(target, target.getFireLoss())
 	target.adjust_disgust(3)
-	//CLONE
-	if(target.getFireLoss() > 49 && target.getFireLoss() < 100 )
-		target.adjustCloneLoss(2.45)
-	if(target.getFireLoss() > 99)
-		target.adjustCloneLoss(4.9)
+	DamageClone(target, target.getFireLoss(), 7.5, 0.66)
 	target.adjustFireLoss(-7.5)
 
 //Basic Toxin Heal//

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -104,16 +104,19 @@
 	healBrute(target, amount_healed, max_clone, base_disgust)
 //The Basic Burn Heal//
 /obj/item/ammo_casing/energy/medical/burn1
-	projectile_type = /obj/projectile/energy/medical/burn1
+	projectile_type = /obj/projectile/energy/medical/burn
 	select_name = "burn"
 
-/obj/projectile/energy/medical/burn1
+/obj/projectile/energy/medical/burn
 	name = "burn heal shot"
 	icon_state = "yellow_laser"
+	var/amount_healed = 7.5
+	var/max_clone = 2/3
+	var/base_disgust = 3
 
-/obj/projectile/energy/medical/burn1/on_hit(mob/living/target)
+/obj/projectile/energy/medical/burn/on_hit(mob/living/target)
 	. = ..()
-	healBurn(target, 7.5, 2/3, 3)
+	healBurn(target, amount_healed, max_clone, base_disgust)
 
 //Basic Toxin Heal//
 /obj/item/ammo_casing/energy/medical/toxin1
@@ -176,16 +179,16 @@
 
 //Tier II Burn Projectile//
 /obj/item/ammo_casing/energy/medical/burn2
-	projectile_type = /obj/projectile/energy/medical/upgraded/burn2
+	projectile_type = /obj/projectile/energy/medical/burn/better
 	select_name = "burn II"
 
-/obj/projectile/energy/medical/upgraded/burn2
+/obj/projectile/energy/medical/burn/better
 	name = "strong burn heal shot"
-	icon_state = "yellow_laser"
+	pass_flags =  UPGRADED_MEDICELL_PASSFLAGS
+	amount_healed = 11.25
+	max_clone = 1/3
+	base_disgust = 2
 
-/obj/projectile/energy/medical/upgraded/burn2/on_hit(mob/living/target)
-	. = ..()
-	healBurn(target, 11.25, 1/3, 2)
 //Tier II Oxy Projectile//
 /obj/item/ammo_casing/energy/medical/oxy2
 	projectile_type = /obj/projectile/energy/medical/upgraded/oxy2
@@ -258,16 +261,15 @@
 
 //Tier III Burn Projectile//
 /obj/item/ammo_casing/energy/medical/burn3
-	projectile_type = /obj/projectile/energy/medical/upgraded/burn3
+	projectile_type = /obj/projectile/energy/medical/burn/better/best
 	select_name = "burn III"
 
-/obj/projectile/energy/medical/upgraded/burn3
+/obj/projectile/energy/medical/burn/better/best
 	name = "powerful burn heal shot"
-	icon_state = "yellow_laser"
+	amount_healed = 15
+	max_clone = 1/9
+	base_disgust = 1
 
-/obj/projectile/energy/medical/upgraded/burn3/on_hit(mob/living/target)
-	. = ..()
-	healBurn(target, 15, 1/9, 1)
 //Tier III Oxy Projectile//
 /obj/item/ammo_casing/energy/medical/oxy3
 	projectile_type = /obj/projectile/energy/medical/upgraded/oxy3

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -134,6 +134,23 @@
 		return
 	target.adjustBruteLoss(-7.5)
 
+/obj/item/ammo_casing/energy/medical/burn1/safe
+	projectile_type = /obj/projectile/energy/medical/safe/burn1
+/obj/projectile/energy/medical/safe/burn1
+	name = "safe burn heal shot"
+	icon_state = "yellow_laser"
+
+/obj/projectile/energy/medical/safe/burn1/on_hit(mob/living/target)
+	. = ..()
+	if(!istype(target, /mob/living/carbon/human))
+		return
+	if(target.stat == DEAD)
+		return
+	//Stops healing from 50 or over
+	if(target.getFireLoss() > 49)
+		return
+	target.adjustFireLoss(-7.5)
+
 //T2 Healing Projectiles//
 //Tier II Brute Projectile//
 /obj/item/ammo_casing/energy/medical/brute2

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medcells.dm
@@ -130,7 +130,7 @@
 	if(target.stat == DEAD)
 		return
 	//Stops healing from 50 or over
-	if(target.getBruteLoss() > 49)
+	if(target.getBruteLoss() >= 50)
 		return
 	target.adjustBruteLoss(-7.5)
 	target.adjust_disgust(3)
@@ -148,7 +148,7 @@
 	if(target.stat == DEAD)
 		return
 	//Stops healing from 50 or over
-	if(target.getFireLoss() > 49)
+	if(target.getFireLoss() >= 50)
 		return
 	target.adjustFireLoss(-7.5)
 	target.adjust_disgust(3)
@@ -171,9 +171,9 @@
 	if(target.stat == DEAD)
 		return
 	//DISGUST
-	if(target.getBruteLoss() > 49)
+	if(target.getBruteLoss() >= 50)
 		target.adjust_disgust(1.5)
-	if(target.getBruteLoss() > 99)
+	if(target.getBruteLoss() >= 100)
 		target.adjust_disgust(1.5)
 	target.adjust_disgust(2)
 	//CLONE

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -96,7 +96,7 @@
 		to_chat(user, span_notice("The safety on the Medicell is now on, you cannot heal when it will cause clone damage to the patient"))
 		src.ammo_type = safe_ammo
 		return
-	if(on_safety ==  1)
+	if(on_safety)
 		on_safety = FALSE
 		to_chat(user, span_notice("The safety on the Medicell is now off, you can heal when it will cause clone damage to the patient"))
 		src.ammo_type = unsafe_ammo

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -112,7 +112,9 @@
 	name = "Burn I Medicell"
 	desc = "A small cell with a yellow glow. Can be used on Mediguns to unlock the Burn I Functoinality"
 	icon_state = "Burn1"
-	ammo_type = /obj/item/ammo_casing/energy/medical/burn1
+	ammo_type = /obj/item/ammo_casing/energy/medical/burn1/safe
+	unsafe_ammo = /obj/item/ammo_casing/energy/medical/burn1
+	safe_ammo = /obj/item/ammo_casing/energy/medical/burn1/safe
 	has_safety = TRUE
 //Toxin I//
 /obj/item/medicell/toxin1

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -77,6 +77,17 @@
 	var/unsafe_ammo = /obj/item/ammo_casing/energy/medical
 
 //MEDIGUN SAFETY
+
+/obj/item/medicell/examine(mob/user)
+	. = ..()
+	if(!has_safety)
+		return
+	if(!on_safety)
+		to_chat(user, span_info("[src] has the safety turned off."))
+		return
+	else
+		to_chat(user, span_info("[src] has the safety turned on."))
+
 /obj/item/medicell/attack_self(mob/living/user)
 	if(!has_safety)
 		return

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -71,6 +71,23 @@
 	icon_state = "Oxy1"
 	w_class = WEIGHT_CLASS_SMALL
 	var/ammo_type = /obj/item/ammo_casing/energy/medical //This is the ammo type that all mediguns come with.
+	var/has_safety = FALSE //Can the cell be toggled between safe and unsafe?
+	var/on_safety = TRUE //Is the safety for the cell on?
+
+//MEDIGUN SAFETY
+/obj/item/medicell/attack_self(mob/living/user)
+	if(!has_safety)
+		return
+	if(!on_safety)
+		on_safety = TRUE
+		to_chat(user, span_notice("The Safety on the Medicell is now on, you will not heal when it could cause clone damage to the patient"))
+		return
+	if(on_safety ==  1)
+		on_safety = FALSE
+		to_chat(user, span_notice("The Safety on the Medicell is now of, you will now heal when it could cause clone damage to the patient"))
+		return
+	else
+		return
 
 /obj/item/medicell/Initialize()
 	. =..()
@@ -82,12 +99,14 @@
 	desc = "A small cell with a red glow. Can be used on Mediguns to unlock the Brute I Functoinality"
 	icon_state = "Brute1"
 	ammo_type = /obj/item/ammo_casing/energy/medical/brute1
+	has_safety = TRUE
 //Burn I//
 /obj/item/medicell/burn1
 	name = "Burn I Medicell"
 	desc = "A small cell with a yellow glow. Can be used on Mediguns to unlock the Burn I Functoinality"
 	icon_state = "Burn1"
 	ammo_type = /obj/item/ammo_casing/energy/medical/burn1
+	has_safety = TRUE
 //Toxin I//
 /obj/item/medicell/toxin1
 	name = "Toxin I Medicell"

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -111,7 +111,7 @@
 //Brute I//
 /obj/item/medicell/brute1
 	name = "Brute I Medicell"
-	desc = "A small cell with a red glow. Can be used on Mediguns to unlock the Brute I Functoinality"
+	desc = "A small cell with a red glow. Can be used on Mediguns to unlock the Brute I Functionality."
 	icon_state = "Brute1"
 	ammo_type = /obj/item/ammo_casing/energy/medical/brute1/safe
 	unsafe_ammo = /obj/item/ammo_casing/energy/medical/brute1
@@ -121,7 +121,7 @@
 //Burn I//
 /obj/item/medicell/burn1
 	name = "Burn I Medicell"
-	desc = "A small cell with a yellow glow. Can be used on Mediguns to unlock the Burn I Functoinality"
+	desc = "A small cell with a yellow glow. Can be used on Mediguns to unlock the Burn I Functionality."
 	icon_state = "Burn1"
 	ammo_type = /obj/item/ammo_casing/energy/medical/burn1/safe
 	unsafe_ammo = /obj/item/ammo_casing/energy/medical/burn1
@@ -130,7 +130,7 @@
 //Toxin I//
 /obj/item/medicell/toxin1
 	name = "Toxin I Medicell"
-	desc = "A small cell with a green glow. Can be used on Mediguns to unlock the Toxin I Functoinality"
+	desc = "A small cell with a green glow. Can be used on Mediguns to unlock the Toxin I Functionality."
 	icon_state = "Toxin1"
 	ammo_type = /obj/item/ammo_casing/energy/medical/toxin1
 //End of Tier I Cells/
@@ -138,7 +138,7 @@
 //Brute II//
 /obj/item/medicell/brute2
 	name = "Brute II Medicell"
-	desc = "A small cell with a intense red glow. Can be used on Mediguns to unlock the Brute II Functoinality"
+	desc = "A small cell with a intense red glow. Can be used on Mediguns to unlock the Brute II Functionality."
 	icon_state = "Brute2"
 	ammo_type = /obj/item/ammo_casing/energy/medical/brute2/safe
 	unsafe_ammo = /obj/item/ammo_casing/energy/medical/brute2
@@ -147,7 +147,7 @@
 //Burn II//
 /obj/item/medicell/burn2
 	name = "Burn II Medicell"
-	desc = "A small cell with a intense yellow glow. Can be used on Mediguns to unlock the Burn II Functoinality"
+	desc = "A small cell with a intense yellow glow. Can be used on Mediguns to unlock the Burn II Functionality."
 	icon_state = "Burn2"
 	ammo_type = /obj/item/ammo_casing/energy/medical/burn2/safe
 	unsafe_ammo = /obj/item/ammo_casing/energy/medical/burn2
@@ -156,13 +156,13 @@
 //Toxin II//
 /obj/item/medicell/toxin2
 	name = "Toxin II Medicell"
-	desc = "A small cell with a intense green glow. Can be used on Mediguns to unlock the Toxin II Functoinality"
+	desc = "A small cell with a intense green glow. Can be used on Mediguns to unlock the Toxin II Functionality."
 	icon_state = "Toxin2"
 	ammo_type = /obj/item/ammo_casing/energy/medical/toxin2
 //Oxygen II//
 /obj/item/medicell/oxy2
 	name = "Oxygen II Medicell"
-	desc = "A small cell with a intense blue glow. Can be used on Mediguns to unlock the Oxygen II Functoinality"
+	desc = "A small cell with a intense blue glow. Can be used on Mediguns to unlock the Oxygen II Functionality."
 	icon_state = "Oxy2"
 	ammo_type = /obj/item/ammo_casing/energy/medical/oxy2
 //End of Tier II
@@ -170,7 +170,7 @@
 //Brute III//
 /obj/item/medicell/brute3
 	name = "Brute III Medicell"
-	desc = "A small cell with a intense red glow. Can be used on Mediguns to unlock the Brute II Functoinality"
+	desc = "A small cell with a intense red glow. Can be used on Mediguns to unlock the Brute II Functionality."
 	icon_state = "Brute3"
 	ammo_type = /obj/item/ammo_casing/energy/medical/brute3/safe
 	unsafe_ammo = /obj/item/ammo_casing/energy/medical/brute3
@@ -179,7 +179,7 @@
 //Burn III//
 /obj/item/medicell/burn3
 	name = "Burn III Medicell"
-	desc = "A small cell with a intense yellow glow. Can be used on Mediguns to unlock the Burn II Functoinality"
+	desc = "A small cell with a intense yellow glow. Can be used on Mediguns to unlock the Burn II Functionality."
 	icon_state = "Burn3"
 	ammo_type = /obj/item/ammo_casing/energy/medical/burn3/safe
 	unsafe_ammo = /obj/item/ammo_casing/energy/medical/burn3
@@ -188,13 +188,13 @@
 //Toxin III//
 /obj/item/medicell/toxin3
 	name = "Toxin III Medicell"
-	desc = "A small cell with a intense green glow. Can be used on Mediguns to unlock the Toxin II Functoinality"
+	desc = "A small cell with a intense green glow. Can be used on Mediguns to unlock the Toxin II Functionality."
 	icon_state = "Toxin3"
 	ammo_type = /obj/item/ammo_casing/energy/medical/toxin3
 //Oxygen III//
 /obj/item/medicell/oxy3
 	name = "Oxygen III Medicell"
-	desc = "A small cell with a intense blue glow. Can be used on Mediguns to unlock the Oxygen II Functoinality"
+	desc = "A small cell with a intense blue glow. Can be used on Mediguns to unlock the Oxygen II Functionality."
 	icon_state = "Oxy3"
 	ammo_type = /obj/item/ammo_casing/energy/medical/oxy3
 //End of Tier III

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -82,27 +82,16 @@
 	. = ..()
 	if(!has_safety)
 		return
-	if(!on_safety)
-		. += span_notice("[src] has the safety turned off.")
-		return
-	else
-		. += span_notice("[src] has the safety turned on.")
+	. += span_notice("[src] has the safety turned [on_safety ? 'on' : 'off'].")
+	return .
 
 /obj/item/medicell/attack_self(mob/living/user)
 	if(!has_safety)
 		return
-	if(!on_safety)
-		on_safety = TRUE
-		to_chat(user, span_notice("The safety on the Medicell is now on, you cannot heal when it will cause clone damage to the patient"))
-		src.ammo_type = safe_ammo
-		return
-	if(on_safety)
-		on_safety = FALSE
-		to_chat(user, span_notice("The safety on the Medicell is now off, you can heal when it will cause clone damage to the patient"))
-		src.ammo_type = unsafe_ammo
-		return
-	else
-		return
+	on_safety = !on_safety
+	to_chat(user, span_notice("The safety on the Medicell is now [on_safety ? "on, you can't" : "off, you can"] use it to heal when it would cause clone damage to the patient."))
+	src.ammo_type = on_safety ? safe_ammo : unsafe_ammo
+	return
 
 /obj/item/medicell/Initialize()
 	. =..()

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -83,10 +83,10 @@
 	if(!has_safety)
 		return
 	if(!on_safety)
-		to_chat(user, span_info("[src] has the safety turned off."))
+		. += span_notice("[src] has the safety turned off.")
 		return
 	else
-		to_chat(user, span_info("[src] has the safety turned on."))
+		. += span_notice("[src] has the safety turned on.")
 
 /obj/item/medicell/attack_self(mob/living/user)
 	if(!has_safety)

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -61,8 +61,8 @@
 	desc = "Upgardes the internal battery inside of the medigun, allowing for faster charging and a higher cell capacity. Any cells inside of the origingal medigun during the upgrade process will be lost!"
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "plasticbox"
-//
-	//Medigun Cells// Spritework is done by Arctaisia!
+
+//Medigun Cells// Spritework is done by Arctaisia!
 //Default Cell//
 /obj/item/medicell
 	name = "Default Medicell"

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -82,12 +82,12 @@
 		return
 	if(!on_safety)
 		on_safety = TRUE
-		to_chat(user, span_notice("The Safety on the Medicell is now on, you will not heal when it could cause clone damage to the patient"))
+		to_chat(user, span_notice("The Safety on the Medicell is now on, you cannot heal when it will do clone damage to the patient"))
 		src.ammo_type = safe_ammo
 		return
 	if(on_safety ==  1)
 		on_safety = FALSE
-		to_chat(user, span_notice("The Safety on the Medicell is now of, you will now heal when it could cause clone damage to the patient"))
+		to_chat(user, span_notice("The Safety on the Medicell is now off, you can heal when it will cause clone damage to the patient."))
 		src.ammo_type = unsafe_ammo
 		return
 	else

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -62,7 +62,7 @@
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "plasticbox"
 
-//Medigun Cells// Spritework is done by Arctaisia!
+//Medigun Cells - Spritework is done by Arctaisia!
 //Default Cell//
 /obj/item/medicell
 	name = "Default Medicell"
@@ -82,12 +82,12 @@
 		return
 	if(!on_safety)
 		on_safety = TRUE
-		to_chat(user, span_notice("The Safety on the Medicell is now on, you cannot heal when it will do clone damage to the patient"))
+		to_chat(user, span_notice("The safety on the Medicell is now on, you cannot heal when it will cause clone damage to the patient"))
 		src.ammo_type = safe_ammo
 		return
 	if(on_safety ==  1)
 		on_safety = FALSE
-		to_chat(user, span_notice("The Safety on the Medicell is now off, you can heal when it will cause clone damage to the patient."))
+		to_chat(user, span_notice("The safety on the Medicell is now off, you can heal when it will cause clone damage to the patient"))
 		src.ammo_type = unsafe_ammo
 		return
 	else
@@ -129,13 +129,19 @@
 	name = "Brute II Medicell"
 	desc = "A small cell with a intense red glow. Can be used on Mediguns to unlock the Brute II Functoinality"
 	icon_state = "Brute2"
-	ammo_type = /obj/item/ammo_casing/energy/medical/brute2
+	ammo_type = /obj/item/ammo_casing/energy/medical/brute2/safe
+	unsafe_ammo = /obj/item/ammo_casing/energy/medical/brute2
+	safe_ammo = /obj/item/ammo_casing/energy/medical/brute2/safe
+	has_safety = TRUE
 //Burn II//
 /obj/item/medicell/burn2
 	name = "Burn II Medicell"
 	desc = "A small cell with a intense yellow glow. Can be used on Mediguns to unlock the Burn II Functoinality"
 	icon_state = "Burn2"
-	ammo_type = /obj/item/ammo_casing/energy/medical/burn2
+	ammo_type = /obj/item/ammo_casing/energy/medical/burn2/safe
+	unsafe_ammo = /obj/item/ammo_casing/energy/medical/burn2
+	safe_ammo = /obj/item/ammo_casing/energy/medical/burn2/safe
+	has_safety = TRUE
 //Toxin II//
 /obj/item/medicell/toxin2
 	name = "Toxin II Medicell"
@@ -155,13 +161,19 @@
 	name = "Brute III Medicell"
 	desc = "A small cell with a intense red glow. Can be used on Mediguns to unlock the Brute II Functoinality"
 	icon_state = "Brute3"
-	ammo_type = /obj/item/ammo_casing/energy/medical/brute3
+	ammo_type = /obj/item/ammo_casing/energy/medical/brute3/safe
+	unsafe_ammo = /obj/item/ammo_casing/energy/medical/brute3
+	safe_ammo = /obj/item/ammo_casing/energy/medical/brute3/safe
+	has_safety = TRUE
 //Burn III//
 /obj/item/medicell/burn3
 	name = "Burn III Medicell"
 	desc = "A small cell with a intense yellow glow. Can be used on Mediguns to unlock the Burn II Functoinality"
 	icon_state = "Burn3"
-	ammo_type = /obj/item/ammo_casing/energy/medical/burn3
+	ammo_type = /obj/item/ammo_casing/energy/medical/burn3/safe
+	unsafe_ammo = /obj/item/ammo_casing/energy/medical/burn3
+	safe_ammo = /obj/item/ammo_casing/energy/medical/burn3/safe
+	has_safety = TRUE
 //Toxin III//
 /obj/item/medicell/toxin3
 	name = "Toxin III Medicell"

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -73,6 +73,8 @@
 	var/ammo_type = /obj/item/ammo_casing/energy/medical //This is the ammo type that all mediguns come with.
 	var/has_safety = FALSE //Can the cell be toggled between safe and unsafe?
 	var/on_safety = TRUE //Is the safety for the cell on?
+	var/safe_ammo = /obj/item/ammo_casing/energy/medical
+	var/unsafe_ammo = /obj/item/ammo_casing/energy/medical
 
 //MEDIGUN SAFETY
 /obj/item/medicell/attack_self(mob/living/user)
@@ -81,10 +83,12 @@
 	if(!on_safety)
 		on_safety = TRUE
 		to_chat(user, span_notice("The Safety on the Medicell is now on, you will not heal when it could cause clone damage to the patient"))
+		src.ammo_type = safe_ammo
 		return
 	if(on_safety ==  1)
 		on_safety = FALSE
 		to_chat(user, span_notice("The Safety on the Medicell is now of, you will now heal when it could cause clone damage to the patient"))
+		src.ammo_type = unsafe_ammo
 		return
 	else
 		return
@@ -98,8 +102,11 @@
 	name = "Brute I Medicell"
 	desc = "A small cell with a red glow. Can be used on Mediguns to unlock the Brute I Functoinality"
 	icon_state = "Brute1"
-	ammo_type = /obj/item/ammo_casing/energy/medical/brute1
+	ammo_type = /obj/item/ammo_casing/energy/medical/brute1/safe
+	unsafe_ammo = /obj/item/ammo_casing/energy/medical/brute1
+	safe_ammo = /obj/item/ammo_casing/energy/medical/brute1/safe
 	has_safety = TRUE
+
 //Burn I//
 /obj/item/medicell/burn1
 	name = "Burn I Medicell"

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -82,7 +82,7 @@
 	. = ..()
 	if(!has_safety)
 		return
-	. += span_notice("[src] has the safety turned [on_safety ? 'on' : 'off'].")
+	. += span_notice("[src] has the safety turned [on_safety ? "on" : "off"].")
 	return .
 
 /obj/item/medicell/attack_self(mob/living/user)

--- a/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modules/projectiles/guns/energy/medgun/medguns.dm
@@ -170,7 +170,7 @@
 //Brute III//
 /obj/item/medicell/brute3
 	name = "Brute III Medicell"
-	desc = "A small cell with a intense red glow. Can be used on Mediguns to unlock the Brute II Functoinality"
+	desc = "A small cell with a intense red glow. Can be used on Mediguns to unlock the Brute III Functoinality"
 	icon_state = "Brute3"
 	ammo_type = /obj/item/ammo_casing/energy/medical/brute3/safe
 	unsafe_ammo = /obj/item/ammo_casing/energy/medical/brute3
@@ -179,7 +179,7 @@
 //Burn III//
 /obj/item/medicell/burn3
 	name = "Burn III Medicell"
-	desc = "A small cell with a intense yellow glow. Can be used on Mediguns to unlock the Burn II Functoinality"
+	desc = "A small cell with a intense yellow glow. Can be used on Mediguns to unlock the Burn III Functoinality"
 	icon_state = "Burn3"
 	ammo_type = /obj/item/ammo_casing/energy/medical/burn3/safe
 	unsafe_ammo = /obj/item/ammo_casing/energy/medical/burn3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives the Medicells an option to toggle the safety on them by using them in hand. Toggling the safety means that they are unable to heal damage if it will cause any kind of clone damage to the patient.  This should make it that healing someone at high damage thresholds with medigun will be much more of an intentional choice. By default, cells have safety on.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents doctors from accidentally doing clone damage when using the brute/burn cells on the medigun. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: Medicells now have a safety toggle, preventing them from healing brute/burn when it would do clone damage.
refactor: refactors a bunch of code pertaining to the healing on medicells. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
