### PR TITLE
added reagent sword to set_holdable

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
@@ -97,7 +97,8 @@
 		/obj/item/nullrod/fedora,
 		/obj/item/nullrod/godhand,
 		/obj/item/nullrod/staff,
-		/obj/item/nullrod/whip
+		/obj/item/nullrod/whip,
+		/obj/item/forging/reagent_weapon/sword
 		))
 
 /obj/item/storage/belt/crusader/PopulateContents()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds the reagent sword from forging items to the set_holdable list in the crusader belt, allowing you to put said sword into the belt.

## How This Contributes To The Skyrat Roleplay Experience

it would be rather nice to be able to actually holster a sword you just forged, especially for people who enjoy blacksmithing/space exploration.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
expansion: ability to hold reagent sword in crusader belt
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
