### PR TITLE
[SEMI-MODULAR] Makes paydays equal

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -11,7 +11,7 @@
 	exotic_blood = /datum/reagent/consumable/liquidelectricity //Liquid Electricity. fuck you think of something better gamer
 	siemens_coeff = 0.5 //They thrive on energy
 	brutemod = 1.25 //They're weak to punches
-	payday_modifier = 0.75
+	//SKYRAT EDIT - EQUAL PAY payday_modifier = 0.75
 	attack_type = BURN //burn bish
 	damage_overlay_type = "" //We are too cool for regular damage overlays
 	species_traits = list(DYNCOLORS, AGENDER, NO_UNDERWEAR, HAIR, HAS_FLESH, HAS_BONE) // i mean i guess they have blood so they can have wounds too

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -13,7 +13,7 @@
 	species_language_holder = /datum/language_holder/felinid
 	disliked_food = GROSS | RAW | CLOTH
 	var/original_felinid = TRUE //set to false for felinids created by mass-purrbation
-	payday_modifier = 0.75
+	//SKYRAT EDIT - EQUAL PAY payday_modifier = 0.75
 	ass_image = 'icons/ass/asscat.png'
 	family_heirlooms = list(/obj/item/toy/cattoy)
 

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -16,7 +16,7 @@
 	toxic_food = NONE
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/fly
-	payday_modifier = 0.75
+	//SKYRAT EDIT - EQUAL PAY payday_modifier = 0.75
 
 	mutanttongue = /obj/item/organ/tongue/fly
 	mutantheart = /obj/item/organ/heart/fly

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -21,7 +21,7 @@
 	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL
 	mutant_organs = list(/obj/item/organ/adamantine_resonator)
 	speedmod = 2
-	payday_modifier = 0.75
+	//SKYRAT EDIT - EQUAL PAY payday_modifier = 0.75
 	armor = 55
 	siemens_coeff = 0
 	punchdamagelow = 5

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -21,7 +21,7 @@
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
 	burnmod = 0.5 // = 1/2x generic burn damage
-	payday_modifier = 0.75
+	//SKYRAT EDIT - EQUAL PAY payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	inherent_factions = list("slime")
 	species_language_holder = /datum/language_holder/jelly

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -17,7 +17,7 @@
 	//mutant_organs = list(/obj/item/organ/tail/lizard) //SKYRAT EDIT REMOVAL - CUSTOMIZATION
 	coldmod = 1.5
 	heatmod = 0.67
-	payday_modifier = 0.75
+	//SKYRAT EDIT - EQUAL PAY payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	attack_verb = "slash"
 	attack_effect = ATTACK_EFFECT_CLAW

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -24,7 +24,7 @@
 	species_language_holder = /datum/language_holder/moth
 	wings_icons = list("Megamoth", "Mothra")
 	has_innate_wings = TRUE
-	payday_modifier = 0.75
+	//SKYRAT EDIT - EQUAL PAY payday_modifier = 0.75
 	family_heirlooms = list(/obj/item/flashlight/lantern/heirloom_moth)
 
 /datum/species/moth/regenerate_organs(mob/living/carbon/C,datum/species/old_species,replace_current=TRUE,list/excluded_zones)

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -24,7 +24,7 @@
 	burnmod = 1.5
 	heatmod = 1.5
 	brutemod = 1.5
-	payday_modifier = 0.75
+	//SKYRAT EDIT - EQUAL PAY payday_modifier = 0.75
 	breathid = "plas"
 	damage_overlay_type = ""//let's not show bloody wounds or burns over bones.
 	var/internal_fire = FALSE //If the bones themselves are burning clothes won't help you much

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -17,7 +17,7 @@
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	burnmod = 1.25
 	heatmod = 1.5
-	payday_modifier = 0.75
+	//SKYRAT EDIT - EQUAL PAY payday_modifier = 0.75
 	meat = /obj/item/food/meat/slab/human/mutant/plant
 	disliked_food = MEAT | DAIRY
 	liked_food = VEGETABLES | FRUIT | GRAIN

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
@@ -25,7 +25,6 @@
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
-	payday_modifier = 0.75
 	liked_food = GROSS | MEAT | FRIED
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/akula_parts_greyscale.dmi'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
@@ -28,7 +28,6 @@
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
-	payday_modifier = 0.75
 	liked_food = GROSS | MEAT | FRIED
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/akula_parts_greyscale.dmi'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
@@ -22,7 +22,6 @@
 	disliked_food = GROSS | RAW
 	liked_food = JUNKFOOD | FRIED
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 0.75
 	liked_food = ALCOHOL | MEAT | DAIRY //Dwarves like alcohol, meat, and dairy products.
 	disliked_food = JUNKFOOD | FRIED //Dwarves hate foods that have no nutrition other than alcohol.
 	species_language_holder = /datum/language_holder/dwarf

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
@@ -38,7 +38,6 @@
 	toxic_food = DAIRY | PINEAPPLE
 	disliked_food = VEGETABLES | FRUIT | CLOTH
 	liked_food = RAW | MEAT
-	payday_modifier = 0.75 //-- "Equality"
 	//armor = -100 //2x more damage
 	brutemod = 2
 	burnmod = 2

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
@@ -26,5 +26,4 @@
 		"horns" = "None"
 	)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 0.75
 	limbs_id = SPECIES_HUMAN

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
@@ -33,6 +33,5 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	liked_food = GROSS | MEAT | TOXIC
-	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/insect_parts_greyscale.dmi'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
@@ -5,7 +5,6 @@
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/lizard_parts_greyscale.dmi'
 	cultures = list(CULTURES_EXOTIC, CULTURES_LIZARD, CULTURES_HUMAN)
 	learnable_languages = list(/datum/language/common, /datum/language/draconic)
-	//SKYRAT EDIT - EQUAL PAY payday_modifier = 0.75
 
 /datum/species/lizard/get_random_features()
 	var/list/returned = MANDATORY_FEATURE_LIST

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
@@ -5,7 +5,7 @@
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/lizard_parts_greyscale.dmi'
 	cultures = list(CULTURES_EXOTIC, CULTURES_LIZARD, CULTURES_HUMAN)
 	learnable_languages = list(/datum/language/common, /datum/language/draconic)
-	payday_modifier = 0.75
+	//SKYRAT EDIT - EQUAL PAY payday_modifier = 0.75
 
 /datum/species/lizard/get_random_features()
 	var/list/returned = MANDATORY_FEATURE_LIST

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
@@ -33,7 +33,7 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	liked_food = GROSS | MEAT | FRIED
-	payday_modifier = 0.75
+
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/mammal_parts_greyscale.dmi'
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/moth.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/moth.dm
@@ -19,7 +19,6 @@
 	)
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/moth_parts_greyscale.dmi'
 	learnable_languages = list(/datum/language/common, /datum/language/moffic)
-	payday_modifier = 0.75
 
 /datum/species/moth/get_random_body_markings(list/passed_features)
 	var/name = "None"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
@@ -7,7 +7,6 @@
 	locations = list(/datum/cultural_info/location/stateless)
 	factions = list(/datum/cultural_info/faction/none)
 	learnable_languages = list(/datum/language/common, /datum/language/sylvan) //I guess plants are smart and they can speak common
-	payday_modifier = 0.75
 
 /datum/species/pod/podweak
 	name = "Podperson"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic.dm
@@ -24,7 +24,6 @@
 	coldmod = 1.2
 	heatmod = 2
 	siemens_coeff = 1.4 //Not more because some shocks will outright crit you, which is very unfun
-	payday_modifier = 0.5 //Robots are cheep labor
 	species_language_holder = /datum/language_holder/machine
 	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
 	mutantbrain = /obj/item/organ/brain/ipc_positron

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -5,7 +5,6 @@
 	hair_color = "mutcolor"
 	hair_alpha = 160 //a notch brighter so it blends better.
 	learnable_languages = list(/datum/language/common, /datum/language/slime)
-	payday_modifier = 0.75
 
 /datum/species/jelly/roundstartslime
 	name = "Xenobiological Slime Hybrid"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
@@ -25,7 +25,6 @@
 	species_language_holder = /datum/language_holder/skrell
 	mutant_bodyparts = list()
 	liked_food = TOXIC | DAIRY | FRUIT
-	payday_modifier = 0.75
 	default_mutant_bodyparts = list("skrell_hair" = ACC_RANDOM)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/skrell_parts_greyscale.dmi'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -26,7 +26,6 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	liked_food = GROSS | MEAT | FRIED
-	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/mammal_parts_greyscale.dmi'
 	limbs_id = SPECIES_MAMMAL

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
@@ -29,7 +29,6 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	liked_food = GROSS | MEAT | FRIED
-	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_id = SPECIES_LIZARD
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vox.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vox.dm
@@ -36,7 +36,6 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	liked_food = MEAT | FRIED
-	payday_modifier = 0.75
 	outfit_important_for_life = /datum/outfit/vox
 	species_language_holder = /datum/language_holder/vox
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
@@ -26,7 +26,6 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	liked_food = GROSS | MEAT | FRIED
-	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/mammal_parts_greyscale.dmi'
 	limbs_id = SPECIES_MAMMAL

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
@@ -30,7 +30,6 @@
 	liked_food = MEAT
 	cultures = list(CULTURES_EXOTIC, CULTURES_XENO)
 	learnable_languages = list(/datum/language/common, /datum/language/xenoknockoff)
-	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/xeno_parts_greyscale.dmi'
 	damage_overlay_type = SPECIES_XENO


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the 3/4ths pay modifier on non-human races.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Having pay based on race feels like a hold that doesn't fit in with skyrat, considering that a significant portion of he population of skyrat is made up of non-humans. Race based pay contributes little to nothing to roleplay because it doesn't factor in the economic factors that a character might have. Removing this allows us to make room for a better character based pay system in the future.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: non-humans are now payed the same as humans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
