### PR TITLE
A tweak for russian autohiss

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -108,14 +108,15 @@
 		message = lizard_ecks.Replace(message, "ecks$1")
 		message = lizard_eckS.Replace(message, "ECKS$1")
 		//SKYRAT EDIT START: Adding russian version to autohiss
-		var/static/regex/lizard_hiss_ru = new("с+", "g")
-		var/static/regex/lizard_hiSS_ru = new("С+", "g")
-		message = replacetext(message, "з", "с")
-		message = replacetext(message, "З", "С")
-		message = replacetext(message, "ж", "ш")
-		message = replacetext(message, "Ж", "Ш")
-		message = lizard_hiss_ru.Replace(message, "ссс")
-		message = lizard_hiSS_ru.Replace(message, "ССС")
+		if(CONFIG_GET(flag/russian_text_formation))
+			var/static/regex/lizard_hiss_ru = new("с+", "g")
+			var/static/regex/lizard_hiSS_ru = new("С+", "g")
+			message = replacetext(message, "з", "с")
+			message = replacetext(message, "З", "С")
+			message = replacetext(message, "ж", "ш")
+			message = replacetext(message, "Ж", "Ш")
+			message = lizard_hiss_ru.Replace(message, "ссс")
+			message = lizard_hiSS_ru.Replace(message, "ССС")
 		//SKYRAT EDIT END: Adding russian version to autohiss
 	speech_args[SPEECH_MESSAGE] = message
 
@@ -233,12 +234,13 @@
 		message = replacetext(message, "s", "z")
 		message = replacetext(message, "S", "Z")
 	//SKYRAT EDIT START: Adding russian version to autohiss
-		var/static/regex/fly_buzz_ru = new("з+", "g")
-		var/static/regex/fly_buZZ_ru = new("З+", "g")
-		message = fly_buzz_ru.Replace(message, "ззз")
-		message = fly_buZZ_ru.Replace(message, "ЗЗЗ")
-		message = replacetext(message, "с", "з")
-		message = replacetext(message, "С", "З")
+		if(CONFIG_GET(flag/russian_text_formation))
+			var/static/regex/fly_buzz_ru = new("з+", "g")
+			var/static/regex/fly_buZZ_ru = new("З+", "g")
+			message = fly_buzz_ru.Replace(message, "ззз")
+			message = fly_buZZ_ru.Replace(message, "ЗЗЗ")
+			message = replacetext(message, "с", "з")
+			message = replacetext(message, "С", "З")
 	//SKYRAT EDIT END: Adding russian version to autohiss
 	speech_args[SPEECH_MESSAGE] = message
 

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -34,13 +34,13 @@
 		/datum/language/vox, //SKYRAT EDIT - customization - extra languages
 		/datum/language/dwarf, //SKYRAT EDIT - customization - extra languages
 		/datum/language/nekomimetic,
-		/datum/language/russian,  //SKYRAT EDIT - customization - extra languages
+		/datum/language/neorusskya,  //SKYRAT EDIT - customization - extra languages
 		/datum/language/spacer,  //SKYRAT EDIT - customization - extra languages
 		/datum/language/selenian,  //SKYRAT EDIT - customization - extra languages
 		/datum/language/gutter,  //SKYRAT EDIT - customization - extra languages
 		/datum/language/zolmach, // SKYRAT EDIT - customization - extra languages
 		/datum/language/xenoknockoff, // SKYRAT EDIT - customization - extra languages
-		/datum/language/japanese // SKYRAT EDIT - customization - extra languages
+		/datum/language/yangyu // SKYRAT EDIT - customization - extra languages
 	))
 
 /obj/item/organ/tongue/Initialize(mapload)

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -34,13 +34,13 @@
 		/datum/language/vox, //SKYRAT EDIT - customization - extra languages
 		/datum/language/dwarf, //SKYRAT EDIT - customization - extra languages
 		/datum/language/nekomimetic,
-		/datum/language/neorusskya,  //SKYRAT EDIT - customization - extra languages
+		/datum/language/russian,  //SKYRAT EDIT - customization - extra languages
 		/datum/language/spacer,  //SKYRAT EDIT - customization - extra languages
 		/datum/language/selenian,  //SKYRAT EDIT - customization - extra languages
 		/datum/language/gutter,  //SKYRAT EDIT - customization - extra languages
 		/datum/language/zolmach, // SKYRAT EDIT - customization - extra languages
 		/datum/language/xenoknockoff, // SKYRAT EDIT - customization - extra languages
-		/datum/language/yangyu // SKYRAT EDIT - customization - extra languages
+		/datum/language/japanese // SKYRAT EDIT - customization - extra languages
 	))
 
 /obj/item/organ/tongue/Initialize(mapload)
@@ -110,10 +110,12 @@
 		//SKYRAT EDIT START: Adding russian version to autohiss
 		var/static/regex/lizard_hiss_ru = new("с+", "g")
 		var/static/regex/lizard_hiSS_ru = new("С+", "g")
-		message = lizard_hiss_ru.Replace(message, "ссс")
-		message = lizard_hiSS_ru.Replace(message, "ССС")
+		message = replacetext(message, "з", "с")
+		message = replacetext(message, "З", "С")
 		message = replacetext(message, "ж", "ш")
 		message = replacetext(message, "Ж", "Ш")
+		message = lizard_hiss_ru.Replace(message, "ссс")
+		message = lizard_hiSS_ru.Replace(message, "ССС")
 		//SKYRAT EDIT END: Adding russian version to autohiss
 	speech_args[SPEECH_MESSAGE] = message
 

--- a/config/skyrat/skyrat_config.txt
+++ b/config/skyrat/skyrat_config.txt
@@ -62,3 +62,6 @@ ROCKPLANET_BUDGET 60
 
 ##Player controlled mob spawn text
 PC_MOB_TEXT As a player controlled mob you are expected to play the role to the best of your ability. This means if you're an animal, act like one. You shouldn't display much intelligence if any. This also means if you're engaging in combat you should refrain from mercing people fully. Play not to win but to create a challenge. You're there to replace AI, make others enjoy the situation as well. If your simple mob is not above simple or mute intelligence, using structures such as welding tanks/canisters/boxes to hinder your opponent is entirely forbidden. Do not do this.
+
+## Toggles various checks for russian texts formation, as an example - autohiss. Useful only for russian servers
+#RUSSIAN_TEXT_FORMATION

--- a/modular_skyrat/master_files/code/controllers/configuration/entries/skryat_config_entries.dm
+++ b/modular_skyrat/master_files/code/controllers/configuration/entries/skryat_config_entries.dm
@@ -4,6 +4,8 @@
 /datum/config_entry/string/wikiurlskyrat
 	config_entry_value = "https://skyrat13.tk/wiki/index.php"
 
+/datum/config_entry/flag/russian_text_formation
+
 //DISCORD GAME ALERT CONFIGS
 //Role id to ping
 /datum/config_entry/string/game_alert_role_id


### PR DESCRIPTION
## About The Pull Request

Previous PR was #7908
After the update, I noticed I forget the letter "з" (z) for lizardmen .-.
I don't want to make the chat to be looking like a constant mess of "ссс" (sss), "шшш" (shhh) and "щщщ" (shhh'?), and in the same moment players noticed the replace of "з" (z) would be a great addition still without cluttering it.
This is the last part of working with the version of autohiss, I think.

## How This Contributes To The Skyrat Roleplay Experience

A little tweak for russian version of autohiss for russian part of the skyrat.

## Changelog
:cl:
expansion: A tweak for russian autohiss, letter "з" (z) now converts into "с" (s).
expansion: The russian autohiss option is now optimised to be in skyrat config. Without being turned on, it doesn't work and have no impact on game.
/:cl:
