### PR TITLE
Reverts #7692 (Venus nerfs)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -107,7 +107,7 @@
 	icon_state = "venus_human_trap"
 	health_doll_icon = "venus_human_trap"
 	mob_biotypes = MOB_ORGANIC | MOB_PLANT
-	layer = ABOVE_ALL_MOB_LAYER //SKYRAT EDIT CHANGE Venus should be able to hide within the vines...
+	layer = SPACEVINE_MOB_LAYER
 	health = 60 //SKYRAT EDIT CHANGE
 	maxHealth = 60 //SKYRAT EDIT CHANGE
 	ranged = TRUE
@@ -142,21 +142,9 @@
 
 	ghost_controllable = TRUE //SKYRAT EDIT ADDITION
 
-	COOLDOWN_DECLARE(help_grow)
-	COOLDOWN_DECLARE(attack_cooldown)
-
-
 /mob/living/simple_animal/hostile/venus_human_trap/Life(delta_time = SSMOBS_DT, times_fired)
 	. = ..()
 	pull_vines()
-	//SKYRAT EDIT CHANGE
-	var/turf/src_turf = get_turf(src)
-	var/obj/structure/spacevine/find_vine = locate() in src_turf.contents
-	if(!find_vine)
-		adjustHealth(maxHealth * 0.05)
-	else
-		adjustHealth(maxHealth * -0.05)
-	//SKYRAT EDIT CHANGE
 
 /mob/living/simple_animal/hostile/venus_human_trap/Moved(atom/OldLoc, Dir)
 	. = ..()
@@ -255,45 +243,5 @@
 /mob/living/simple_animal/hostile/venus_human_trap/death(gibbed)
 	for(var/i in vines)
 		qdel(i)
-	return ..()
-
-/mob/living/simple_animal/hostile/venus_human_trap/UnarmedAttack(atom/attack_target, proximity_flag, list/modifiers)
-	if(!istype(attack_target, /obj/structure/spacevine))
-		return ..()
-	if(!proximity_flag)
-		return
-	var/obj/structure/spacevine/attacked_spacevine = attack_target
-	if(COOLDOWN_FINISHED(src, help_grow))
-		COOLDOWN_START(src, help_grow, 1 SECONDS)
-		if(attacked_spacevine.energy >= 2)
-			attacked_spacevine.spread()
-			to_chat(src, span_notice("You help [attacked_spacevine] expand..."))
-		else
-			attacked_spacevine.grow()
-			to_chat(src, span_notice("You help [attacked_spacevine] grow..."))
-	if(!COOLDOWN_FINISHED(src, attack_cooldown))
-		return
-	COOLDOWN_START(src, attack_cooldown, 1 SECONDS)
-	var/turf/vine_turf = get_turf(attack_target)
-	var/static/list/break_list = typecacheof(list(
-		/obj/machinery/door,
-		/obj/structure/table,
-		/obj/structure/window,
-		/obj/structure/girder,
-		/obj/structure/grille,
-		/obj/structure/rack,
-		/obj/structure/door_assembly,
-		/obj/structure/closet,
-	))
-	for(var/check_contents in vine_turf.contents)
-		if(isliving(check_contents) && !istype(check_contents, /mob/living/simple_animal/hostile/venus_human_trap))
-			UnarmedAttack(check_contents)
-		if(is_type_in_typecache(check_contents, break_list))
-			UnarmedAttack(check_contents)
-
-/mob/living/simple_animal/hostile/venus_human_trap/start_pulling(atom/movable/AM, state, force, supress_message)
-	if(isliving(AM))
-		to_chat(src, span_warning("You are unable to pull living creatures, they are too heavy!"))
-		return FALSE
 	return ..()
 //SKYRAT EDIT END

--- a/modular_skyrat/master_files/code/modules/events/spacevine.dm
+++ b/modular_skyrat/master_files/code/modules/events/spacevine.dm
@@ -642,6 +642,13 @@
 		return
 	for(var/datum/spacevine_mutation/vine_mutation in mutations)
 		vine_mutation.on_cross(src, moving_atom)
+	if(istype(moving_atom, /mob/living/simple_animal/hostile/venus_human_trap))
+		var/mob/living/simple_animal/hostile/venus_human_trap/venus_trap = moving_atom
+		if(venus_trap.health >= venus_trap.maxHealth)
+			return
+		venus_trap.adjustHealth(-clamp(venus_trap.health += 2, 0, venus_trap.maxHealth), TRUE, TRUE)
+		to_chat(venus_trap, span_notice("The vines attempt to regenerate some of your wounds!"))
+		return
 
 // ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/structure/spacevine/attack_hand(mob/user, list/modifiers)
@@ -843,13 +850,6 @@
 	. = ..()
 	if(isvineimmune(mover))
 		return TRUE
-
-/obj/structure/spacevine/attack_ghost(mob/user)
-	var/turf/src_turf = get_turf(src)
-	var/mob/living/simple_animal/hostile/venus_human_trap/check_venus = locate() in src_turf.contents
-	if(!check_venus)
-		return ..()
-	check_venus.attack_ghost(user)
 
 /proc/isvineimmune(atom/checked_atom)
 	if(isliving(checked_atom))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reverts #7692 and the following PR that fixed a bug it created.

## How This Contributes To The Skyrat Roleplay Experience

The reason given for the PR was "vines are getting decimated by scythe changes". However the PR only served to intensely nerf the vine's defender mobs. The PR was made only 2 weeks after venus traps were buffed, and removed most of their combat utility and healing.
Helping vines grow faster is not a significant utility, it didn't help the vines mutate (which is the only way vines get stronger) and removing their ability to pull mobs just made it needlessly hard to make more plant mobs if vines mutated seeding.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Reverted some Venus Human Trap nerfs, which removed their ability to pull mobs and heal by walking in vines, in exchange for being able to grow vines slightly faster.
/:cl: