### PR TITLE
Fixes missing color for undershirt/socks

### DIFF
--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -33,7 +33,7 @@
 			to_chat(user, span_warning("You are not capable of wearing underwear."))
 			return
 
-		var/choice = input(user, "Underwear, Undershirt, or Socks?", "Changing") as null|anything in list("Underwear","Underwear Color","Undershirt","Socks")
+		var/choice = input(user, "Underwear, Undershirt, or Socks?", "Changing") as null|anything in list("Underwear","Underwear Color","Undershirt","Undershirt Color","Socks","Socks Color")
 
 		if(!Adjacent(user))
 			return
@@ -50,10 +50,18 @@
 				var/new_undershirt = input(user, "Select your undershirt", "Changing") as null|anything in GLOB.undershirt_list
 				if(new_undershirt)
 					H.undershirt = new_undershirt
+			if("Undershirt Color")
+				var/new_undershirt_color = input(H, "Choose your undershirt color", "Undershirt Color","#"+H.undershirt_color) as color|null
+				if(new_undershirt_color)
+					H.undershirt_color = sanitize_hexcolor(new_undershirt_color)
 			if("Socks")
 				var/new_socks = input(user, "Select your socks", "Changing") as null|anything in GLOB.socks_list
 				if(new_socks)
 					H.socks= new_socks
+			if("Socks Color")
+				var/new_socks_color = input(H, "Choose your socks color", "Socks Color","#"+H.socks_color) as color|null
+				if(new_socks_color)
+					H.socks_color = sanitize_hexcolor(new_socks_color)
 
 		add_fingerprint(H)
 		H.update_body()

--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -1,3 +1,5 @@
+//THIS FILE HAS BEEN EDITED BY SKYRAT EDIT
+
 /obj/structure/dresser//SKYRAT EDIT - ICON OVERRIDEN BY AESTHETICS - SEE MODULE
 	name = "dresser"
 	desc = "A nicely-crafted wooden dresser. It's filled with lots of undies."
@@ -33,7 +35,7 @@
 			to_chat(user, span_warning("You are not capable of wearing underwear."))
 			return
 
-		var/choice = input(user, "Underwear, Undershirt, or Socks?", "Changing") as null|anything in list("Underwear","Underwear Color","Undershirt","Undershirt Color","Socks","Socks Color")
+		var/choice = input(user, "Underwear, Undershirt, or Socks?", "Changing") as null|anything in list("Underwear","Underwear Color","Undershirt","Undershirt Color","Socks","Socks Color") //SKYRAT EDIT ADDITION - Colorable Undershirt/Socks
 
 		if(!Adjacent(user))
 			return
@@ -42,6 +44,7 @@
 				var/new_undies = input(user, "Select your underwear", "Changing")  as null|anything in GLOB.underwear_list
 				if(new_undies)
 					H.underwear = new_undies
+
 			if("Underwear Color")
 				var/new_underwear_color = input(H, "Choose your underwear color", "Underwear Color","#"+H.underwear_color) as color|null
 				if(new_underwear_color)
@@ -50,6 +53,7 @@
 				var/new_undershirt = input(user, "Select your undershirt", "Changing") as null|anything in GLOB.undershirt_list
 				if(new_undershirt)
 					H.undershirt = new_undershirt
+			//SKYRAT EDIT ADDITION BEGIN - Colorable Undershirt/Socks
 			if("Undershirt Color")
 				var/new_undershirt_color = input(H, "Choose your undershirt color", "Undershirt Color","#"+H.undershirt_color) as color|null
 				if(new_undershirt_color)
@@ -62,6 +66,6 @@
 				var/new_socks_color = input(H, "Choose your socks color", "Socks Color","#"+H.socks_color) as color|null
 				if(new_socks_color)
 					H.socks_color = sanitize_hexcolor(new_socks_color)
-
+			//SKYRAT EDIT ADDITION END - Colorable Undershirt/Socks
 		add_fingerprint(H)
 		H.update_body()

