### PR TITLE
[MODULAR] turns down the weighting of the swanson announcer

### DIFF
--- a/modular_skyrat/modules/modular_station_traits/datums/_station_trait_skyrat.dm
+++ b/modular_skyrat/modules/modular_station_traits/datums/_station_trait_skyrat.dm
@@ -1,7 +1,7 @@
 /datum/station_trait/announcement_swanson
 	name = "Announcement Intern"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 5
+	weight = 1
 	show_in_report = TRUE
 	report_message = "Show some respect."
 	blacklist = list(/datum/station_trait/announcement_medbot, /datum/station_trait/announcement_intern)


### PR DESCRIPTION
## About The Pull Request

copy of #3875 but for swanson

swanson now rolls less frequently due to his high chance of hiding priority alerts, such as CC Updates, blobs and radstorms

## How This Contributes To The Skyrat Roleplay Experience

swanson rolls too often and causes serious damage to RP and the round itself.

## Changelog
:cl:
config: changed the weighting of the swanson announcements from 5 to 1
/:cl: