### PR TITLE
Fixes the Foreigner quirk to work correctly given that 90% of players aren't basic human.

### DIFF
--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -39,14 +39,16 @@
 /datum/quirk/foreigner/add()
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	human_holder.add_blocked_language(/datum/language/common)
-	if(ishumanbasic(human_holder))
-		human_holder.grant_language(/datum/language/uncommon)
+	//SKYRAT EDIT: Fixes most people not getting Galactic Uncommon.
+	//if(ishumanbasic(human_holder))
+	human_holder.grant_language(/datum/language/uncommon)
 
 /datum/quirk/foreigner/remove()
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	human_holder.remove_blocked_language(/datum/language/common)
-	if(ishumanbasic(human_holder))
-		human_holder.remove_language(/datum/language/uncommon)
+	//SKYRAT EDIT: Fixes most people not getting Galactic Uncommon.
+	//if(ishumanbasic(human_holder))
+	human_holder.remove_language(/datum/language/uncommon)
 
 /datum/quirk/vegetarian
 	name = "Vegetarian"


### PR DESCRIPTION
## About The Pull Request

See title.

## How This Contributes To The Skyrat Roleplay Experience

Perk is bugged and leaves you with no languages currently.

:cl:
fix: Fixes the Foreigner quirk to work correctly given that 90% of players aren't basic human.
/:cl:
