### PR TITLE
Nerfs the CME event by reworking it.

### DIFF
--- a/modular_skyrat/modules/cme/code/_cme_defines.dm
+++ b/modular_skyrat/modules/cme/code/_cme_defines.dm
@@ -3,12 +3,8 @@
 ///////////////////////
 
 GLOBAL_LIST_INIT(cme_loot_list, list(
-	/obj/item/stack/sheet/bluespace_crystal = 30,
-	/obj/item/stack/sheet/mineral/diamond = 20,
-	/obj/item/stack/sheet/mineral/plasma = 50,
-	/obj/item/stack/sheet/mineral/gold = 80,
-	/obj/item/raw_anomaly_core/random = 10,
-	/obj/item/relic = 40))
+	/obj/item/bombcore/emp = 1
+))
 
 /obj/item/strange
 
@@ -21,47 +17,39 @@ GLOBAL_LIST_INIT(cme_loot_list, list(
 //Times are SECONDS, they're devided by 2 because that's how long the controller takes to process. 20 deciseconds = 2 seconds. I know, it's dumb as fuck.
 //NOT ANYMORE, NOW WE MULTIPLY BY A HALF
 
-#define CME_MINIMAL_LIGHT_RANGE_LOWER 7 //The lowest range for the emp pulse light range.
-#define CME_MINIMAL_LIGHT_RANGE_UPPER 10 //The highest range for the emp pulse light range.
-#define CME_MINIMAL_HEAVY_RANGE_LOWER 5 //The lowest range for the emp pulse heavy range.
-#define CME_MINIMAL_HEAVY_RANGE_UPPER 7 //The highest range for the emp pulse heavy range.
-#define CME_MINIMAL_FREQUENCY_LOWER 25 * 0.5 //The lower time range for cme bubbles to appear.
-#define CME_MINIMAL_FREQUENCY_UPPER 30 * 0.5 //The higher time range for cme bubbles to appear.
-#define CME_MINIMAL_BUBBLE_BURST_TIME 40 SECONDS //The time taken for a cme bubble to pop.
-#define CME_MINIMAL_START_LOWER 120 * 0.5 //The lowest amount of time for the event to start from the announcement. - Prep time
-#define CME_MINIMAL_START_UPPER 180 * 0.5 //The highest amount of time for the event to start from the announcement. - Prep time
-#define CME_MINIMAL_END 240 * 0.5 //The amount of time starting from THE MINIMAL START TIME for the event to end. - How long it actually lasts.
+#define CME_MINIMAL_LIGHT_RANGE_LOWER 3 //The lowest range for the emp pulse light range.
+#define CME_MINIMAL_LIGHT_RANGE_UPPER 5 //The highest range for the emp pulse light range.
+#define CME_MINIMAL_HEAVY_RANGE_LOWER 2 //The lowest range for the emp pulse heavy range.
+#define CME_MINIMAL_HEAVY_RANGE_UPPER 3 //The highest range for the emp pulse heavy range.
+#define CME_MINIMAL_FREQUENCY_LOWER 50 * 0.5 //The lower time range for cme bubbles to appear.
+#define CME_MINIMAL_FREQUENCY_UPPER 60 * 0.5 //The higher time range for cme bubbles to appear.
+#define CME_MINIMAL_BUBBLE_BURST_TIME 120 SECONDS //The time taken for a cme bubble to pop.
+#define CME_MINIMAL_END 480 * 0.5 //The amount of time starting from THE MINIMAL START TIME for the event to end. - How long it actually lasts.
 
-#define CME_MODERATE_LIGHT_RANGE_LOWER 10
-#define CME_MODERATE_LIGHT_RANGE_UPPER 15
-#define CME_MODERATE_HEAVY_RANGE_LOWER 7
-#define CME_MODERATE_HEAVY_RANGE_UPPER 10
-#define CME_MODERATE_FREQUENCY_LOWER 20 * 0.5
-#define CME_MODERATE_FREQUENCY_UPPER 25 * 0.5
+#define CME_MODERATE_LIGHT_RANGE_LOWER 5
+#define CME_MODERATE_LIGHT_RANGE_UPPER 7
+#define CME_MODERATE_HEAVY_RANGE_LOWER 3
+#define CME_MODERATE_HEAVY_RANGE_UPPER 5
+#define CME_MODERATE_FREQUENCY_LOWER 40 * 0.5
+#define CME_MODERATE_FREQUENCY_UPPER 50 * 0.5
 #define CME_MODERATE_BUBBLE_BURST_TIME 30 SECONDS
-#define CME_MODERATE_START_LOWER 120 * 0.5
-#define CME_MODERATE_START_UPPER 180 * 0.5
-#define CME_MODERATE_END 240 * 0.5
+#define CME_MODERATE_END 480 * 0.5
 
 
-#define CME_EXTREME_LIGHT_RANGE_LOWER 15
-#define CME_EXTREME_LIGHT_RANGE_UPPER 20
-#define CME_EXTREME_HEAVY_RANGE_LOWER 10
-#define CME_EXTREME_HEAVY_RANGE_UPPER 13
-#define CME_EXTREME_FREQUENCY_LOWER 15 * 0.5
-#define CME_EXTREME_FREQUENCY_UPPER 20 * 0.5
+#define CME_EXTREME_LIGHT_RANGE_LOWER 6
+#define CME_EXTREME_LIGHT_RANGE_UPPER 8
+#define CME_EXTREME_HEAVY_RANGE_LOWER 4
+#define CME_EXTREME_HEAVY_RANGE_UPPER 6
+#define CME_EXTREME_FREQUENCY_LOWER 30 * 0.5
+#define CME_EXTREME_FREQUENCY_UPPER 40 * 0.5
 #define CME_EXTREME_BUBBLE_BURST_TIME 20 SECONDS
-#define CME_EXTREME_START_LOWER 60 * 0.5
-#define CME_EXTREME_START_UPPER 120 * 0.5
-#define CME_EXTREME_END 300 * 0.5
+#define CME_EXTREME_END 600 * 0.5
 
-#define CME_ARMAGEDDON_LIGHT_RANGE_LOWER 25
-#define CME_ARMAGEDDON_LIGHT_RANGE_UPPER 30
-#define CME_ARMAGEDDON_HEAVY_RANGE_LOWER 20
-#define CME_ARMAGEDDON_HEAVY_RANGE_UPPER 25
-#define CME_ARMAGEDDON_FREQUENCY_LOWER 5 * 0.5
-#define CME_ARMAGEDDON_FREQUENCY_UPPER 7 * 0.5
+#define CME_ARMAGEDDON_LIGHT_RANGE_LOWER 8
+#define CME_ARMAGEDDON_LIGHT_RANGE_UPPER 10
+#define CME_ARMAGEDDON_HEAVY_RANGE_LOWER 7
+#define CME_ARMAGEDDON_HEAVY_RANGE_UPPER 9
+#define CME_ARMAGEDDON_FREQUENCY_LOWER 10 * 0.5
+#define CME_ARMAGEDDON_FREQUENCY_UPPER 20 * 0.5
 #define CME_ARMAGEDDON_BUBBLE_BURST_TIME 10 SECONDS
-#define CME_ARMAGEDDON_START_LOWER 60 * 0.5
-#define CME_ARMAGEDDON_START_UPPER 70 * 0.5
-#define CME_ARMAGEDDON_END 600 * 0.5
+#define CME_ARMAGEDDON_END 1200 * 0.5

--- a/modular_skyrat/modules/cme/code/cme.dm
+++ b/modular_skyrat/modules/cme/code/cme.dm
@@ -18,12 +18,12 @@ Armageddon is truly going to fuck the station, use it sparingly.
 	weight = 10
 	min_players = 30
 	max_occurrences = 1 // Why was this allowed to roll three times bruh
-	earliest_start = 25 MINUTES
+	earliest_start = 40 MINUTES
 
 /datum/round_event/cme
-	startWhen = 6
-	endWhen	= 66
-	announceWhen = 10
+	startWhen = 60 //This is actually 2 minutes.
+	endWhen	= 60 //This is set depending on the type, but this is a fallback.
+	announceWhen = 5 //10 second announcement time.
 	var/cme_intensity
 	var/cme_frequency_lower
 	var/cme_frequency_upper
@@ -37,7 +37,7 @@ Armageddon is truly going to fuck the station, use it sparingly.
 
 /datum/round_event/cme/unknown
 	cme_intensity = CME_UNKNOWN
-	
+
 /datum/round_event_control/cme/minimal
 	name = "Coronal Mass Ejection: Minimal"
 	typepath = /datum/round_event/cme/minimal
@@ -76,32 +76,27 @@ Armageddon is truly going to fuck the station, use it sparingly.
 
 /datum/round_event/cme/setup()
 	if(!cme_intensity)
-		cme_intensity = pick(CME_MINIMAL, CME_UNKNOWN, CME_MODERATE, CME_EXTREME)
+		cme_intensity = pick(CME_MINIMAL, CME_MODERATE)
 	switch(cme_intensity)
 		if(CME_UNKNOWN)
 			cme_frequency_lower = CME_MODERATE_FREQUENCY_LOWER
 			cme_frequency_upper = CME_MODERATE_FREQUENCY_UPPER
-			startWhen = rand(CME_MODERATE_START_LOWER, CME_MODERATE_START_UPPER)
 			endWhen = startWhen + rand(CME_MINIMAL_END, CME_EXTREME_END)
 		if(CME_MINIMAL)
 			cme_frequency_lower = CME_MINIMAL_FREQUENCY_LOWER
 			cme_frequency_upper = CME_MINIMAL_FREQUENCY_UPPER
-			startWhen = rand(CME_MINIMAL_START_LOWER, CME_MINIMAL_START_UPPER)
 			endWhen = startWhen + CME_MINIMAL_END
 		if(CME_MODERATE)
 			cme_frequency_lower = CME_MODERATE_FREQUENCY_LOWER
 			cme_frequency_upper = CME_MODERATE_FREQUENCY_UPPER
-			startWhen = rand(CME_MODERATE_START_LOWER, CME_MODERATE_START_UPPER)
 			endWhen = startWhen + CME_MODERATE_END
 		if(CME_EXTREME)
 			cme_frequency_lower = CME_EXTREME_FREQUENCY_LOWER
 			cme_frequency_upper = CME_EXTREME_FREQUENCY_UPPER
-			startWhen = rand(CME_EXTREME_START_LOWER, CME_EXTREME_START_UPPER)
 			endWhen = startWhen + CME_EXTREME_END
 		if(CME_ARMAGEDDON)
 			cme_frequency_lower = CME_ARMAGEDDON_FREQUENCY_LOWER
 			cme_frequency_upper = CME_ARMAGEDDON_FREQUENCY_UPPER
-			startWhen = rand(CME_ARMAGEDDON_START_LOWER, CME_ARMAGEDDON_START_UPPER)
 			endWhen = startWhen + CME_ARMAGEDDON_END
 		else
 			message_admins("CME setup failure, aborting.")
@@ -248,6 +243,9 @@ Armageddon is truly going to fuck the station, use it sparingly.
 	empulse(src, pulse_range_heavy, pulse_range_light)
 	playsound(src,'sound/weapons/resonator_blast.ogg',100,TRUE)
 	explosion(src, 0, 0, 2, flame_range = 3)
+	var/turf/T = get_turf(src)
+	if(istype(T))
+		T.atmos_spawn_air("o2=30;TEMP=5778")
 	for(var/i in GLOB.mob_list)
 		var/mob/M = i
 		if(M.client && M.z == z)
@@ -265,6 +263,9 @@ Armageddon is truly going to fuck the station, use it sparingly.
 	var/pulse_range_heavy = rand(cme_heavy_range_lower, cme_heavy_range_upper)
 	empulse(src, pulse_range_heavy, pulse_range_light)
 	explosion(src, 0, 3, 10, flame_range = 10)
+	var/turf/T = get_turf(src)
+	if(istype(T))
+		T.atmos_spawn_air("o2=30;TEMP=5778")
 	playsound(src,'sound/weapons/resonator_blast.ogg',100,TRUE)
 	for(var/i in GLOB.mob_list)
 		var/mob/M = i
@@ -279,33 +280,6 @@ Armageddon is truly going to fuck the station, use it sparingly.
 /obj/effect/cme/proc/anomalyNeutralize()
 	playsound(src,'sound/weapons/resonator_blast.ogg',100,TRUE)
 	new /obj/effect/particle_effect/smoke/bad(loc)
-	var/turf/open/T = get_turf(src)
-	if(istype(T))
-		T.atmos_spawn_air("o2=30;TEMP=5778")
-	color = COLOR_WHITE
-	light_color = COLOR_WHITE
-	neutralized = TRUE
-	var/atom/movable/loot = pickweight(GLOB.cme_loot_list)
-	new loot(loc)
-
-/obj/effect/cme/extreme/anomalyNeutralize()
-	playsound(src,'sound/weapons/resonator_blast.ogg',100,TRUE)
-	new /obj/effect/particle_effect/smoke/bad(loc)
-	var/turf/open/T = get_turf(src)
-	if(istype(T))
-		T.atmos_spawn_air("o2=30;plasma=30;TEMP=5778")
-	color = COLOR_WHITE
-	light_color = COLOR_WHITE
-	neutralized = TRUE
-	var/atom/movable/loot = pickweight(GLOB.cme_loot_list)
-	new loot(loc)
-
-/obj/effect/cme/armageddon/anomalyNeutralize()
-	playsound(src,'sound/weapons/resonator_blast.ogg',100,TRUE)
-	new /obj/effect/particle_effect/smoke/bad(loc)
-	var/turf/open/T = get_turf(src)
-	if(istype(T))
-		T.atmos_spawn_air("o2=30;plasma=80;TEMP=5778")
 	color = COLOR_WHITE
 	light_color = COLOR_WHITE
 	neutralized = TRUE


### PR DESCRIPTION
## About The Pull Request

The possible loot from successfully defusing a CME core is now an EMP Payload instead of random materials.
The EMP range for all CMEs were reduced by roughly half.
The delay of CME spawning was increased by double.
The length of CME events was increased by double.
CMEs can no longer start before 40 minutes into the shift (Previously 25).
All CME events will take 2 minutes to start spawning CMEs (Before: Variable).
All CME events will announce faster.
CME intensity will now be between minimal and moderate, instead of minimal, moderate, extreme, and random.
CMEs will no longer spew hot plasma fire when defused.
CMEs will now spew hot plasma fire when detonated.
CMEs will now take 120 seconds to detonate instead of 40 seconds.

## Why It's Good For The Game

The CME event is honestly bad. It should 100% be removed given how much it affects the round for the worse, but most players seem to want a rework so here it is. These changes make it possible to counter a CME with a decently sized science staff.

## Every Change Explained
Given that all events reward antags in some way, the CME did not. Now it does by spawning an EMP core every time one is defused, so they can go defuse it themselves and get an EMP payload for themselves.

CMEs had an absurd EMP range, usually the size of a department, so this was tweaked.

The delay of spawning CMEs was doubled as well. It was insane how much announcement spam there was.

The length of the CME event was doubled to compensate for the reducing of frequency.

CMEs could start as early as 25 minutes. About the 35 minute mark is when everyone is settled in, so I increased it to 40 minutes.

CMEs had a very small amount of prep time. It sucked. It was increased to 2 minutes to match the average meteor event warning.

CMEs will announce faster. This isn't much of a change but there was no reason to keep it high.

The possible intensity options were absurd. Extreme almost always resulted in a shuttle call if science wasn't on their game. It was removed from possible options, as well as the "Unknown" option which was just dumb.

CME spewing hot plasma fire when it was defused was dumb. It punished players for defusing it.

CME spewing hot plasma fire when it's detonated makes more sense.

CME detonation time increased because 40 seconds wasn't enough. 120 seconds is fair. Regular anomalies are 90 seconds so given the spam of CMEs, this seems fair.

## Changelog
:cl: BurgerBB
balance: Reworks the CME event so it is not as awful anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
