### PR TITLE
[NONMODULAR] Adds TG's "Environment Bodybag" to the mining vendor

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -24,7 +24,7 @@
 		new /datum/data/mining_equipment("Stabilizing Serum", /obj/item/hivelordstabilizer, 400),
 		new /datum/data/mining_equipment("Fulton Beacon", /obj/item/fulton_core, 400),
 		new /datum/data/mining_equipment("Shelter Capsule", /obj/item/survivalcapsule, 400),
-		new /datum/data/mining_equipment("Environment Proof Bodybag", /obj/item/bodybag/environmental, 500),
+		new /datum/data/mining_equipment("Environment Proof Bodybag", /obj/item/bodybag/environmental, 500), //SKYRAT EDIT - ADDITION
 		new /datum/data/mining_equipment("GAR Meson Scanners", /obj/item/clothing/glasses/meson/gar, 500),
 		new /datum/data/mining_equipment("Explorer's Webbing", /obj/item/storage/belt/mining, 500),
 		new /datum/data/mining_equipment("Point Transfer Card", /obj/item/card/mining_point_card, 500),

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -24,7 +24,7 @@
 		new /datum/data/mining_equipment("Stabilizing Serum", /obj/item/hivelordstabilizer, 400),
 		new /datum/data/mining_equipment("Fulton Beacon", /obj/item/fulton_core, 400),
 		new /datum/data/mining_equipment("Shelter Capsule", /obj/item/survivalcapsule, 400),
-		new /datum/data/mining_equipment("Enviroment Proof Bodybag", /obj/item/bodybag/environmental, 500),
+		new /datum/data/mining_equipment("Environment Proof Bodybag", /obj/item/bodybag/environmental, 500),
 		new /datum/data/mining_equipment("GAR Meson Scanners", /obj/item/clothing/glasses/meson/gar, 500),
 		new /datum/data/mining_equipment("Explorer's Webbing", /obj/item/storage/belt/mining, 500),
 		new /datum/data/mining_equipment("Point Transfer Card", /obj/item/card/mining_point_card, 500),

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -24,6 +24,7 @@
 		new /datum/data/mining_equipment("Stabilizing Serum", /obj/item/hivelordstabilizer, 400),
 		new /datum/data/mining_equipment("Fulton Beacon", /obj/item/fulton_core, 400),
 		new /datum/data/mining_equipment("Shelter Capsule", /obj/item/survivalcapsule, 400),
+		new /datum/data/mining_equipment("Enviroment Proof Bodybag", /obj/item/bodybag/environmental, 500),
 		new /datum/data/mining_equipment("GAR Meson Scanners", /obj/item/clothing/glasses/meson/gar, 500),
 		new /datum/data/mining_equipment("Explorer's Webbing", /obj/item/storage/belt/mining, 500),
 		new /datum/data/mining_equipment("Point Transfer Card", /obj/item/card/mining_point_card, 500),


### PR DESCRIPTION


## About The Pull Request

Adds the mining bodybag from https://github.com/tgstation/tgstation/pull/59752 to the vendor, see there for what it does.

## How This Contributes To The Skyrat Roleplay Experience

Unique alternative to leaving survival pods everywhere, the reusable environment-proofed bodybag, that's already in the code.

## Changelog
:cl:
add: Added the Environment Proof Bodybag to the mining equipment vendor for 500 points.
/:cl:


