### PR TITLE
[MODULAR] Gives ghost cafe a botanical chem dispenser and a oven.

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -3257,10 +3257,7 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "aEp" = (
-/obj/structure/table/wood,
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
-	},
+/obj/machinery/chem_dispenser/mutagensaltpeter,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
@@ -3665,6 +3662,9 @@
 /obj/structure/table/wood,
 /obj/item/gun/energy/floragun,
 /obj/item/geneshears,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -1897,7 +1897,7 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "atq" = (
-/obj/machinery/vending/dinnerware,
+/obj/machinery/oven,
 /turf/open/indestructible/hoteltile{
 	icon_state = "cafeteria"
 	},
@@ -3263,7 +3263,7 @@
 	},
 /area/centcom/holding/cafe)
 "aEG" = (
-/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/vending/dinnerware,
 /turf/open/indestructible/hoteltile{
 	icon_state = "cafeteria"
 	},
@@ -9977,6 +9977,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
+"rxB" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/indestructible/hoteltile{
+	icon_state = "cafeteria"
+	},
+/area/centcom/holding/cafe)
 "ryl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -54944,7 +54950,7 @@ aBd
 anL
 akJ
 aBd
-aBd
+rxB
 aFn
 alp
 alp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/68373373/131204429-acd7abba-7d7a-4e47-9f87-8b4ab19f396a.png)
Gives the ghost cafe hydroponics area a botanical chem dispenser where the disk compartmentalizer used to be. This is the same botany dispenser that Interdyne and DS-2 have access to. To account for this change, the disk compartmentalizer has been moved up one tile to the table with the botanogenetic shears and floral somatoray. 
![image](https://user-images.githubusercontent.com/68373373/131205277-6769a827-4469-4d6b-b919-7719c48e2764.png)
A oven has been added in to the kitchen area. because of this the Dinnerware vendor and meat fridge have been moved to make space.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fleshes out the botany part of the ghost cafe. This should hopefully make it easier to grow and experiment with plants. The oven is a vital part of cooking and was previously missing in the ghost cafe.  
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The botany area of the ghost cafe now has a botany chem dispenser along with the kitchen now having an oven.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
