### PR TITLE
[MODULAR] Fixes to mold mobs and nerfing the Oil Chambler and the Centaur

### DIFF
--- a/modular_skyrat/modules/biohazard_blob/code/biohazard_blob_mobs.dm
+++ b/modular_skyrat/modules/biohazard_blob/code/biohazard_blob_mobs.dm
@@ -45,12 +45,7 @@
 	update_overlays()
 
 /mob/living/simple_animal/hostile/biohazard_blob/oil_shambler/Destroy()
-	visible_message("<span class='warning'>The [src] ruptures!</span>")
-	var/datum/reagents/R = new/datum/reagents(300)
-	R.my_atom = src
-	R.add_reagent(/datum/reagent/napalm, 50)
-	chem_splash(loc, 5, list(R))
-	playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
+	visible_message(span_warning("The [src] evaporates!"))
 	return ..()
 
 /mob/living/simple_animal/hostile/biohazard_blob/oil_shambler/update_overlays()
@@ -97,7 +92,7 @@
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
 		if(src.can_inject(target))
-			to_chat(C, "<span class='danger'>[src] manages to penetrate your clothing with it's teeth!</span>")
+			to_chat(C, span_danger("[src] manages to penetrate your clothing with it's teeth!"))
 			C.ForceContractDisease(new /datum/disease/cordyceps(), FALSE, TRUE)
 
 /mob/living/simple_animal/hostile/biohazard_blob/electric_mosquito
@@ -167,10 +162,10 @@
 	update_overlays()
 
 /mob/living/simple_animal/hostile/biohazard_blob/centaur/death(gibbed)
-	visible_message("<span class='warning'>The [src] ruptures!</span>")
+	visible_message(span_warning("The [src] ruptures!"))
 	var/datum/reagents/R = new/datum/reagents(300)
 	R.my_atom = src
-	R.add_reagent(/datum/reagent/toxin/mutagen, 50)
+	R.add_reagent(/datum/reagent/toxin/mutagen, 20)
 	chem_splash(loc, 5, list(R))
 	playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The use of spans without using the macros is bad practice now.

Oil shamblers no longer will drop napalm upon death and will simply evaporate.
Centaurs will drop 60% less mutagen, just because it doesn't do much anyway aside from spilling everywhere.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Let's face it, the infinite smoke and the insane napalm spills weren't doing the fire mold any favor, especially considering that the oil shambler takes technically no damage from burn sources.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex
fix: The Oil Shamblers will no longer leave behind napalm upon dying, they will instead evaporate, leaving you to wonder if they were even there to begin with...
code: Changed some spans to span procs in mold mob code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
