### PR TITLE
hurtsposals

### DIFF
--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -18,8 +18,8 @@
 	var/flip_type // If set, the pipe is flippable and becomes this type when flipped
 	var/obj/structure/disposalconstruct/stored
 	//SKYRAT EDIT: HURTSPOSALS
-	///whether a disposal pipe will hurt if a person changes direction
-	var/fluffy = FALSE
+	/// Whether a disposal pipe will hurt if a person changes direction. `FALSE` for hurting, `TRUE` to prevent making them hurt.
+	var/padded_corners = FALSE
 	//SKYRAT EDIT: HURTSPOSALS
 
 

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -17,6 +17,10 @@
 	var/initialize_dirs = NONE // bitflags of pipe directions added on init, see \code\_DEFINES\pipe_construction.dm
 	var/flip_type // If set, the pipe is flippable and becomes this type when flipped
 	var/obj/structure/disposalconstruct/stored
+	//SKYRAT EDIT: HURTSPOSALS
+	///whether a disposal pipe will hurt if a person changes direction
+	var/fluffy = FALSE
+	//SKYRAT EDIT: HURTSPOSALS
 
 
 /obj/structure/disposalpipe/Initialize(mapload, obj/structure/disposalconstruct/make_from)
@@ -81,7 +85,7 @@
 	if(H2 && !H2.active)
 		H.merge(H2)
 	//SKYRAT EDIT: HURTSPOSAL
-	if(dir != P.dir)
+	if(dir != P.dir && !fluffy)
 		if(prob(20))
 			for(var/objects_within in H.contents)
 				if(!isliving(objects_within))

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -84,8 +84,8 @@
 	var/obj/structure/disposalholder/H2 = locate() in P
 	if(H2 && !H2.active)
 		H.merge(H2)
-	//SKYRAT EDIT: HURTSPOSAL
-	if(dir != P.dir && !fluffy)
+	/// SKYRAT EDIT START - HURTSPOSAL
+	if(dir != P.dir && !padded_corners)
 		if(prob(20))
 			for(var/objects_within in H.contents)
 				if(!isliving(objects_within))
@@ -94,7 +94,7 @@
 				if(living_within.stat == DEAD)
 					continue
 				living_within.adjustBruteLoss(5)
-	//SKYRAT EDIT: HURTSPOSAL
+	/// SKYRAT EDIT END
 	H.forceMove(P)
 	return P
 

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -80,7 +80,17 @@
 	var/obj/structure/disposalholder/H2 = locate() in P
 	if(H2 && !H2.active)
 		H.merge(H2)
-
+	//SKYRAT EDIT: HURTSPOSAL
+	if(dir != P.dir)
+		if(prob(20))
+			for(var/objects_within in H.contents)
+				if(!isliving(objects_within))
+					continue
+				var/mob/living/living_within = objects_within
+				if(living_within.stat == DEAD)
+					continue
+				living_within.adjustBruteLoss(5)
+	//SKYRAT EDIT: HURTSPOSAL
 	H.forceMove(P)
 	return P
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
makes disposals have a chance of hurting you when changing direction.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
a large metal chute that makes the objects going down it go down fast... and yet they arent getting banged up?
introduces an element of "last resort" where if you want to escape through the bin, you gotta think carefully
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: added hurtsposal (disposals now can hurt you)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
