### PR TITLE
[MODULAR] Gives NT Rep the quirk restrictions of a head of staff rather than a member of sec. 

### DIFF
--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -67,7 +67,7 @@
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 
 /datum/job/nanotrasen_representative
-	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
+	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
 
 // Command
 /datum/job/captain


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the banned quirks list from SEC_RESTRICTED_QUIRKS to HEAD_RESTRICTED_QUIRKS, meaning that NT Reps will have the same disallowed quirks as a head of staff rather than a member of the security team.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
NT Rep isn't necessarily designed to be a combat type role, it makes more sense for them to have the restrictions that a captain would rather than sec. This would hopefully allow people to roleplay more interesting Nanotransen Representative characters.  
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Nanotransen Representative now has the same job restricted quirks as a head of staff, instead of having the ones of a security member. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
