### PR TITLE
[modular?] allows the boxes in the examine menu to use newlines again

### DIFF
--- a/tgui/packages/tgui/interfaces/ExaminePanel.js
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.js
@@ -36,19 +36,31 @@ export const ExaminePanel = (props, context) => {
             <Stack fill vertical>
               <Stack.Item grow>
                 <Section scrollable fill title={character_name + "'s Flavor Text:"}>
-                  {flavor_text}
+                  {flavor_text.split("\n").map((val, i) => (
+                    <Stack.Item key={i} grow fill>
+                      {val || val !== "" ? val : <br />}
+                    </Stack.Item>
+                  ))}
                 </Section>
               </Stack.Item>
               <Stack.Item grow>
                 <Stack fill>
                   <Stack.Item grow basis={0}>
                     <Section scrollable fill title="OOC Notes">
-                      {ooc_notes}
+                      {ooc_notes.split("\n").map((val, i) => (
+                        <Stack.Item key={i} grow fill>
+                          {val || val !== "" ? val : <br />}
+                        </Stack.Item>
+                      ))}
                     </Section>
                   </Stack.Item>
                   <Stack.Item grow basis={0}>
                     <Section scrollable fill title={(custom_species ? "Species: " + custom_species : "No Custom Species!")}>
-                      {(custom_species ? custom_species_lore : "Just a normal space dweller.")}
+                      {(custom_species ? custom_species_lore.split("\n").map((val, i) => (
+                        <Stack.Item key={i} grow fill>
+                          {val || val !== "" ? val : <br />}
+                        </Stack.Item>
+                      )) : "Just a normal space dweller.")}
                     </Section>
                   </Stack.Item>
                 </Stack>


### PR DESCRIPTION
## About The Pull Request

title

## How This Contributes To The Skyrat Roleplay Experience

better formatting is better readability and thus better RP

## Changelog

:cl:
qol: allows the boxes in the examine menu to use newlines again
/:cl: