### PR TITLE
Disables the CME from occurring naturally.

### DIFF
--- a/modular_skyrat/modules/cme/code/cme.dm
+++ b/modular_skyrat/modules/cme/code/cme.dm
@@ -17,7 +17,7 @@ Armageddon is truly going to fuck the station, use it sparingly.
 	typepath = /datum/round_event/cme
 	weight = 10
 	min_players = 30
-	max_occurrences = 1 // Why was this allowed to roll three times bruh
+	max_occurrences = 0 // Why was this allowed to roll three times bruh
 	earliest_start = 25 MINUTES
 
 /datum/round_event/cme
@@ -37,7 +37,7 @@ Armageddon is truly going to fuck the station, use it sparingly.
 
 /datum/round_event/cme/unknown
 	cme_intensity = CME_UNKNOWN
-	
+
 /datum/round_event_control/cme/minimal
 	name = "Coronal Mass Ejection: Minimal"
 	typepath = /datum/round_event/cme/minimal


### PR DESCRIPTION

## About The Pull Request

Disables the CME event that causes the round to end because no one wants to deal with this.

## Why It's Good For The Game

No one really likes the CME event. Remember the old days when people would buy the EMP grenade kit and chuck EMP grenades randomly and the kit had to be removed because of that? Why is there an event that is literally that but with worse roleplay and a worse counter?

## Changelog
:cl: BurgerBB
del: Disables the CME event from occuring.
/:cl: