### PR TITLE
Mass Map Fixes

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -97723,6 +97723,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"wAL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/machinery/rnd/server/master,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/science/server)
 "wAZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -137970,7 +137975,7 @@ jRm
 kHa
 lak
 dIH
-emG
+wAL
 cOR
 dMc
 qsi

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -4200,6 +4200,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/vending/dorms,
 /turf/open/floor/iron/dark,
 /area/commons/locker)
 "aEH" = (
@@ -7058,16 +7059,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
-"bgB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/commons/vacant_room/office)
 "bgH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -29483,6 +29474,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/posialert{
+	pixel_x = 28;
+	pixel_y = 24
+	},
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "dEP" = (
@@ -30248,6 +30243,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/posialert{
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "dIO" = (
@@ -36358,7 +36356,7 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "ewj" = (
-/turf/open/floor/carpet/executive,
+/turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "ewl" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -37319,12 +37317,11 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "eLb" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/structure/table/wood,
+/obj/item/taperecorder,
+/obj/machinery/light/small/directional/north,
 /obj/machinery/status_display/evac/directional/north,
-/obj/structure/closet/secure_closet/nanotrasen_representative/station,
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "eLv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -40571,7 +40568,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/machinery/light_switch/directional/north,
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "fIN" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -41887,9 +41884,6 @@
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "gjd" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
@@ -43747,7 +43741,7 @@
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_x = -32
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "gOe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43914,7 +43908,7 @@
 /area/service/kitchen)
 "gQS" = (
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "gRl" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44754,7 +44748,7 @@
 "hfp" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/turf/open/floor/carpet/executive,
+/turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "hfr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -46189,8 +46183,8 @@
 /area/engineering/gravity_generator)
 "hDb" = (
 /obj/machinery/status_display/evac/directional/east,
-/obj/structure/filingcabinet/medical,
-/turf/open/floor/carpet/executive,
+/obj/structure/frame/computer,
+/turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "hDe" = (
 /obj/machinery/light_switch/directional/south{
@@ -46214,12 +46208,14 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/solars/port/fore)
 "hDq" = (
-/obj/machinery/cryopod,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/cryopod{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
 "hDz" = (
@@ -46851,11 +46847,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "hNT" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = 32
 	},
-/obj/structure/filingcabinet/security,
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "hOg" = (
 /obj/machinery/door/firedoor,
@@ -46940,9 +46938,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "hPx" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/mob/living/basic/cockroach,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "hPM" = (
@@ -51094,19 +51092,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"iZD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/commons/vacant_room/office)
 "iZF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51450,9 +51435,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "jgt" = (
-/obj/effect/spawner/random/entertainment/arcade,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/cryopod{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/cryopod,
 /turf/open/floor/iron,
 /area/security/prison)
 "jgH" = (
@@ -51867,8 +51856,7 @@
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
-/obj/item/taperecorder,
-/turf/open/floor/carpet/executive,
+/turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "jmU" = (
 /obj/effect/landmark/start/station_engineer,
@@ -54506,7 +54494,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/newscaster/directional/north,
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "kdV" = (
 /obj/effect/turf_decal/tile/blue,
@@ -54643,8 +54631,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/newscaster/directional/south,
-/obj/item/storage/secure/briefcase,
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "kfz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -54656,7 +54643,7 @@
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
 "kfB" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/commons/vacant_room/office)
 "kfD" = (
 /obj/effect/decal/cleanable/oil,
@@ -54703,6 +54690,7 @@
 /turf/open/floor/iron/checker,
 /area/engineering/atmos)
 "kgb" = (
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
 "kgo" = (
@@ -58066,10 +58054,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ldY" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "lef" = (
@@ -62777,15 +62762,8 @@
 "mui" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "muI" = (
@@ -62971,7 +62949,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/newscaster/directional/south,
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "mxS" = (
 /obj/machinery/shower{
@@ -64581,10 +64559,10 @@
 /turf/closed/wall,
 /area/engineering/atmos)
 "mZH" = (
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "nad" = (
 /obj/structure/cable,
@@ -65767,6 +65745,7 @@
 	name = "prison intercom";
 	prison_radio = 1
 	},
+/obj/machinery/cryopod,
 /turf/open/floor/iron,
 /area/security/prison)
 "npZ" = (
@@ -65889,12 +65868,8 @@
 /area/hallway/primary/central/fore)
 "nrg" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "nru" = (
@@ -66180,10 +66155,8 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "nvw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/carpet/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "nvW" = (
 /obj/structure/window/reinforced{
@@ -68609,7 +68582,7 @@
 	dir = 1
 	},
 /obj/item/toy/figure/assistant,
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "ofO" = (
 /obj/effect/turf_decal/tile/red{
@@ -70653,11 +70626,7 @@
 	},
 /obj/item/folder/yellow,
 /obj/item/pen,
-/obj/item/stamp/centcom{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "oHg" = (
 /obj/structure/chair/office,
@@ -71061,22 +71030,9 @@
 /area/command/heads_quarters/cmo)
 "oLJ" = (
 /obj/structure/table/wood,
-/obj/item/folder/blue{
-	pixel_x = -6;
-	pixel_y = -4
-	},
-/obj/item/folder/white{
-	pixel_x = 9
-	},
-/obj/item/stamp/denied{
-	pixel_x = 7;
-	pixel_y = 13
-	},
-/obj/item/stamp{
-	pixel_x = -8;
-	pixel_y = 9
-	},
-/turf/open/floor/carpet/green,
+/obj/item/folder,
+/obj/item/pen,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "oMa" = (
 /obj/effect/turf_decal/stripes/line{
@@ -71551,6 +71507,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "oSl" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/wood,
@@ -71967,6 +71924,10 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "oYK" = (
+/obj/machinery/door/airlock{
+	name = "Auxiliary Office"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -71974,10 +71935,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/command{
-	name = "Representative's Office";
-	req_access_txt = "101"
-	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/office)
 "oYL" = (
@@ -72818,8 +72775,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "pmL" = (
-/obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/east,
+/obj/machinery/cryopod,
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
 "pmP" = (
@@ -73684,8 +73641,8 @@
 /area/ai_monitored/turret_protected/ai)
 "pBU" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin/carbon,
-/turf/open/floor/carpet/green,
+/obj/item/storage/briefcase,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "pCj" = (
 /obj/structure/cable,
@@ -74906,11 +74863,9 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "pVq" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/photocopier,
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "pVu" = (
 /obj/machinery/light/directional/south,
@@ -76170,12 +76125,12 @@
 /turf/open/floor/iron/grimy,
 /area/service/abandoned_gambling_den/secondary)
 "qnU" = (
-/obj/structure/closet/crate/trashcart,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 30
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/iron,
 /area/security/prison)
 "qnX" = (
@@ -77397,7 +77352,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "qGc" = (
 /obj/structure/cable,
@@ -77972,7 +77927,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/turf/open/floor/carpet/executive,
+/turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "qNT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -78037,7 +77992,6 @@
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
 "qOr" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -78048,6 +78002,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/vending/access/command,
 /turf/open/floor/iron/dark,
 /area/command/meeting_room/council)
 "qOw" = (
@@ -79822,8 +79777,8 @@
 /area/service/kitchen)
 "rmR" = (
 /obj/machinery/status_display/ai/directional/east,
-/obj/structure/filingcabinet/employment,
-/turf/open/floor/carpet/executive,
+/obj/structure/frame/computer,
+/turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "rmX" = (
 /obj/structure/bed/roller,
@@ -81699,7 +81654,7 @@
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
 /obj/machinery/newscaster/directional/north,
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "rRV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -82317,9 +82272,10 @@
 /area/service/bar/atrium)
 "scj" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Representative's Office Maintenance";
-	req_access_txt = "101"
+	name = "Office Maintenance";
+	req_access_txt = "32"
 	},
+/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -82328,12 +82284,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "scA" = (
@@ -87624,7 +87576,6 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "tCL" = (
-/obj/machinery/cryopod,
 /obj/machinery/computer/cryopod{
 	pixel_y = 24
 	},
@@ -88038,7 +87989,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "tHU" = (
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "tHV" = (
 /obj/structure/bookcase,
@@ -90009,6 +89960,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/crate/trashcart,
 /turf/open/floor/iron,
 /area/security/prison)
 "ume" = (
@@ -92099,12 +92051,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "uQY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "uRh" = (
@@ -94406,7 +94353,7 @@
 /area/science/mixing)
 "vAo" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "vAq" = (
 /obj/machinery/door/firedoor,
@@ -95124,9 +95071,6 @@
 "vKU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "vKW" = (
@@ -96120,7 +96064,7 @@
 "wbb" = (
 /obj/structure/table/wood,
 /obj/item/camera,
-/obj/machinery/light,
+/obj/machinery/light/small/directional/south,
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
 	},
@@ -97742,11 +97686,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "wBj" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
+/mob/living/basic/cockroach,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "wBS" = (
 /obj/machinery/light/small/directional/north,
@@ -97778,7 +97719,7 @@
 /area/command/heads_quarters/captain/private)
 "wCM" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/commons/vacant_room/office)
 "wCO" = (
 /obj/structure/closet/secure_closet/atmospherics,
@@ -98641,7 +98582,7 @@
 "wSb" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "wSu" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -98721,11 +98662,11 @@
 /area/space)
 "wTo" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light,
+/obj/machinery/light/small/directional/south,
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = -32
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "wTq" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -99423,9 +99364,6 @@
 "xcV" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "xdx" = (
@@ -99485,12 +99423,10 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "xem" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/cryopod,
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
 "xeo" = (
@@ -101253,7 +101189,7 @@
 /area/hallway/primary/central/aft)
 "xJg" = (
 /obj/structure/chair/office,
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "xJi" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -101489,7 +101425,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/turf/open/floor/carpet/executive,
+/turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "xNn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -136313,14 +136249,14 @@ pog
 mVm
 tRN
 ajV
-opc
-opc
-opc
-opc
-opc
-opc
-opc
-opc
+alf
+alf
+alf
+alf
+alf
+alf
+alf
+alf
 arB
 fMK
 alf
@@ -136577,7 +136513,7 @@ vAo
 gQS
 xJg
 mZH
-opc
+alf
 alg
 iXT
 aug
@@ -136834,7 +136770,7 @@ qNM
 ewj
 tHU
 kfv
-opc
+alf
 arC
 iXT
 iXT
@@ -137089,9 +137025,9 @@ pVq
 qGb
 jmG
 hfp
-tHU
+wBj
 wTo
-opc
+alf
 arC
 mRw
 nIV
@@ -137348,7 +137284,7 @@ xNl
 xNl
 tHU
 mxL
-opc
+alf
 arE
 ozq
 nIV
@@ -137605,7 +137541,7 @@ tHU
 tHU
 xJg
 oeE
-opc
+alf
 arE
 oBU
 nIV
@@ -137858,11 +137794,11 @@ bSS
 kfB
 xcV
 uQY
-hPx
+wkR
 ldY
-hPx
-wBj
-opc
+wkR
+rhZ
+alf
 arC
 mMF
 nIV
@@ -138114,12 +138050,12 @@ tRN
 fgw
 oYK
 vKU
-bgB
 vKU
+hPx
 nrg
 qCl
 oSl
-opc
+alf
 arF
 qoM
 nIV
@@ -138373,10 +138309,10 @@ kfB
 fIF
 oGR
 wSb
-iZD
-wkR
+nrg
+ldY
 rhZ
-opc
+alf
 arC
 nUI
 nIV
@@ -138630,10 +138566,10 @@ kfB
 eLb
 xNl
 ewj
-iZD
+nrg
 wkR
 wbb
-opc
+alf
 arC
 ozq
 nIV
@@ -138890,7 +138826,7 @@ hDb
 mui
 yls
 nkz
-opc
+alf
 arG
 jfU
 alf
@@ -139140,14 +139076,14 @@ abf
 abf
 eWE
 aka
-opc
-opc
-opc
-opc
+alf
+alf
+alf
+alf
 scj
-opc
-opc
-opc
+alf
+alf
+alf
 arC
 xNd
 hOU

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -48540,6 +48540,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"vrg" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/rnd/server/master,
+/turf/open/openspace/icemoon,
+/area/science/server)
 "vrn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -96270,7 +96275,7 @@ box
 boz
 buU
 byf
-jAK
+vrg
 mIT
 jAK
 kLD

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -2948,6 +2948,7 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
+/obj/machinery/cryopod,
 /turf/open/floor/iron,
 /area/security/prison)
 "asy" = (
@@ -15917,6 +15918,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"cvM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/posialert{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/white,
+/area/science/robotics/lab)
 "cvO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18217,6 +18226,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"dBL" = (
+/obj/machinery/cryopod,
+/obj/machinery/computer/cryopod{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "dBO" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -24989,6 +25006,10 @@
 /area/commons/storage/art)
 "hKu" = (
 /obj/machinery/modular_computer/console/preset/civilian,
+/obj/machinery/posialert{
+	pixel_x = 28;
+	pixel_y = 24
+	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "hKw" = (
@@ -34400,10 +34421,12 @@
 /turf/open/floor/carpet,
 /area/service/library)
 "nhU" = (
-/obj/machinery/cryopod,
 /obj/machinery/light/directional/north,
 /obj/machinery/computer/cryopod{
 	pixel_y = 24
+	},
+/obj/machinery/cryopod{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
@@ -36792,7 +36815,7 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "oEP" = (
-/obj/effect/spawner/random/vending/colavend,
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/iron,
 /area/commons/locker)
 "oEU" = (
@@ -43624,7 +43647,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "sBd" = (
-/obj/structure/closet/wardrobe/pjs,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -43632,7 +43654,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover/closet,
+/obj/machinery/vending/dorms,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "sBl" = (
@@ -50024,13 +50046,11 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "whN" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/machinery/light_switch/directional/south,
+/obj/machinery/cryopod,
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
 "whY" = (
@@ -50557,6 +50577,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"wAW" = (
+/obj/machinery/vending/access/command,
+/turf/open/floor/wood,
+/area/command/meeting_room)
 "wBd" = (
 /obj/structure/railing,
 /obj/structure/disposalpipe/segment{
@@ -79752,7 +79776,7 @@ afy
 abz
 aaw
 iQf
-aaw
+dBL
 asw
 acd
 awX
@@ -81097,7 +81121,7 @@ nuf
 kKh
 wBy
 rRa
-xQa
+wAW
 kcR
 cGo
 suY
@@ -98326,7 +98350,7 @@ cHR
 bou
 eqR
 bqd
-aPm
+cvM
 box
 btS
 job

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -49339,6 +49339,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"iSF" = (
+/obj/machinery/rnd/server/master,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/science/server)
 "iSG" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -122990,7 +122994,7 @@ aim
 bkd
 cNa
 gVB
-baJ
+iSF
 bcz
 baJ
 iOj

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -17312,6 +17312,9 @@
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
+/obj/machinery/posialert{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "bhC" = (
@@ -42997,7 +43000,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "fOZ" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -43013,6 +43015,7 @@
 	dir = 4;
 	name = "command camera"
 	},
+/obj/machinery/vending/access/command,
 /turf/open/floor/iron,
 /area/command/bridge)
 "fPq" = (
@@ -57373,6 +57376,11 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
+"mtz" = (
+/obj/structure/cable,
+/obj/machinery/cryopod,
+/turf/open/floor/plating,
+/area/security/prison)
 "mtA" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -61687,6 +61695,10 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/machinery/light_switch/directional/north,
+/obj/machinery/posialert{
+	pixel_x = 28;
+	pixel_y = 24
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "oub" = (
@@ -65645,11 +65657,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/spawner/random/vending/colavend,
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/poster/official/no_erp{
 	pixel_y = -32
 	},
+/obj/machinery/vending/dorms,
 /turf/open/floor/iron/dark,
 /area/commons/locker)
 "qcN" = (
@@ -82292,6 +82304,13 @@
 	dir = 4;
 	network = list("ss13","prison")
 	},
+/obj/machinery/computer/cryopod{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/cryopod{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "xzO" = (
@@ -90138,7 +90157,7 @@ aeu
 aeU
 aeU
 anu
-cTl
+mtz
 qKa
 iig
 qKa

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -34227,6 +34227,10 @@
 	pixel_x = -10;
 	pixel_y = -1
 	},
+/obj/machinery/posialert{
+	pixel_x = 28;
+	pixel_y = 24
+	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "keP" = (
@@ -39686,7 +39690,7 @@
 /area/command/heads_quarters/hos)
 "mds" = (
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/vending/cigarette,
+/obj/machinery/vending/access/command,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "mdB" = (
@@ -40282,6 +40286,11 @@
 "mnI" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
+	},
+/obj/machinery/cryopod,
+/obj/machinery/computer/cryopod{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -42424,15 +42433,11 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "mZe" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/clothing/under/misc/assistantformal,
 /obj/structure/sign/map/right{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
 	icon_state = "map-right-MS";
 	pixel_y = 32
 	},
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -42443,6 +42448,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/iron/dark,
 /area/commons/locker)
 "mZh" = (
@@ -51881,6 +51887,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/office)
+"qub" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/mecha_part_fabricator{
+	dir = 4
+	},
+/obj/machinery/posialert{
+	pixel_x = -32
+	},
+/turf/open/floor/iron,
+/area/science/robotics/lab)
 "quc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
@@ -69853,6 +69872,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
+"wMc" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "wMh" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 8;
@@ -73380,7 +73408,6 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/landmark/start/blueshield,
 /turf/open/floor/carpet/executive,
 /area/command/heads_quarters/captain/private)
 "xWz" = (
@@ -97255,7 +97282,7 @@ lmr
 uzt
 lmr
 jNH
-nPZ
+wMc
 aio
 aol
 anb
@@ -102476,7 +102503,7 @@ cCq
 xwa
 dRv
 aAR
-dRv
+qub
 pWJ
 mLr
 nGN

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -49238,6 +49238,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/surgery)
+"prA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/machinery/rnd/server/master,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "prB" = (
 /obj/item/paper_bin{
 	pixel_x = -2;
@@ -109404,7 +109409,7 @@ dwL
 dwL
 dwL
 dwL
-pCk
+prA
 ped
 tag
 rzZ

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -17399,7 +17399,7 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "bmz" = (
-/obj/item/kirbyplants/random,
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/iron/dark,
 /area/commons/fitness)
 "bmA" = (
@@ -28666,7 +28666,9 @@
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bXX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/plasma_output,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/plasma_output{
+	dir = 8
+	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bXZ" = (
@@ -28948,7 +28950,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bYT" = (
-/obj/machinery/computer/atmos_control/tank/plasma_tank,
+/obj/machinery/computer/atmos_control/tank/plasma_tank{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -29135,7 +29139,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bZL" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/plasma_input,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/plasma_input{
+	dir = 8
+	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bZM" = (

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -21867,16 +21867,11 @@
 /area/science/server)
 "bzx" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/machinery/airalarm/directional/north,
-/obj/structure/table,
 /obj/machinery/button/door/directional/east{
 	id = "serverroomrd"
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer/on,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bzA" = (
@@ -22131,6 +22126,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bAB" = (
@@ -22142,17 +22138,22 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bAC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bAD" = (
 /obj/structure/chair/office/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bAF" = (
@@ -39092,6 +39093,9 @@
 /turf/open/floor/wood,
 /area/security/prison)
 "fHZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	name = "Server Vent"
+	},
 /turf/open/floor/iron/dark/telecomms,
 /area/science/server)
 "fJv" = (
@@ -40821,6 +40825,7 @@
 /area/science/storage)
 "htg" = (
 /obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/plating/catwalk_floor{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -43099,10 +43104,10 @@
 /turf/open/floor/iron/smooth_large,
 /area/service/hydroponics)
 "jAK" = (
-/obj/machinery/rnd/server,
 /obj/effect/turf_decal/siding/purple{
 	dir = 6
 	},
+/obj/machinery/rnd/server/master,
 /turf/open/floor/iron/dark/telecomms,
 /area/science/server)
 "jBL" = (
@@ -49004,6 +49009,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/cafeteria,
 /area/maintenance/port/aft)
+"oYm" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/science/server)
 "oYv" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -50228,6 +50237,11 @@
 	dir = 8;
 	name = "science camera";
 	network = list("ss13","rd")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 1;
+	external_pressure_bound = 120;
+	name = "server vent"
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/science/server)
@@ -102936,7 +102950,7 @@ bsS
 box
 bWr
 aRU
-byf
+oYm
 bzx
 bAC
 bBW

--- a/_maps/map_files/WaterKiloStation/WaterKiloStation.dmm
+++ b/_maps/map_files/WaterKiloStation/WaterKiloStation.dmm
@@ -53059,12 +53059,12 @@
 	pixel_y = -25
 	},
 /obj/machinery/door/window{
+	atom_integrity = 300;
 	base_state = "rightsecure";
 	dir = 4;
 	icon_state = "rightsecure";
 	layer = 4.1;
 	name = "Secondary AI Core Access";
-	atom_integrity = 300;
 	pixel_x = 4;
 	req_access_txt = "16"
 	},
@@ -61914,11 +61914,11 @@
 	pixel_y = 28
 	},
 /obj/machinery/door/window{
+	atom_integrity = 300;
 	base_state = "leftsecure";
 	dir = 8;
 	icon_state = "leftsecure";
 	name = "Primary AI Core Access";
-	atom_integrity = 300;
 	req_access_txt = "16"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -65984,12 +65984,12 @@
 	pixel_y = -25
 	},
 /obj/machinery/door/window{
+	atom_integrity = 300;
 	base_state = "leftsecure";
 	dir = 8;
 	icon_state = "leftsecure";
 	layer = 4.1;
 	name = "Tertiary AI Core Access";
-	atom_integrity = 300;
 	pixel_x = -3;
 	req_access_txt = "16"
 	},
@@ -71884,6 +71884,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"nbp" = (
+/obj/machinery/rnd/server/master,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/science/server)
 "nbv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
@@ -74048,11 +74052,11 @@
 /area/command/heads_quarters/hop)
 "ojx" = (
 /obj/machinery/door/window{
+	atom_integrity = 300;
 	base_state = "rightsecure";
 	dir = 4;
 	icon_state = "rightsecure";
 	name = "Primary AI Core Access";
-	atom_integrity = 300;
 	req_access_txt = "16"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -132056,7 +132060,7 @@ awK
 bkd
 cNa
 aZF
-baJ
+nbp
 bcz
 baJ
 iOj

--- a/_maps/map_files/WaterKiloStation/WaterKiloStation.dmm
+++ b/_maps/map_files/WaterKiloStation/WaterKiloStation.dmm
@@ -21512,6 +21512,10 @@
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
+/obj/machinery/posialert{
+	pixel_x = 28;
+	pixel_y = 24
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "aZE" = (
@@ -25926,6 +25930,9 @@
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
+/obj/machinery/posialert{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "bhC" = (
@@ -64971,7 +64978,6 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "jDJ" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -64990,6 +64996,7 @@
 	dir = 4;
 	name = "command camera"
 	},
+/obj/machinery/vending/access/command,
 /turf/open/floor/iron,
 /area/command/bridge)
 "jDT" = (
@@ -79136,6 +79143,11 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
 /area/engineering/gravity_generator)
+"qTC" = (
+/obj/structure/cable,
+/obj/machinery/cryopod,
+/turf/open/floor/plating,
+/area/security/prison)
 "qUJ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -91532,6 +91544,13 @@
 	dir = 4;
 	network = list("ss13","prison")
 	},
+/obj/machinery/computer/cryopod{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/cryopod{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "xAk" = (
@@ -99204,7 +99223,7 @@ aeu
 cry
 cry
 anu
-cTl
+qTC
 cuQ
 cQs
 vKK

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -643,6 +643,14 @@
 	},
 /turf/open/floor/plating/grass/planet,
 /area/centcom/holding/cafepark)
+"ajQ" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/plating/grass/planet,
+/area/centcom/interlink)
 "ajR" = (
 /obj/structure/chair/sofa{
 	dir = 8
@@ -880,6 +888,13 @@
 "alp" = (
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
+"alt" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "alu" = (
 /obj/structure/artilleryplaceholder/decorative{
 	icon_state = "33"
@@ -1748,13 +1763,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
-"arH" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Administrative Office";
-	req_access_txt = "101"
-	},
-/turf/open/floor/iron,
-/area/centcom/interlink)
 "arP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1882,6 +1890,10 @@
 	name = "Arrivals"
 	},
 /turf/open/floor/mineral/titanium/blue,
+/area/centcom/interlink)
+"atj" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plating/asteroid,
 /area/centcom/interlink)
 "atk" = (
 /obj/structure/sign/directions/evac{
@@ -4722,6 +4734,11 @@
 "aQY" = (
 /turf/open/floor/wood,
 /area/centcom/interlink)
+"aRa" = (
+/obj/structure/flora/ausbushes/leafybush,
+/obj/machinery/light,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "aRc" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
@@ -5916,6 +5933,13 @@
 /obj/item/pen/blue,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafepark)
+"aZJ" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "aZK" = (
 /obj/machinery/food_cart,
 /turf/open/indestructible/hoteltile{
@@ -5988,6 +6012,12 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
+"beH" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "bfK" = (
 /obj/machinery/button/door{
 	id = "dorm28";
@@ -6107,6 +6137,14 @@
 	},
 /turf/open/floor/plating/grass/planet,
 /area/centcom/holding/cafepark)
+"bBd" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "bDi" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 9
@@ -6204,6 +6242,13 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/carpet/green,
 /area/centcom/ncvtitan)
+"cdQ" = (
+/obj/structure/transit_tube/crossing{
+	dir = 4
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "chn" = (
 /turf/open/floor/iron/dark/red,
 /area/centcom/ncvtitan)
@@ -6215,6 +6260,10 @@
 	dir = 8
 	},
 /turf/open/floor/iron/brown/side,
+/area/centcom/interlink)
+"ciW" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/plating/asteroid,
 /area/centcom/interlink)
 "cjl" = (
 /obj/machinery/door/airlock{
@@ -6278,6 +6327,17 @@
 "cvG" = (
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron,
+/area/centcom/interlink)
+"cvK" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/grass/planet,
+/area/centcom/interlink)
+"cxz" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plating/asteroid,
 /area/centcom/interlink)
 "cxY" = (
 /obj/effect/turf_decal/siding/wood{
@@ -6415,6 +6475,14 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"cVP" = (
+/obj/structure/transit_tube/curved/flipped{
+	dir = 4
+	},
+/obj/structure/spacevine,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "cWI" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 8
@@ -6442,6 +6510,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
+/area/centcom/interlink)
+"dji" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/plating/asteroid,
 /area/centcom/interlink)
 "dkA" = (
 /obj/structure/chair/sofa/corp/corner{
@@ -6495,6 +6570,13 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/purple,
 /area/centcom/ncvtitan)
+"dBx" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "dCg" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/poster/official/anniversary_vintage_reprint{
@@ -6502,6 +6584,10 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
+"dCi" = (
+/obj/item/banner,
+/turf/open/floor/carpet/executive,
+/area/centcom/interlink)
 "dCQ" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 4
@@ -6514,6 +6600,15 @@
 	},
 /turf/open/floor/glass,
 /area/centcom/ncvtitan)
+"dED" = (
+/obj/structure/flora/ausbushes/leafybush,
+/obj/machinery/light,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
+"dFn" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "dFE" = (
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/smooth_large,
@@ -6524,6 +6619,20 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"dGn" = (
+/obj/structure/transit_tube/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
+"dIO" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "dKt" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/seclite,
@@ -6597,6 +6706,13 @@
 "dPq" = (
 /turf/open/floor/iron/smooth,
 /area/centcom/ncvtitan)
+"dPv" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "dRf" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -6617,6 +6733,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
+"dXR" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "dXZ" = (
 /obj/machinery/button/door{
 	id = "dorm27";
@@ -6759,6 +6879,12 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/indestructible/titanium/nodiagonal,
 /area/centcom/ncvtitan)
+"eoV" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid,
+/area/space)
 "epR" = (
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
@@ -6782,6 +6908,13 @@
 /obj/structure/awaymissions/wildwest/masterclock,
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
+"exH" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "eEE" = (
 /obj/effect/turf_decal/trimline/green/end,
 /turf/open/floor/iron/dark,
@@ -6858,6 +6991,13 @@
 	},
 /turf/open/floor/carpet/executive,
 /area/centcom/ncvtitan)
+"eXz" = (
+/obj/structure/transit_tube/curved/flipped{
+	dir = 8
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "eYZ" = (
 /obj/structure/table/wood,
 /obj/item/coin/antagtoken,
@@ -6902,6 +7042,13 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/centcom/interlink)
+"feY" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "fft" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -6961,6 +7108,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"fud" = (
+/obj/structure/transit_tube/curved{
+	dir = 1
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/space)
 "fuD" = (
 /turf/open/floor/carpet/neon/simple/cyan,
 /area/centcom/ncvtitan)
@@ -6987,6 +7141,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
+"fGe" = (
+/obj/structure/transit_tube/curved{
+	dir = 1
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "fGr" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -7048,6 +7209,13 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
+"fRH" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "fUk" = (
 /obj/machinery/button/door{
 	id = "dorm23";
@@ -7160,6 +7328,14 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/centcom/ncvtitan)
+"goA" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "gpK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -7199,11 +7375,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
-"gzZ" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/plating/grass/planet,
-/area/centcom/interlink)
 "gAW" = (
 /obj/structure/toilet{
 	dir = 4
@@ -7259,6 +7430,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/nanotrasen_representative/station,
+/obj/item/clothing/under/rank/centcom/intern,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "gLI" = (
@@ -7308,6 +7481,14 @@
 	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/interlink)
+"gYg" = (
+/obj/structure/transit_tube/curved{
+	dir = 8
+	},
+/obj/structure/spacevine,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "haG" = (
 /turf/open/floor/iron/dark/green/corner{
 	dir = 1
@@ -7339,6 +7520,13 @@
 	},
 /turf/closed/indestructible/riveted,
 /area/centcom/interlink)
+"hdy" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "hdQ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -7350,6 +7538,11 @@
 	},
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
+"hfg" = (
+/obj/structure/transit_tube/station,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/space)
 "hfm" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 4
@@ -7436,10 +7629,18 @@
 	},
 /turf/open/floor/plating/airless,
 /area/centcom/ncvtitan)
+"hBv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "hCU" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
+"hDl" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "hES" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -7534,6 +7735,11 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet/executive,
 /area/centcom/interlink)
+"hXZ" = (
+/obj/structure/transit_tube/crossing,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "iao" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -7544,6 +7750,13 @@
 	},
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
+"idh" = (
+/obj/structure/flora/ausbushes/pointybush,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid,
+/area/space)
 "idT" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 10
@@ -7644,6 +7857,27 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/centcom/ncvtitan)
+"itP" = (
+/obj/structure/transit_tube/station/reverse{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
+"iup" = (
+/obj/structure/flora/ausbushes/pointybush,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid,
+/area/space)
+"iuq" = (
+/obj/structure/spacevine{
+	name = "thick vines";
+	opacity = 1
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "ivg" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -7699,6 +7933,13 @@
 /area/centcom/ncvtitan)
 "iTZ" = (
 /turf/open/indestructible/hoteltile,
+/area/centcom/interlink)
+"iVF" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Administrative Office";
+	req_access_txt = "101"
+	},
+/turf/open/floor/plating,
 /area/centcom/interlink)
 "iVW" = (
 /obj/effect/turf_decal/siding/wood{
@@ -8027,10 +8268,15 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
+"kgn" = (
+/obj/structure/transit_tube/curved/flipped{
+	dir = 8
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/space)
 "khB" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/grass/planet,
 /area/centcom/interlink)
 "khG" = (
@@ -8106,6 +8352,18 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/ncvtitan)
+"kmP" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/plating/grass/planet,
+/area/centcom/interlink)
+"kny" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "knH" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
@@ -8194,6 +8452,11 @@
 	dir = 4
 	},
 /area/centcom/interlink)
+"kBB" = (
+/obj/structure/transit_tube/curved,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "kGR" = (
 /obj/structure/dresser,
 /obj/structure/plaque/static_plaque/golden/captain{
@@ -8223,6 +8486,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
+"kLo" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "kLP" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light{
@@ -8371,6 +8640,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
+"lhP" = (
+/obj/structure/flora/grass/jungle,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "lin" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -8506,9 +8782,11 @@
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
 "lLq" = (
-/obj/item/toy/plush/borbplushie,
-/turf/open/space/basic,
-/area/space)
+/obj/structure/transit_tube/station/reverse/flipped{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "lMu" = (
 /obj/machinery/light{
 	dir = 4
@@ -8577,6 +8855,10 @@
 /obj/machinery/vending/games,
 /turf/open/floor/carpet/neon/simple/cyan/nodots,
 /area/centcom/ncvtitan)
+"mfL" = (
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "mih" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron,
@@ -8662,6 +8944,10 @@
 "mtW" = (
 /obj/machinery/vending/games,
 /turf/open/floor/carpet/green,
+/area/centcom/interlink)
+"muq" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid,
 /area/centcom/interlink)
 "muS" = (
 /obj/structure/artilleryplaceholder/decorative{
@@ -8758,6 +9044,13 @@
 /obj/machinery/vending/access/command,
 /turf/open/floor/carpet/neon/simple/cyan/nodots,
 /area/centcom/ncvtitan)
+"mRP" = (
+/obj/structure/transit_tube/station{
+	dir = 8
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "mRW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -8812,6 +9105,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
+"mZc" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "mZd" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorm27";
@@ -8832,24 +9129,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
 "ncg" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Administrative Office";
-	req_access_txt = "101"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/transit_tube/station,
+/turf/open/floor/plating/asteroid,
 /area/centcom/interlink)
 "nci" = (
 /obj/machinery/shower{
@@ -8922,6 +9203,13 @@
 	dir = 8
 	},
 /area/centcom/ncvtitan)
+"nmp" = (
+/obj/effect/turf_decal/stripes/asteroid/corner{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "npu" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 8
@@ -8940,6 +9228,10 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/carpet/royalblue,
 /area/centcom/ncvtitan)
+"ntq" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "nuy" = (
 /obj/structure/artilleryplaceholder/decorative{
 	icon_state = "34"
@@ -8994,6 +9286,13 @@
 	name = "Arrivals Hallway"
 	},
 /area/centcom/interlink)
+"nFN" = (
+/obj/structure/transit_tube/station{
+	dir = 8
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/space)
 "nGK" = (
 /obj/machinery/button/door{
 	id = "dorm25";
@@ -9077,6 +9376,9 @@
 /obj/item/gun/energy/ionrifle,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/ncvtitan)
+"nTZ" = (
+/turf/open/floor/plating/asteroid,
+/area/space)
 "nVo" = (
 /obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/iron/textured,
@@ -9102,6 +9404,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
+"oaj" = (
+/obj/structure/transit_tube/station,
+/obj/structure/spacevine{
+	name = "thick vines";
+	opacity = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "odB" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -9128,9 +9439,24 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
+"ofZ" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "okl" = (
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
+"olY" = (
+/obj/item/toy/plush/borbplushie,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
+"onZ" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "ooG" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -9172,6 +9498,13 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/ncvtitan)
+"orS" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "osu" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/siding/blue{
@@ -9207,6 +9540,10 @@
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet,
 /area/centcom/interlink)
+"ozz" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "oAL" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/supply{
@@ -9214,6 +9551,13 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
+"oBy" = (
+/obj/structure/spacevine{
+	name = "thick vines";
+	opacity = 1
+	},
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "oEK" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 8
@@ -9275,6 +9619,19 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
+"oNb" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/asteroid,
+/area/space)
+"oNi" = (
+/obj/structure/transit_tube/crossing{
+	dir = 4
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/space)
 "oQj" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -9297,8 +9654,10 @@
 /turf/open/floor/carpet,
 /area/centcom/interlink)
 "oSf" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/plating/cobblestone,
+/obj/structure/transit_tube/curved{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid,
 /area/centcom/interlink)
 "oVj" = (
 /turf/open/floor/carpet/green,
@@ -9352,6 +9711,10 @@
 	},
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
+"plm" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "pmJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -9386,6 +9749,13 @@
 	dir = 8
 	},
 /area/centcom/interlink)
+"pyX" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "pAC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -9465,6 +9835,14 @@
 	},
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
+"pOe" = (
+/obj/structure/transit_tube/curved{
+	dir = 4
+	},
+/obj/structure/spacevine,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "pOo" = (
 /obj/item/storage/box/donkpockets/donkpocketgondola,
 /turf/open/floor/iron/dark,
@@ -9485,9 +9863,9 @@
 "pPo" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
-	req_access_txt = "101"
+	req_one_access_txt = "20;101"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "pRy" = (
 /obj/effect/turf_decal/arrows/white{
@@ -9516,6 +9894,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
+"pTB" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/plating/grass/planet,
+/area/centcom/interlink)
+"pTK" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/grass/planet,
+/area/centcom/interlink)
 "pUb" = (
 /obj/item/pen,
 /obj/structure/table/glass,
@@ -9529,7 +9915,6 @@
 /area/centcom/ncvtitan)
 "pUG" = (
 /obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/plating/grass/planet,
 /area/centcom/interlink)
 "pUV" = (
@@ -9559,6 +9944,13 @@
 "pYQ" = (
 /obj/structure/closet/wardrobe,
 /turf/open/floor/iron/white,
+/area/centcom/interlink)
+"qbZ" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/plating/asteroid,
 /area/centcom/interlink)
 "qcv" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -9597,6 +9989,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/indestructible/hotelwood,
 /area/centcom/interlink)
+"qky" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "qkX" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -9718,6 +10117,10 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/carpet/neon/simple/cyan,
 /area/centcom/ncvtitan)
+"qwZ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "qxa" = (
 /obj/structure/closet/crate/bin{
 	pixel_x = -6;
@@ -9769,8 +10172,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
 "qLJ" = (
-/obj/item/banner,
-/turf/open/floor/carpet/executive,
+/turf/open/floor/plating/asteroid,
 /area/centcom/interlink)
 "qLM" = (
 /obj/structure/mirror{
@@ -9836,6 +10238,11 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
+"qXQ" = (
+/obj/structure/transit_tube/crossing,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/space)
 "qYJ" = (
 /obj/machinery/light/directional/east,
 /obj/structure/table,
@@ -9849,6 +10256,18 @@
 "qZp" = (
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
+"rbt" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid,
+/area/space)
+"rek" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/spacevine,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "rie" = (
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 8
@@ -9863,7 +10282,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
 "rjx" = (
-/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/grass/planet,
 /area/centcom/interlink)
 "rkj" = (
@@ -9920,6 +10339,13 @@
 /obj/structure/cable,
 /turf/open/floor/glass,
 /area/centcom/ncvtitan)
+"rqO" = (
+/obj/structure/flora/ausbushes/pointybush,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "rtY" = (
 /obj/structure/flora/ausbushes/brflowers{
 	pixel_x = -3;
@@ -10012,12 +10438,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
+"rAc" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "rBb" = (
 /obj/structure/artilleryplaceholder{
 	icon_state = "20"
 	},
 /turf/open/floor/plating/airless,
 /area/centcom/ncvtitan)
+"rEa" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "rFH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -10038,6 +10472,13 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/ncvtitan)
+"rGP" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "rHx" = (
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
@@ -10096,6 +10537,15 @@
 /obj/structure/sign/poster/official/walk,
 /turf/closed/indestructible/riveted,
 /area/centcom/interlink)
+"rPv" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
+"rPF" = (
+/obj/structure/transit_tube/station,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "rPN" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -10122,6 +10572,10 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/glass,
 /area/centcom/ncvtitan)
+"rTR" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "rUK" = (
 /obj/structure/table/wood,
 /obj/item/stamp{
@@ -10208,6 +10662,10 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/eighties,
 /area/centcom/interlink)
+"smU" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/floor/plating/grass/planet,
+/area/centcom/interlink)
 "snU" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -10282,6 +10740,10 @@
 /obj/item/medicell/toxin3,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
+"svy" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "syJ" = (
 /obj/machinery/telecomms/relay/preset/auto,
 /turf/open/floor/plating,
@@ -10290,6 +10752,10 @@
 /obj/machinery/light,
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
+"sBY" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/space)
 "sFG" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/smooth,
@@ -10322,6 +10788,13 @@
 	dir = 4
 	},
 /area/centcom/interlink)
+"sNj" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid,
+/area/space)
 "sQb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -10429,6 +10902,11 @@
 /obj/structure/sign/warning/explosives,
 /turf/closed/indestructible/titanium/nodiagonal,
 /area/centcom/ncvtitan)
+"tkR" = (
+/obj/structure/transit_tube/curved/flipped,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "tkY" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -10568,6 +11046,11 @@
 /obj/machinery/door/airlock/multi_tile/glass,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"tDD" = (
+/obj/structure/spacevine,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "tGb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -10648,6 +11131,10 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
+/area/centcom/interlink)
+"tZK" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plating/grass/planet,
 /area/centcom/interlink)
 "uaS" = (
 /obj/machinery/light/directional/south,
@@ -10732,6 +11219,13 @@
 	},
 /turf/open/floor/carpet/neon/simple/cyan,
 /area/centcom/ncvtitan)
+"uoo" = (
+/obj/effect/turf_decal/stripes/asteroid/corner{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "upc" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet,
@@ -10815,12 +11309,24 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"uGS" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "uKz" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
+"uLP" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "uMK" = (
 /obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/iron/cafeteria,
@@ -10831,6 +11337,11 @@
 	},
 /turf/open/floor/carpet/neon/simple/cyan,
 /area/centcom/ncvtitan)
+"uQm" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "uQr" = (
 /turf/open/floor/plating,
 /area/centcom/ncvtitan)
@@ -10865,6 +11376,9 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
+"var" = (
+/turf/closed/indestructible/rock,
+/area/space)
 "vaC" = (
 /obj/structure/chair/sofa,
 /turf/open/floor/carpet/green,
@@ -10931,6 +11445,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
+"vug" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/asteroid,
+/area/space)
+"vvH" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "vxA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -11029,6 +11554,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"vLH" = (
+/obj/structure/flora/grass/jungle,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid,
+/area/space)
 "vRI" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -11138,9 +11670,10 @@
 	},
 /area/centcom/ncvtitan)
 "wbR" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/plating/grass/planet,
+/obj/structure/transit_tube/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid,
 /area/centcom/interlink)
 "wbU" = (
 /obj/machinery/door/poddoor/ert,
@@ -11262,8 +11795,21 @@
 /turf/open/floor/plating/airless,
 /area/centcom/ncvtitan)
 "wsk" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/plating/cobblestone,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/spacevine{
+	name = "thick vines";
+	opacity = 1
+	},
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
+"wtn" = (
+/obj/structure/spacevine,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid,
 /area/centcom/interlink)
 "wtv" = (
 /obj/structure/chair/comfy/shuttle{
@@ -11274,6 +11820,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
+"wwg" = (
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "wxw" = (
 /obj/machinery/light{
 	dir = 1
@@ -11295,6 +11845,13 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/centcom/interlink)
+"wzA" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "wzO" = (
 /obj/machinery/light{
 	dir = 1
@@ -11564,6 +12121,11 @@
 	},
 /turf/open/floor/plating/airless,
 /area/centcom/ncvtitan)
+"xMi" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/asteroid,
+/area/space)
 "xMG" = (
 /obj/machinery/light{
 	dir = 1
@@ -11588,6 +12150,13 @@
 "xPn" = (
 /turf/open/floor/iron/dark/textured_edge,
 /area/centcom/ncvtitan)
+"xQc" = (
+/obj/structure/flora/ausbushes/pointybush,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid,
+/area/centcom/interlink)
 "xQF" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/smooth_large,
@@ -11600,8 +12169,12 @@
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
 "xQQ" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/plating/grass/planet,
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/spacevine{
+	name = "thick vines";
+	opacity = 1
+	},
+/turf/open/floor/plating,
 /area/centcom/interlink)
 "xRa" = (
 /obj/structure/table/reinforced,
@@ -14661,23 +15234,23 @@ aaa
 aaa
 aaa
 aaa
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
-aHC
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
 aaa
 aaa
 aaa
@@ -14918,23 +15491,23 @@ aaa
 aaa
 aaa
 aaa
-aHC
-mmy
-mmy
-mmy
-mmy
-mmy
-mmy
-mmy
-mmy
-mmy
-mmy
-mmy
-mmy
+vLx
+vLx
+vLx
+vLx
+rjx
+vTA
+kmP
+rjx
+vLx
+vLx
+vLx
+khB
+vTA
 xuG
-mmy
-mmy
-aHC
+smU
+vLx
+vLx
 aaa
 aaa
 aaa
@@ -15175,23 +15748,23 @@ aaa
 aaa
 aaa
 aaa
-aHC
-mmy
-mmy
+vLx
+vLx
+pUG
 xuG
-mmy
-mmy
-mmy
+pTB
+tZK
+rjx
 xuG
+rjx
+tZK
+vTA
 mmy
+rjx
 mmy
-mmy
-mmy
-mmy
-mmy
-mmy
-mmy
-aHC
+khB
+pUG
+vLx
 aaa
 aaa
 aaa
@@ -15423,32 +15996,32 @@ aaa
 aaa
 aaa
 aaa
+var
+var
+var
+xMi
+oNi
+feY
+oNb
+var
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aHC
-mmy
-mmy
+vLx
+tZK
+rjx
 chp
 chp
 chp
-mmy
-mmy
-mmy
-mmy
-mmy
+khB
+pUG
+ajQ
+rjx
+khB
 chp
 chp
 chp
 chp
-mmy
-aHC
+khB
+vLx
 aaa
 aaa
 aaa
@@ -15680,32 +16253,32 @@ aaa
 aaa
 aaa
 aaa
+var
+bBd
+vLH
+uLP
+hfg
+sNj
+ozz
+hDl
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aHC
-mmy
+vLx
+rjx
 chp
 chp
-mmy
+vTA
 chp
 chp
-mmy
-mmy
-mmy
+rjx
+khB
+rjx
 chp
 chp
 chp
-mmy
+tZK
 chp
 chp
-aHC
+vLx
 aaa
 aaa
 aaa
@@ -15937,32 +16510,32 @@ aaa
 aaa
 aaa
 aaa
+wzA
+pyX
+dPv
+idh
+kgn
+eoV
+wwg
+ozz
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aHC
+vLx
 mmy
 chp
+vTA
+nvx
+smU
+chp
+chp
+chp
+chp
+chp
+mmy
 mmy
 nvx
-mmy
+smU
 chp
-chp
-chp
-chp
-chp
-mmy
-mmy
-nvx
-mmy
-chp
-aHC
+vLx
 aaa
 aaa
 aaa
@@ -16194,32 +16767,32 @@ aaa
 aaa
 aaa
 aaa
+nFN
+nFN
+qXQ
+fud
+sBY
+qky
+dFn
+aRa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aHC
-mmy
+vLx
+pUG
 chp
-mmy
-mmy
-chp
-chp
-chp
-mmy
+rjx
 mmy
 chp
 chp
 chp
-mmy
+khB
+pUG
 chp
 chp
-aHC
+chp
+rjx
+chp
+chp
+vLx
 aaa
 aaa
 aaa
@@ -16451,32 +17024,32 @@ aaa
 aaa
 aaa
 aaa
+vug
+iup
+kny
+rbt
+exH
+nmp
+dIO
+rTR
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aHC
+vLx
 mmy
 chp
 chp
 chp
 chp
 chp
+tZK
 mmy
-mmy
-mmy
-mmy
+cvK
+rjx
 chp
 chp
 chp
 chp
-mmy
-aHC
+khB
+vLx
 aaa
 aaa
 aaa
@@ -16708,32 +17281,32 @@ aaa
 aaa
 aaa
 aaa
+mZc
+qwZ
+dFn
+nTZ
+plm
+qwZ
+vvH
+nTZ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aHC
+vLx
+rjx
 mmy
-mmy
-mmy
-mmy
+khB
+rjx
 chp
 chp
 mmy
+vTA
+pTK
 mmy
 mmy
+tZK
 mmy
 mmy
-mmy
-mmy
-mmy
-mmy
-aHC
+rjx
+vLx
 aaa
 aaa
 aaa
@@ -16974,23 +17547,23 @@ aaa
 aaa
 aaa
 aaa
-aHC
+vLx
+vLx
 xuG
-mmy
-mmy
+pUG
 mmy
 chp
 chp
+rjx
 mmy
 mmy
-mmy
-mmy
+rjx
 xuG
-mmy
-mmy
-mmy
-mmy
-aHC
+rjx
+khB
+pUG
+khB
+vLx
 aaa
 aaa
 aaa
@@ -17232,22 +17805,22 @@ aHC
 aHC
 aHC
 aHC
-wbR
-vTA
-pUG
+vLx
+rjx
+mmy
 khB
-wsk
-oSf
+chp
+chp
 pUG
-xQQ
-khB
-wbR
+mmy
+smU
+mmy
 rjx
 vTA
-khB
-gzZ
-pUG
-aHC
+mmy
+rjx
+vLx
+vLx
 aaa
 aaa
 aaa
@@ -22323,20 +22896,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
 aHC
 aHC
 aHC
@@ -22580,20 +23153,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
 aHC
 akv
 mHF
@@ -22837,20 +23410,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
 aHC
 akA
 kVK
@@ -23094,20 +23667,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+olY
+vLx
+vLx
 aHC
 aBO
 hvQ
@@ -23351,20 +23924,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+atj
+kBB
+itP
+vLx
+vLx
 aHC
 aNb
 aCr
@@ -23608,20 +24181,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+cVP
+iuq
+vLx
+vLx
+vLx
 aHC
 aIQ
 aqp
@@ -23865,20 +24438,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+oaj
+ntq
+vLx
+vLx
+vLx
 aHC
 aJY
 kRW
@@ -24122,20 +24695,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+gYg
+tDD
+vLx
+vLx
+vLx
 aHC
 aPb
 qxS
@@ -24379,20 +24952,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vLx
+lLq
+qLJ
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+uQm
+pOe
+vLx
+vLx
+vLx
 aHC
 aTn
 sqx
@@ -24636,11 +25209,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vLx
+ncg
 vLx
 vLx
 vLx
@@ -24648,6 +25218,9 @@ vLx
 vLx
 vLx
 vLx
+vLx
+rPF
+wtn
 vLx
 vLx
 aHC
@@ -24893,20 +25466,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 vLx
-aVM
-aSz
-aVM
-aVM
-aVM
-aVM
-aVM
-aVM
+oSf
+qLJ
+vLx
+vLx
+vLx
+vLx
+vLx
+vLx
+uQm
+cdQ
+rGP
+kLo
+vLx
 aHC
 trp
 gFu
@@ -25150,20 +25723,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 vLx
-aVM
-aVM
-aVM
-aVM
-aVM
-aCy
-aVM
-aVM
+qLJ
+wbR
+oBy
+vLx
+vLx
+vLx
+goA
+lhP
+cxz
+rPF
+alt
+rPv
+muq
 aHC
 ieL
 aQY
@@ -25407,20 +25980,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 vLx
-aVM
-aVM
-aVM
-aSz
-aVM
-aVM
-aSz
-aVM
+vLx
+wsk
+dGn
+orS
+vLx
+fRH
+qbZ
+dji
+rqO
+eXz
+beH
+mfL
+rPv
 aHC
 qkX
 tiZ
@@ -25664,20 +26237,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 vLx
-aVM
-aSz
-aVM
-aVM
-aVM
-aVM
-aVM
-aVM
+vLx
+xQQ
+rek
+tkR
+mRP
+mRP
+mRP
+hXZ
+fGe
+ntq
+dBx
+rEa
+dED
 aHC
 mOa
 oQj
@@ -25921,20 +26494,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 vLx
-aVM
-aVM
-aVM
-aCy
-aVM
-aVM
-aSz
-aVM
+vLx
+vLx
+vLx
+vLx
+vLx
+uGS
+xQc
+onZ
+aZJ
+hdy
+uoo
+ciW
+dXR
 aHC
 mRZ
 nwM
@@ -26178,20 +26751,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 vLx
-aCy
-aVM
-aVM
-aVM
-aVM
-aVM
-aVM
-aVM
+vLx
+vLx
+vLx
+vLx
+vLx
+rAc
+hBv
+rEa
+qLJ
+svy
+hBv
+ofZ
+qLJ
 aHC
 qSf
 aQY
@@ -26707,7 +27280,7 @@ aiL
 aiL
 aiL
 aiL
-aRZ
+aiL
 uCW
 aiL
 aiL
@@ -26969,7 +27542,7 @@ aiL
 aiL
 aiL
 aiL
-arH
+pPo
 hvQ
 hvQ
 hvQ
@@ -27214,18 +27787,18 @@ aqG
 aHC
 aRZ
 aiL
+aiL
+aiL
+aiL
+aiL
+aiL
+aiL
+aiL
+aiL
+dCi
+aiL
+dCi
 aRZ
-aiL
-aiL
-aRZ
-aiL
-aRZ
-aiL
-qLJ
-aiL
-qLJ
-aiL
-aiL
 aDg
 aIK
 hvQ
@@ -27479,8 +28052,8 @@ pPo
 aDg
 aHC
 jgq
-ncg
 jgq
+iVF
 jgq
 jgq
 aHC
@@ -34537,7 +35110,7 @@ aaa
 aaa
 aaa
 aaa
-lLq
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -27752,6 +27752,10 @@
 /obj/item/storage/bag/ore,
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
+"hDq" = (
+/obj/machinery/rnd/server/master,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "hEv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -179811,7 +179815,7 @@ wsJ
 qSg
 aNN
 xjn
-vnK
+hDq
 gDX
 vnK
 xjn

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -27903,6 +27903,9 @@
 	pixel_x = 6;
 	pixel_y = 13
 	},
+/obj/machinery/posialert{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "hHe" = (
@@ -31012,6 +31015,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/bluespace_vendor/north,
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "iSL" = (
@@ -41556,6 +41560,7 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
+/obj/machinery/vending/access/command,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "nnP" = (
@@ -58594,6 +58599,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
+/obj/machinery/posialert{
+	pixel_x = 28;
+	pixel_y = 24
+	},
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "ukM" = (
@@ -60195,6 +60204,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/vending/dorms,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "uYj" = (


### PR DESCRIPTION
## About The Pull Request
• Adds autodrobes to dorms in all maps.
• Fixes Journey atmos plasma tank.
• Adds Lustwish to all maps.
• Adds posibrain alert consoles all over.
• Fixes access on CC2 for Blueshield.
• Beautifies some ugly parts of CC2.
• Removes NT rep office on Delta.
• Removes Blueshield spawn from Meta.
• Adds cryo to Icebox prison.
• Adds cryo to Kilo prison.
• Adds cryo to Waterkilo prison.
• Adds cryo to Meta prison.
• Adds cryo to Delta prison.
• Command vendors on all maps

## Changelog
:cl:
fix: Cryo is now in all of the prisons again.
fix: All maps now have all-access autodrobes in dorms again.
fix: All maps have posibrain alert consoles again.
fix: Blueshields are no longer imprisoned in their own office roundstart.
fix: Lustwish vendors should now be back in dorms.
fix: Whatever happened to the plasma tank in Journey/Spacebox Atmos has been fixed.
fix: Blueshields should always start in their office on Meta. Or more accurately, off station when the station is Meta.
fix: Command vendors back on the maps.
/:cl:
