### PR TITLE
Fixes Libital/Lenturi/Meth in plumbing

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_chems.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_chems.dm
@@ -1,10 +1,13 @@
 /datum/reagent/medicine/c2/libital/borer_version
+	name = "Unknown Libital Isomer"
 	impure_chem = null
 
 /datum/reagent/medicine/c2/lenturi/borer_version
+	name = "Unknown Lenturi Isomer"
 	impure_chem = null
 
 /datum/reagent/drug/methamphetamine/borer_version
+	name = "Unknown Methamphetamine Isomer"
 	overdose_threshold = 40
 
 /datum/reagent/drug/methamphetamine/borer_version/on_mob_life(mob/living/carbon/M, delta_time, times_fired)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When #7916 was merged, it added three new chem subtypes but without new `name`s. Plumbing machines depend on the `name` of the chem to know what to pull. Since two versions of libital, lenturi, and meth existed, when you tried to add any of these three chems to any plumbing machine, you could add them, but the game was selecting the `/borer_version` subtype. This adds a distinct `name` to each of these three chems which allows plumbing to work again.

Fixes #7972 

## How This Contributes To The Skyrat Roleplay Experience

Plumbing machines now work as expected when dealing with these three chems.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: libital, lenturi, and meth work in plumbing machines again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
