### PR TITLE
Removes prison wing curtains from all cells.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -2881,17 +2881,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal)
-"arq" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell5";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/purple/side{
-	dir = 1
-	},
-/area/security/prison/safe)
 "arx" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -5215,19 +5204,6 @@
 "aKZ" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
-"aLa" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell9";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/brown/side{
-	dir = 1
-	},
-/area/security/prison/safe)
 "aLd" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/machinery/light/directional/west,
@@ -47945,17 +47921,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/commons/toilet/auxiliary)
-"hka" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell4";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/purple/side{
-	dir = 1
-	},
-/area/security/prison/safe)
 "hkj" = (
 /obj/structure/table/wood,
 /obj/item/poster/random_contraband{
@@ -48077,17 +48042,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/security/prison)
-"hmp" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell5";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "hmD" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -50945,17 +50899,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
-"hYt" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell8";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "hYA" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -52490,17 +52433,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"irA" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell4";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "irC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -53419,17 +53351,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
-"iFk" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell4";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "iFr" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -56316,17 +56237,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/iron,
 /area/science/misc_lab)
-"jwH" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell11";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "jwO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -57298,17 +57208,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"jIP" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell3";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "jJc" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /obj/effect/turf_decal/tile/neutral{
@@ -63914,19 +63813,6 @@
 /obj/structure/cable,
 /turf/closed/wall,
 /area/security/checkpoint/medical)
-"lsD" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell10";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/brown/side{
-	dir = 1
-	},
-/area/security/prison/safe)
 "lsL" = (
 /obj/machinery/camera{
 	c_tag = "Hydroponics Backroom";
@@ -68670,17 +68556,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"mDi" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell7";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/blue/side{
-	dir = 1
-	},
-/area/security/prison/safe)
 "mDk" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/green{
@@ -75981,17 +75856,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"orO" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell6";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "orZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
 	dir = 4
@@ -79516,17 +79380,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/medical/virology)
-"plN" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell9";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "plV" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/disposalpipe/segment{
@@ -86036,10 +85889,6 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "qUg" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell11";
-	pixel_y = 21
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -88071,17 +87920,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"ruA" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell8";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/blue/side{
-	dir = 1
-	},
-/area/security/prison/safe)
 "ruK" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/corner{
@@ -92272,17 +92110,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/toilet/auxiliary)
-"sAd" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell6";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "sAj" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron{
@@ -97175,10 +97002,6 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "tKH" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell3";
-	pixel_y = 21
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/purple/side{
@@ -98240,17 +98063,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"tWD" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell5";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "tWF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
@@ -99353,17 +99165,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
-"uoy" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell10";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "uoV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -101882,10 +101683,6 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "uVn" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell6";
-	pixel_y = 21
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/blue/side{
@@ -105590,17 +105387,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/cargo/office)
-"vTR" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell8";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "vTW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -106238,17 +106024,6 @@
 	},
 /turf/open/floor/carpet,
 /area/service/chapel/office)
-"wce" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell7";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "wcg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/xeno_spawn,
@@ -111076,17 +110851,6 @@
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
-"xuz" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell7";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "xuC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -163316,19 +163080,19 @@ aaa
 aaa
 rjB
 rjB
-vTR
+egs
 rjB
 rjB
-xuz
+egs
 rjB
 rjB
-orO
+egs
 rjB
 rjB
-hmp
+egs
 rjB
 rjB
-iFk
+egs
 rjB
 rjB
 rjB
@@ -163829,19 +163593,19 @@ rjB
 rjB
 rjB
 rjB
-ruA
+uVn
 mql
 xVh
-mDi
+uVn
 mql
 xVh
 uVn
 jgA
 xVh
-arq
+tKH
 buL
 xVh
-hka
+tKH
 buL
 xVh
 tKH
@@ -164344,22 +164108,22 @@ dhr
 tcU
 xVh
 mSS
-hYt
+szm
 xVh
 mSS
-wce
+szm
 xVh
 mSS
-sAd
+szm
 xVh
 hnC
-tWD
+szm
 xVh
 hnC
-irA
+szm
 xVh
 hnC
-jIP
+szm
 xVh
 hlz
 aQX
@@ -170007,13 +169771,13 @@ sWC
 aKV
 xVh
 wDi
-jwH
+szm
 xVh
 wDi
-uoy
+szm
 xVh
 wDi
-plN
+szm
 xVh
 xVh
 rjB
@@ -170523,10 +170287,10 @@ xVh
 qUg
 aMq
 xVh
-lsD
+qUg
 aMq
 xVh
-aLa
+qUg
 aMq
 xVh
 lPi

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -571,19 +571,6 @@
 	dir = 8
 	},
 /area/security/prison/safe)
-"adH" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell11";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/brown/side{
-	dir = 1
-	},
-/area/security/prison)
 "adI" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -614,17 +601,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"adU" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell5";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "adV" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -2085,19 +2061,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"all" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell10";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/brown/side{
-	dir = 1
-	},
-/area/security/prison)
 "aln" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -2109,17 +2072,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"alo" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell4";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "alp" = (
 /turf/open/floor/plating,
 /area/security/processing)
@@ -3281,10 +3233,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aqm" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell9";
-	pixel_y = 21
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -15028,17 +14976,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"bRl" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell5";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/purple/side{
-	dir = 1
-	},
-/area/security/prison)
 "bRm" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -19384,16 +19321,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/NTREP)
-"cKX" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell10";
-	name = "curtain"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "cKY" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
@@ -22035,17 +21962,6 @@
 /obj/machinery/seed_extractor,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"ejG" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell6";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "ejI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -24077,10 +23993,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "fns" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell4";
-	pixel_y = 21
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/purple/side{
@@ -24154,17 +24066,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"fqr" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell4";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison)
 "fqI" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/red/half{
@@ -26107,17 +26008,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
-"gro" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell6";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/blue/side{
-	dir = 1
-	},
-/area/security/prison)
 "grr" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/reagent_dispensers/peppertank/directional/east,
@@ -28764,17 +28654,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"hQR" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell7";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison)
 "hQX" = (
 /obj/machinery/light/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -33992,17 +33871,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/genetics)
-"kHk" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell7";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/blue/side{
-	dir = 1
-	},
-/area/security/prison)
 "kHP" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -36814,12 +36682,6 @@
 /turf/open/floor/plating,
 /area/security/office)
 "med" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell6";
-	name = "curtain"
-	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38209,12 +38071,6 @@
 /area/maintenance/disposal/incinerator)
 "mMB" = (
 /obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell11";
-	name = "curtain"
-	},
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "mMH" = (
@@ -39189,10 +39045,6 @@
 /turf/open/floor/iron,
 /area/medical/pharmacy)
 "nlP" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell8";
-	pixel_y = 21
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/blue/side{
@@ -50866,17 +50718,6 @@
 	dir = 1
 	},
 /area/science/misc_lab)
-"tuf" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell8";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "tun" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
@@ -52928,16 +52769,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"uuO" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell9";
-	name = "curtain"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "uvd" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -55524,17 +55355,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
-"vOi" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell8";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison)
 "vOj" = (
 /turf/closed/wall,
 /area/security/office)
@@ -56659,12 +56479,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
 "wsg" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell5";
-	name = "curtain"
-	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -58192,17 +58006,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"xgP" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell7";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "xgT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -81395,10 +81198,10 @@ boP
 adb
 aai
 aai
-vOi
+wsg
 aai
 aai
-hQR
+wsg
 aai
 aai
 med
@@ -81407,7 +81210,7 @@ aai
 wsg
 aai
 aai
-fqr
+wsg
 aai
 aai
 aai
@@ -81911,13 +81714,13 @@ aai
 nlP
 xhz
 acd
-kHk
+nlP
 xhz
 acd
-gro
+nlP
 air
 acd
-bRl
+fns
 ckr
 acd
 fns
@@ -82423,19 +82226,19 @@ wHi
 nDX
 acd
 eyp
-tuf
+dkQ
 acd
 eyp
-xgP
+dkQ
 acd
 eyp
-ejG
+dkQ
 acd
 aqF
-adU
+dkQ
 acd
 aqF
-alo
+dkQ
 acd
 aqF
 aKL
@@ -88089,10 +87892,10 @@ alf
 mMB
 acd
 vhS
-cKX
+azv
 acd
 vhS
-uuO
+azv
 acd
 acd
 aai
@@ -88599,10 +88402,10 @@ bFR
 hfU
 eKQ
 acd
-adH
+aqm
 aoV
 acd
-all
+aqm
 aoV
 acd
 aqm

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -661,17 +661,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"afJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell4";
-	name = "curtain"
-	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "afM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -14218,10 +14207,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/red,
 /obj/effect/landmark/start/prisoner,
-/obj/machinery/button/curtain{
-	id = "prisoncell1";
-	pixel_x = 32
-	},
 /turf/open/floor/iron/dark/blue/side{
 	dir = 5
 	},
@@ -20435,10 +20420,6 @@
 /obj/item/candle{
 	pixel_x = -5
 	},
-/obj/machinery/button/curtain{
-	id = "prisoncell3";
-	pixel_x = -24
-	},
 /turf/open/floor/iron/dark/blue/side{
 	dir = 9
 	},
@@ -22303,17 +22284,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
-"eUz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell2";
-	name = "curtain"
-	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "eUM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -22484,10 +22454,6 @@
 "eWu" = (
 /obj/structure/table,
 /obj/item/clothing/under/rank/prisoner,
-/obj/machinery/button/curtain{
-	id = "prisoncell4";
-	pixel_y = 21
-	},
 /turf/open/floor/iron/dark/blue/side{
 	dir = 9
 	},
@@ -38125,17 +38091,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"knZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell1";
-	name = "curtain"
-	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "koz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -54366,12 +54321,6 @@
 "ptv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell3";
-	name = "curtain"
-	},
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "ptF" = (
@@ -73762,10 +73711,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/red,
 /obj/effect/landmark/start/prisoner,
-/obj/machinery/button/curtain{
-	id = "prisoncell2";
-	pixel_x = -24
-	},
 /turf/open/floor/iron/dark/blue/side{
 	dir = 9
 	},
@@ -103070,7 +103015,7 @@ abe
 fpQ
 yee
 agH
-afJ
+ptv
 vVq
 agH
 ptv
@@ -103590,7 +103535,7 @@ vzJ
 vzJ
 caX
 aeO
-eUz
+ptv
 vCw
 oPQ
 aeJ
@@ -104618,7 +104563,7 @@ adt
 alL
 rcr
 aeO
-knZ
+ptv
 cIV
 omh
 aeJ

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -19300,17 +19300,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/lab)
-"brr" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell3";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "brs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -37128,17 +37117,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"dJo" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell3";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/purple/side{
-	dir = 1
-	},
-/area/security/prison/safe)
 "dJx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38285,19 +38263,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
-"eVr" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell9";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/brown/side{
-	dir = 1
-	},
-/area/security/prison/safe)
 "eVH" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
@@ -38593,17 +38558,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"fjY" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell6";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "fka" = (
 /obj/machinery/griddle,
 /obj/structure/cable,
@@ -38954,17 +38908,6 @@
 	icon_state = "wood-broken6"
 	},
 /area/maintenance/port/aft)
-"fAT" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell10";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "fBf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -39630,17 +39573,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"gfn" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell6";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "gfO" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Lockers";
@@ -39689,17 +39621,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/escape)
-"giF" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell8";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "giQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -43224,17 +43145,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/service/hydroponics)
-"jCT" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell4";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/purple/side{
-	dir = 1
-	},
-/area/security/prison/safe)
 "jCY" = (
 /obj/effect/loot_site_spawner,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -43644,17 +43554,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"jUh" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell9";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "jUA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -45068,17 +44967,6 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"kZK" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell8";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "kZR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -45911,17 +45799,6 @@
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"lRK" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell8";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/blue/side{
-	dir = 1
-	},
-/area/security/prison/safe)
 "lRV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46381,17 +46258,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
-"mrk" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell5";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "mrM" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -48347,17 +48213,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
-"oht" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell6";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/blue/side{
-	dir = 1
-	},
-/area/security/prison/safe)
 "ohN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48561,17 +48416,6 @@
 /obj/effect/turf_decal/tile/blue/darkblue,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"otA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell10";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "otB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -48875,10 +48719,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "oGM" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell5";
-	pixel_y = 21
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/purple/side{
@@ -49429,17 +49269,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
-"piB" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell5";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "piD" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/portable_atmospherics/pump,
@@ -49589,17 +49418,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"prz" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell11";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "prA" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral{
@@ -49611,19 +49429,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"prV" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell11";
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/brown/side{
-	dir = 1
-	},
-/area/security/prison/safe)
 "psh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -49918,17 +49723,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"pCn" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncel4";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "pEr" = (
 /obj/machinery/portable_atmospherics/canister/tier_1,
 /turf/open/floor/iron,
@@ -49976,17 +49770,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"pGf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell11";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "pHl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -50305,12 +50088,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "pUm" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell9";
-	name = "curtain"
-	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -52936,10 +52713,6 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "sAb" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell7";
-	pixel_y = 21
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/blue/side{
@@ -54147,25 +53920,8 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/aft)
-"tAA" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell7";
-	name = "curtain"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "tBk" = (
 /obj/effect/spawner/structure/window,
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncell7";
-	name = "curtain"
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison/safe)
@@ -55619,12 +55375,6 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "uRJ" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "prisoncel4";
-	name = "curtain"
-	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -57166,10 +56916,6 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "wik" = (
-/obj/machinery/button/curtain{
-	id = "prisoncell10";
-	pixel_y = 21
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -80503,16 +80249,16 @@ sUX
 sUX
 aaJ
 aaJ
-kZK
+uRJ
 aaJ
 aaJ
-tAA
+uRJ
 aaJ
 aaJ
-fjY
+uRJ
 aaJ
 aaJ
-mrk
+uRJ
 aaJ
 aaJ
 uRJ
@@ -81016,22 +80762,22 @@ aai
 aai
 aai
 aaJ
-lRK
+sAb
 qtk
 abz
 sAb
 qtk
 abz
-oht
+sAb
 kvD
 abz
 oGM
 xuu
 abz
-jCT
+oGM
 xuu
 abz
-dJo
+oGM
 azJ
 abz
 soI
@@ -81531,22 +81277,22 @@ pIM
 lJt
 abz
 rOV
-giF
+tBk
 abz
 rOV
 tBk
 abz
 rOV
-gfn
+tBk
 abz
 wHa
-piB
+tBk
 abz
 wHa
-pCn
+tBk
 abz
 wHa
-brr
+tBk
 abz
 mnV
 pqf
@@ -87194,13 +86940,13 @@ jqP
 acd
 abz
 tLN
-prz
+tBk
 abz
 tLN
-fAT
+tBk
 abz
 tLN
-jUh
+tBk
 abz
 abz
 aaJ
@@ -87707,13 +87453,13 @@ apZ
 vul
 kAE
 abz
-prV
+wik
 mam
 abz
 wik
 mam
 abz
-eVr
+wik
 mam
 aaJ
 aaZ
@@ -88222,10 +87968,10 @@ aai
 aai
 aaJ
 aaJ
-pGf
+pUm
 aaJ
 aaJ
-otA
+pUm
 aaJ
 aaJ
 pUm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
These make no sense at an IC level nor at an OOC level, actively *hinder* sec gameplay, and especially CO gameplay.

"Ah yes, let's make the place we put our discovered antags have *no way of knowing when they're escaping*"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because the addition of them in the first place was stupid and they remain stupid to this day.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Prisons no longer get *crime obfuscating curtains*. they're prisoners for gods sakes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
