### PR TITLE
Xenomorph Balancing VI: Return of the Beans

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -25,14 +25,15 @@
 	role_name = "alien larva"
 
 	// 50% chance of being incremented by one
-	var/spawncount = 1
+//	var/spawncount = 1
+	var/spawncount = 2	//SKYRAT EDIT
 	fakeable = TRUE
 
 
 /datum/round_event/ghost_role/alien_infestation/setup()
 	announceWhen = rand(announceWhen, announceWhen + 50)
-	if(prob(50))
-		spawncount++
+//	if(prob(50))	//SKYRAT EDIT
+//		spawncount++	//SKYRAT EDIT
 
 /datum/round_event/ghost_role/alien_infestation/announce(fake)
 	var/living_aliens = FALSE

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -291,7 +291,10 @@ Doesn't work on other aliens/AI.*/
 
 /obj/effect/proc_holder/alien/sneak/fire(mob/living/carbon/alien/humanoid/user)
 	if(!active)
-		user.alpha = 75 //Still easy to see in lit areas with bright tiles, almost invisible on resin.
+//	SKYRAT EDIT: Start
+//		user.alpha = 75 //Still easy to see in lit areas with bright tiles, almost invisible on resin.
+		user.alpha = 50
+//	SKYRAT EDIT: End
 		user.sneaking = 1
 		active = 1
 		to_chat(user, span_noticealien("You blend into the shadows..."))

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -75,7 +75,11 @@
 					blocked = TRUE
 			if(!blocked)
 				L.visible_message(span_danger("[src] pounces on [L]!"), span_userdanger("[src] pounces on you!"))
-				L.Paralyze(100)
+				//	SKYRAT EDIT: START
+				//	L.Paralyze(100)	// Original Line
+				L.Knockdown(100)
+				L.apply_damage(75, STAMINA)
+				//	SKYRAT EDIT: END
 				sleep(2)//Runtime prevention (infinite bump() calls on hulks)
 				step_towards(src,L)
 			else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -283,7 +283,16 @@
 			to_chat(user, span_danger("You disarm [src]!"))
 		else
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, TRUE, -1)
-			Paralyze(100)
+			//Paralyze(100)	//SKYRAT EDIT: Original Line
+			//SKYRAT EDIT START
+			Paralyze(10)
+			Knockdown(50)
+			var/obj/item/bodypart/affecting = get_bodypart(ran_zone(user.zone_selected))
+			if(!affecting)
+				affecting = get_bodypart(BODY_ZONE_CHEST)
+			var/armor_block = run_armor_check(affecting, MELEE,"","",10)//10 armor penetration
+			apply_damage((rand(user.melee_damage_lower, user.melee_damage_upper)), STAMINA, affecting, armor_block)
+			//SKYRAT EDIT END
 			log_combat(user, src, "tackled")
 			visible_message(span_danger("[user] tackles [src] down!"), \
 							span_userdanger("[user] tackles you down!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), null, user)

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -1,15 +1,25 @@
 /obj/projectile/neurotoxin
 	name = "neurotoxin spit"
 	icon_state = "neurotoxin"
-	damage = 5
-	damage_type = TOX
+//	SKYRAT EDIT: Original Lines
+//	damage = 5
+//	damage_type = TOX
+//	nodamage = FALSE
+//	paralyze = 100
+//	SKYRAT EDIT: START
+	damage = 100
+	damage_type = STAMINA
 	nodamage = FALSE
-	paralyze = 100
+	paralyze = 30
+	knockdown = 100
+//	SKYRAT EDIT: END
 	flag = BIO
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/neurotoxin
 
 /obj/projectile/neurotoxin/on_hit(atom/target, blocked = FALSE)
 	if(isalien(target))
 		paralyze = 0
+		knockdown = 0	//SKYRAT EDIT
+		damage = 0	//SKYRAT EDIT
 		nodamage = TRUE
 	return ..()

--- a/modular_skyrat/modules/xenomorph/code/xenomorph_balance.dm
+++ b/modular_skyrat/modules/xenomorph/code/xenomorph_balance.dm
@@ -3,8 +3,8 @@
 	key_mode = KEY_MODE_TYPE
 	value_mode = VALUE_MODE_NUM
 	config_entry_value = list(			//DEFAULTS
-	/mob/living/carbon/alien/humanoid/drone = -0.2,
-	/mob/living/carbon/alien/humanoid/hunter = -0.5,
+	/mob/living/carbon/alien/humanoid/drone = -0.1,
+	/mob/living/carbon/alien/humanoid/hunter = -0.4,
 	/mob/living/carbon/alien/humanoid/royal/praetorian = 1,
 	/mob/living/carbon/alien/humanoid/royal/queen = 1.5
 	)
@@ -49,8 +49,8 @@
 ///////////////////////////////////////////
 /////////////     HUNTER      /////////////
 /mob/living/carbon/alien/humanoid/hunter
-	maxHealth = 150				//TG: 125
-	health = 150				//TG: 125
+	maxHealth = 125				//TG: 125
+	health = 125				//TG: 125
 	melee_damage_lower = 25		//TG: 20
 	melee_damage_upper = 25		//TG: 20
 	next_move_modifier = 0.75
@@ -58,11 +58,11 @@
 ///////////////////////////////////////////
 /////////////   XENO  DRONE   /////////////
 /mob/living/carbon/alien/humanoid/drone
-	maxHealth = 150				//TG: 125
-	health = 150				//TG: 125
+	maxHealth = 125				//TG: 125
+	health = 125				//TG: 125
 	melee_damage_lower = 20		//TG: 20
 	melee_damage_upper = 20		//TG: 20
-	next_move_modifier = 0.75
+	next_move_modifier = 1
 /////////////   XENO  DRONE   /////////////
 ///////////////////////////////////////////
 /////////////   FLAVOR TEXT   /////////////


### PR DESCRIPTION
## About The Pull Request
• Massively weakens the disarm attacks by replacing the long 10s hardstuns with knockdowns and stamina damage.
• Slows down hunters even further, now over half as slow as TG speed, and slows drones down a little.
• Lowers drone and hunter health from 150 to 125, the TG standards.
• Slightly buffs sentinel invisibility. Alpha from 70 to 150, they're now at a bout the spot where an inattentive player has a small chance of missing them.
• Neurotoxin spit now deals 10s of knockdown instead of 10s of hardstun and a hefty amount of stamina damage.
• Increases xeno spawn count to 2. We shouldn't have a random chance for how many xenos spawn, this just makes it the event inconsistent.
• Hunter pounce now deals 75 stamina damage no matter what armor is worn.

## Why It's Good For The Game
Removes the biggest source of frustration of fighting xenomorphs: 10 second hardstuns.
Xenomorphs are now in a position where the crew can win almost every time, simply by bunching up. It'll be very difficult to lose unless the crew conga lines into the nest. Xenomorphs now have absolutely no ability to groupfight whatsoever, if they are outnumbered, they will lose almost every time against lightly armed opponents unless they crew fumbles. Three assistants with welding tools is more than enough to keep a single hunter at bay.
Xenos need to get someone alone and keep attacking them to capture them, they only have a single second of hardstun to work with, after that the downed person can pick up items, crawl and fight back again.

Having two roundstart xenos no longer forces prospective Queens to almost exclusively rely on monkeys. Without monkeys, you're too slow to capture anyone - not that you can unless they for some reason run into tail-swipe range anymore. Even if someone's keyboard disconnects and you manage to get an embryo in them, the crew probably already know your location and your nest is about three or four minutes from being flamethrowered, and security is already kiting you with lasers. Even if you manage to get a larvae out, it's probably not going to survive long enough to evolve since by that time the Queen is low health and can't heal at all. Stop to heal and you get lasered.
Now if you have two xenos? You have a chance to actually capture people with ventcrawling and speed, although this is much harder now and you really need someone who is completely alone **and** to have disabled tcomms beforehand.

To put it simply:
It removes frustration.
It increases consistency.
It makes xenos much much less likely to end rounds outside of extreme lowpop.

## Changelog
:cl:
balance: Xenomorphs are now considerably weaker, their hardstuns are largely removed, replaced with knockdowns and stamina damage.
balance: Xenomorph drones have taken a minor speed, attack speed and health nerf.
balance: Xenomorph hunters are now under half the speed of TG's hunters.
balance: Xenomorph hunter pounce now deals 75 stamina damage - no matter what armor is worn.
balance: Xenomorph neurotoxin spit now deals 100 stamina damage and doesn't completely freeze people now, they only knock them down.
balance: Xenomorphs now start with two beans instead of one with a 50% chance of a second.
balance: Xenomorph sentinel invisibility is now useful.
/:cl: