### PR TITLE
Journey departures disposals fix

### DIFF
--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -15306,7 +15306,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/open/floor/iron/cafeteria,
 /area/hallway/secondary/exit)
 "bgg" = (


### PR DESCRIPTION
## About The Pull Request

Fixes an issue with roundstart disposals pathing

## Why It's Good For The Game

fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/7796

## Changelog
:cl:
fix: NSS Journey's disposals got an overhaul, and now no longer break in departures
/:cl: