### PR TITLE
[NON-MODULAR] Paper bin buffs

### DIFF
--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -50,6 +50,52 @@
 		qdel(I)
 		stored_paper++
 		return TRUE
+	/// SKYRAT EDIT ADDITION BEGIN: Paper Buffs
+	if(istype(I, /obj/item/paper_bin))
+		var/obj/item/paper_bin/bin = I
+		if(stored_paper >= max_paper)
+			to_chat(user, span_warning("You try to dump \the [bin] into [src], but its paper bin is full!"))
+			return FALSE
+		if(LAZYLEN(bin.papers))
+			var/papers_added = 0 // Number of sheets we added overall
+			var/rejected_sheets = 0 // Dump any sheets with info on them, in case some goober put their manifesto in there
+			for(var/obj/item/paper/the_paper in bin.papers)
+				if(the_paper.info != "") // Uh oh, paper has words!
+					LAZYREMOVE(bin.papers, the_paper)
+					the_paper.add_fingerprint(user)
+					the_paper.forceMove(user.loc)
+					user.put_in_hands(the_paper)
+					rejected_sheets ++
+					continue
+				var/num_to_add = 1
+				if(istype(the_paper, /obj/item/paper/carbon))
+					var/obj/item/paper/carbon/carbon_paper = the_paper
+					if(!carbon_paper.copied && ((max_paper - stored_paper) >= 2)) // See if there's room for both
+						num_to_add = 2
+				LAZYREMOVE(bin.papers, the_paper)
+				qdel(the_paper)
+				stored_paper += num_to_add
+				papers_added += num_to_add
+				if(stored_paper >= max_paper)
+					break // All full!
+			bin.update_appearance()
+			switch(papers_added)
+				if(0)
+					to_chat(user, span_warning("You try to dump \the [bin] into [src]'s paper recycler, but it simply spits out everything you added!"))
+				if(1)
+					to_chat(user, span_notice("You insert a single [initial(bin.papertype)] into [src]'s paper recycler."))
+				if(2 to INFINITY)
+					if(rejected_sheets)
+						to_chat(user, span_notice("You insert [papers_added] sheets into [src]'s paper recycler, but it detects [rejected_sheets] of them aren't blank, spitting those right back out!"))
+					else
+						to_chat(user, span_notice("You insert [papers_added] sheets into [src]'s paper recycler."))
+				else
+					to_chat(user, span_warning("You somehow manage to insert a negative number sheets into [src]'s paper recycler. Nothing seems to happen."))
+			return TRUE
+		else
+			to_chat(user, span_warning("\The [bin] is empty."))
+			return FALSE
+	/// SKYRAT EDIT ADDITION END
 	return FALSE
 
 /obj/item/computer_hardware/printer/mini

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -202,7 +202,7 @@
 		return
 
 	// Enable picking paper up by clicking on it with the clipboard or folder
-	if(istype(P, /obj/item/clipboard) || istype(P, /obj/item/folder))
+	if(istype(P, /obj/item/clipboard) || istype(P, /obj/item/folder) || istype(P, /obj/item/paper_bin)) /// SKYRAT EDIT - Paper Buffs - Original: if(istype(P, /obj/item/clipboard) || istype(P, /obj/item/folder))
 		P.attackby(src, user)
 		return
 	else if(istype(P, /obj/item/pen) || istype(P, /obj/item/toy/crayon))

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -78,7 +78,7 @@
 		var/mob/living/living_mob = user
 		if(!(living_mob.mobility_flags & MOBILITY_PICKUP))
 			return
-	user.changeNext_move(CLICK_CD_MELEE)
+	user.changeNext_move(CLICK_CD_RAPID) /// SKYRAT EDIT - Paper Buffs - Original: user.changeNext_move(CLICK_CD_RAPID)
 	if(at_overlay_limit())
 		dump_contents(drop_location(), TRUE)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Lowered the cooldown on paperbin usage from 0.8 seconds to 0.2 seconds. Felt like it took way too long to dump paper onto the floor.

Made paperbins dump their papers into machines that have a printer in them. Carbon papers count for two, and any papers with writing on them are auto-rejected onto the floor. Rejected sheets can still be inserted one at a time by hand though!

Using a paperbin on a sheet of paper adds the sheet to the bin.

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Reloading printers takes ages, paper messes are annoying to clean up (without a folder), and it just feels strange that paperbins use the full attack cooldown for something that's pretty much harmless (unless knowledge is power!).

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Paperbins now can dump their contents into computers.
qol: Greatly reduced click cooldown on paperbins.
qol: Paperbins can now pick up papers by clicking on them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
