### PR TITLE
[modular] ghost cafe borg name fix + loadout in the ghost cafe

### DIFF
--- a/modular_skyrat/modules/ghostcafe/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_skyrat/modules/ghostcafe/code/game/objects/structures/ghost_role_spawners.dm
@@ -23,6 +23,7 @@
 
 /obj/effect/mob_spawn/robot/ghostcafe/special(mob/living/silicon/robot/new_spawn)
 	if(new_spawn.client)
+		new_spawn.custom_name = null
 		new_spawn.updatename(new_spawn.client)
 		new_spawn.gender = NEUTER
 		var/area/A = get_area(src)
@@ -47,7 +48,7 @@
 	density = FALSE
 	death = FALSE
 	any_station_species = TRUE
-	outfit = /datum/outfit/ghostcafe
+	outfit = /datum/outfit
 	short_desc = "You are a Cafe Visitor!"
 	flavour_text = "You are off-duty and have decided to visit your favourite cafe. Enjoy yourself."
 
@@ -65,6 +66,7 @@
 		//to_chat(new_spawn,"<span class='narsiesmall'>Be warned: People who opt out of EORG will come here. Do not make the area uninhabitable and do NOT commit EORG. This is a safe-zone. If you attack people in EORG, you will be banned for griefing.</span>")
 		var/datum/action/toggle_dead_chat_mob/D = new(new_spawn)
 		new_spawn.put_in_hand(new /obj/item/storage/box/syndie_kit/chameleon/ghostcafe, LEFT_HANDS, forced = TRUE)
+		new_spawn.equip_outfit_and_loadout(/datum/outfit/ghostcafe, new_spawn.client.prefs, FALSE, null)
 		D.Grant(new_spawn)
 
 /datum/outfit/ghostcafe


### PR DESCRIPTION
## About The Pull Request

title, borgs now actually spawn as their name in the ghost cafe

## How This Contributes To The Skyrat Roleplay Experience

because I don't want to be bwoinking a borg named Default Cyborg 415

## Changelog

:cl:
fix: ghost cafe loadout now appears + ghost cafe borgs now spawn with their name
/:cl: