### PR TITLE
Gives Warden the Sergeant's Megaphone

### DIFF
--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -54,7 +54,7 @@
 	head = /obj/item/clothing/head/beret/sec/navywarden/peacekeeper //SKYRAT EDIT CHANGE - SEC_HAUL - ORIGINAL: /obj/item/clothing/head/warden
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/peacekeeper //SKYRAT EDIT CHANGE - SEC_HAUL - ORIGINAL: /obj/item/clothing/glasses/hud/security/sunglasses
 	r_pocket = /obj/item/assembly/flash/handheld
-	l_pocket = /obj/item/restraints/handcuffs
+	l_pocket = /obj/item/megaphone/sec //SKYRAT EDIT CHANGE
 
 	suit_store = /obj/item/gun/energy/disabler
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title.

## Why It's Good For The Game

The Warden not having the Security Megaphone is really an oversight in my opinion. The Brig is a constant sort of action especially with antags running around blowing up the armoury and shit, and the Warden needs a way to quickly establish a presence. As well, the Warden is (arguably) higher ranking than the Sergeant, at least in the Brig, so it makes little sense for them to have on and for the warden to not.

## Changelog
:cl:
add: Gave Warden Security Megaphone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