--- a/code/modules/client/preferences/clothing.dm
+++ b/code/modules/client/preferences/clothing.dm
@@ -1,4 +1,6 @@
-/proc/generate_values_for_underwear(list/accessory_list, list/icons, color, icon_offset)
+//THIS FILE HAS BEEN EDITED BY SKYRAT EDIT
+
+/proc/generate_values_for_underwear(list/accessory_list, list/icons, color, icon_offset) //SKYRAT EDIT CHANGE - Colorable Undershirt/Socks
 	var/icon/lower_half = icon('icons/blanks/32x32.dmi', "nothing")
 
 	for (var/icon in icons)
@@ -16,8 +18,8 @@
 			if (color && !accessory.use_static)
 				accessory_icon.Blend(color, ICON_MULTIPLY)
 			icon_with_socks.Blend(accessory_icon, ICON_OVERLAY)
-		icon_with_socks.Crop(10, 1+icon_offset, 22, 13+icon_offset)			
-		
+		icon_with_socks.Crop(10, 1+icon_offset, 22, 13+icon_offset)	//SKYRAT EDIT CHANGE - Colorable Undershirt/Socks
+
 		icon_with_socks.Scale(32, 32)
 
 		values[accessory_name] = icon_with_socks
@@ -81,18 +83,19 @@
 	should_generate_icons = TRUE
 
 /datum/preference/choiced/socks/init_possible_values()
-	return generate_values_for_underwear(GLOB.socks_list, list("human_r_leg", "human_l_leg"), COLOR_ALMOST_BLACK, 0)
+	return generate_values_for_underwear(GLOB.socks_list, list("human_r_leg", "human_l_leg"), COLOR_ALMOST_BLACK, 0) //SKYRAT EDIT CHANGE - Colorable Undershirt/Socks
 
 /datum/preference/choiced/socks/apply_to_human(mob/living/carbon/human/target, value)
 	target.socks = value
 
+//SKYRAT EDIT CHANGE BEGIN - Colorable Undershirt/Socks
 /datum/preference/choiced/socks/compile_constant_data()
 	var/list/data = ..()
 
 	data[SUPPLEMENTAL_FEATURE_KEY] = "socks_color"
 
 	return data
-
+//SKYRAT EDIT CHANGE END - Colorable Undershirt/Socks
 
 /// Undershirt preference
 /datum/preference/choiced/undershirt
@@ -102,6 +105,7 @@
 	category = PREFERENCE_CATEGORY_CLOTHING
 	should_generate_icons = TRUE
 
+//SKYRAT EDIT CHANGE BEGIN - Colorable Undershirt/Socks
 /datum/preference/choiced/undershirt/init_possible_values()
 	return generate_values_for_underwear(GLOB.undershirt_list, list("human_chest_m", "human_r_arm", "human_l_arm", "human_r_leg", "human_l_leg", "human_r_hand", "human_l_hand"), COLOR_ALMOST_BLACK,10)
 
@@ -114,7 +118,8 @@
 	data[SUPPLEMENTAL_FEATURE_KEY] = "undershirt_color"
 
 	return data
-	
+//SKYRAT EDIT CHANGE END - Colorable Undershirt/Socks
+
 /// Underwear preference
 /datum/preference/choiced/underwear
 	savefile_key = "underwear"
@@ -124,7 +129,7 @@
 	should_generate_icons = TRUE
 
 /datum/preference/choiced/underwear/init_possible_values()
-	return generate_values_for_underwear(GLOB.underwear_list, list("human_chest_m", "human_r_leg", "human_l_leg"), COLOR_ALMOST_BLACK, 5)
+	return generate_values_for_underwear(GLOB.underwear_list, list("human_chest_m", "human_r_leg", "human_l_leg"), COLOR_ALMOST_BLACK, 5) //SKYRAT EDIT CHANGE - Colorable Undershirt/Socks
 
 /datum/preference/choiced/underwear/apply_to_human(mob/living/carbon/human/target, value)
 	target.underwear = value

--- a/code/modules/client/preferences/clothing.dm
+++ b/code/modules/client/preferences/clothing.dm
@@ -1,4 +1,4 @@
-/proc/generate_values_for_underwear(list/accessory_list, list/icons, color)
+/proc/generate_values_for_underwear(list/accessory_list, list/icons, color, icon_offset)
 	var/icon/lower_half = icon('icons/blanks/32x32.dmi', "nothing")
 
 	for (var/icon in icons)
@@ -16,8 +16,8 @@
 			if (color && !accessory.use_static)
 				accessory_icon.Blend(color, ICON_MULTIPLY)
 			icon_with_socks.Blend(accessory_icon, ICON_OVERLAY)
-
-		icon_with_socks.Crop(10, 1, 22, 13)
+		icon_with_socks.Crop(10, 1+icon_offset, 22, 13+icon_offset)			
+		
 		icon_with_socks.Scale(32, 32)
 
 		values[accessory_name] = icon_with_socks
@@ -81,10 +81,18 @@
 	should_generate_icons = TRUE
 
 /datum/preference/choiced/socks/init_possible_values()
-	return generate_values_for_underwear(GLOB.socks_list, list("human_r_leg", "human_l_leg"))
+	return generate_values_for_underwear(GLOB.socks_list, list("human_r_leg", "human_l_leg"), COLOR_ALMOST_BLACK, 0)
 
 /datum/preference/choiced/socks/apply_to_human(mob/living/carbon/human/target, value)
 	target.socks = value
+
+/datum/preference/choiced/socks/compile_constant_data()
+	var/list/data = ..()
+
+	data[SUPPLEMENTAL_FEATURE_KEY] = "socks_color"
+
+	return data
+
 
 /// Undershirt preference
 /datum/preference/choiced/undershirt
@@ -95,32 +103,18 @@
 	should_generate_icons = TRUE
 
 /datum/preference/choiced/undershirt/init_possible_values()
-	var/icon/body = icon('icons/mob/human_parts_greyscale.dmi', "human_r_leg")
-	body.Blend(icon('icons/mob/human_parts_greyscale.dmi', "human_l_leg"), ICON_OVERLAY)
-	body.Blend(icon('icons/mob/human_parts_greyscale.dmi', "human_r_arm"), ICON_OVERLAY)
-	body.Blend(icon('icons/mob/human_parts_greyscale.dmi', "human_l_arm"), ICON_OVERLAY)
-	body.Blend(icon('icons/mob/human_parts_greyscale.dmi', "human_r_hand"), ICON_OVERLAY)
-	body.Blend(icon('icons/mob/human_parts_greyscale.dmi', "human_l_hand"), ICON_OVERLAY)
-	body.Blend(icon('icons/mob/human_parts_greyscale.dmi', "human_chest_m"), ICON_OVERLAY)
-
-	var/list/values = list()
-
-	for (var/accessory_name in GLOB.undershirt_list)
-		var/icon/icon_with_undershirt = icon(body)
-
-		if (accessory_name != "Nude")
-			var/datum/sprite_accessory/accessory = GLOB.undershirt_list[accessory_name]
-			icon_with_undershirt.Blend(icon('icons/mob/clothing/underwear.dmi', accessory.icon_state), ICON_OVERLAY)
-
-		icon_with_undershirt.Crop(9, 9, 23, 23)
-		icon_with_undershirt.Scale(32, 32)
-		values[accessory_name] = icon_with_undershirt
-
-	return values
+	return generate_values_for_underwear(GLOB.undershirt_list, list("human_chest_m", "human_r_arm", "human_l_arm", "human_r_leg", "human_l_leg", "human_r_hand", "human_l_hand"), COLOR_ALMOST_BLACK,10)
 
 /datum/preference/choiced/undershirt/apply_to_human(mob/living/carbon/human/target, value)
 	target.undershirt = value
 
+/datum/preference/choiced/undershirt/compile_constant_data()
+	var/list/data = ..()
+
+	data[SUPPLEMENTAL_FEATURE_KEY] = "undershirt_color"
+
+	return data
+	
 /// Underwear preference
 /datum/preference/choiced/underwear
 	savefile_key = "underwear"
@@ -130,7 +124,7 @@
 	should_generate_icons = TRUE
 
 /datum/preference/choiced/underwear/init_possible_values()
