### PR TITLE
fix speed upgrade still being in the techweb

### DIFF
--- a/modular_skyrat/modules/powerarmor/code/powerarmor.dm
+++ b/modular_skyrat/modules/powerarmor/code/powerarmor.dm
@@ -778,7 +778,6 @@
 		"powerarmor_construct",
 	)
 	design_ids = list(
-		"paupgradespeed",
 		"paupgradelight",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
fix
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: removed speed upgrade (power armor) from the techweb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
