### PR TITLE
[MODULAR] Fixes fishnet socks 

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
@@ -227,7 +227,7 @@
 	name = "Thigh-high - Fishnet"
 	icon_state = "fishnet"
 
-/datum/sprite_accessory/socks/fishnet_thigh
+/datum/sprite_accessory/socks/pantyhose_ripped
 	name = "Pantyhose - Ripped"
 	icon_state = "pantyhose_ripped"
 	use_static = null


### PR DESCRIPTION
## About The Pull Request

Seems that fishnet thigh-highs were overwritten at some point by the ripped pantyhose, this PR makes them both available.
![image](https://user-images.githubusercontent.com/79718450/135476006-bb02bdb9-f8f1-4b7d-9c24-b6cbd7f4321e.png)

## How This Contributes To The Skyrat Roleplay Experience

Good to have access to content already in the game.

## Changelog

:cl:
fix: brought fishnet socks back
/:cl: