### PR TITLE
Disables CMEs until a rework is made.

### DIFF
--- a/modular_skyrat/modules/cme/code/cme.dm
+++ b/modular_skyrat/modules/cme/code/cme.dm
@@ -17,7 +17,7 @@ Armageddon is truly going to fuck the station, use it sparingly.
 	typepath = /datum/round_event/cme
 	weight = 10
 	min_players = 30
-	max_occurrences = 1 // Why was this allowed to roll three times bruh
+	max_occurrences = 0 // Why was this allowed to roll three times bruh
 	earliest_start = 25 MINUTES
 
 /datum/round_event/cme


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
CMEs are unfun, anti-RP, and round ending. No one cares to fix them because the damage is done when they hit, so it ends the round prematurely, hindering RP.

Meteors are fine because they give ample warning of when, and by their nature, where, they're going to hit, allowing people to hide from them and RP out the "oh god we're going to die." CMEs don't do that.

CMEs have no benefit, no positive upside, and are all negatives. 
They have the same reason for being in the game as an event that suddenly gibs everyone on station with no warning.

I've heard mention of a possible rework, but until then, they should be disabled to prevent any more round-ruining.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: CMEs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
