### PR TITLE
[READY] Deletes depreciated cyrodorms area

### DIFF
--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -6356,7 +6356,7 @@
 /obj/machinery/cryopod,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "aCe" = (
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 4
@@ -6764,7 +6764,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "aDN" = (
 /obj/machinery/camera{
 	c_tag = "Bathroom";
@@ -35892,7 +35892,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "cKA" = (
 /obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -38125,7 +38125,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "eNB" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
@@ -38457,7 +38457,7 @@
 	pixel_y = -22
 	},
 /turf/open/floor/iron/dark,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "fey" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -46683,7 +46683,7 @@
 "mGM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "mGO" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47484,7 +47484,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "nvh" = (
 /obj/structure/table/reinforced,
 /obj/item/fuel_pellet{
@@ -48460,7 +48460,7 @@
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "opE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -49763,7 +49763,7 @@
 	layer = 2.9
 	},
 /turf/open/floor/grass,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "pwL" = (
 /turf/open/floor/iron/white/side{
 	dir = 10
@@ -49848,7 +49848,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "pAx" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -51687,7 +51687,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "rlt" = (
 /obj/machinery/computer/piratepad_control/civilian{
 	dir = 1
@@ -53899,7 +53899,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "tqp" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/brown{
@@ -53959,7 +53959,7 @@
 	pixel_x = -24
 	},
 /turf/open/floor/iron/dark,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "ttn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
@@ -55754,7 +55754,7 @@
 	layer = 2.9
 	},
 /turf/open/floor/grass,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "uUn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -57134,7 +57134,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "wgc" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -58245,7 +58245,7 @@
 /area/security/office)
 "xbG" = (
 /turf/closed/wall,
-/area/crew_quarters/cryopod)
+/area/commons/cryopods)
 "xcn" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"

--- a/modular_skyrat/modules/cryosleep/code/area.dm
+++ b/modular_skyrat/modules/cryosleep/code/area.dm
@@ -1,3 +1,0 @@
-/area/crew_quarters/cryopod
-	name = "Cryogenic Sleepers"
-	icon_state = "green"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4138,7 +4138,6 @@
 #include "modular_skyrat\modules\cortical_borer\code\cortical_borer_abilities.dm"
 #include "modular_skyrat\modules\cortical_borer\code\cortical_borer_antag.dm"
 #include "modular_skyrat\modules\cryosleep\code\ai.dm"
-#include "modular_skyrat\modules\cryosleep\code\area.dm"
 #include "modular_skyrat\modules\cryosleep\code\config.dm"
 #include "modular_skyrat\modules\customization\__DEFINES\augment.dm"
 #include "modular_skyrat\modules\customization\__DEFINES\DNA.dm"


### PR DESCRIPTION
Does what it says. We use `/area/commons/cryopods` now.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
