### PR TITLE
Mostly Reverts "Language Consistency Tweaks"

### DIFF
--- a/modular_skyrat/modules/customization/modules/language/japanese.dm
+++ b/modular_skyrat/modules/customization/modules/language/japanese.dm
@@ -1,5 +1,5 @@
 /datum/language/yangyu
-	name = "Japanese"
+	name = "Yangyu"
 	desc = "An old language from Earth, originally from the country of Japan. While not as prevalent as Common, and having taken on a wealth of loanwords, its managed to hold on both in its country of origin and across space."
 	key = "J"
 	flags = TONGUELESS_SPEECH

--- a/modular_skyrat/modules/customization/modules/language/russian.dm
+++ b/modular_skyrat/modules/customization/modules/language/russian.dm
@@ -1,5 +1,5 @@
 /datum/language/neorusskya
-	name = "Pan-Slavic"
+	name = "Neo-Russkya"
 	desc = "The official language of the Independent Colonial Confederation of Gilgamesh, originally established in 2122 by the short-lived United Slavic Confederation on Earth."
 	key = "r"
 	flags = TONGUELESS_SPEECH

--- a/modular_skyrat/modules/customization/modules/language/russian.dm
+++ b/modular_skyrat/modules/customization/modules/language/russian.dm
@@ -1,5 +1,5 @@
 /datum/language/neorusskya
-	name = "Neo-Russkya"
+	name = "Pan-Slavic"
 	desc = "The official language of the Independent Colonial Confederation of Gilgamesh, originally established in 2122 by the short-lived United Slavic Confederation on Earth."
 	key = "r"
 	flags = TONGUELESS_SPEECH


### PR DESCRIPTION
# About This Pull Request
Reverts Skyrat-SS13/Skyrat-tg#8251

Yangyu is not Japanese. It was specifically changed to not be Japanese.

# How Does This Contribute to the Skyrat Roleplay Experience?
None of the languages are named directly after the language they're based of. This sets a bad precedent and is just uncreative. Yangyu is a nice name, we don't need it to be literally Japanese.

# Changelog 
🆑 GoldenAlpharex
spelling: Yangyu is now called Yangyu again.
/:cl: