### PR TITLE
what the fuck is a peackeeper (also slightly buffs peacekeeper belt)

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_backpack.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_backpack.dm
@@ -1,5 +1,5 @@
 /obj/item/storage/backpack/security/peacekeeper
-	name = "peackeeper backpack"
+	name = "peacekeeper backpack"
 	desc = "A robust feeling backpack."
 	icon_state = "peacepack"
 	icon = 'modular_skyrat/modules/sec_haul/icons/peacekeeper/peacekeeper_items.dmi'
@@ -7,7 +7,7 @@
 	inhand_icon_state = "securitypack"
 
 /obj/item/storage/backpack/satchel/sec/peacekeeper
-	name = "peackeeper satchel"
+	name = "peacekeeper satchel"
 	desc = "A robust feeling satchel."
 	icon_state = "peacekeepersatchel"
 	icon = 'modular_skyrat/modules/sec_haul/icons/peacekeeper/peacekeeper_items.dmi'
@@ -15,7 +15,7 @@
 	inhand_icon_state = "satchel-sec"
 
 /obj/item/storage/backpack/duffelbag/sec/peacekeeper
-	name = "peackeeper duffelbag"
+	name = "peacekeeper duffelbag"
 	desc = "A robust feeling duffelbag."
 	icon_state = "peacekeeperduffle"
 	icon = 'modular_skyrat/modules/sec_haul/icons/peacekeeper/peacekeeper_items.dmi'

--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
@@ -47,7 +47,7 @@
 //PEACEKEEPER UNIFORM
 /obj/item/clothing/under/rank/security/peacekeeper
 	name = "peacekeeper uniform"
-	desc = "A sleek peackeeper uniform, made to a price."
+	desc = "A sleek peacekeeper uniform, made to a price."
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/uniforms.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/uniform.dmi'
 	icon_state = "peacekeeper"
@@ -58,7 +58,7 @@
 
 /obj/item/clothing/under/rank/security/peacekeeper/tactical
 	name = "tactical peacekeeper uniform"
-	desc = "A tactical peackeeper uniform, woven with a lightweight layer of kevlar to provide minor ballistic and stab protection."
+	desc = "A tactical peacekeeper uniform, woven with a lightweight layer of kevlar to provide minor ballistic and stab protection."
 	icon_state = "peacekeeper_tac"
 	armor = list(MELEE = 5, BULLET = 5, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 30, ACID = 30, WOUND = 10)
 
@@ -173,7 +173,7 @@
 //PEACEKEEPER BELTS
 /obj/item/storage/belt/security/peacekeeper
 	name = "peacekeeper belt"
-	desc = "Can hold security gear like handcuffs and flashes. Has a holster for a gun."
+	desc = "This belt can hold security gear like handcuffs and flashes. It has a holster for a gun."
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/belts.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/belt.dmi'
 	icon_state = "peacekeeperbelt"
@@ -225,6 +225,7 @@
 	STR.set_holdable(list(
 		/obj/item/gun/ballistic/automatic/pistol,
 		/obj/item/gun/ballistic/revolver,
+		/obj/item/gun/energy/disabler,
 		/obj/item/melee/baton,
 		/obj/item/melee/classic_baton,
 		/obj/item/grenade,
@@ -253,7 +254,7 @@
 
 /obj/item/storage/belt/security/webbing/peacekeeper
 	name = "peacekeeper webbing"
-	desc = "Unique and versatile chest rig, can hold security gear."
+	desc = "A tactical chest rig issued to peacekeepers; slow is smooth, smooth is fast. Has a notable lack of a holster that fits energy-based weapons."
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/belts.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/belt.dmi'
 	icon_state = "peacekeeper_webbing"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The only actually important change to the video game is that the peacekeeper belt has /obj/item/gun/energy/disabler added to its set_holdable list

The much more personally important change is tHAT IT FIXES THE FUCKING "peackeeper" TYPO IN EVERY INSTANCE

## How This Contributes To The Skyrat Roleplay Experience

A roleplay pet peeve of mine is seeing seccies trotting around in Le Epic Tactical Tacticool Chest Rigs™ on green alert. Just get a belt dude- oh wait the webbing is objectively better in every case as things stand...
This change makes the belt more attractive on green alert, as you can hold your disabler in it; if you want the two extra slots the webbing provides, your disabler's gotta go (into your suit storage slot). Doesn't force them to get belts on green, just encourages them to.

Also fuck peackeepers, all my homies hate peackeepers.

## Changelog
:cl:
balance: Rebalanced sec webbing vs belt; the webbing still gets the extra two slots, but the belt can now hold disablers
spellcheck: peackeeper
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
