### PR TITLE
[Modular] Various SSDecay fixes and tweaks

### DIFF
--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -12,7 +12,7 @@
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	flags_1 = NO_SCREENTIPS_1
-	turf_flags = CAN_BE_DIRTY_1
+	turf_flags = CAN_BE_DIRTY_1 /// SKYRAT EDIT - Overriden in modular_skyrat\modules\decay_subsystem\code\decay_turf_handling.dm
 	smoothing_groups = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_OPEN_FLOOR)
 	canSmoothWith = list(SMOOTH_GROUP_OPEN_FLOOR, SMOOTH_GROUP_TURF_OPEN)
 

--- a/config/skyrat/skyrat_config.txt
+++ b/config/skyrat/skyrat_config.txt
@@ -65,3 +65,6 @@ PC_MOB_TEXT As a player controlled mob you are expected to play the role to the 
 
 ## Toggles various checks for russian texts formation, as an example - autohiss. Useful only for russian servers
 #RUSSIAN_TEXT_FORMATION
+
+## Toggles off SSDecay when uncommented, HIGHLY recommended for map test-merges, to avoid giving it a bad first impression.
+#SSDECAY_DISABLED

--- a/modular_skyrat/master_files/code/controllers/configuration/entries/skryat_config_entries.dm
+++ b/modular_skyrat/master_files/code/controllers/configuration/entries/skryat_config_entries.dm
@@ -12,3 +12,6 @@
 
 //Reaction roles channel
 /datum/config_entry/string/role_assign_channel_id
+
+// To turn off SSDecay based on a config. You're welcome.
+/datum/config_entry/flag/ssdecay_disabled

--- a/modular_skyrat/modules/decay_subsystem/code/decaySS.dm
+++ b/modular_skyrat/modules/decay_subsystem/code/decaySS.dm
@@ -34,10 +34,20 @@ SUBSYSTEM_DEF(decay)
 		)
 
 /datum/controller/subsystem/decay/Initialize()
+	if(CONFIG_GET(flag/ssdecay_disabled))
+		message_admins("SSDecay was disabled in config.")
+		log_world("SSDecay was disabled in config.")
+		return ..()
+	// Putting this first so that it just doesn't waste time iterating through everything if it's not going to do anything anyway.
+	if(prob(0/*50*/))
+		message_admins("SSDecay will not interact with this round.")
+		log_world("SSDecay will not interact with this round.")
+		return ..()
+
 	for(var/turf/iterating_turf in world)
 		if(!is_station_level(iterating_turf.z))
 			continue
-		if(istype(iterating_turf, /turf/open/floor/plating/asteroid/snow))
+		if(!(iterating_turf.turf_flags & CAN_BE_DIRTY_1))
 			continue
 		possible_turfs += iterating_turf
 
@@ -49,13 +59,10 @@ SUBSYSTEM_DEF(decay)
 	if(!possible_turfs)
 		CRASH("SSDecay had no possible turfs to use!")
 
-	if(prob(50))
-		message_admins("SSDecay will not interact with this round.")
-		return ..()
-
-	severity_modifier = rand(1, 4)
+	severity_modifier = 4 //rand(1, 4)
 
 	message_admins("SSDecay severity modifier set to [severity_modifier]")
+	log_world("SSDecay severity modifier set to [severity_modifier]")
 
 	do_common()
 
@@ -69,7 +76,7 @@ SUBSYSTEM_DEF(decay)
 
 /datum/controller/subsystem/decay/proc/do_common()
 	for(var/turf/open/floor/iterating_floor in possible_turfs)
-		if(!istype(iterating_floor, /turf/open/floor/plating))
+		if(iterating_floor.turf_flags & CAN_DECAY_BREAK_1)
 			if(prob(FLOOR_TILE_MISSING_PERCENT_CHANCE * severity_modifier) && prob(60))
 				iterating_floor.break_tile_to_plating()
 

--- a/modular_skyrat/modules/decay_subsystem/code/decaySS.dm
+++ b/modular_skyrat/modules/decay_subsystem/code/decaySS.dm
@@ -39,7 +39,7 @@ SUBSYSTEM_DEF(decay)
 		log_world("SSDecay was disabled in config.")
 		return ..()
 	// Putting this first so that it just doesn't waste time iterating through everything if it's not going to do anything anyway.
-	if(prob(0/*50*/))
+	if(prob(50))
 		message_admins("SSDecay will not interact with this round.")
 		log_world("SSDecay will not interact with this round.")
 		return ..()
@@ -59,7 +59,7 @@ SUBSYSTEM_DEF(decay)
 	if(!possible_turfs)
 		CRASH("SSDecay had no possible turfs to use!")
 
-	severity_modifier = 4 //rand(1, 4)
+	severity_modifier = rand(1, 4)
 
 	message_admins("SSDecay severity modifier set to [severity_modifier]")
 	log_world("SSDecay severity modifier set to [severity_modifier]")

--- a/modular_skyrat/modules/decay_subsystem/code/decay_turf_handling.dm
+++ b/modular_skyrat/modules/decay_subsystem/code/decay_turf_handling.dm
@@ -1,0 +1,14 @@
+/// A turf flag, much higher than what the other turf flags are at because I don't want to cause conflicts by accident.
+#define CAN_DECAY_BREAK_1 (1<<23)
+
+/turf/open/floor
+	turf_flags = CAN_BE_DIRTY_1 | CAN_DECAY_BREAK_1 // We do it this way because we can then easily pick what we don't want to be broken.
+
+/turf/open/floor/plating
+	turf_flags = CAN_BE_DIRTY_1 /// No breaking the plating
+
+/turf/open/floor/glass
+	turf_flags = CAN_BE_DIRTY_1 /// No breaking the glass (doesn't leave plating behind)
+
+/turf/open/floor/plating/asteroid
+	turf_flags = NONE /// They shouldn't break and they shouldn't be dirty, it's literally already a dirty turf.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4377,6 +4377,7 @@
 #include "modular_skyrat\modules\cyborg\code\mechafabricator_designs.dm"
 #include "modular_skyrat\modules\cyborg\code\robot_upgrades.dm"
 #include "modular_skyrat\modules\cyborgpda\code\_onclick\hud\robot.dm"
+#include "modular_skyrat\modules\decay_subsystem\code\decay_turf_handling.dm"
 #include "modular_skyrat\modules\decay_subsystem\code\decaySS.dm"
 #include "modular_skyrat\modules\decay_subsystem\code\nests.dm"
 #include "modular_skyrat\modules\digi_bloodsole\code\modules\clothing\shoes\_shoes.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
SSDecay can no longer break glass tiles.
SSDecay doesn't use `istype()` and uses `turf_flags` instead.
You can now turn SSDecay off via uncommenting the new config option `SSDECAY_DISABLED` in `config/skyrat/skyrat_config.txt` (mostly for test-merges, and for people that want it off while testing their stuff locally)
Added a new turf flag for SSDecay, `CAN_DECAY_BREAK_1`, which when added means the turf can be broken by decay.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Less broken stuff, faster loading time when SSDecay doesn't interact with the round, clean stations during test-merges, all around a good thing.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: GoldenAlpharex
fix: SSDecay will no longer break glass floors.
code: SSDecay will no longer take a few seconds to load even when it's deemed not to be active for the shift.
config: Added a SSDECAY_DISABLED config option, to be uncommented in order to disable SSDecay, particularly useful for map test-merges.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
