### PR TITLE
Language Consistency Tweaks

### DIFF
--- a/modular_skyrat/modules/customization/modules/language/japanese.dm
+++ b/modular_skyrat/modules/customization/modules/language/japanese.dm
@@ -1,5 +1,5 @@
 /datum/language/yangyu
-	name = "Yangyu"
+	name = "Japanese"
 	desc = "An old language from Earth, originally from the country of Japan. While not as prevalent as Common, and having taken on a wealth of loanwords, its managed to hold on both in its country of origin and across space."
 	key = "J"
 	flags = TONGUELESS_SPEECH

--- a/modular_skyrat/modules/customization/modules/language/russian.dm
+++ b/modular_skyrat/modules/customization/modules/language/russian.dm
@@ -1,5 +1,5 @@
 /datum/language/neorusskya
-	name = "Neo-Russkya"
+	name = "Pan-Slavic"
 	desc = "The official language of the Independent Colonial Confederation of Gilgamesh, originally established in 2122 by the short-lived United Slavic Confederation on Earth."
 	key = "r"
 	flags = TONGUELESS_SPEECH


### PR DESCRIPTION
## About The Pull Request

All this PR does is reflavor some languages so that they're more consistent with the rest.

## How This Contributes To The Skyrat Roleplay Experience

All the languages we have are either named in English (in the game's own language) or pertain to their own unique region like Zolmach or Vox-pidgin do. I don't think there should be many exceptions.

Also having just Russian and ditching 11 other languages of the same family just because you went to space sounds very stupid for no good reason.

## Changelog

:cl:
tweak: "Yangyu" renamed to "Japanese" as its description suggests, for consistency's sake.
tweak: "Neo-Russkye" renamed to "Pan-Slavic" for RP flavor.
/:cl: