### PR TITLE
Returns brainwash disk to 5 TC

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1467,7 +1467,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A disk containing the procedure to perform a brainwashing surgery, allowing you to implant an objective onto a target. \
 	Insert into an Operating Console to enable the procedure."
 	item = /obj/item/disk/surgery/brainwashing
-	cost = 9
+	cost = 5
 //SKYRAT EDIT END
 
 //SKYRAT EDIT REMOVAL BEGIN - Remove Hypnostuff


### PR DESCRIPTION
## About The Pull Request
as title

## How This Contributes To The Skyrat Roleplay Experience

There wasn't really a reason to price hike it to 9. Anyone outside of the specific job the disk was offered to (Medbay, Robotics) already has a handicap in that they must build a full surgical facility (the silver bed and console) to use the disk, or otherwise get access to non-ghetto surgery without needless suspicion. It also nerfed jobs that already got it for no real reason.

Many maps have a maint surgery room, but this doesn't come with the trust a doctor innately is given to people (meaning you will have to abduct them forcefully, usually). 

Overall, there's no real argument to hike it to 9. Making it more available has nothing to do with the balance of the item, and further availability beyond Med/Robo has to put in more work to get any use out of it anyway.

## Alternatives considered:
-Instead of just dropping the price, I will consider re-adding the restricted variation at the original price, without removing the 'unlocked' version, to undo the needless Medical Doctor / Roboticist nerf that came with raising the price. I'll do this instead if there's significantly more support for that.

-Reverting #7797. Some jobs should have mechanical differences as antag, including access to items well-suited for their job. TC trades also exist.

## Changelog
:cl: YakumoChen
balance: Lowered the Brainwash Disk back to 5 TC
/:cl:
