### PR TITLE
[Modular] Med Bandolier Buff

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
@@ -157,15 +157,7 @@
 		/obj/item/reagent_containers/pill,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/medigel,
-		/obj/item/reagent_containers/glass/bottle/vial,
-		/obj/item/lighter, // This was too funny to pass up.
-		/obj/item/storage/fancy/cigarettes, // Same here.
 		/obj/item/storage/pill_bottle,
-		/obj/item/reagent_containers/hypospray,
-		/obj/item/hypospray/mkii,
-		/obj/item/implantcase,
-		/obj/item/implant,
 		/obj/item/implanter,
-		/obj/item/reagent_containers/spray,
 		/obj/item/medicell
 		))

--- a/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
@@ -140,7 +140,7 @@
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/belts.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/belt.dmi'
 	name = "medical bandolier"
-	desc = "A pocketed, pine green belt slung like a sash over the shoulder. Features numerous pockets for medicines, poisons, and your smoke break. Now is coward healing time."
+	desc = "A pocketed, pine green belt slung like a sash over the shoulder. Features numerous pockets for medicines and poisons alike. Now is coward healing time."
 	icon_state = "med_bandolier"
 	worn_icon_state = "med_bandolier"
 
@@ -149,7 +149,7 @@
 	var/datum/component/storage/bandolier_storage = GetComponent(/datum/component/storage)
 	bandolier_storage.max_w_class = WEIGHT_CLASS_NORMAL
 	bandolier_storage.max_items = 14
-	bandolier_storage.max_combined_w_class = 21
+	bandolier_storage.max_combined_w_class = 35
 	bandolier_storage.set_holdable(list(
 		/obj/item/dnainjector,
 		/obj/item/reagent_containers/dropper,

--- a/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
@@ -148,11 +148,11 @@
 	. = ..()
 	var/datum/component/storage/bandolier_storage = GetComponent(/datum/component/storage)
 	bandolier_storage.max_w_class = WEIGHT_CLASS_NORMAL
+	bandolier.max_items = 14
 	bandolier_storage.max_combined_w_class = 21
 	bandolier_storage.set_holdable(list(
 		/obj/item/dnainjector,
 		/obj/item/reagent_containers/dropper,
-		/obj/item/reagent_containers/glass/beaker,
 		/obj/item/reagent_containers/glass/bottle,
 		/obj/item/reagent_containers/pill,
 		/obj/item/reagent_containers/syringe,

--- a/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
@@ -148,7 +148,7 @@
 	. = ..()
 	var/datum/component/storage/bandolier_storage = GetComponent(/datum/component/storage)
 	bandolier_storage.max_w_class = WEIGHT_CLASS_NORMAL
-	bandolier.max_items = 14
+	bandolier_storage.max_items = 14
 	bandolier_storage.max_combined_w_class = 21
 	bandolier_storage.set_holdable(list(
 		/obj/item/dnainjector,
@@ -163,7 +163,6 @@
 		/obj/item/storage/pill_bottle,
 		/obj/item/reagent_containers/hypospray,
 		/obj/item/hypospray/mkii,
-		/obj/item/gun/syringe/syndicate,
 		/obj/item/implantcase,
 		/obj/item/implant,
 		/obj/item/implanter,


### PR DESCRIPTION
## About The Pull Request
Nothing unrealistic or too drastic or severe, just some subtle tweaks to improve the atmosphere.

Removes the ability for it to hold beakers. I will accept it no longer holding pill bottles too if that would make it more balanced.
Allows it to hold 14 items instead of 7.

## Why It's Good For The Game
The bandolier is pretty underwhelming at the moment and doesn't really suit as a replacement for the medical belt. This should hopefully even the odds and make it a bit more useful to actually take.

## Changelog
:cl:
balance: Medical Bandolier now holds 2x the items. Can't hold beakers or the syndicate syringe gun anymore.
/:cl:
