### PR TITLE
Personal space quirk

### DIFF
--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -3,9 +3,7 @@
 #define TRAIT_NORUNNING "norunning"		// You walk!
 #define TRAIT_EXCITABLE	"wagwag" //Will wag when patted!
 #define TRAIT_OXYIMMUNE	"oxyimmune"		// Immune to oxygen damage, ideally give this to all non-breathing species or bad stuff will happen
-/// Block/counter-attack ass-slaps
-#define TRAIT_PERSONALSPACE "personalspace"
-#define TRAIT_IRONASS "ironass"
+#define TRAIT_PERSONALSPACE "personalspace" // Block/counter-attack ass-slaps
 #define TRAIT_MOOD_NOEXAMINE "mood_noexamine" // Can't assess your own mood
 #define TRAIT_DNR "cant_revive" //You just can't be revived without supernatural means
 #define TRAIT_HARD_SOLES "hard_soles" // No step on glass

--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -3,7 +3,8 @@
 #define TRAIT_NORUNNING "norunning"		// You walk!
 #define TRAIT_EXCITABLE	"wagwag" //Will wag when patted!
 #define TRAIT_OXYIMMUNE	"oxyimmune"		// Immune to oxygen damage, ideally give this to all non-breathing species or bad stuff will happen
-#define TRAIT_PERSONALSPACE "personalspace"
+#define TRAIT_PERSONALSPACE "personalspace" //Block/counterattack ass-slaps
+#define TRAIT_IRONASS "ironass"
 #define TRAIT_MOOD_NOEXAMINE "mood_noexamine" // Can't assess your own mood
 #define TRAIT_DNR "cant_revive" //You just can't be revived without supernatural means
 #define TRAIT_HARD_SOLES "hard_soles" // No step on glass

--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -3,7 +3,7 @@
 #define TRAIT_NORUNNING "norunning"		// You walk!
 #define TRAIT_EXCITABLE	"wagwag" //Will wag when patted!
 #define TRAIT_OXYIMMUNE	"oxyimmune"		// Immune to oxygen damage, ideally give this to all non-breathing species or bad stuff will happen
-#define TRAIT_IRONASS "ironass"
+#define TRAIT_PERSONALSPACE "personalspace"
 #define TRAIT_MOOD_NOEXAMINE "mood_noexamine" // Can't assess your own mood
 #define TRAIT_DNR "cant_revive" //You just can't be revived without supernatural means
 #define TRAIT_HARD_SOLES "hard_soles" // No step on glass

--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -3,7 +3,8 @@
 #define TRAIT_NORUNNING "norunning"		// You walk!
 #define TRAIT_EXCITABLE	"wagwag" //Will wag when patted!
 #define TRAIT_OXYIMMUNE	"oxyimmune"		// Immune to oxygen damage, ideally give this to all non-breathing species or bad stuff will happen
-#define TRAIT_PERSONALSPACE "personalspace" //Block/counterattack ass-slaps
+/// Block/counter-attack ass-slaps
+#define TRAIT_PERSONALSPACE "personalspace"
 #define TRAIT_IRONASS "ironass"
 #define TRAIT_MOOD_NOEXAMINE "mood_noexamine" // Can't assess your own mood
 #define TRAIT_DNR "cant_revive" //You just can't be revived without supernatural means

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -271,17 +271,7 @@
 			return
 	//SKYRAT EDIT ADDITION BEGIN - EMOTES
 	if(zone_selected == BODY_ZONE_PRECISE_GROIN && target.dir == src.dir)
-		if(HAS_TRAIT(target, TRAIT_IRONASS))
-			var/obj/item/bodypart/affecting = src.get_bodypart("[(src.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
-			if(affecting?.receive_damage(2))
-				src.update_damage_overlays()
-			visible_message("<span class='danger'>[src] tried slapping [target]'s ass, however it was much harder than expected!</span>",
-			"<span class='danger'>You tried slapping [target]'s ass, but it felt like metal, ouch!</span>",\
-			"You hear a sore sounding slap.", ignored_mobs = list(target))
-			playsound(target.loc, 'sound/effects/snap.ogg', 50, TRUE, ASS_SLAP_EXTRARANGE)
-			to_chat(target, "<span class='danger'>[src] tried slapping your ass, but it was deflected!")
-			return
-		else if(HAS_TRAIT(target, TRAIT_PERSONALSPACE) && (target.stat != UNCONSCIOUS) && (!target.handcuffed)) //You need to be conscious and uncuffed to use Personal Space
+		if(HAS_TRAIT(target, TRAIT_PERSONALSPACE) && (target.stat != UNCONSCIOUS) && (!target.handcuffed)) //You need to be conscious and uncuffed to use Personal Space
 			if(target.combat_mode && (!HAS_TRAIT(target, TRAIT_PACIFISM))) //Being pacified prevents violent counters
 				var/obj/item/bodypart/affecting = src.get_bodypart(BODY_ZONE_HEAD)
 				if(affecting?.receive_damage(PERSONAL_SPACE_DAMAGE))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -269,16 +269,24 @@
 			return
 	//SKYRAT EDIT ADDITION BEGIN - EMOTES
 	if(zone_selected == BODY_ZONE_PRECISE_GROIN && target.dir == src.dir)
-		if(HAS_TRAIT(target, TRAIT_IRONASS))
-			var/obj/item/bodypart/affecting = src.get_bodypart("[(src.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
-			if(affecting?.receive_damage(2))
-				src.update_damage_overlays()
-			visible_message("<span class='danger'>[src] tried slapping [target]'s ass, however it was much harder than expected!</span>",
-			"<span class='danger'>You tried slapping [target]'s ass, but it felt like metal, ouch!</span>",\
-			"You hear a sore sounding slap.", ignored_mobs = list(target))
-			playsound(target.loc, 'sound/effects/snap.ogg', 50, TRUE, -1)
-			to_chat(target, "<span class='danger'>[src] tried slapping your ass, but it was deflected!")
-			return
+		if(HAS_TRAIT(target, TRAIT_PERSONALSPACE))
+			if(target.combat_mode)
+				var/obj/item/bodypart/affecting = src.get_bodypart(BODY_ZONE_HEAD)
+				if(affecting?.receive_damage(2))
+					src.update_damage_overlays()
+				visible_message("<span class='danger'>[src] tried slapping [target]'s ass, but they were slapped!</span>",
+				"<span class='danger'>You tried slapping [target]'s ass, but they hit you back, ouch!</span>",\
+				"You hear a slap.", ignored_mobs = list(target))
+				playsound(target.loc, 'sound/effects/snap.ogg', 50, TRUE, -1)
+				to_chat(target, "<span class='danger'>[src] tried slapping your ass, but you hit them back!")
+				return
+			else
+				visible_message("<span class='danger'>[src] tried slapping [target]'s ass, but they were blocked!</span>",
+				"<span class='danger'>You tried slapping [target]'s ass, but they blocked you!</span>",\
+				"You hear a slap.", ignored_mobs = list(target))
+				playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
+				to_chat(target, "<span class='danger'>[src] tried slapping your ass, but you blocked them!")
+				return
 		else
 			do_ass_slap_animation(target)
 			playsound(target.loc, 'sound/weapons/slap.ogg', 50, TRUE, -1)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -269,7 +269,17 @@
 			return
 	//SKYRAT EDIT ADDITION BEGIN - EMOTES
 	if(zone_selected == BODY_ZONE_PRECISE_GROIN && target.dir == src.dir)
-		if(HAS_TRAIT(target, TRAIT_PERSONALSPACE))
+		if(HAS_TRAIT(target, TRAIT_IRONASS))
+			var/obj/item/bodypart/affecting = src.get_bodypart("[(src.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
+			if(affecting?.receive_damage(2))
+				src.update_damage_overlays()
+			visible_message("<span class='danger'>[src] tried slapping [target]'s ass, however it was much harder than expected!</span>",
+			"<span class='danger'>You tried slapping [target]'s ass, but it felt like metal, ouch!</span>",\
+			"You hear a sore sounding slap.", ignored_mobs = list(target))
+			playsound(target.loc, 'sound/effects/snap.ogg', 50, TRUE, -1)
+			to_chat(target, "<span class='danger'>[src] tried slapping your ass, but it was deflected!")
+			return
+		else if(HAS_TRAIT(target, TRAIT_PERSONALSPACE))
 			if(target.combat_mode)
 				var/obj/item/bodypart/affecting = src.get_bodypart(BODY_ZONE_HEAD)
 				if(affecting?.receive_damage(2))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -279,8 +279,8 @@
 			playsound(target.loc, 'sound/effects/snap.ogg', 50, TRUE, -1)
 			to_chat(target, "<span class='danger'>[src] tried slapping your ass, but it was deflected!")
 			return
-		else if(HAS_TRAIT(target, TRAIT_PERSONALSPACE))
-			if(target.combat_mode)
+		else if(HAS_TRAIT(target, TRAIT_PERSONALSPACE) && (target.stat != UNCONSCIOUS) && (!target.handcuffed)) //You need to be conscious and uncuffed to use Personal Space
+			if(target.combat_mode && (!HAS_TRAIT(target, TRAIT_PACIFISM))) //Being pacified prevents violent counters
 				var/obj/item/bodypart/affecting = src.get_bodypart(BODY_ZONE_HEAD)
 				if(affecting?.receive_damage(2))
 					src.update_damage_overlays()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -1,6 +1,6 @@
 #define SHAKE_ANIMATION_OFFSET 4
 #define PERSONAL_SPACE_DAMAGE 2
-#define ASS_SLAP_EXTRARANGE -1
+#define ASS_SLAP_EXTRA_RANGE -1
 
 /mob/living/carbon/get_eye_protection()
 	. = ..()
@@ -279,7 +279,7 @@
 				visible_message(span_danger("[src] tried slapping [target]'s ass, but they were slapped instead!"),
 				span_danger("You tried slapping [target]'s ass, but they hit you back, ouch!"),
 				"You hear a slap.", ignored_mobs = list(target))
-				playsound(target.loc, 'sound/effects/snap.ogg', 50, TRUE, -1)
+				playsound(target.loc, 'sound/effects/snap.ogg', 50, TRUE, ASS_SLAP_EXTRA_RANGE)
 				to_chat(target, span_danger("[src] tried slapping your ass, but you hit them back!"))
 				return
 			else

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -284,18 +284,18 @@
 				var/obj/item/bodypart/affecting = src.get_bodypart(BODY_ZONE_HEAD)
 				if(affecting?.receive_damage(2))
 					src.update_damage_overlays()
-				visible_message("<span class='danger'>[src] tried slapping [target]'s ass, but they were slapped!</span>",
-				"<span class='danger'>You tried slapping [target]'s ass, but they hit you back, ouch!</span>",\
+				visible_message(span_danger("[src] tried slapping [target]'s ass, but they were slapped instead!"),
+				span_danger("You tried slapping [target]'s ass, but they hit you back, ouch!"),
 				"You hear a slap.", ignored_mobs = list(target))
 				playsound(target.loc, 'sound/effects/snap.ogg', 50, TRUE, -1)
-				to_chat(target, "<span class='danger'>[src] tried slapping your ass, but you hit them back!")
+				to_chat(target, span_danger("[src] tried slapping your ass, but you hit them back!"))
 				return
 			else
-				visible_message("<span class='danger'>[src] tried slapping [target]'s ass, but they were blocked!</span>",
-				"<span class='danger'>You tried slapping [target]'s ass, but they blocked you!</span>",\
+				visible_message(span_danger("[src] tried slapping [target]'s ass, but they were blocked!"),
+				span_danger("You tried slapping [target]'s ass, but they blocked you!"),
 				"You hear a slap.", ignored_mobs = list(target))
 				playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
-				to_chat(target, "<span class='danger'>[src] tried slapping your ass, but you blocked them!")
+				to_chat(target, span_danger("[src] tried slapping your ass, but you blocked them!"))
 				return
 		else
 			do_ass_slap_animation(target)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -1,4 +1,6 @@
 #define SHAKE_ANIMATION_OFFSET 4
+#define PERSONAL_SPACE_DAMAGE 2
+#define ASS_SLAP_EXTRARANGE -1
 
 /mob/living/carbon/get_eye_protection()
 	. = ..()
@@ -276,13 +278,13 @@
 			visible_message("<span class='danger'>[src] tried slapping [target]'s ass, however it was much harder than expected!</span>",
 			"<span class='danger'>You tried slapping [target]'s ass, but it felt like metal, ouch!</span>",\
 			"You hear a sore sounding slap.", ignored_mobs = list(target))
-			playsound(target.loc, 'sound/effects/snap.ogg', 50, TRUE, -1)
+			playsound(target.loc, 'sound/effects/snap.ogg', 50, TRUE, ASS_SLAP_EXTRARANGE)
 			to_chat(target, "<span class='danger'>[src] tried slapping your ass, but it was deflected!")
 			return
 		else if(HAS_TRAIT(target, TRAIT_PERSONALSPACE) && (target.stat != UNCONSCIOUS) && (!target.handcuffed)) //You need to be conscious and uncuffed to use Personal Space
 			if(target.combat_mode && (!HAS_TRAIT(target, TRAIT_PACIFISM))) //Being pacified prevents violent counters
 				var/obj/item/bodypart/affecting = src.get_bodypart(BODY_ZONE_HEAD)
-				if(affecting?.receive_damage(2))
+				if(affecting?.receive_damage(PERSONAL_SPACE_DAMAGE))
 					src.update_damage_overlays()
 				visible_message(span_danger("[src] tried slapping [target]'s ass, but they were slapped instead!"),
 				span_danger("You tried slapping [target]'s ass, but they hit you back, ouch!"),
@@ -802,3 +804,5 @@
 	return TRUE
 
 #undef SHAKE_ANIMATION_OFFSET
+#undef PERSONAL_SPACE_DAMAGE
+#undef ASS_SLAP_EXTRARANGE

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -286,12 +286,12 @@
 				visible_message(span_danger("[src] tried slapping [target]'s ass, but they were blocked!"),
 				span_danger("You tried slapping [target]'s ass, but they blocked you!"),
 				"You hear a slap.", ignored_mobs = list(target))
-				playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
+				playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, ASS_SLAP_EXTRA_RANGE)
 				to_chat(target, span_danger("[src] tried slapping your ass, but you blocked them!"))
 				return
 		else
 			do_ass_slap_animation(target)
-			playsound(target.loc, 'sound/weapons/slap.ogg', 50, TRUE, -1)
+			playsound(target.loc, 'sound/weapons/slap.ogg', 50, TRUE, ASS_SLAP_EXTRA_RANGE)
 			visible_message("<span class='danger'>[src] slaps [target] right on the ass!</span>",\
 				"<span class='notice'>You slap [target] on the ass, how satisfying.</span>",\
 				"You hear a slap.", ignored_mobs = list(target))
@@ -795,4 +795,4 @@
 
 #undef SHAKE_ANIMATION_OFFSET
 #undef PERSONAL_SPACE_DAMAGE
-#undef ASS_SLAP_EXTRARANGE
+#undef ASS_SLAP_EXTRA_RANGE

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -34,6 +34,7 @@
 	medical_record_text = "Patient demonstrates negative reactions to their posterior being touched."
 	value = 0
 	mob_trait = TRAIT_PERSONALSPACE
+	icon = "hand-paper"
 
 /datum/quirk/dnr
 	name = "Do Not Revive"

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -22,15 +22,9 @@
 
 /datum/quirk/personalspace
 	name = "Personal Space"
-<<<<<<< HEAD
 	desc = "You'd rather people keep their hands to themselves, and you won't let anyone touch your ass.."
 	gain_text = span_notice("You'd like it if people kept their hands off your ass.")
 	lose_text = span_notice("You're less concerned about people touching your ass.")
-=======
-	desc = "You'd rather people keep their hands to themselves, and you won't let anyone touch your ass. If you're ready for a fight, you might even slap someone for it!"
-	gain_text = "<span class='notice'>You'd like it if people kept their hands off your ass.</span>"
-	lose_text = "<span class='notice'>You're less concerned about people touching your ass.</span>"
->>>>>>> 565af1f16bc (minor punctuation fix + added to trait description)
 	medical_record_text = "Patient demonstrates negative reactions to their posterior being touched."
 	value = 0
 	mob_trait = TRAIT_PERSONALSPACE

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -17,6 +17,7 @@
 	gain_text = "<span class='notice'>Your ass feels solid!</span>"
 	lose_text = "<span class='notice'>Your ass doesn't feel so solid anymore.</span>"
 	medical_record_text = "Patient's ass seems incredibly solid."
+	value = 0
 	mob_trait = TRAIT_IRONASS
 
 /datum/quirk/personalspace

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -11,15 +11,14 @@
 	mob_trait = TRAIT_EXCITABLE
 	icon = "laugh-beam"
 
-/datum/quirk/ironass
-	name = "Iron Ass"
-	desc = "Your ass is incredibly firm, so firm infact that anyone slapping it will suffer grave injuries."
-	gain_text = span_notice("Your ass feels solid!")
-	lose_text = span_notice("Your ass doesn't feel so solid anymore.")
-	medical_record_text = "Patient's ass seems incredibly solid."
+/datum/quirk/personalspace
+	name = "Personal Space"
+	desc = "You'd rather people keep their hands to themselves, and you won't let anyone touch your ass.."
+	gain_text = span_notice("You'd like it if people kept their hands off your ass.")
+	lose_text = span_notice("You're less concerned about people touching your ass.")
+	medical_record_text = "Patient demonstrates negative reactions to their posterior being touched."
 	value = 0
-	mob_trait = TRAIT_IRONASS
-	icon = "hand-paper"
+	mob_trait = TRAIT_PERSONALSPACE
 
 /datum/quirk/dnr
 	name = "Do Not Revive"

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -21,9 +21,15 @@
 
 /datum/quirk/personalspace
 	name = "Personal Space"
+<<<<<<< HEAD
 	desc = "You'd rather people keep their hands to themselves, and you won't let anyone touch your ass.."
 	gain_text = span_notice("You'd like it if people kept their hands off your ass.")
 	lose_text = span_notice("You're less concerned about people touching your ass.")
+=======
+	desc = "You'd rather people keep their hands to themselves, and you won't let anyone touch your ass. If you're ready for a fight, you might even slap someone for it!"
+	gain_text = "<span class='notice'>You'd like it if people kept their hands off your ass.</span>"
+	lose_text = "<span class='notice'>You're less concerned about people touching your ass.</span>"
+>>>>>>> 565af1f16bc (minor punctuation fix + added to trait description)
 	medical_record_text = "Patient demonstrates negative reactions to their posterior being touched."
 	value = 0
 	mob_trait = TRAIT_PERSONALSPACE

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -11,6 +11,14 @@
 	mob_trait = TRAIT_EXCITABLE
 	icon = "laugh-beam"
 
+/datum/quirk/ironass
+	name = "Iron Ass"
+	desc = "Your ass is incredibly firm, so firm infact that anyone slapping it will suffer grave injuries."
+	gain_text = "<span class='notice'>Your ass feels solid!</span>"
+	lose_text = "<span class='notice'>Your ass doesn't feel so solid anymore.</span>"
+	medical_record_text = "Patient's ass seems incredibly solid."
+	mob_trait = TRAIT_IRONASS
+
 /datum/quirk/personalspace
 	name = "Personal Space"
 	desc = "You'd rather people keep their hands to themselves, and you won't let anyone touch your ass.."

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -11,15 +11,6 @@
 	mob_trait = TRAIT_EXCITABLE
 	icon = "laugh-beam"
 
-/datum/quirk/ironass
-	name = "Iron Ass"
-	desc = "Your ass is incredibly firm, so firm infact that anyone slapping it will suffer grave injuries."
-	gain_text = "<span class='notice'>Your ass feels solid!</span>"
-	lose_text = "<span class='notice'>Your ass doesn't feel so solid anymore.</span>"
-	medical_record_text = "Patient's ass seems incredibly solid."
-	value = 0
-	mob_trait = TRAIT_IRONASS
-
 /datum/quirk/personalspace
 	name = "Personal Space"
 	desc = "You'd rather people keep their hands to themselves, and you won't let anyone touch your ass.."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR replaces the Iron Ass trait with Personal Space and reflavours it slightly. Now instead of ass-slappers taking damage from your steel cheeks, you'll harmlessly block them from touching your ass. Unless you're on combat mode, in which case you'll deliver a swift (yet light) blow to the head.

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
- Even if you want to keep your ass un-slapped, you may not want to cause actual damage to those that try, and this allows you to harmlessly defend your rear.  
- This is somewhat more grounded than a supernaturally tough ass. While non-serious aspects of the game are not inherently bad (and are arguably necessary!), I think it would be good for this trait (which is specifically a way to block something you're OOC not okay with) to be a bit more grounded.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: The Personal Space trait, which allows you to harmlessly block attempts at slapping your ass... or deliver a swift slap to the ass-slapper if you're in combat mode.
del: Iron Ass trait has been removed for replacement with Personal Space
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
