### PR TITLE
[SEMI-MODULAR] Traitor Uplink Changes (Part I) Changes to TC prices/pop locks in the uplink, disables powersinks, makes sentience potion available for purchase

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -648,7 +648,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			The pen holds one dose of the mixture, and can be refilled with any chemicals. Note that before the target \
 			falls asleep, they will be able to move and act."
 	item = /obj/item/pen/sleepy
-	cost = 3 //Skyrat Edit - Original: 4 - Honestly, I've been penned a lot as a secoff. This thing's not worth 4 considering how easy it is to escape most of the time if you're smart, not to mention it's been made more reasonable through nerfs.
+	cost = 4
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/stealthy_weapons/suppressor

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -233,7 +233,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A dusty SUPER-SIZED from the back of the Syndicate warehouse. Rumored to contain a valuable assortment of items, \
 			but you never know. Contents are sorted to always be worth 125 TC."
 	cost = 50 //SKYRAT EDIT CHANGE - ORIGINAL: 40
-	player_minimum = 40
+	player_minimum = 80 //SKYRAT EDIT CHANGE - ORIGINAL: 40 - We never have less than 50 people.
 	starting_crate_value = 145 //SKYRAT EDIT CHANGE - ORIGINAL: 125
 
 /datum/uplink_item/bundles_tc/surplus/purchase(mob/user, datum/component/uplink/U)
@@ -449,10 +449,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an \
 			organic host as a home base and source of fuel. Holoparasites come in various types and share damage with their host."
 	item = /obj/item/storage/box/syndie_kit/guardian
-	cost = 18
+	cost = 20 //SKYRAT EDIT CHANGE - ORIGINAL: 18 - Stupidly powerful considering traitors get 35tc now.
 	surplus = 0
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
-	player_minimum = 25
+	player_minimum = 90 //SKYRAT EDIT CHANGE - ORINGINAL:  - Again: we're always above 40 or so.
 	restricted = TRUE
 
 /datum/uplink_item/dangerous/machinegun
@@ -593,8 +593,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat \
 			and gain the ability to swat bullets from the air, but you will also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/book/granter/martial/carp
-	player_minimum = 25
-	cost = 13
+	player_minimum = 90 // SKYRAT EDIT - ORIGINAL: 25
+	cost = 18 // SKYRAT EDIT - ORIGINAL: 13 - 35tc means you can do some way too powerful combos with this at 13tc. Raising it.
 	surplus = 0
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
@@ -1008,7 +1008,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A box that contains five EMP grenades and an EMP implant with three uses. Useful to disrupt communications, \
 			security's energy weapons and silicon lifeforms when you're in a tight spot."
 	item = /obj/item/storage/box/syndie_kit/emp
-	cost = 2
+	cost = 4 // SKYRAT EDIT - ORIGINAL: 2 - IPCs and synth players are more common here, I'd say this should be raised a bit.
 
 /datum/uplink_item/explosives/virus_grenade
 	name = "Fungal Tuberculosis Grenade"
@@ -1053,7 +1053,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			The bomb core can be pried out and manually detonated with other explosives."
 	item = /obj/item/sbeacondrop/bomb
 	//cost = 11 //ORIGINAL
-	cost = 18 //SKYRAT EDIT CHANGE
+	cost = 21 //SKYRAT EDIT CHANGE - Raised from 18 to 21 - make traitors less likely to use these every single round and put more thought into their actions.
 	cant_discount = TRUE //SKYRAT EDIT ADDITION
 
 /datum/uplink_item/explosives/syndicate_bomb/emp
@@ -1467,7 +1467,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A disk containing the procedure to perform a brainwashing surgery, allowing you to implant an objective onto a target. \
 	Insert into an Operating Console to enable the procedure."
 	item = /obj/item/disk/surgery/brainwashing
-	cost = 9
+	cost = 5
 //SKYRAT EDIT END
 
 //SKYRAT EDIT REMOVAL BEGIN - Remove Hypnostuff
@@ -1510,7 +1510,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			traditional bags and boxes. Caution: Will explode if the powernet contains sufficient amounts of energy."
 	item = /obj/item/powersink
 	cost = 18 //SKYRAT EDIT: Original value (10)
-	player_minimum = 25
+	player_minimum = 80 //SKYRAT EDIT: original value 25
 
 /datum/uplink_item/device_tools/rad_laser
 	name = "Radioactive Microlaser"
@@ -1587,8 +1587,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A potion recovered at great risk by undercover Syndicate operatives and then subsequently modified with Syndicate technology. \
 			Using it will make any animal sentient, and bound to serve you, as well as implanting an internal radio for communication and an internal ID card for opening doors."
 	cost = 4
-	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
-	restricted = TRUE
+	//purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS - SKYRAT EDIT: lets traitors buy this too.
 
 //SKYRAT EDIT REMOVAL BEGIN
 /*
@@ -1620,7 +1619,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "CNS Rebooter Implant"
 	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."
 	item = /obj/item/autosurgeon/organ/syndicate/anti_stun
-	cost = 12
+	cost = 8 // Skyrat edit - ORIGINAL: 12 - Honestly it isn't that good anymore, no point being 12tc.
 	surplus = 0
 	purchasable_from = UPLINK_NUKE_OPS
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -452,7 +452,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 20 //SKYRAT EDIT CHANGE - ORIGINAL: 18 - Stupidly powerful considering traitors get 35tc now.
 	surplus = 0
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
-	player_minimum = 90 //SKYRAT EDIT CHANGE - ORINGINAL:  - Again: we're always above 40 or so.
+	player_minimum = 25
 	restricted = TRUE
 
 /datum/uplink_item/dangerous/machinegun
@@ -593,7 +593,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat \
 			and gain the ability to swat bullets from the air, but you will also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/book/granter/martial/carp
-	player_minimum = 90 // SKYRAT EDIT - ORIGINAL: 25
+	player_minimum = 50 // SKYRAT EDIT - ORIGINAL: 25
 	cost = 18 // SKYRAT EDIT - ORIGINAL: 13 - 35tc means you can do some way too powerful combos with this at 13tc. Raising it.
 	surplus = 0
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
@@ -1503,14 +1503,18 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/sbeacondrop
 	cost = 10
 
+//SKYRAT EDIT REMOVAL BEGIN:disables powersinks
+/*
 /datum/uplink_item/device_tools/powersink
 	name = "Power Sink"
 	desc = "When screwed to wiring attached to a power grid and activated, this large device lights up and places excessive \
 			load on the grid, causing a station-wide blackout. The sink is large and cannot be stored in most \
 			traditional bags and boxes. Caution: Will explode if the powernet contains sufficient amounts of energy."
 	item = /obj/item/powersink
-	cost = 18 //SKYRAT EDIT: Original value (10)
-	player_minimum = 80 //SKYRAT EDIT: original value 25
+	cost = 10
+	player_minimum = 25
+*/
+//SKYRAT EDIT REMOVAL END
 
 /datum/uplink_item/device_tools/rad_laser
 	name = "Radioactive Microlaser"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1008,7 +1008,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A box that contains five EMP grenades and an EMP implant with three uses. Useful to disrupt communications, \
 			security's energy weapons and silicon lifeforms when you're in a tight spot."
 	item = /obj/item/storage/box/syndie_kit/emp
-	cost = 4 // SKYRAT EDIT - ORIGINAL: 2 - IPCs and synth players are more common here, I'd say this should be raised a bit.
+	cost = 2
 
 /datum/uplink_item/explosives/virus_grenade
 	name = "Fungal Tuberculosis Grenade"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -233,7 +233,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A dusty SUPER-SIZED from the back of the Syndicate warehouse. Rumored to contain a valuable assortment of items, \
 			but you never know. Contents are sorted to always be worth 125 TC."
 	cost = 50 //SKYRAT EDIT CHANGE - ORIGINAL: 40
-	player_minimum = 80 //SKYRAT EDIT CHANGE - ORIGINAL: 40 - We never have less than 50 people.
+	player_minimum = 60 //SKYRAT EDIT CHANGE - ORIGINAL: 40 - We don't have super low pop often.
 	starting_crate_value = 145 //SKYRAT EDIT CHANGE - ORIGINAL: 125
 
 /datum/uplink_item/bundles_tc/surplus/purchase(mob/user, datum/component/uplink/U)
@@ -449,7 +449,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an \
 			organic host as a home base and source of fuel. Holoparasites come in various types and share damage with their host."
 	item = /obj/item/storage/box/syndie_kit/guardian
-	cost = 20 //SKYRAT EDIT CHANGE - ORIGINAL: 18 - Stupidly powerful considering traitors get 35tc now.
+	cost = 19 //SKYRAT EDIT CHANGE - ORIGINAL: 18 - Stupidly powerful considering traitors get 35tc now. You can offset the negatives with decent armor or an esword on top of that.
 	surplus = 0
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	player_minimum = 25
@@ -480,7 +480,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			Using a wrench on the piston valve will allow you to tweak the amount of gas used per punch to \
 			deal extra damage and hit targets further. Use a screwdriver to take out any attached tanks."
 	item = /obj/item/melee/powerfist
-	cost = 6
+	cost = 5 //SKYRAT EDIT - Original: 6 - Power Fist is a noob trap. Shaving a single TC of the price seems fair considering it's more gimmicky than anything.
 
 /datum/uplink_item/dangerous/sniper
 	name = "Sniper Rifle"
@@ -572,7 +572,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A miniaturized version of a normal syringe gun. It is very quiet when fired and can fit into any \
 			space a small item can."
 	item = /obj/item/gun/syringe/syndicate
-	cost = 4
+	cost = 2 // Skyrat Edit - Original: 4 - Encouraging chem warfare is bad, but at the same time if someone RPG syringes the HOS they're gonna get banned anyway. I think it's worth lowering this.
 	surplus = 50
 
 /datum/uplink_item/stealthy_weapons/dehy_carp
@@ -593,8 +593,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat \
 			and gain the ability to swat bullets from the air, but you will also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/book/granter/martial/carp
-	player_minimum = 50 // SKYRAT EDIT - ORIGINAL: 25
-	cost = 18 // SKYRAT EDIT - ORIGINAL: 13 - 35tc means you can do some way too powerful combos with this at 13tc. Raising it.
+	player_minimum = 25
+	cost = 16 // SKYRAT EDIT - ORIGINAL: 13 - This was specifically priced to be combo'd with the Gloves of the North Star. Considering how lethal that combo is, and how powerful scarp on it's own it, it's worth bumping this up.
 	surplus = 0
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
@@ -617,7 +617,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "This box contains a guide on how to craft masterful works of origami, allowing you to transform normal pieces of paper into \
 			perfectly aerodynamic (and potentially lethal) paper airplanes."
 	item = /obj/item/storage/box/syndie_kit/origami_bundle
-	cost = 12 //SKYRAT EDIT: Original value (14)
+	cost = 11 //SKYRAT EDIT: Original value (14, Skyrat Edit was 12) - Shaving a TC off the price here because this is kinda like the Power Fist, gimmicky as hell and not entirely efficient or powerful.
 	surplus = 0
 	purchasable_from = ~UPLINK_NUKE_OPS //clown ops intentionally left in, because that seems like some s-tier shenanigans.
 
@@ -648,14 +648,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			The pen holds one dose of the mixture, and can be refilled with any chemicals. Note that before the target \
 			falls asleep, they will be able to move and act."
 	item = /obj/item/pen/sleepy
-	cost = 4
+	cost = 3 //Skyrat Edit - Original: 4 - Honestly, I've been penned a lot as a secoff. This thing's not worth 4 considering how easy it is to escape most of the time if you're smart, not to mention it's been made more reasonable through nerfs.
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/stealthy_weapons/suppressor
 	name = "Suppressor"
 	desc = "This suppressor will silence the shots of the weapon it is attached to for increased stealth and superior ambushing capability. It is compatible with many small ballistic guns including the Makarov, Stechkin APS and C-20r, but not revolvers or energy guns."
 	item = /obj/item/suppressor
-	cost = 3
+	cost = 1 //Skyrat Edit - Original: 3 - Literally nobody buys this anyway, and it's kinda useless since CI exists. Might as well make it 1 cause it's more useful for flavor than anything.
 	surplus = 10
 	purchasable_from = ~UPLINK_CLOWN_OPS
 
@@ -1041,7 +1041,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Slipocalypse Clusterbang"
 	desc = "A traditional clusterbang grenade with a payload consisting entirely of Syndicate soap. Useful in any scenario!"
 	item = /obj/item/grenade/clusterbuster/soap
-	cost = 3
+	cost = 2 //Skyrat Edit - Original: 3 - Another super gimmicky thing. It's pretty slow, and while it is pretty useful and arguably powerful, it doesn't need to be 3tc.
 
 /datum/uplink_item/explosives/syndicate_bomb
 	name = "Syndicate Bomb"
@@ -1241,7 +1241,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Screwed up and have security on your tail? This handy syringe will give you a completely new identity \
 			and appearance."
 	item = /obj/item/reagent_containers/syringe/mulligan
-	cost = 4
+	cost = 2 //Skyrat Edit - Original: 4 - I dunno, I feel like this thing ain't worth 4 considering it's not very useful, especially if you're not human.
 	surplus = 30
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
@@ -1574,7 +1574,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			of the originals, these inferior copies are still quite useful, being able to provide \
 			both weal and woe on the battlefield, even if they do occasionally bite off a finger."
 	item = /obj/item/storage/book/bible/syndicate
-	cost = 5
+	cost = 3 //Skyrat Edit - Original: 6 - This thing is just absolutely useless and good for gimmicks instead of practicality. 6tc is too much.
 
 /datum/uplink_item/device_tools/thermal
 	name = "Thermal Imaging Glasses"
@@ -1623,7 +1623,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "CNS Rebooter Implant"
 	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."
 	item = /obj/item/autosurgeon/organ/syndicate/anti_stun
-	cost = 8 // Skyrat edit - ORIGINAL: 12 - Honestly it isn't that good anymore, no point being 12tc.
+	cost = 6 // Skyrat edit - ORIGINAL: 12 - Honestly it isn't that good anymore, no point being 12tc. Originally considered 8, changing to 6 because maybe then it'll be worth it?
 	surplus = 0
 	purchasable_from = UPLINK_NUKE_OPS
 

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -37,7 +37,7 @@
 	desc = "Fishsticks prepared through ritualistic means in honor of the god Carp-sie, capable of binding a holocarp \
 			to act as a servant and guardian to their host."
 	item = /obj/item/guardiancreator/carp/choose
-	cost = 10
+	cost = 19
 	surplus = 0
 	player_minimum = 25
 	restricted = TRUE
@@ -47,21 +47,21 @@
 	desc = "A fully-loaded Scarborough Arms bullpup submachine gun. The C-20r fires .45 rounds with a \
 			24-round magazine and is compatible with suppressors."
 	item = /obj/item/gun/ballistic/automatic/c20r/unrestricted
-	cost = 14
+	cost = 15
 
 /datum/uplink_item/dangerous/shotgun_traitor
 	name = "Bulldog Shotgun"
 	desc = "A fully-loaded semi-automatic drum-fed shotgun. Compatible with all 12g rounds. Designed for close \
 			quarter anti-personnel engagements."
 	item = /obj/item/gun/ballistic/shotgun/bulldog/unrestricted
-	cost = 13
+	cost = 18
 
 /datum/uplink_item/dangerous/shield_traitor
 	name = "Energy Shield"
 	desc = "An incredibly useful personal shield projector, capable of reflecting energy projectiles and defending \
 			against other attacks. Pair with an Energy Sword for a killer combination."
 	item = /obj/item/shield/energy
-	cost = 5
+	cost = 3
 
 /datum/uplink_item/dangerous/katana_traitor
 	name = "Katana"
@@ -132,12 +132,14 @@
 	restricted_roles = list("Bartender")
 
 //EXPLOSIVES
+/*
 /datum/uplink_item/explosives/buzzkill_traitor
 	name = "Buzzkill Grenade Box"
 	desc = "A box with three grenades that release a swarm of angry bees upon activation. These bees indiscriminately attack friend or foe \
 			with random toxins. Courtesy of the BLF and Tiger Cooperative."
 	item = /obj/item/storage/box/syndie_kit/bee_grenades
 	cost = 10
+
 
 /datum/uplink_item/explosives/viscerators_traitor
 	name = "Viscerator Delivery Grenade"
@@ -146,12 +148,13 @@
 	item = /obj/item/grenade/spawnergrenade/manhacks
 	cost = 7
 	surplus = 35
+*/
 
 /datum/uplink_item/explosives/nukeop_traitor
 	name = "Nuclear Delivery Grenade"
 	desc = "A very confusing grenade containing 2 dehydrated nuclear operatives. Stand back when primed."
 	item = /obj/item/grenade/spawnergrenade/therealnuke
-	cost = 7
+	cost = 9
 	surplus = 35
 
 /datum/uplink_item/explosives/bonebang
@@ -371,11 +374,13 @@
 	item = /obj/item/storage/backpack/duffelbag/syndie/loadout/donkshillkit
 	cost = 10
 
+/*
 /datum/uplink_item/loadout_skyrat/downtownspecial
 	name = "Downtown Special bundle"
 	desc = "Ayyy fuggedaboudit! This bundle contains everything to be your own one man mafioso. Including an icon of the Virgin Mary for your own authentic mafia nickname. Gang members not included."
 	item = /obj/item/storage/backpack/duffelbag/syndie/loadout/downtownspecial
 	cost = 25
+*/
 
 /datum/uplink_item/loadout_skyrat/ocelotfoxtrot
 	name = "Snake Eater bundle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#7860 already changes the cost of the brainwash surgery disk, however I incorporated that into here too. I'll let maintainers decide if they'd rather merge this one or just the brainwash disk one.

Essentially, this change will rebalance the costs of several items in the traitor uplink, with reasons for each change listed in the comments. I also made the sentience potion a traitor item instead of nukie only. Also Powersink is disabled because it's a zero-effort station-wide cucking that forces everyone to just drop any sense of RP or character and start screaming power sink.

Consider this Part 1 in a series of changes I'll be doing to the Uplink, btw. I intend on adding new items soon, mainly porting from Citadel.

## How This Contributes To The Skyrat Roleplay Experience

Traitors have a significant power advantage over security, and a lot of items are poplocked for TG lowpop. Our lowpop is around 70 active people, and so several items have had their pop numbers and prices changed to accommodate this. This should help make traitors think their plans and ambitions through a bit more, and hopefully lessen the over abundance of extreme traitors we see so often. The sentience potion being freely available should also allow for some funny gimmicks.
## Changelog
:cl:
balance: several traitor uplink items have had their prices adjusted. Some lowered a bit, some raised. Sentience potion is now a traitor item as well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
