### PR TITLE
spacewalking vine mutation + spacevines allow moving in space

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -792,6 +792,9 @@
 	if(locate(/obj/structure/lattice) in range(1, get_turf(src))) //Not realistic but makes pushing things in space easier
 		return TRUE
 
+	if(locate(/obj/structure/spacevine) in range(1, get_turf(src))) //SKYRAT EDIT: allow walking when vines are around
+		return TRUE
+
 	return FALSE
 
 

--- a/modular_skyrat/master_files/code/modules/events/spacevine.dm
+++ b/modular_skyrat/master_files/code/modules/events/spacevine.dm
@@ -539,6 +539,12 @@
 	var/turf/holder_turf = get_turf(holder)
 	holder_turf.atmos_spawn_air("n2=100;TEMP=293")
 
+//allows the vine to walk 1 tile away from turfs
+/datum/spacevine_mutation/spacewalking
+	name = "space-walking"
+	hue = "#0a1330"
+	severity = 5
+	quality = NEGATIVE
 
 // SPACE VINES (Note that this code is very similar to Biomass code)
 /obj/structure/spacevine
@@ -791,21 +797,30 @@
 	for(var/obj/machinery/door/target_door in stepturf.contents)
 		if(prob(50))
 			target_door.open()
+	var/datum/spacevine_mutation/spacewalking/space_mutation = locate() in mutations
 	if(!isspaceturf(stepturf) && stepturf.Enter(src))
-		//Locates any vine on target turf. Calls that vine "spot_taken".
-		var/obj/structure/spacevine/spot_taken = locate() in stepturf
+		spread_two(stepturf, direction)
+	else if(space_mutation && isspaceturf(stepturf) && stepturf.Enter(src))
+		var/turf/closed/wall/find_wall = locate() in range(2, src)
+		var/turf/open/floor/find_floor = locate() in range(2, src)
+		if(find_floor || find_wall)
+			spread_two(stepturf, direction)
 
-		//Locates the vine eating trait in our own seed and calls it eating_mutation.
-		var/datum/spacevine_mutation/vine_eating/eating_mutation = locate() in mutations
+/obj/structure/spacevine/proc/spread_two(turf/target_turf, target_dir)
+	//Locates any vine on target turf. Calls that vine "spot_taken".
+	var/obj/structure/spacevine/spot_taken = locate() in target_turf
 
-		//Proceed if there isn't a vine on the target turf, OR we have vine eater AND target vine is from our seed and doesn't. Vines from other seeds are eaten regardless.
-		if(!spot_taken || (eating_mutation && (spot_taken && !spot_taken.mutations.Find(eating_mutation))))
-			if(!master)
-				return
-			for(var/datum/spacevine_mutation/vine_mutation in mutations)
-				vine_mutation.on_spread(src, stepturf) //Only do the on_spread proc if it actually spreads.
-				stepturf = get_step(src,direction) //in case turf changes, to make sure no runtimes happen
-			master.spawn_spacevine_piece(stepturf, src)
+	//Locates the vine eating trait in our own seed and calls it eating_mutation.
+	var/datum/spacevine_mutation/vine_eating/eating_mutation = locate() in mutations
+
+	//Proceed if there isn't a vine on the target turf, OR we have vine eater AND target vine is from our seed and doesn't. Vines from other seeds are eaten regardless.
+	if(!spot_taken || (eating_mutation && (spot_taken && !spot_taken.mutations.Find(eating_mutation))))
+		if(!master)
+			return
+		for(var/datum/spacevine_mutation/vine_mutation in mutations)
+			vine_mutation.on_spread(src, target_turf) //Only do the on_spread proc if it actually spreads.
+			target_turf = get_step(src,target_dir) //in case turf changes, to make sure no runtimes happen
+		master.spawn_spacevine_piece(target_turf, src)
 
 /obj/structure/spacevine/ex_act(severity, target)
 	var/i


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
spacevines have a new mutation: spacewalking
allows vines to spread only 3 tiles away from the station essentially
spacevines, similar to lattices, allow you to spacewalk without flying off
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
spacevines are called spacevines, they should be able to go into space with some limitations
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: added spacevine spacewalking mutation
add: spacevines allow you to spacewalk, similar to lattices
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
