### PR TITLE
[MODULAR] Nerfs some Black Mesa mobs, makes headcrab zombies stronger

### DIFF
--- a/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa.dm
+++ b/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa.dm
@@ -44,8 +44,8 @@
 	emote_taunt = list("growls", "snarls", "grumbles")
 	taunt_chance = 100
 	turns_per_move = 7
-	maxHealth = 110
-	health = 110
+	maxHealth = 80
+	health = 80
 	obj_damage = 50
 	harm_intent_damage = 15
 	melee_damage_lower = 15
@@ -71,7 +71,7 @@
 	damage = 5
 	damage_type = BURN
 	nodamage = FALSE
-	knockdown = 20
+	knockdown = 10
 	flag = BIO
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/neurotoxin
 	hitsound = 'modular_skyrat/master_files/sound/blackmesa/bullsquid/splat1.ogg'
@@ -97,12 +97,12 @@
 	emote_taunt = list("growls", "snarls", "grumbles")
 	taunt_chance = 100
 	turns_per_move = 7
-	maxHealth = 110
-	health = 110
+	maxHealth = 80
+	health = 80
 	obj_damage = 50
 	harm_intent_damage = 10
-	melee_damage_lower = 20
-	melee_damage_upper = 20
+	melee_damage_lower = 15
+	melee_damage_upper = 15
 	attack_sound = 'sound/weapons/bite.ogg'
 	gold_core_spawnable = HOSTILE_SPAWN
 	//Since those can survive on Xen, I'm pretty sure they can thrive on any atmosphere
@@ -142,15 +142,15 @@
 	emote_taunt = list("growls", "snarls", "grumbles")
 	taunt_chance = 100
 	turns_per_move = 7
-	maxHealth = 100
-	health = 100
-	harm_intent_damage = 15
-	melee_damage_lower = 17
-	melee_damage_upper = 17
+	maxHealth = 50
+	health = 50
+	harm_intent_damage = 8
+	melee_damage_lower = 10
+	melee_damage_upper = 10
 	attack_sound = 'sound/weapons/bite.ogg'
 	gold_core_spawnable = HOSTILE_SPAWN
 	charger = TRUE
-	charge_frequency = 3 SECONDS
+	charge_frequency = 5 SECONDS
 	loot = list(/obj/item/stack/sheet/bone)
 	alert_sounds = list(
 		'modular_skyrat/master_files/sound/blackmesa/headcrab/alert1.ogg'
@@ -196,9 +196,9 @@
 	name = "zombie"
 	desc = "A shambling corpse animated by a headcrab!"
 	mob_biotypes |= MOB_HUMANOID
-	melee_damage_lower += 8
-	melee_damage_upper += 11
-	obj_damage = 21 //now that it has a corpse to puppet, it can properly attack structures
+	melee_damage_lower += 12
+	melee_damage_upper += 15
+	obj_damage = 30 //now that it has a corpse to puppet, it can properly attack structures
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES
 	movement_type = GROUND
 	icon_state = ""

--- a/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa.dm
+++ b/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa.dm
@@ -142,8 +142,8 @@
 	emote_taunt = list("growls", "snarls", "grumbles")
 	taunt_chance = 100
 	turns_per_move = 7
-	maxHealth = 50
-	health = 50
+	maxHealth = 30
+	health = 30
 	harm_intent_damage = 8
 	melee_damage_lower = 10
 	melee_damage_upper = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lowered the health of the black Mesa mobs (not guards or hecu, just the monsters) by a bit and decreased their damage somewhat. I also reduced the knockdown on bullsquid spit cause holy fuck is it god awful to deal with. To compensate, headcrab zombies are slightly stronger now.

## How This Contributes To The Skyrat Roleplay Experience

Black Mesa is CBT in the current state and it's mostly to do with how strong and annoying the alien creatures are. Especially headcrabs since they do stamina damage too. Considering the HECU part is a damn gauntlet as is anyway, I doubt these changes will make the mission too easy

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Black Mesa monsters have had their health and damage reduced just a bit to make them less frustrating to deal with, but headcrab zombies are now stronger to compensate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
