### PR TITLE
Disables Moldies until a rework is made.

### DIFF
--- a/modular_skyrat/modules/biohazard_blob/code/mold_event.dm
+++ b/modular_skyrat/modules/biohazard_blob/code/mold_event.dm
@@ -2,7 +2,7 @@
 	name = "Moldies"
 	typepath = /datum/round_event/mold
 	weight = 5
-	max_occurrences = 1
+	max_occurrences = 0
 	min_players = 10
 
 /datum/round_event/mold

--- a/modular_skyrat/modules/biohazard_blob/code/mold_event.dm
+++ b/modular_skyrat/modules/biohazard_blob/code/mold_event.dm
@@ -2,7 +2,7 @@
 	name = "Moldies"
 	typepath = /datum/round_event/mold
 	weight = 5
-	max_occurrences = 0
+	max_occurrences = 0 // SKYRAT EDIT - disables moldies until a rework is made - Moldies are unfun, anti-RP, and round ending. It has got to the point where the best way to deal with them is often just wall up the area if they spawn in maint, and decide that it has just been lost. It also loves to spawn in the middle of perma with people around (something blob can't do), which is kind of crap if you had anything going on there. Blob is fine, because they don't spawn in pairs. They provide a more engaging fight for both groups, and don't spawn mobs that use broken/buggy mechanics that end up turning half of the station into an unending smoke cloud. While leaving behind a bunch of weird corpses that reply the death animation whenever they came off/on your screen. Moldies have no benefit, no positive upside, and are all negatives. They have the same reason for being in the game as an event that suddenly gibs everyone on station with no warning. I've heard mention of a possible rework, but until then, they should be disabled to prevent any more round-ruining.
 	min_players = 10
 
 /datum/round_event/mold


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Moldies are unfun, anti-RP, and round ending. It has got to the point where the best way to deal with them is often just wall up the area if they spawn in maint, and decide that it has just been lost. It also loves to spawn in the middle of perma with people around (something blob can't do), which is kind of crap if you had anything going on there. 

Blob is fine, because they don't spawn in pairs. They provide a more engaging fight for both groups, and don't spawn mobs that use broken/buggy mechanics that end up turning half of the station into an unending smoke cloud. While leaving behind a bunch of weird corpses that reply the death animation whenever they came off/on your screen.

Moldies have no benefit, no positive upside, and are all negatives. 
They have the same reason for being in the game as an event that suddenly gibs everyone on station with no warning.

I've heard mention of a possible rework, but until then, they should be disabled to prevent any more round-ruining.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Moldies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
