### PR TITLE
[NONMODULAR] fuck you dynamic (turns the admin cancel button for midrounds from 10 seconds to 60 seconds)

### DIFF
--- a/code/game/gamemodes/dynamic/ruleset_picking.dm
+++ b/code/game/gamemodes/dynamic/ruleset_picking.dm
@@ -1,4 +1,4 @@
-#define ADMIN_CANCEL_MIDROUND_TIME (60 SECONDS)
+#define ADMIN_CANCEL_MIDROUND_TIME (60 SECONDS) //SKYRAT EDIT - ORIGINAL 10 SECONDS
 
 /// From a list of rulesets, returns one based on weight and availability.
 /// Mutates the list that is passed into it to remove invalid rules.

--- a/code/game/gamemodes/dynamic/ruleset_picking.dm
+++ b/code/game/gamemodes/dynamic/ruleset_picking.dm
@@ -1,4 +1,4 @@
-#define ADMIN_CANCEL_MIDROUND_TIME (10 SECONDS)
+#define ADMIN_CANCEL_MIDROUND_TIME (60 SECONDS)
 
 /// From a list of rulesets, returns one based on weight and availability.
 /// Mutates the list that is passed into it to remove invalid rules.


### PR DESCRIPTION
## About The Pull Request

now you don't have to be like fuck fuck should I click it and you actually get a tiny bit to discuss it

## How This Contributes To The Skyrat Roleplay Experience

because then we don't have shit like round 2977, where it was all filled with roleplay, until the xenos midround, and I couldn't cancel it, so they wiped the floor with the lowpop station

## Changelog

:cl:
config: changes the admin midround pick time from 10 seconds to 60 seconds
/:cl: