### PR TITLE
[Modular] DS-2 armory prettification and swap outs + other misc changes.

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
@@ -1175,6 +1175,7 @@
 "em" = (
 /obj/machinery/door/airlock/security/old{
 	hackProof = 1;
+	id_tag = Armory;
 	name = "Armory";
 	req_access_txt = "151"
 	},
@@ -1189,6 +1190,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
 "eo" = (
@@ -7061,6 +7063,14 @@
 	real_name = null
 	},
 /obj/structure/cable,
+/obj/machinery/button/door/directional/west{
+	desc = "To keep your valuable gear away from prying eyes.";
+	id = Armory;
+	name = "Armory Door bolt";
+	normaldoorcontrol = 1;
+	req_access_txt = "151";
+	specialfunctions = 4
+	},
 /turf/open/floor/iron/dark/smooth_corner,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "yB" = (
@@ -7786,8 +7796,11 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "Bc" = (
 /obj/machinery/button/door/directional/north{
+	desc = "Keep out the riff-raff.";
 	id = "sadmiral";
+	name = "Admiral's room bolt";
 	normaldoorcontrol = 1;
+	req_access_txt = "151";
 	specialfunctions = 4
 	},
 /obj/effect/turf_decal/siding/wood{
@@ -10585,6 +10598,9 @@
 /obj/item/radio/headset/interdyne/command,
 /obj/item/clothing/suit/armor/vest/capcarapace/syndicate_winter,
 /obj/item/clothing/suit/armor/vest/capcarapace/syndicate_winter,
+/obj/item/encryptionkey/headset_interdyne,
+/obj/item/encryptionkey/headset_interdyne,
+/obj/item/encryptionkey/headset_interdyne,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
 "Kz" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
@@ -1443,19 +1443,6 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "fr" = (
 /obj/structure/rack,
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
@@ -1465,6 +1452,38 @@
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
+	},
+/obj/item/shield/riot{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/item/shield/riot{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/item/shield/riot{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 9
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_y = 2
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -6
 	},
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
@@ -1877,18 +1896,24 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "gM" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/automatic/pistol{
-	desc = "It's small, it'll fit in your pocket - and's a great last resort self-defense weapon!"
-	},
-/obj/item/gun/ballistic/automatic/pistol{
-	desc = "It's small, it'll fit in your pocket - and's a great last resort self-defense weapon!"
-	},
-/obj/item/gun/ballistic/automatic/pistol{
-	desc = "It's small, it'll fit in your pocket - and's a great last resort self-defense weapon!"
-	},
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/closet/crate/secure/gear,
+/obj/item/ammo_box/magazine/m12g{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/item/ammo_box/magazine/m12g{
+	pixel_x = -8;
+	pixel_y = -7
+	},
+/obj/item/clothing/gloves/krav_maga/combatglovesplus{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/obj/item/clothing/gloves/krav_maga/combatglovesplus{
+	pixel_x = 10
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
 "gN" = (
@@ -2065,6 +2090,9 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "ht" = (
 /obj/structure/table/reinforced,
+/obj/machinery/syndicatebomb/training{
+	desc = "A defective syndicate bomb gutted of its explosives to be used as a training aid for aspiring bomb defusers."
+	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "hv" = (
@@ -4625,8 +4653,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "qr" = (
 /obj/machinery/suit_storage_unit/syndicate{
-	helmet_type = /obj/item/clothing/head/helmet/space/syndicate/black/red;
-	suit_type = /obj/item/clothing/suit/space/syndicate/black/red
+	helmet_type = null
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/machinery/airalarm/directional/north{
@@ -6423,15 +6450,26 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "wv" = (
+/obj/item/ammo_box/c9mm{
+	pixel_x = -2
+	},
 /obj/structure/rack,
-/obj/item/storage/box/rubbershot{
+/obj/item/ammo_box/c9mm{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/ammo_box/magazine/m9mm{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/ammo_box/magazine/m9mm,
+/obj/item/ammo_box/magazine/m9mm{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/item/ammo_box/magazine/m9mm{
+	pixel_x = -6;
+	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
@@ -7422,6 +7460,18 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "zY" = (
 /obj/structure/table/wood,
+/obj/item/storage/photo_album/syndicate{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/stamp/syndicate{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/obj/item/camera{
+	pixel_x = -5;
+	pixel_y = 11
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
 "zZ" = (
@@ -7589,15 +7639,6 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "AE" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
 	},
@@ -7609,6 +7650,25 @@
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 9
+	},
+/obj/item/melee/transforming/energy/sword/saber/purple,
+/obj/item/melee/transforming/energy/sword/saber/purple{
+	pixel_x = 7
+	},
+/obj/item/melee/transforming/energy/sword/saber/purple{
+	pixel_x = 13
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -2;
+	pixel_y = 9
 	},
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
@@ -10084,8 +10144,9 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "Jd" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/vending/medical/syndicate_access{
-	onstation = 0
+/obj/machinery/vending/medical/syndicate_access/cybersun{
+	desc = "An advanced vendor that dispenses medical drugs, both recreational and medicinal. It's said to have been salvaged from an old decomissioned Cybersun Cruiser.";
+	name = "\improper SyndiMed ++"
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
@@ -10107,6 +10168,16 @@
 "Ji" = (
 /obj/structure/safe,
 /obj/item/reagent_containers/food/drinks/soda_cans/pwr_game,
+/obj/item/storage/box/syndie_kit/chameleon/ghostcafe{
+	desc = "A sleek, sturdy box.";
+	name = "Chameleon Kit"
+	},
+/obj/item/bikehorn,
+/obj/item/paper/crumpled{
+	desc = A letter from Donk co. it has a clown stamp on it, garish.;
+	info = "Hey there Deep Space 2 crew, sorry about your stolen book, hope this horn helps! HONK! -Love Donk Co.";
+	name = "A Note from Donk co."
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
 "Jj" = (
@@ -10452,6 +10523,17 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "Kq" = (
 /obj/structure/table/reinforced,
+/obj/item/bodybag/environmental/prisoner/syndicate{
+	pixel_x = 7;
+	pixel_y = 15
+	},
+/obj/item/bodybag/environmental/prisoner/syndicate{
+	pixel_x = -7;
+	pixel_y = 15
+	},
+/obj/item/bodybag/environmental/prisoner/syndicate{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "Kr" = (
@@ -10703,17 +10785,36 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "Lg" = (
-/obj/structure/rack,
 /obj/item/gun/ballistic/shotgun/riot{
-	desc = "A riot shotgun - this one is advertised to 'Not miss', quote, 'unlike the shitty hybrid taser'."
+	desc = "A riot shotgun - this one is advertised to 'Not miss', quote, 'unlike the shitty hybrid taser'.";
+	pixel_x = 7;
+	pixel_y = -5
 	},
 /obj/item/gun/ballistic/shotgun/riot{
 	desc = "A riot shotgun - this one is advertised to 'Not miss', quote, 'unlike the shitty hybrid taser'."
 	},
 /obj/item/gun/ballistic/shotgun/riot{
-	desc = "A riot shotgun - this one is advertised to 'Not miss', quote, 'unlike the shitty hybrid taser'."
+	desc = "A riot shotgun - this one is advertised to 'Not miss', quote, 'unlike the shitty hybrid taser'.";
+	pixel_x = -6;
+	pixel_y = 5
 	},
 /obj/structure/reagent_dispensers/peppertank/directional/north,
+/obj/structure/rack/gunrack,
+/obj/item/gun/ballistic/automatic/pistol{
+	desc = "It's small, it'll fit in your pocket - and's a great last resort self-defense weapon!";
+	pixel_x = 9;
+	pixel_y = -9
+	},
+/obj/item/gun/ballistic/automatic/pistol{
+	desc = "It's small, it'll fit in your pocket - and's a great last resort self-defense weapon!";
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/gun/ballistic/automatic/pistol{
+	desc = "It's small, it'll fit in your pocket - and's a great last resort self-defense weapon!";
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
 "Lh" = (
@@ -12137,19 +12238,6 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "PT" = (
 /obj/structure/rack,
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
 	},
@@ -12159,6 +12247,27 @@
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
+	},
+/obj/item/storage/belt/holster/nukie{
+	pixel_x = 9
+	},
+/obj/item/storage/belt/holster/nukie{
+	pixel_y = 6
+	},
+/obj/item/storage/belt/holster/nukie{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -4
+	},
+/obj/item/storage/belt/military{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/storage/belt/military{
+	pixel_x = 6;
+	pixel_y = -6
 	},
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
@@ -12363,12 +12472,14 @@
 "QC" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/vest{
-	pixel_x = -3;
+	pixel_x = -5;
 	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/vest,
 /obj/item/clothing/suit/armor/vest{
-	pixel_x = 3;
+	pixel_x = 1
+	},
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = 7;
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced/survival_pod{
@@ -12382,6 +12493,17 @@
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 5
+	},
+/obj/item/clothing/head/helmet{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/clothing/head/helmet{
+	pixel_y = -7
+	},
+/obj/item/clothing/head/helmet{
+	pixel_x = 6;
+	pixel_y = -11
 	},
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
@@ -12486,6 +12608,17 @@
 /obj/item/clothing/under/utility/sec/old/syndicate,
 /obj/structure/cable,
 /obj/item/clothing/head/sec/navywarden/syndicate,
+/obj/item/clothing/suit/armor/hos/trenchcoat{
+	armor = list("melee" = 35, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50, "wound" = 10);
+	desc = "A trenchcoat enhanced with a special lightweight kevlar. It has little Syndicate logos sewn onto the shoulder badges with the letters 'MAA' just under it.";
+	name = "Master at arms' armored trenchcoat"
+	},
+/obj/item/clothing/suit/armor/hos{
+	armor = list("melee" = 35, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50, "wound" = 10);
+	desc = "A greatcoat enhanced with a special alloy for some extra protection and style for those with a likely chance to get bullied for being outside of the brig";
+	name = "Master at arms' armored greatcoat"
+	},
+/obj/item/clothing/head/hos/beret/syndicate,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
@@ -13790,8 +13923,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "VD" = (
 /obj/machinery/suit_storage_unit/syndicate{
-	helmet_type = /obj/item/clothing/head/helmet/space/syndicate/black/red;
-	suit_type = /obj/item/clothing/suit/space/syndicate/black/red
+	helmet_type = null
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron/smooth_large,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds two mags to the Armory for the Admiral's bulldog, 3 eswords, telescopic batons, holsters, chest rigs, and 3 sets of riot gear to the armory, making it look like a genuine Syndicate armory without giving us literal newcop tier guns (c20r, more bulldogs, etc) No new ranged weapons were added in this, the armory still only has 3 makarovs and 3 shotguns. Along with adding some coat options for the Master at arms that have the same stats as the original coat, so he can act like the Syndicate Hoss he never will truly be. Adds in some of the Syndicate enviroment transport bags to the brig for either flavor ™️ or if someone wants to be taken prisoner onto DS-2. This also adds in another chameleon kit like Interdyne's to DS-2's vault along with a bike horn and a little note from Donk co.

![](https://cdn.discordapp.com/attachments/376656352405225477/883126642099257444/unknown.png)

![](https://cdn.discordapp.com/attachments/376656352405225477/883126719349927956/unknown.png)

![](https://cdn.discordapp.com/attachments/376656352405225477/883126866679066684/unknown.png)

![](https://cdn.discordapp.com/attachments/376656352405225477/883127110271635506/unknown.png)

Removes and replaces the original SyndiMed from DS-2 cutting 20 of the 40 blood red cortical stack removers and 20 of the 40 autoimplanters we get (Yes, DS-2 + Interdyne combined had a total of 40 esword tier melees in cortical stack removers and 40 free auto implanters) with the old Cybersun SyndiMed which let's us get let's us get more medical supplies that are actually needed on DS-2, removes redundant bulletproof armor in the armory since Brig officers spawn with one equipped.

Replaces the black and red space suit in the suit storages with normal red hardsuits seeing as they have the same protection rating and it's a suit in the armory, meant for people to arm up for combat should it come to that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

DS-2's armory was extremely lacking in presentation and usefulness, a few pieces of armor, 6 mediocre guns, no riot gear, black space suits. This hopefully rectifies it by making it look presentable, something worth guarding and... actually get armed when needed.
The enviroment transport bags are rarely used and could provide some potential to bring in people that want to be brought in as prisoners to DS-2.
Ghost role Syndicate players are usually regarded as the 'RR prevention squad' on lavaland since we usually don't have anything else to do, getting tools to actually find dead miners and fix them since paramedics usually don't check lavaland helps immensely, the old Cybersun vendor provides everything needed to fill that in.
_That and having 40 energy sword tier melee damage weapons and 40 auto implanters is a bit silly._

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The Syndicate have sent Deep Space 2 a new shipment of gear for their armory, holsters, chest rigs and more.
add: Gorlex have supplied spare Blood-red hardsuits to Deep space 2 for their armory.
del: The Syndicate have realized that they already send their brig officers off with bullet proof armor worn and have taken DS-2's extra ones in the armory for use elsewhere
del: The Syndicate have taken an extra SyndiMed after noticing a lack of cortical stack removers and implanters for field agents, in replacement for this they have salvaged an old Cybersun Cruiser's SyndiMed filled with actual medical supplies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
