### PR TITLE
Makes it so cyborgs can get the affection modules again after getting their model reset

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -648,6 +648,7 @@
 		hasShrunk = FALSE
 		resize = (4/3)
 		update_transform()
+	hasAffection = FALSE //Just so they can get the affection modules back if they want them.
 	//SKYRAT EDIT ADDITION END
 	logevent("Chassis model has been reset.")
 	model.transform_to(/obj/item/robot_model)

--- a/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
+++ b/modular_skyrat/modules/cyborg/code/robot_upgrades.dm
@@ -129,10 +129,10 @@
     if(!.)
         return
     if(borg.hasAffection)
-        to_chat(usr, "<span class='warning'>This unit already has a affection module installed!</span>")
+        to_chat(usr, span_warning("This unit already has a affection module installed!"))
         return FALSE
     if(!(R_TRAIT_WIDE in borg.model.model_features))
-        to_chat(usr, "<span class='warning'>This unit's chassis does not support this module.</span>")
+        to_chat(usr, span_warning("This unit's chassis does not support this module."))
         return FALSE
 
     var/obj/item/dogborg_tongue/dogtongue = new /obj/item/dogborg_tongue(borg.model)
@@ -192,7 +192,6 @@
 		return
 	if(borgo.hasAdvanced)
 		to_chat(user, span_warning("This unit already has advanced materials installed!"))
-		to_chat(user, "There's no room for more materials!")
 		return FALSE;
 
 	var/obj/item/stack/sheet/plasteel/cyborg/plasteel_holder = new(borgo.model)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
~~I haven't tested this yet, so don't merge it until I do.~~
Does what it says on the tin. It was very simple, and works as expected.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
People are complaining about it, and it makes no sense for it to not be able to work properly.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: GoldenAlpharex
fix: Cyborgs can now be given the affection modules after getting their model reset while they had them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
