### PR TITLE
[READY][MOSTLY NON-MODULAR] Flavour-ifies conflict resolution messages, adds mold to it

### DIFF
--- a/code/__DEFINES/~skyrat_defines/shuttle.dm
+++ b/code/__DEFINES/~skyrat_defines/shuttle.dm
@@ -1,0 +1,6 @@
+//Defines used for determining flavour for "hostile environment" shuttle lockdown
+#define NOSHUTTLE_BIOHAZARD "Biohazard"
+#define NOSHUTTLE_DELTA "Delta Alert"
+#define NOSHUTTLE_REVS "Active Revolution"
+#define NOSHUTTLE_GANG "Sol Federal Police Lockdown"
+#define NOSHUTTLE_NARSIE "The end is nigh"

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -380,10 +380,10 @@ SUBSYSTEM_DEF(shuttle)
 			emergency.request(null, set_coefficient = 2.5)
 			log_shuttle("There is no means of calling the emergency shuttle anymore. Shuttle automatically called.")
 			message_admins("All the communications consoles were destroyed and all AIs are inactive. Shuttle called.")
-
+/* SKYRAT EDIT -- MOVED TO MASTER FILES
 /datum/controller/subsystem/shuttle/proc/registerHostileEnvironment(datum/bad)
 	hostileEnvironments[bad] = TRUE
-	checkHostileEnvironment()
+	checkHostileEnvironment() */ // SKYAT EDIT ADD END
 
 /datum/controller/subsystem/shuttle/proc/clearHostileEnvironment(datum/bad)
 	hostileEnvironments -= bad
@@ -412,7 +412,7 @@ SUBSYSTEM_DEF(shuttle)
 	if(!supplyBlocked && (supply.mode == SHUTTLE_STRANDED))
 		supply.mode = SHUTTLE_DOCKED
 		//Make all cargo consoles speak up
-
+/* SKYRAT EDIT -- MOVED TO MASTER FILES
 /datum/controller/subsystem/shuttle/proc/checkHostileEnvironment()
 	for(var/datum/d in hostileEnvironments)
 		if(!istype(d) || QDELETED(d))
@@ -431,7 +431,7 @@ SUBSYSTEM_DEF(shuttle)
 		emergency.setTimer(emergencyDockTime)
 		priority_announce("Hostile environment resolved. \
 			You have 3 minutes to board the Emergency Shuttle.",
-			null, ANNOUNCER_SHUTTLEDOCK, "Priority")
+			null, ANNOUNCER_SHUTTLEDOCK, "Priority") */ // SKYRAT EDIT ADD END
 
 //try to move/request to dockHome if possible, otherwise dockAway. Mainly used for admin buttons
 /datum/controller/subsystem/shuttle/proc/toggleShuttle(shuttleId, dockHome, dockAway, timed)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -113,7 +113,7 @@
 		new_head = M.mind.add_antag_datum(new_head, revolution)
 		revolution.update_objectives()
 		revolution.update_heads()
-		SSshuttle.registerHostileEnvironment(revolution)
+		SSshuttle.registerHostileEnvironment(revolution, NOSHUTTLE_REVS) //SKYRAT EDIT ADD -- ADDED ARG "NOSHUTTLE_REVS"
 		return TRUE
 	else
 		log_game("DYNAMIC: [ruletype] [name] discarded [M.name] from head revolutionary due to ineligibility.")

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -456,7 +456,7 @@
 	if(revolution.members.len)
 		revolution.update_objectives()
 		revolution.update_heads()
-		SSshuttle.registerHostileEnvironment(revolution)
+		SSshuttle.registerHostileEnvironment(revolution, NOSHUTTLE_REVS) //SKYRAT EDIT ADD -- ADDED ARG "NOSHUTTLE_REVS"
 		return TRUE
 	log_game("DYNAMIC: [ruletype] [name] failed to get any eligible headrevs. Refunding [cost] threat.")
 	return FALSE

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -103,7 +103,7 @@
 	revolution.update_objectives()
 	revolution.update_heads()
 
-	SSshuttle.registerHostileEnvironment(src)
+	SSshuttle.registerHostileEnvironment(src, NOSHUTTLE_REVS) //SKYRAT EDIT ADD -- ADDED ARG "NOSHUTTLE_REVS"
 	..()
 
 

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	color = blobstrain.complementary_color
 	if(blob_core)
 		blob_core.update_appearance()
-	SSshuttle.registerHostileEnvironment(src)
+	SSshuttle.registerHostileEnvironment(src, NOSHUTTLE_BIOHAZARD) // SKYRAT EDIT ADD -- ADDED ARG "NOSHUTTLE_BIOHAZARD"
 	. = ..()
 	START_PROCESSING(SSobj, src)
 

--- a/code/modules/antagonists/gang/handler.dm
+++ b/code/modules/antagonists/gang/handler.dm
@@ -220,7 +220,7 @@ GLOBAL_VAR_INIT(deaths_during_shift, 0)
 		// see /datum/antagonist/gang/create_team() for how the gang team datum gets instantiated and added to our gangs list
 
 	addtimer(CALLBACK(src, .proc/announce_gang_locations), 5 MINUTES)
-	SSshuttle.registerHostileEnvironment(src)
+	SSshuttle.registerHostileEnvironment(src, NOSHUTTLE_GANG) //SKYRAT EDIT ADD -- ADDED ARG "NOSHUTTLE_GANG"
 	return TRUE
 
 /**

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -492,7 +492,7 @@ GLOBAL_VAR(station_nuke_source)
 		off_station = NUKE_MISS_STATION
 
 	if(off_station < NUKE_MISS_STATION)
-		SSshuttle.registerHostileEnvironment(src)
+		SSshuttle.registerHostileEnvironment(src, NOSHUTTLE_DELTA) //SKYRAT EDIT -- ADDED ARG "NOSHUTTLE_DELTA"
 		SSshuttle.lockdown = TRUE
 
 	KillEveryoneOnZLevel(z) //SKYRAT EDIT ADDITION

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -335,7 +335,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	timing = TRUE
 	countdown.start()
 	START_PROCESSING(SSfastprocess, src)
-	SSshuttle.registerHostileEnvironment(src)
+	SSshuttle.registerHostileEnvironment(src, NOSHUTTLE_DELTA) //SKYRAT EDIT, ADDED ARG "NOSHUTTLE_DELTA"
 	SSmapping.add_nuke_threat(src) //This causes all blue "circuit" tiles on the map to change to animated red icon state.
 	for(var/mob/living/silicon/robot/borg in owner.connected_robots)
 		borg.lamp_doom = TRUE

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -236,7 +236,7 @@
 ///security level and shuttle lockdowns for [/proc/begin_the_end()]
 /proc/narsie_start_destroy_station()
 	set_security_level("gamma") //SKYRAT EDIT CHANGE - ALERTS - ORIGINAL "delta"
-	SSshuttle.registerHostileEnvironment(GLOB.cult_narsie)
+	SSshuttle.registerHostileEnvironment(GLOB.cult_narsie, NOSHUTTLE_NARSIE) // SKYRAT EDIT -- added arg "NOSHUTTLE_NARSIE"
 	SSshuttle.lockdown = TRUE
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/narsie_apocalypse), 1 MINUTES)
 

--- a/modular_skyrat/master_files/code/controllers/subsystem/shuttle.dm
+++ b/modular_skyrat/master_files/code/controllers/subsystem/shuttle.dm
@@ -7,9 +7,9 @@
 	checkHostileEnvironment()
 
 /datum/controller/subsystem/shuttle/proc/checkHostileEnvironment()
-	for(var/datum/d in hostileEnvironments)
-		if(!istype(d) || QDELETED(d))
-			hostileEnvironments -= d
+	for(var/datum/environment in hostileEnvironments)
+		if(!istype(environment) || QDELETED(environment))
+			hostileEnvironments -= environment
 	emergencyNoEscape = hostileEnvironments.len
 
 	if(emergencyNoEscape && (emergency.mode == SHUTTLE_IGNITING))

--- a/modular_skyrat/master_files/code/controllers/subsystem/shuttle.dm
+++ b/modular_skyrat/master_files/code/controllers/subsystem/shuttle.dm
@@ -1,10 +1,3 @@
-#define NOSHUTTLE_BIOHAZARD "Biohazard"
-#define NOSHUTTLE_DELTA "Delta Alert"
-#define NOSHUTTLE_REVS "Active Revolution"
-#define NOSHUTTLE_GANG "Sol Federal Police Lockdown"
-#define NOSHUTTLE_NARSIE "The end is nigh"
-
-
 /datum/controller/subsystem/shuttle/proc/registerHostileEnvironment(datum/bad, reason)
 	hostileEnvironments[bad] = TRUE
 	checkHostileEnvironment(reason)
@@ -22,24 +15,24 @@
 		switch(reason)
 			if(NOSHUTTLE_BIOHAZARD)
 				priority_announce("Severe Biohazard detected. \
-				[GLOB.station_name] is under indefinite quarantine \
-				pending biohazard cleanse.", "Station Quarantine", 'sound/misc/notice1.ogg', "Priority")
+					[GLOB.station_name] is under indefinite quarantine \
+					pending biohazard cleanse.", null, 'sound/misc/notice1.ogg', "Priority")
 			if(NOSHUTTLE_DELTA)
 				priority_announce("Station destruction imminent. \
-				All hands of [GLOB.station_name] are expected to prevent \
-				station destruction before leaving.", "Delta Alert Lockdown", 'sound/misc/notice1.ogg', "Priority")
+					All hands of [GLOB.station_name] are expected to prevent \
+					station destruction before leaving.", "Delta Alert Lockdown", 'sound/misc/notice1.ogg', "Priority")
 			if(NOSHUTTLE_REVS)
 				priority_announce("Armed 'revolution' detected. \
-				All hands of [GLOB.station_name] are expected to suppress \
-				violent terrorists before leaving.", "NT Anti-Terror Lockdown", 'sound/misc/notice1.ogg', "Priority")
+					All hands of [GLOB.station_name] are expected to suppress \
+					violent terrorists before leaving.", "NT Anti-Terror Lockdown", 'sound/misc/notice1.ogg', "Priority")
 			if(NOSHUTTLE_GANG)
 				priority_announce("Emergency shuttle under lockdown \
-				on order of Sol Federal Police. Please comply with \
-				orders and resolution will be easy.", "Sol Federal Police Lockdown", 'sound/misc/notice1.ogg', "Priority")
+					on order of Sol Federal Police. Please comply with \
+					orders and resolution will be easy.", "Sol Federal Police Lockdown", 'sound/misc/notice1.ogg', "Priority")
 			if(NOSHUTTLE_NARSIE)
 				priority_announce("YOU CANNOT ESCAPE INEVITABILITY. \
-				I HUNGER. \
-				YOUR SHUTTLE WILL NOT HELP YOU.", "Message from Nar'Sie", 'sound/creatures/narsie_rises.ogg', "Priority")
+					I HUNGER. \
+					YOUR SHUTTLE WILL NOT HELP YOU.", "Message from Nar'Sie", 'sound/creatures/narsie_rises.ogg', "Priority")
 	if(!emergencyNoEscape && (emergency.mode == SHUTTLE_STRANDED))
 		emergency.mode = SHUTTLE_DOCKED
 		emergency.setTimer(emergencyDockTime)

--- a/modular_skyrat/master_files/code/controllers/subsystem/shuttle.dm
+++ b/modular_skyrat/master_files/code/controllers/subsystem/shuttle.dm
@@ -1,0 +1,48 @@
+#define NOSHUTTLE_BIOHAZARD "Biohazard"
+#define NOSHUTTLE_DELTA "Delta Alert"
+#define NOSHUTTLE_REVS "Active Revolution"
+#define NOSHUTTLE_GANG "Sol Federal Police Lockdown"
+#define NOSHUTTLE_NARSIE "The end is nigh"
+
+
+/datum/controller/subsystem/shuttle/proc/registerHostileEnvironment(datum/bad, reason)
+	hostileEnvironments[bad] = TRUE
+	checkHostileEnvironment(reason)
+
+/datum/controller/subsystem/shuttle/proc/checkHostileEnvironment(reason)
+	for(var/datum/d in hostileEnvironments)
+		if(!istype(d) || QDELETED(d))
+			hostileEnvironments -= d
+	emergencyNoEscape = hostileEnvironments.len
+
+	if(emergencyNoEscape && (emergency.mode == SHUTTLE_IGNITING))
+		emergency.mode = SHUTTLE_STRANDED
+		emergency.timer = null
+		emergency.sound_played = FALSE
+		switch(reason)
+			if(NOSHUTTLE_BIOHAZARD)
+				priority_announce("Severe Biohazard detected. \
+				[GLOB.station_name] is under indefinite quarantine \
+				pending biohazard cleanse.", "Station Quarantine", 'sound/misc/notice1.ogg', "Priority")
+			if(NOSHUTTLE_DELTA)
+				priority_announce("Station destruction imminent. \
+				All hands of [GLOB.station_name] are expected to prevent \
+				station destruction before leaving.", "Delta Alert Lockdown", 'sound/misc/notice1.ogg', "Priority")
+			if(NOSHUTTLE_REVS)
+				priority_announce("Armed 'revolution' detected. \
+				All hands of [GLOB.station_name] are expected to suppress \
+				violent terrorists before leaving.", "NT Anti-Terror Lockdown", 'sound/misc/notice1.ogg', "Priority")
+			if(NOSHUTTLE_GANG)
+				priority_announce("Emergency shuttle under lockdown \
+				on order of Sol Federal Police. Please comply with \
+				orders and resolution will be easy.", "Sol Federal Police Lockdown", 'sound/misc/notice1.ogg', "Priority")
+			if(NOSHUTTLE_NARSIE)
+				priority_announce("YOU CANNOT ESCAPE INEVITABILITY. \
+				I HUNGER. \
+				YOUR SHUTTLE WILL NOT HELP YOU.", "Message from Nar'Sie", 'sound/creatures/narsie_rises.ogg', "Priority")
+	if(!emergencyNoEscape && (emergency.mode == SHUTTLE_STRANDED))
+		emergency.mode = SHUTTLE_DOCKED
+		emergency.setTimer(emergencyDockTime)
+		priority_announce("Shuttle Lockdown Lifted. \
+			You have 3 minutes to board the Emergency Shuttle.",
+			null, ANNOUNCER_SHUTTLEDOCK, "Priority")

--- a/modular_skyrat/master_files/code/controllers/subsystem/shuttle.dm
+++ b/modular_skyrat/master_files/code/controllers/subsystem/shuttle.dm
@@ -1,8 +1,12 @@
+/datum/controller/subsystem/shuttle/
+	var/hostileEnvironmentTypes = list()
+
 /datum/controller/subsystem/shuttle/proc/registerHostileEnvironment(datum/bad, reason)
 	hostileEnvironments[bad] = TRUE
-	checkHostileEnvironment(reason)
+	hostileEnvironmentTypes += reason
+	checkHostileEnvironment()
 
-/datum/controller/subsystem/shuttle/proc/checkHostileEnvironment(reason)
+/datum/controller/subsystem/shuttle/proc/checkHostileEnvironment()
 	for(var/datum/d in hostileEnvironments)
 		if(!istype(d) || QDELETED(d))
 			hostileEnvironments -= d
@@ -12,19 +16,19 @@
 		emergency.mode = SHUTTLE_STRANDED
 		emergency.timer = null
 		emergency.sound_played = FALSE
-		switch(reason)
+		switch(hostileEnvironmentTypes[1])
 			if(NOSHUTTLE_BIOHAZARD)
 				priority_announce("Severe Biohazard detected. \
 					[GLOB.station_name] is under indefinite quarantine \
-					pending biohazard cleanse.", null, 'sound/misc/notice1.ogg', "Priority")
+					pending biohazard cleanse.", "Station Quarantine", 'sound/misc/notice1.ogg', "Priority")
 			if(NOSHUTTLE_DELTA)
 				priority_announce("Station destruction imminent. \
 					All hands of [GLOB.station_name] are expected to prevent \
-					station destruction before leaving.", "Delta Alert Lockdown", 'sound/misc/notice1.ogg', "Priority")
+					station destruction before leaving.", "Destruction Imminent", 'sound/misc/notice1.ogg', "Priority")
 			if(NOSHUTTLE_REVS)
 				priority_announce("Armed 'revolution' detected. \
 					All hands of [GLOB.station_name] are expected to suppress \
-					violent terrorists before leaving.", "NT Anti-Terror Lockdown", 'sound/misc/notice1.ogg', "Priority")
+					violent terrorists before leaving.", "NT Anti-Terror Announcement", 'sound/misc/notice1.ogg', "Priority")
 			if(NOSHUTTLE_GANG)
 				priority_announce("Emergency shuttle under lockdown \
 					on order of Sol Federal Police. Please comply with \

--- a/modular_skyrat/master_files/code/modules/events/spacevine.dm
+++ b/modular_skyrat/master_files/code/modules/events/spacevine.dm
@@ -661,7 +661,7 @@
 	var/mutativeness = 1
 
 /datum/spacevine_controller/New(turf/location, list/muts, potency, production, datum/round_event/event = null)
-    vines = list()
+	vines = list()
 	growth_queue = list()
 	var/obj/structure/spacevine/spawned_vine = spawn_spacevine_piece(location, null, muts)
 	if (event)

--- a/modular_skyrat/master_files/code/modules/events/spacevine.dm
+++ b/modular_skyrat/master_files/code/modules/events/spacevine.dm
@@ -661,8 +661,7 @@
 	var/mutativeness = 1
 
 /datum/spacevine_controller/New(turf/location, list/muts, potency, production, datum/round_event/event = null)
-	SSshuttle.registerHostileEnvironment(src, NOSHUTTLE_BIOHAZARD)
-	vines = list()
+    vines = list()
 	growth_queue = list()
 	var/obj/structure/spacevine/spawned_vine = spawn_spacevine_piece(location, null, muts)
 	if (event)

--- a/modular_skyrat/master_files/code/modules/events/spacevine.dm
+++ b/modular_skyrat/master_files/code/modules/events/spacevine.dm
@@ -661,6 +661,7 @@
 	var/mutativeness = 1
 
 /datum/spacevine_controller/New(turf/location, list/muts, potency, production, datum/round_event/event = null)
+	SSshuttle.registerHostileEnvironment(src, NOSHUTTLE_BIOHAZARD)
 	vines = list()
 	growth_queue = list()
 	var/obj/structure/spacevine/spawned_vine = spawn_spacevine_piece(location, null, muts)
@@ -689,6 +690,7 @@
 	QDEL_LIST(vines) //this will also qdel us
 
 /datum/spacevine_controller/Destroy()
+	SSshuttle.clearHostileEnvironment(src)
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 

--- a/modular_skyrat/modules/biohazard_blob/code/biohazard_blob_structures.dm
+++ b/modular_skyrat/modules/biohazard_blob/code/biohazard_blob_structures.dm
@@ -80,7 +80,6 @@
 	update_overlays()
 
 /obj/structure/biohazard_blob/structure/core/Destroy()
-	SSshuttle.clearHostileEnvironment(src)
 	if(our_controller)
 		our_controller.our_core = null
 	soundloop.stop()

--- a/modular_skyrat/modules/biohazard_blob/code/biohazard_blob_structures.dm
+++ b/modular_skyrat/modules/biohazard_blob/code/biohazard_blob_structures.dm
@@ -80,6 +80,7 @@
 	update_overlays()
 
 /obj/structure/biohazard_blob/structure/core/Destroy()
+	SSshuttle.clearHostileEnvironment(src)
 	if(our_controller)
 		our_controller.our_core = null
 	soundloop.stop()

--- a/modular_skyrat/modules/biohazard_blob/code/mold_event.dm
+++ b/modular_skyrat/modules/biohazard_blob/code/mold_event.dm
@@ -5,6 +5,12 @@
 	max_occurrences = 1
 	min_players = 10
 
+/datum/round_event_control/mold/canSpawnEvent(players)
+	if(EMERGENCY_PAST_POINT_OF_NO_RETURN) // no molds if the shuttle is past the point of no return
+		return FALSE
+
+	return ..()
+
 /datum/round_event/mold
 	fakeable = FALSE
 	var/list/available_molds_t1 = list(
@@ -18,6 +24,9 @@
 		/obj/structure/biohazard_blob/structure/core/emp,
 		/obj/structure/biohazard_blob/structure/core/fungus
 	)
+
+/datum/round_event/mold/announce(fake)
+	priority_announce("Confirmed outbreak of level 6 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", ANNOUNCER_OUTBREAK5)
 
 /datum/round_event/mold/start()
 	var/list/turfs = list() //list of all the empty floor turfs in the hallway areas

--- a/modular_skyrat/modules/biohazard_blob/code/mold_event.dm
+++ b/modular_skyrat/modules/biohazard_blob/code/mold_event.dm
@@ -21,7 +21,7 @@
 
 /datum/round_event/mold/start()
 	var/list/turfs = list() //list of all the empty floor turfs in the hallway areas
-	var/molds2spawn 
+	var/molds2spawn
 	if(get_active_player_count(alive_check = TRUE, afk_check = TRUE, human_check = TRUE) >= 60)
 		molds2spawn	= 2 //Guaranteedly worse
 	else
@@ -59,6 +59,7 @@
 				continue
 			var/obj/structure/biohazard_blob/boob = new picked_mold(picked_turf)
 			announce_to_ghosts(boob)
+			SSshuttle.registerHostileEnvironment(boob, NOSHUTTLE_BIOHAZARD)
 			turfs -= picked_turf
 			i++
 		else

--- a/modular_skyrat/modules/biohazard_blob/code/mold_event.dm
+++ b/modular_skyrat/modules/biohazard_blob/code/mold_event.dm
@@ -29,7 +29,7 @@
 
 	var/obj/structure/biohazard_blob/resin/resintest = new()
 
-	var/list/possible_spawn_areas = typecacheof(typesof(/area/maintenance, /area/security/prison, /area/construction))
+	var/list/possible_spawn_areas = typecacheof(typesof(/area/maintenance, /area/construction))
 
 	for(var/area/A in world)
 		if(!is_station_level(A.z))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3845,6 +3845,7 @@
 #include "modular_skyrat\master_files\code\_globalvars\lists\ambience.dm"
 #include "modular_skyrat\master_files\code\_onclick\cyborg.dm"
 #include "modular_skyrat\master_files\code\controllers\configuration\entries\skryat_config_entries.dm"
+#include "modular_skyrat\master_files\code\controllers\subsystem\shuttle.dm"
 #include "modular_skyrat\master_files\code\controllers\subsystem\statpanel.dm"
 #include "modular_skyrat\master_files\code\datums\ert.dm"
 #include "modular_skyrat\master_files\code\datums\components\fullauto.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -195,6 +195,7 @@
 #include "code\__DEFINES\~skyrat_defines\robot_defines.dm"
 #include "code\__DEFINES\~skyrat_defines\say.dm"
 #include "code\__DEFINES\~skyrat_defines\security_alerts.dm"
+#include "code\__DEFINES\~skyrat_defines\shuttle.dm"
 #include "code\__DEFINES\~skyrat_defines\signals.dm"
 #include "code\__DEFINES\~skyrat_defines\traits.dm"
 #include "code\__DEFINES\~skyrat_defines\vox_defines.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds some flavour to the shuttle lockdown caused by blob/nukies/revs/gangs/etc. The announcement now states *why* the shuttle is locked down "Biohazard, imminent destruction, police lockdown, "kill the revs", narsie rises"

Also adds mold to the "pending conflict resolution" shuttle lockdown, and adds an announcement to it

Removes prison from the mold's available spawn locations
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Being able to leave a station with a severe biohazard is dumb, and if it's that bad you're going to evacuate, you should adhere to the atmosphere of a deserted frontier station and evacuate everyone to lavaland before detonating the nuke to prevent the spread of the biohazard. The round would end either way, one makes more sense from an IC POV.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: "Conflict Resolution" messages now detail the cause of the conflict
balance: Molds are now biohazards, and make an announcement accordingly.
balance: Molds can no longer spawn in the prison
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