-	return generate_values_for_underwear(GLOB.underwear_list, list("human_chest_m", "human_r_leg", "human_l_leg"), COLOR_ALMOST_BLACK)
+	return generate_values_for_underwear(GLOB.underwear_list, list("human_chest_m", "human_r_leg", "human_l_leg"), COLOR_ALMOST_BLACK, 5)
 
 /datum/preference/choiced/underwear/apply_to_human(mob/living/carbon/human/target, value)
 	target.underwear = value

--- a/code/modules/client/preferences/underwear_color.dm
+++ b/code/modules/client/preferences/underwear_color.dm
@@ -1,3 +1,5 @@
+//THIS FILE HAS BEEN EDITED BY SKYRAT EDIT
+
 /datum/preference/color_legacy/underwear_color
 	savefile_key = "underwear_color"
 	savefile_identifier = PREFERENCE_CHARACTER
@@ -14,6 +16,7 @@
 	var/datum/species/species = new species_type
 	return !(NO_UNDERWEAR in species.species_traits)
 
+//SKYRAT EDIT ADDITION BEGIN - Colorable Undershirt/Socks
 /datum/preference/color_legacy/undershirt_color
 	savefile_key = "undershirt_color"
 	savefile_identifier = PREFERENCE_CHARACTER
@@ -45,3 +48,4 @@
 	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type
 	return !(NO_UNDERWEAR in species.species_traits)
+//SKYRAT EDIT ADDITION END - Colorable Undershirt/Socks

--- a/code/modules/client/preferences/underwear_color.dm
+++ b/code/modules/client/preferences/underwear_color.dm
@@ -1,5 +1,3 @@
-//THIS FILE HAS BEEN EDITED BY SKYRAT EDIT
-
 /datum/preference/color_legacy/underwear_color
 	savefile_key = "underwear_color"
 	savefile_identifier = PREFERENCE_CHARACTER
@@ -15,37 +13,3 @@
 	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type
 	return !(NO_UNDERWEAR in species.species_traits)
-
-//SKYRAT EDIT ADDITION BEGIN - Colorable Undershirt/Socks
-/datum/preference/color_legacy/undershirt_color
-	savefile_key = "undershirt_color"
-	savefile_identifier = PREFERENCE_CHARACTER
-	category = PREFERENCE_CATEGORY_SUPPLEMENTAL_FEATURES
-
-/datum/preference/color_legacy/undershirt_color/apply_to_human(mob/living/carbon/human/target, value)
-	target.undershirt_color = value
-
-/datum/preference/color_legacy/undershirt_color/is_accessible(datum/preferences/preferences)
-	if (!..(preferences))
-		return FALSE
-
-	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
-	var/datum/species/species = new species_type
-	return !(NO_UNDERWEAR in species.species_traits)
-
-/datum/preference/color_legacy/socks_color
-	savefile_key = "socks_color"
-	savefile_identifier = PREFERENCE_CHARACTER
-	category = PREFERENCE_CATEGORY_SUPPLEMENTAL_FEATURES
-
-/datum/preference/color_legacy/socks_color/apply_to_human(mob/living/carbon/human/target, value)
-	target.socks_color = value
-
-/datum/preference/color_legacy/socks_color/is_accessible(datum/preferences/preferences)
-	if (!..(preferences))
-		return FALSE
-
-	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
-	var/datum/species/species = new species_type
-	return !(NO_UNDERWEAR in species.species_traits)
-//SKYRAT EDIT ADDITION END - Colorable Undershirt/Socks

--- a/code/modules/client/preferences/underwear_color.dm
+++ b/code/modules/client/preferences/underwear_color.dm
@@ -13,3 +13,35 @@
 	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type
 	return !(NO_UNDERWEAR in species.species_traits)
+
+/datum/preference/color_legacy/undershirt_color
+	savefile_key = "undershirt_color"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_SUPPLEMENTAL_FEATURES
+
+/datum/preference/color_legacy/undershirt_color/apply_to_human(mob/living/carbon/human/target, value)
+	target.undershirt_color = value
+
+/datum/preference/color_legacy/undershirt_color/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species = new species_type
+	return !(NO_UNDERWEAR in species.species_traits)
+
+/datum/preference/color_legacy/socks_color
+	savefile_key = "socks_color"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_SUPPLEMENTAL_FEATURES
+
+/datum/preference/color_legacy/socks_color/apply_to_human(mob/living/carbon/human/target, value)
+	target.socks_color = value
+
+/datum/preference/color_legacy/socks_color/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species = new species_type
+	return !(NO_UNDERWEAR in species.species_traits)

--- a/modular_skyrat/master_files/code/modules/client/preferences/underwear_color.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/underwear_color.dm
@@ -1,0 +1,51 @@
+//THIS FILE HAS BEEN EDITED BY SKYRAT EDIT
+
+/datum/preference/color_legacy/underwear_color
+	savefile_key = "underwear_color"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_SUPPLEMENTAL_FEATURES
+
+/datum/preference/color_legacy/underwear_color/apply_to_human(mob/living/carbon/human/target, value)
+	target.underwear_color = value
+
+/datum/preference/color_legacy/underwear_color/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species = new species_type
+	return !(NO_UNDERWEAR in species.species_traits)
+
+//SKYRAT EDIT ADDITION BEGIN - Colorable Undershirt/Socks
+/datum/preference/color_legacy/undershirt_color
+	savefile_key = "undershirt_color"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_SUPPLEMENTAL_FEATURES
+
+/datum/preference/color_legacy/undershirt_color/apply_to_human(mob/living/carbon/human/target, value)
+	target.undershirt_color = value
+
+/datum/preference/color_legacy/undershirt_color/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species = new species_type
+	return !(NO_UNDERWEAR in species.species_traits)
+
+/datum/preference/color_legacy/socks_color
+	savefile_key = "socks_color"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_SUPPLEMENTAL_FEATURES
+
+/datum/preference/color_legacy/socks_color/apply_to_human(mob/living/carbon/human/target, value)
+	target.socks_color = value
+
+/datum/preference/color_legacy/socks_color/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species = new species_type
+	return !(NO_UNDERWEAR in species.species_traits)
+//SKYRAT EDIT ADDITION END - Colorable Undershirt/Socks

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
@@ -450,3 +450,13 @@ export const skin_tone_toggle: FeatureToggle = {
   name: "Uses skintone",
   component: CheckboxInput,
 };
+
+export const undershirt_color: Feature<string> = {
+  name: "Undershirt color",
+  component: FeatureColorInput,
+};
+
+export const socks_color: Feature<string> = {
+  name: "Socks color",
+  component: FeatureColorInput,
+};


### PR DESCRIPTION
## About The Pull Request

Both "undershirt" and "socks" were missing their color choice in the new prefmenu, as well as in the dresser. 
The undershirt category was also a bit broken, and had missing preview icons for half the items. 
While I was at it, I also shifted the preview-crop of "underwear" upwards, as there are a lot of underwear options that go above the belt line.

The undershirt_color and socks_color preference do already exist, so I just set everything up the same way as underwear_color is handled. On a sidenote, I think someone claimed there might be clashes because those categories include both greyscale and static sprites, which was not the case (After all, "underwear" itself already has those, e.g. Union Jack boxers).

<details>
  <summary>What it looked like before</summary>

![grafik](https://user-images.githubusercontent.com/46299792/135698790-e1317a12-a7be-48e1-84e2-7d0aaba4ee3a.png)

</details>

<details>
  <summary>What it looks like now</summary>

![grafik](https://user-images.githubusercontent.com/46299792/135698937-8c721148-3868-4072-8180-9c5ff30006d4.png)
![grafik](https://user-images.githubusercontent.com/46299792/135698945-6c653d64-8454-4114-8b0b-3a66ff403644.png)


</details>



## How This Contributes To The Skyrat Roleplay Experience

Reintroduces color choices that went missing along the way

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Missing color choices for undershirt/socks in loadout
fix: Broken preview sprites for undershirts
fix: Missing color choices at the dresser
/:cl: