### PR TITLE
makes t3 and t4 scythes purchaseable only

### DIFF
--- a/modular_skyrat/modules/apocolypse_of_scythes/code/scythes.dm
+++ b/modular_skyrat/modules/apocolypse_of_scythes/code/scythes.dm
@@ -19,7 +19,6 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
 	var/hit_range = 0
-	var/venus_chance = 0
 	var/swiping = FALSE
 
 /obj/item/scythe/pre_attack(atom/A, mob/living/user, params)
@@ -29,17 +28,10 @@
 		return ..()
 	swiping = TRUE
 	if(istype(A, /obj/structure/spacevine) && hit_range >= 1)
-		for(var/obj/structure/spacevine/choose_vine in range(hit_range, A))
-			if(prob(venus_chance/2))
-				choose_vine.Destroy()
-				continue
+		for(var/obj/structure/spacevine/choose_vine in view(hit_range, A))
 			melee_attack_chain(user, choose_vine)
 		swiping = FALSE
 		return
-	if(istype(A, /mob/living/simple_animal/hostile/venus_human_trap))
-		var/mob/living/simple_animal/hostile/venus_human_trap/hostile_venus = A
-		if(prob(venus_chance))
-			hostile_venus.death()
 	swiping = FALSE
 
 /obj/item/scythe/tier1
@@ -51,21 +43,18 @@
 	icon_state = "scythe_t2"
 	force = 13
 	hit_range = 1
-	venus_chance = 20
 
 /obj/item/scythe/tier3
 	name = "scythe (tier 3)"
 	icon_state = "scythe_t3"
 	force = 16
 	hit_range = 2
-	venus_chance = 40
 
 /obj/item/scythe/tier4
 	name = "scythe (tier 4)"
 	icon_state = "scythe_t4"
 	force = 20
 	hit_range = 3
-	venus_chance = 60
 
 /datum/design/scythe_t1
 	name = "Scythe (Tier 1)"
@@ -84,26 +73,6 @@
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
 	build_path = /obj/item/scythe/tier2
-	category = list("Equipment")
-	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
-
-/datum/design/scythe_t3
-	name = "Scythe (Tier 3)"
-	desc = "A sharp and curved blade on a long fibremetal handle, this tool makes it easy to reap what you sow."
-	id = "scythet3"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
-	build_path = /obj/item/scythe/tier3
-	category = list("Equipment")
-	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
-
-/datum/design/scythe_t4
-	name = "Scythe (Tier 4)"
-	desc = "A sharp and curved blade on a long fibremetal handle, this tool makes it easy to reap what you sow."
-	id = "scythet4"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
-	build_path = /obj/item/scythe/tier4
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
@@ -129,24 +98,16 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	discount_experiments = list(/datum/experiment/scanning/random/plants/wild = 1000)
 
-/datum/techweb_node/scythe_t3
-	id = "t3scythe"
-	display_name = "Scythe (Tier 3)"
-	description = "Culling tools"
-	prereq_ids = list("t2scythe")
-	design_ids = list(
-		"scythet3",
-	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
-	discount_experiments = list(/datum/experiment/scanning/random/plants/wild = 1500)
+/datum/supply_pack/organic/tier3_scythe
+	name = "Tier 3 Scythe"
+	desc = "Have pesky vines and need a way to chop it down faster? Order this crate now!"
+	cost = CARGO_CRATE_VALUE * 20
+	contains = list(/obj/item/scythe/tier3)
+	crate_name = "tier 3 scythe supply crate"
 
-/datum/techweb_node/scythe_t4
-	id = "t4scythe"
-	display_name = "Scythe (Tier 4)"
-	description = "Culling tools"
-	prereq_ids = list("t3scythe")
-	design_ids = list(
-		"scythet4",
-	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
-	discount_experiments = list(/datum/experiment/scanning/random/plants/wild = 2000)
+/datum/supply_pack/organic/tier4_scythe
+	name = "Tier 4 Scythe"
+	desc = "Have pesky vines and need a way to chop it down faster? Order this crate now!"
+	cost = CARGO_CRATE_VALUE * 40
+	contains = list(/obj/item/scythe/tier4)
+	crate_name = "tier 4 scythe supply crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
vines get messed up badly by t3 and t4, lets make it cargo only
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
vine balance is crippling.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: you are required to buy t3/t4 scythes from cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
