### PR TITLE
[MOSTLY NON-MODULAR] Buffs/Re-Enables some events, Creates an APC failure event, Disables the split personality trauma from random gain

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -11,6 +11,7 @@
 	var/initialized = FALSE //to prevent personalities deleting themselves while we wait for ghosts
 	var/mob/living/split_personality/stranger_backseat //there's two so they can swap without overwriting
 	var/mob/living/split_personality/owner_backseat
+	random_gain = FALSE // SKYRAT EDIT ADD -- FUCK SPLIT PERSONALITY
 
 /datum/brain_trauma/severe/split_personality/on_gain()
 	var/mob/living/M = owner

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -18,7 +18,7 @@
 
 	area_type = /area
 	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer, /area/ai_monitored/turret_protected/aisat/maint, /area/ai_monitored/command/storage/satellite,
-	/area/ai_monitored/turret_protected/ai, /area/commons/storage/emergency/starboard, /area/commons/storage/emergency/port, /area/shuttle, /area/security/prison/safe, /area/security/prison/toilet)
+	/area/ai_monitored/turret_protected/ai, /area/commons/storage/emergency/starboard, /area/commons/storage/emergency/port, /area/shuttle, /area/security/prison/safe, /area/security/prison/toilet, /area/commons/dorms, /area/commons/cryopods) // SKYRAT EDIT ADD, CRYO AND DORMS RAD-PROOF
 	target_trait = ZTRAIT_STATION
 
 	immunity_type = WEATHER_RAD

--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -2,7 +2,7 @@
 	name = "Aurora Caelus"
 	typepath = /datum/round_event/aurora_caelus
 	max_occurrences = 1
-	weight = 1
+	weight = 5 // SKYRAT EDIT pretty -- ORIGINAL = 1
 	earliest_start = 5 MINUTES
 
 /datum/round_event_control/aurora_caelus/canSpawnEvent(players)

--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -2,6 +2,7 @@
 	name = "Spontaneous Brain Trauma"
 	typepath = /datum/round_event/brain_trauma
 	weight = 25
+	min_players = 40 // SKYRAT EDIT -- To avoid shafting lowpop
 
 /datum/round_event/brain_trauma
 	fakeable = FALSE

--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -2,7 +2,6 @@
 	name = "Spontaneous Brain Trauma"
 	typepath = /datum/round_event/brain_trauma
 	weight = 25
-	max_occurrences = 0 //SKYRAT EDIT CHANGE
 
 /datum/round_event/brain_trauma
 	fakeable = FALSE
@@ -23,10 +22,9 @@
 
 /datum/round_event/brain_trauma/proc/traumatize(mob/living/carbon/human/H)
 	var/resistance = pick(
-		50;TRAUMA_RESILIENCE_BASIC,
+		55;TRAUMA_RESILIENCE_BASIC,
 		30;TRAUMA_RESILIENCE_SURGERY,
-		15;TRAUMA_RESILIENCE_LOBOTOMY,
-		5;TRAUMA_RESILIENCE_MAGIC)
+		15;TRAUMA_RESILIENCE_LOBOTOMY) // SKYRAT EDIT -- FORCED PERMANENT TRAUMAS AREN'T FUN, ORIGINAL HAD 50;TRAUMA_RESILIENCE_BASIC, 5;TRAUMA_RESILIENCE_MAGIC.
 
 	var/trauma_type = pickweight(list(
 		BRAIN_TRAUMA_MILD = 60,

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -1,8 +1,7 @@
 /datum/round_event_control/heart_attack
 	name = "Random Heart Attack"
 	typepath = /datum/round_event/heart_attack
-	//weight = 20 //ORIGINAL
-	weight = 10 //SKYRAT EDIT CHANGE
+	weight = 20
 	max_occurrences = 2
 	min_players = 40 // To avoid shafting lowpop
 

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/ion_storm
 	name = "Ion Storm"
 	typepath = /datum/round_event/ion_storm
-	weight = 30 // SKYRAT EDIT - ORIGINAL 15
+	weight = 15
 	min_players = 2
 
 /datum/round_event/ion_storm

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/ion_storm
 	name = "Ion Storm"
 	typepath = /datum/round_event/ion_storm
-	weight = 15
+	weight = 30 // SKYRAT EDIT - ORIGINAL 15
 	min_players = 2
 
 /datum/round_event/ion_storm

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -1,8 +1,7 @@
 /datum/round_event_control/radiation_storm
 	name = "Radiation Storm"
 	typepath = /datum/round_event/radiation_storm
-	//max_occurrences = 1 //ORIGINAL
-	max_occurrences = 0 //SKYRAT EDIT CHANGE - EVENTS
+	max_occurrences = 1
 
 /datum/round_event/radiation_storm
 

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -2,6 +2,8 @@
 	name = "Radiation Storm"
 	typepath = /datum/round_event/radiation_storm
 	max_occurrences = 1
+	weight = 5 //SKYRAT EDIT ADD
+	earliest_start = 20 MINUTES // SKYRAT EDIT ADD
 
 /datum/round_event/radiation_storm
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -499,12 +499,12 @@
 						return
 					else if (obj_flags & EMAGGED)
 						obj_flags &= ~EMAGGED
-						user.visible_message(span_notice("[user.name] discards an emagged power control board from [src.name]!"),\
-							span_notice("You discard the emagged power control board."))
+						user.visible_message(span_notice("[user.name] discards a fried power control board from [src.name]!"),\ // SKYRAT EDIT -- PLAUSIBLE DENIABILITY (emagged/hacked APCs don't reveal their cause)
+							span_notice("You discard the fried power control board."))
 						return
 					else if (malfhack)
-						user.visible_message(span_notice("[user.name] discards a strangely programmed power control board from [src.name]!"),\
-							span_notice("You discard the strangely programmed board."))
+						user.visible_message(span_notice("[user.name] discards a fried power control board from [src.name]!"),\
+							span_notice("You discard the fried programmed board.")) // SKYRAT EDIT END
 						malfai = null
 						malfhack = 0
 						return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -499,8 +499,8 @@
 						return
 					else if (obj_flags & EMAGGED)
 						obj_flags &= ~EMAGGED
-						user.visible_message(span_notice("[user.name] discards a fried power control board from [src.name]!"),\// SKYRAT EDIT -- PLAUSIBLE DENIABILITY (emagged/hacked APCs don't reveal their cause)
-							span_notice("You discard the fried power control board."))
+						user.visible_message(span_notice("[user.name] discards a fried power control board from [src.name]!"),\ 
+							span_notice("You discard the fried power control board.")) // SKYRAT EDIT -- PLAUSIBLE DENIABILITY -- (emagged/hacked APCs don't reveal their cause)
 						return
 					else if (malfhack)
 						user.visible_message(span_notice("[user.name] discards a fried power control board from [src.name]!"),\

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -499,7 +499,7 @@
 						return
 					else if (obj_flags & EMAGGED)
 						obj_flags &= ~EMAGGED
-						user.visible_message(span_notice("[user.name] discards a fried power control board from [src.name]!"),\ // SKYRAT EDIT -- PLAUSIBLE DENIABILITY (emagged/hacked APCs don't reveal their cause)
+						user.visible_message(span_notice("[user.name] discards a fried power control board from [src.name]!"),\// SKYRAT EDIT -- PLAUSIBLE DENIABILITY (emagged/hacked APCs don't reveal their cause)
 							span_notice("You discard the fried power control board."))
 						return
 					else if (malfhack)

--- a/modular_skyrat/modules/events/code/modules/events/apc_failure.dm
+++ b/modular_skyrat/modules/events/code/modules/events/apc_failure.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/apc_failure
 	name = "APC Failure"
 	typepath = /datum/round_event/apc_failure
-	weight = 50
+	weight = 20
 	max_occurrences = 5 // want this to be rare, so as to not piss off engies
 	alert_observers = FALSE
 

--- a/modular_skyrat/modules/events/code/modules/events/apc_failure.dm
+++ b/modular_skyrat/modules/events/code/modules/events/apc_failure.dm
@@ -25,3 +25,4 @@
 				target_apc.locked = FALSE
 			target_apc.update_appearance()
 		iterations *= 2.5
+

--- a/modular_skyrat/modules/events/code/modules/events/apc_failure.dm
+++ b/modular_skyrat/modules/events/code/modules/events/apc_failure.dm
@@ -9,14 +9,27 @@
 	fakeable = FALSE
 
 /datum/round_event/apc_failure/start()
-	var/obj/machinery/power/apc/target_apc = pick(GLOB.apcs_list)
-	if(is_station_level(target_apc.z))
-		flick("apc-spark", target_apc)
-		playsound(target_apc, "sparks", 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		target_apc.obj_flags |= EMAGGED
-		if(prob(75)) // Give malfies a chance, too, but most likely to be unlocked so as to not hinder controlling said APC
-			target_apc.locked = FALSE
-		target_apc.update_appearance()
-		return
+	var/iterations = 1
+	var/list/apcs = GLOB.apcs_list.Copy()
+	while(prob(round(100/iterations)))
+		var/obj/machinery/power/apc/target_apc = pick_n_take(apcs)
+		if(!target_apc)
+			break
+		if(!(is_station_level(target_apc.z)))
+			continue
+		if(!(target_apc.obj_flags & EMAGGED))
+			flick("apc-spark", target_apc)
+			playsound(target_apc, "sparks", 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+			target_apc.obj_flags |= EMAGGED
+			if(prob(75)) // Give malfies a chance, too, but most likely to be unlocked so as to not hinder controlling said APC
+				target_apc.locked = FALSE
+			target_apc.update_appearance()
+		iterations *= 2.5
+
+
+
+
+
+
 
 

--- a/modular_skyrat/modules/events/code/modules/events/apc_failure.dm
+++ b/modular_skyrat/modules/events/code/modules/events/apc_failure.dm
@@ -1,0 +1,22 @@
+/datum/round_event_control/apc_failure
+	name = "APC Failure"
+	typepath = /datum/round_event/apc_failure
+	weight = 50
+	max_occurrences = 5 // want this to be rare, so as to not piss off engies
+	alert_observers = FALSE
+
+/datum/round_event/apc_failure
+	fakeable = FALSE
+
+/datum/round_event/apc_failure/start()
+	var/obj/machinery/power/apc/target_apc = pick(GLOB.apcs_list)
+	if(is_station_level(target_apc.z))
+		flick("apc-spark", target_apc)
+		playsound(target_apc, "sparks", 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+		target_apc.obj_flags |= EMAGGED
+		if(prob(75)) // Give malfies a chance, too, but most likely to be unlocked so as to not hinder controlling said APC
+			target_apc.locked = FALSE
+		target_apc.update_appearance()
+		return
+
+

--- a/modular_skyrat/modules/events/code/modules/events/apc_failure.dm
+++ b/modular_skyrat/modules/events/code/modules/events/apc_failure.dm
@@ -25,11 +25,3 @@
 				target_apc.locked = FALSE
 			target_apc.update_appearance()
 		iterations *= 2.5
-
-
-
-
-
-
-
-

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4354,6 +4354,7 @@
 #include "modular_skyrat\modules\events\code\event_spawner.dm"
 #include "modular_skyrat\modules\events\code\event_spawner_menu.dm"
 #include "modular_skyrat\modules\events\code\event_spawner_templates.dm"
+#include "modular_skyrat\modules\events\code\modules\events\apc_failure.dm"
 #include "modular_skyrat\modules\events\code\modules\events\meteor_wave.dm"
 #include "modular_skyrat\modules\examinemore\code\examine_more.dm"
 #include "modular_skyrat\modules\exp_corps\code\clothing.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Re-Enables: Random Brain Trauma (With a min pop of 40 players) (MINUS SPLIT PERSONALITY AND PERMANENT TRAUMAS)
Re-Enables: Rad storm -- however, as common as a CME
Buffs: Aurora Caelus
Buffs: Heart Attack

Creates an "APC failure" event, a random APC on station will break as if it were emagged (or at a lower chance, if it were hacked by a malf AI). APCs now no longer say "haha I was emagged" or "haha i was malf hacked" when repaired. cause that's dumb.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
We're stagnating in events, causing things like CMEs etc to have much more relative weight.

Trauma/heart attack/rad storm are sources of conflict and drama, which are good and conductive to RP, all of which are solvable, and seeing as we have the interlink, none will interrupt protected ERP scenes like they would have when they were disabled (I checked the histories of the files)

APC failure and the APC changes gives malf AIs more mechanical protections, provided they act smart about it.

Caelus is pretty :)
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: More events: Rad storms, random brain traumas, APC failure
balance: Caelus, Heart attack have been made more common
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
