### PR TITLE
Adds a colorable beret as loadout choice

### DIFF
--- a/modular_skyrat/modules/berets/code/modules/clothing/head/jobs.dm
+++ b/modular_skyrat/modules/berets/code/modules/clothing/head/jobs.dm
@@ -144,3 +144,11 @@
 	name = "head of personnel's beret"
 	desc = "A fancy beret designed by NT's Personnel division for their favorite head's head. This one is made out of white fabric. Fancy"
 	greyscale_colors = "#FFFFFF#D60000"
+
+/obj/item/clothing/head/beret/color
+	name = "beret"
+	desc = "A beret, perfect for war veterans and dark, brooding, anti-hero mimes."
+	icon_state = "beret"
+	greyscale_config = /datum/greyscale_config/beret
+	greyscale_config_worn = /datum/greyscale_config/beret/worn
+	greyscale_colors = "#ffffff"

--- a/modular_skyrat/modules/customization/modules/client/loadout/head.dm
+++ b/modular_skyrat/modules/customization/modules/client/loadout/head.dm
@@ -21,6 +21,11 @@
 	name = "Black beret"
 	path = /obj/item/clothing/head/beret/black
 
+/datum/loadout_item/head/beretcolor
+	name = "Beret"
+	path = /obj/item/clothing/head/beret/color
+	extra_info = LOADOUT_INFO_ONE_COLOR
+
 /datum/loadout_item/head/flatcap
 	name = "Flat cap"
 	path = /obj/item/clothing/head/flatcap


### PR DESCRIPTION
## About The Pull Request

Adds a colorable #ffffff beret to the loadout menu.

First I thought the lack off those was a design decision so people don't fake department berets. But then I discovered that recolorable berets already exist in the vending machines.

The one (non-job) beret in the loadout is called "Black Beret", and as I did not want to mess up people's loadouts by renaming stuff, I added a blank white one called just "Beret" that can be colored.

<details>
  <summary>Scantily clad, but color-coordinated space elfs</summary>

![grafik](https://user-images.githubusercontent.com/46299792/134334326-75058aeb-398c-42d7-9e2f-483f97eafcf3.png)
![grafik](https://user-images.githubusercontent.com/46299792/134334486-8eb8f092-4d50-402c-8067-51cfcfa96f3f.png)

</details>
       





## How This Contributes To The Skyrat Roleplay Experience

- Shortens the roundstart line at the tramstation clothing vendors by allowing people to get their colored berets straight from their loadout. 
- Rectifies crimes against fashion.

## Changelog


:cl:
add: Colorable beret in the loadout menu
/:cl:


