### PR TITLE
less destructive rodstopper

### DIFF
--- a/code/modules/power/singularity/boh_tear.dm
+++ b/code/modules/power/singularity/boh_tear.dm
@@ -21,19 +21,22 @@
 	pixel_y = -32
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	flags_1 = SUPERMATTER_IGNORES_1
-
+//SKYRAT EDIT START: Nicer RodStopper
 /obj/boh_tear/Initialize()
 	. = ..()
-	QDEL_IN(src, 5 SECONDS) // vanishes after 5 seconds
+	QDEL_IN(src, 10 SECONDS) // vanishes after 10 seconds
+	addtimer(CALLBACK(src, .proc/add_singularity), 5 SECONDS)
 
+/obj/boh_tear/proc/add_singularity()
+	// the grav_pull was BOH_TEAR_GRAV_PULL (25), but that is a whole lot
 	AddComponent(
 		/datum/component/singularity, \
 		consume_range = BOH_TEAR_CONSUME_RANGE, \
-		grav_pull = BOH_TEAR_GRAV_PULL, \
+		grav_pull = 4, \
 		roaming = FALSE, \
 		singularity_size = STAGE_SIX, \
 	)
-
+//SKYRAT EDIT STOP: Nicer RodStopper
 /obj/boh_tear/attack_tk(mob/user)
 	if(!isliving(user))
 		return

--- a/modular_skyrat/modules/rod-stopper/code/immovable_skyrat.dm
+++ b/modular_skyrat/modules/rod-stopper/code/immovable_skyrat.dm
@@ -5,8 +5,8 @@
 	. = ..()
 	if(should_self_destroy)
 
-		visible_message("<span class='boldwarning'>The rod tears into the rodstopper with a reality-rending screech!</span>")
+		visible_message(span_boldwarning("The rod tears into the rodstopper with a reality-rending screech!"))
 		playsound(src.loc,'sound/effects/supermatter.ogg', 200, TRUE)
-
+		visible_message(span_boldwarning("You have five seconds to move away before the localized reality-collapse!"))
 		new/obj/boh_tear(src.loc)
 		qdel(src)

--- a/modular_skyrat/modules/rod-stopper/code/rodstopper.dm
+++ b/modular_skyrat/modules/rod-stopper/code/rodstopper.dm
@@ -15,3 +15,7 @@
 	use_power = NO_POWER_USE
 	circuit = /obj/item/circuitboard/machine/rodstopper
 	layer = BELOW_OBJ_LAYER
+
+/obj/machinery/rodstopper/examine(mob/user)
+	. = ..()
+	. += span_warning("It will create a localized reality-collapse when stopping a rod, keep your distance!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
makes the rod stopper a little nicer: gives you 5 seconds to run away and less destructive
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
requested: less destruction means less problems; less RR means more fun to be gained
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: rodstoppers now give you 5 seconds to evacuate the area
balance: rodstopper is not so destructive
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
