### PR TITLE
Fixes the Ant Reagent Recipe literally not working how did no one test this

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -911,12 +911,12 @@
 
 /datum/chemical_reaction/ants
 	results = list(/datum/reagent/ants = 3)
-	required_reagents = list(/datum/reagent/ants = 2, /datum/reagent/consumable/sugar = 6)
+	required_reagents = list(/datum/reagent/ants = 2, /datum/reagent/consumable/sugar = 10) //SKYRAT CHANGE, SUGAR FROM 6 TO 10.
 	//FermiChem vars:
 	optimal_ph_min = 3
 	optimal_ph_max = 12
 	required_temp = 50
-	reaction_flags = REACTION_INSTANT
+	reaction_flags = NONE //SKYRAT CHANGE, REACTION_INSTANT TO NONE
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE
 
 /datum/chemical_reaction/ant_slurry // We're basically gluing ants together with synthflesh & maint sludge to make a bigger ant.


### PR DESCRIPTION
## About The Pull Request

Before: Ants could not be created from sugar because of fermichem fuckery.
After: I fixed the fermichem fuckery and made it so that ants require 10 sugar to reproduce because it's easier than 6 and having that mess with purity.

## Why It's Good For The Game

Bug fixes are good.

## Why it was broken
Because it was a unique recipe where it was removing reagents it was creating, it could break and cause a runtime. Instead of touching /tg/code I just decided to just change the flag of it because no one is paying me to fix this.

Is it an upstream issue? Don't fucking know, don't see any bug reports about it, I see people on reddit making ants on /tg/. Something broke here and again I'm not paid enough to diagnose reagentcode especially for a system I don't like.

## Changelog
:cl: BurgerBB
fix: Fixes the Ant Reagent Recipe.
/:cl:

