### PR TITLE
[MODULAR][MAP EDITS][FIX] Cargodise fixes, this time final hopefully

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/cargodiselost.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/cargodiselost.dmm
@@ -2022,6 +2022,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/circuitboard/machine/protolathe,
 /obj/effect/spawner/random/engineering/toolbox,
+/obj/item/circuitboard/machine/circuit_imprinter/department,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "LC" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/cargodiselost.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/cargodiselost.dmm
@@ -6,6 +6,11 @@
 	dir = 1
 	},
 /area/ruin/space/has_grav/deepstorage/lostcargo)
+"aC" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/entertainment/money_large,
+/turf/open/floor/iron/dark/blue,
+/area/ruin/space/has_grav/deepstorage/lostcargo)
 "aH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/light{
@@ -42,6 +47,17 @@
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/tablet/preset/advanced,
 /turf/open/floor/iron/dark/blue,
+/area/ruin/space/has_grav/deepstorage/lostcargo)
+"bo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/brown/side{
+	dir = 1
+	},
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "bq" = (
 /obj/structure/table,
@@ -119,12 +135,6 @@
 /obj/item/modular_computer/laptop/preset/civilian,
 /turf/open/floor/iron/dark/blue,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
-"dq" = (
-/mob/living/simple_animal/hostile/mining_drone{
-	faction = list("russian")
-	},
-/turf/open/floor/iron/dark/brown,
-/area/ruin/space/has_grav/deepstorage/lostcargo)
 "du" = (
 /obj/machinery/shower{
 	pixel_y = 6
@@ -157,13 +167,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
-"er" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/mob/living/simple_animal/hostile/russian,
-/turf/open/floor/iron/brown/side{
-	dir = 1
-	},
-/area/ruin/space/has_grav/deepstorage/lostcargo)
 "eJ" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -180,7 +183,9 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "eR" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	name = "Delivery - NSV Titan"
+	},
 /obj/effect/spawner/random/engineering/vending_restock,
 /obj/effect/spawner/random/engineering/vending_restock,
 /turf/open/floor/iron/brown/side{
@@ -214,6 +219,9 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "fB" = (
 /obj/machinery/light,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/iron/brown/side,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "fO" = (
@@ -285,6 +293,10 @@
 /obj/structure/ore_box,
 /turf/open/floor/iron/dark/brown,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
+"hl" = (
+/mob/living/simple_animal/hostile/giant_spider/tarantula/scrawny,
+/turf/open/floor/iron/dark/brown,
+/area/ruin/space/has_grav/deepstorage/lostcargo)
 "hq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -325,7 +337,9 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "hN" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large{
+	name = "Delivery - NSS Exodus"
+	},
 /obj/effect/spawner/random/exotic/languagebook,
 /obj/effect/spawner/random/exotic/languagebook,
 /obj/effect/spawner/random/exotic/languagebook,
@@ -347,6 +361,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "hT" = (
@@ -375,12 +390,6 @@
 /obj/effect/spawner/random/entertainment/coin,
 /obj/effect/spawner/random/entertainment/wallet_storage,
 /turf/open/floor/carpet,
-/area/ruin/space/has_grav/deepstorage/lostcargo)
-"iC" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark/green/side{
-	dir = 1
-	},
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "iF" = (
 /obj/structure/closet/emcloset/anchored,
@@ -423,7 +432,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/clipboard,
 /turf/open/floor/carpet/green,
+/area/ruin/space/has_grav/deepstorage/lostcargo)
+"js" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark/blue,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "jt" = (
 /obj/structure/table/wood,
@@ -504,7 +518,6 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "kL" = (
 /obj/structure/bed,
-/obj/structure/safe/floor,
 /obj/item/bedsheet/qm,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
@@ -512,6 +525,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/bureaucracy/briefcase,
 /obj/effect/spawner/random/bureaucracy/folder,
+/obj/item/clipboard,
 /turf/open/floor/iron/brown/side,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "lh" = (
@@ -669,7 +683,9 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "oQ" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	name = "Delivery - Flint and Nettles"
+	},
 /obj/effect/spawner/random/decoration/paint,
 /obj/effect/spawner/random/decoration/paint,
 /obj/effect/spawner/random/decoration/paint,
@@ -678,6 +694,11 @@
 /obj/effect/spawner/random/decoration/ornament,
 /obj/effect/spawner/random/decoration/ornament,
 /obj/effect/spawner/random/decoration/ornament,
+/obj/effect/spawner/random/decoration/carpet,
+/obj/effect/spawner/random/decoration/carpet,
+/obj/effect/spawner/random/decoration/carpet,
+/obj/effect/spawner/random/decoration/carpet,
+/obj/effect/spawner/random/decoration/carpet,
 /turf/open/floor/iron/brown,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "oZ" = (
@@ -697,9 +718,18 @@
 	dir = 8
 	},
 /area/ruin/space/has_grav/deepstorage/lostcargo)
+"pe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/brown/side{
+	dir = 1
+	},
+/area/ruin/space/has_grav/deepstorage/lostcargo)
 "pj" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	name = "Delivery - Toy House"
+	},
 /obj/effect/spawner/random/entertainment/toy,
 /obj/effect/spawner/random/entertainment/toy,
 /obj/effect/spawner/random/entertainment/toy,
@@ -733,7 +763,9 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "pH" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	name = "Delivery - NSS Citadel"
+	},
 /obj/effect/spawner/random/engineering/vending_restock,
 /obj/effect/spawner/random/engineering/vending_restock,
 /obj/effect/spawner/random/engineering/vending_restock,
@@ -763,6 +795,9 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/iron/brown,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "qy" = (
@@ -784,11 +819,17 @@
 /obj/item/stack/sheet/plasteel/twenty,
 /obj/item/stack/sheet/plastic/five,
 /obj/item/stack/sheet/mineral/diamond,
+/obj/effect/spawner/random/entertainment/money_large,
+/obj/effect/spawner/random/entertainment/money_large,
+/obj/effect/spawner/random/entertainment/money_large,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "qU" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/engineering,
+/obj/structure/closet/crate/engineering{
+	desc = "A rectangular steel crate. The delivery label is smudged and faded";
+	name = "Delivery - ???"
+	},
 /obj/effect/spawner/random/engineering/material,
 /obj/effect/spawner/random/engineering/material,
 /obj/effect/spawner/random/engineering/material_cheap,
@@ -810,7 +851,16 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/closet/crate/secure/loot,
+/obj/structure/closet/crate{
+	name = "Delivery - Lea Heatherholm"
+	},
+/obj/item/clothing/sextoy/dildo,
+/obj/item/clothing/glasses/hypno,
+/obj/item/reagent_containers/glass/bottle/hexacrocin,
+/obj/item/key/lasso,
+/obj/item/reagent_containers/glass/bottle/morphine,
+/obj/item/gun/syringe/syndicate,
+/obj/item/restraints/handcuffs/cable/zipties,
 /turf/open/floor/iron/brown/side,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "rm" = (
@@ -826,13 +876,20 @@
 "rz" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/secure/tradership_cargo_very_valuable{
-	req_access_txt = "3"
+	name = "Delivery - DS-2";
+	req_access_txt = "150"
 	},
 /obj/effect/spawner/random/exotic/syndie,
 /obj/effect/spawner/random/exotic/syndie,
 /obj/effect/spawner/random/exotic/syndie,
 /obj/effect/spawner/random/exotic/syndie,
 /obj/effect/spawner/random/exotic/syndie,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/clothing/suit/armor/riot,
+/obj/item/shield/riot,
+/obj/item/clothing/head/helmet/riot,
 /turf/open/floor/iron/brown,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "rE" = (
@@ -949,7 +1006,7 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "tJ" = (
 /obj/machinery/button/door/directional/north{
-	id = "loadingbay";
+	id = "lockdown";
 	name = "Loading Bay Blastdoors";
 	pixel_y = -24
 	},
@@ -988,11 +1045,9 @@
 "ug" = (
 /obj/structure/safe,
 /obj/effect/spawner/random/entertainment/money_large,
-/obj/effect/spawner/random/entertainment/money_large,
-/obj/effect/spawner/random/entertainment/money_large,
-/obj/effect/spawner/random/entertainment/money_large,
 /obj/effect/spawner/random/exotic/antag_gear,
 /obj/item/clothing/suit/space/hardsuit/syndi,
+/obj/effect/spawner/random/entertainment/money_large,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "uj" = (
@@ -1009,7 +1064,9 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "ut" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large{
+	name = "DO NOT OPEN"
+	},
 /obj/effect/spawner/random/entertainment/drugs,
 /obj/effect/spawner/random/entertainment/drugs,
 /obj/effect/spawner/random/contraband/narcotics,
@@ -1026,6 +1083,20 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/iron/checker,
+/area/ruin/space/has_grav/deepstorage/lostcargo)
+"uU" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/green/side{
+	dir = 1
+	},
+/area/ruin/space/has_grav/deepstorage/lostcargo)
+"uZ" = (
+/obj/machinery/airalarm/all_access{
+	pixel_y = 26
+	},
+/turf/open/floor/iron/dark/green/side{
+	dir = 1
+	},
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "vi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -1155,9 +1226,11 @@
 /turf/open/floor/iron/checker,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "wA" = (
-/mob/living/simple_animal/hostile/mining_drone{
-	faction = list("russian")
-	},
+/mob/living/simple_animal/hostile/giant_spider/hunter,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/deepstorage/lostcargo)
+"wB" = (
+/mob/living/simple_animal/hostile/giant_spider,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "wG" = (
@@ -1168,6 +1241,7 @@
 "wN" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/secure/gear{
+	name = "Delivery - Central Command Frontier Division";
 	req_access_txt = "3"
 	},
 /obj/effect/spawner/random/exotic/antag_gear_weak,
@@ -1190,6 +1264,9 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "xb" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/airalarm/all_access{
+	pixel_y = -35
+	},
 /turf/open/floor/iron/dark/blue,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "xn" = (
@@ -1210,7 +1287,8 @@
 "xQ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/secure/weapon{
-	req_access_txt = "3"
+	name = "Delivery - Interdyne Mining Co";
+	req_access_txt = "150"
 	},
 /obj/effect/spawner/random/exotic/antag_gear,
 /obj/effect/spawner/random/exotic/antag_gear,
@@ -1244,7 +1322,9 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "yD" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/hydroponics,
+/obj/structure/closet/crate/hydroponics{
+	name = "Delivery - Seed Vault"
+	},
 /obj/effect/spawner/random/food_or_drink/seed_vault,
 /obj/effect/spawner/random/food_or_drink/seed_rare,
 /obj/effect/spawner/random/food_or_drink/seed_rare,
@@ -1265,6 +1345,9 @@
 /obj/effect/spawner/random/food_or_drink/seed,
 /obj/effect/spawner/random/food_or_drink/seed,
 /obj/effect/spawner/random/food_or_drink/seed,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/iron/brown,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "yF" = (
@@ -1341,6 +1424,12 @@
 	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
+"zU" = (
+/obj/machinery/airalarm/all_access{
+	pixel_y = 26
+	},
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/deepstorage/lostcargo)
 "zY" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -1415,6 +1504,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark/green/side{
 	dir = 4
 	},
@@ -1503,6 +1593,16 @@
 /obj/structure/rack/gunrack,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
+"DL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/green/side{
+	dir = 1
+	},
+/area/ruin/space/has_grav/deepstorage/lostcargo)
 "DN" = (
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/refreshing_beverage,
@@ -1578,7 +1678,9 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Fy" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/secure/plasma,
+/obj/structure/closet/crate/secure/plasma{
+	name = "Delivery - NTSS Cyberiad"
+	},
 /obj/effect/spawner/random/engineering/material_rare,
 /obj/effect/spawner/random/engineering/material_rare,
 /obj/effect/spawner/random/engineering/material_rare,
@@ -1676,7 +1778,9 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Ib" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/medical,
+/obj/structure/closet/crate/medical{
+	name = "Delivery - Hartmann von Berlichingen"
+	},
 /obj/effect/spawner/random/medical/firstaid,
 /obj/effect/spawner/random/medical/firstaid,
 /obj/effect/spawner/random/medical/firstaid_rare,
@@ -1707,15 +1811,25 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "IX" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/hydroponics,
+/obj/structure/closet/crate/secure/gear{
+	name = "Delivery - Enclave";
+	req_access_txt = "2"
+	},
+/obj/item/kitchen/knife/combat,
+/obj/item/reagent_containers/hypospray/medipen/stimpack,
+/obj/item/clothing/glasses/hud/security/sunglasses/gars/supergars,
+/obj/item/clothing/under/enclave/real,
 /turf/open/floor/iron/brown/side,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "IZ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/secure/science{
+	name = "Delivery - NSV Nebula";
 	req_access_txt = "3"
 	},
-/obj/effect/spawner/random/exotic/technology,
+/obj/item/raw_anomaly_core/random,
+/obj/item/raw_anomaly_core/random,
+/obj/item/raw_anomaly_core/random,
 /obj/item/raw_anomaly_core/random,
 /obj/item/raw_anomaly_core/random,
 /turf/open/floor/iron/brown,
@@ -1736,6 +1850,41 @@
 /obj/effect/turf_decal/arrows/red{
 	dir = 1
 	},
+/obj/structure/closet/crate/freezer{
+	name = "Delivery - Grima Rainwater"
+	},
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/organ/heart{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/organ/liver{
+	pixel_y = -10
+	},
+/obj/item/organ/lungs{
+	pixel_x = -10;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/blood/random{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/blood/random{
+	pixel_x = 9
+	},
+/obj/item/reagent_containers/blood/random{
+	pixel_x = 9
+	},
+/obj/item/reagent_containers/blood/random{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/blood/random{
+	pixel_x = 9;
+	pixel_y = 3
+	},
 /turf/open/floor/iron/brown/side{
 	dir = 1
 	},
@@ -1749,6 +1898,7 @@
 "JE" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/caution,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/brown/side{
 	dir = 10
 	},
@@ -1907,6 +2057,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 8
+	},
 /turf/open/floor/iron/brown/side{
 	dir = 1
 	},
@@ -1927,6 +2080,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/airalarm/all_access{
+	pixel_y = -35
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Mz" = (
@@ -1977,7 +2133,7 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "MS" = (
 /obj/machinery/button/door/directional/north{
-	id = "loadingbay";
+	id = "lockdown";
 	name = "Loading Bay Blastdoors"
 	},
 /obj/machinery/light{
@@ -2003,14 +2159,29 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
+"Np" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 26
+	},
+/turf/open/floor/iron/dark/green/side{
+	dir = 1
+	},
+/area/ruin/space/has_grav/deepstorage/lostcargo)
 "Nu" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/decoration/carpet,
-/obj/effect/spawner/random/decoration/carpet,
+/obj/structure/closet/crate{
+	name = "Delivery - Xyverious"
+	},
 /obj/effect/spawner/random/decoration/carpet,
 /obj/effect/spawner/random/decoration/carpet,
 /obj/machinery/light,
+/obj/effect/spawner/random/engineering/toolbox,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/circuitboard/machine/chem_dispenser/drinks/beer/fullupgrade,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
 /turf/open/floor/iron/brown/side,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "ND" = (
@@ -2025,8 +2196,15 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "NS" = (
-/obj/structure/table/wood,
 /obj/machinery/light,
+/obj/structure/safe/floor,
+/obj/item/clothing/accessory/medal/gold,
+/obj/item/coin/gold/doubloon,
+/obj/item/coin/gold/doubloon,
+/obj/item/coin/gold/doubloon,
+/obj/item/stack/sheet/mineral/gold{
+	amount = 20
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "NX" = (
@@ -2057,13 +2235,19 @@
 	dir = 1
 	},
 /area/ruin/space/has_grav/deepstorage/lostcargo)
+"Oj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 26
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/deepstorage/lostcargo)
 "Om" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark/blue,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "OE" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/medical,
 /obj/effect/spawner/random/medical/organs,
 /obj/effect/spawner/random/medical/organs,
 /obj/effect/spawner/random/medical/organs,
@@ -2071,6 +2255,10 @@
 /obj/effect/spawner/random/medical/memeorgans,
 /obj/effect/spawner/random/medical/memeorgans,
 /obj/effect/spawner/random/medical/memeorgans,
+/obj/structure/closet/crate/secure/freezer{
+	name = "Delivery - NSV Torch"
+	},
+/obj/item/organ/heart/gland/heal,
 /turf/open/floor/iron/brown/side,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "OP" = (
@@ -2089,12 +2277,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/airalarm/all_access{
+	pixel_y = -35
+	},
 /turf/open/floor/iron/brown/side,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Pq" = (
 /obj/item/storage/box/shipping,
 /obj/item/storage/box/shipping,
 /obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/paper,
 /turf/open/floor/iron/brown/side{
 	dir = 1
 	},
@@ -2115,6 +2308,7 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "PC" = (
 /obj/structure/table/reinforced,
+/obj/item/clipboard,
 /obj/item/pen,
 /turf/open/floor/iron/dark/blue,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
@@ -2153,6 +2347,12 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron/brown/side,
+/area/ruin/space/has_grav/deepstorage/lostcargo)
+"PO" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark/green/side{
+	dir = 8
+	},
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "PQ" = (
 /obj/structure/table/reinforced,
@@ -2233,6 +2433,7 @@
 	pixel_x = 24;
 	pixel_y = 0
 	},
+/mob/living/simple_animal/hostile/giant_spider/nurse,
 /turf/open/floor/iron/dark/brown,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "QW" = (
@@ -2343,6 +2544,12 @@
 /turf/open/floor/iron/dark/green/side{
 	dir = 8
 	},
+/area/ruin/space/has_grav/deepstorage/lostcargo)
+"SS" = (
+/obj/machinery/airalarm/all_access{
+	pixel_y = -35
+	},
+/turf/open/floor/iron/dark/brown,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "SU" = (
 /obj/machinery/door/airlock/hatch{
@@ -2580,7 +2787,9 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Vl" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	name = "Delivery - NSS Terry"
+	},
 /obj/effect/spawner/random/engineering/material,
 /obj/effect/spawner/random/engineering/material,
 /obj/effect/spawner/random/engineering/material,
@@ -2713,6 +2922,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/secure/science{
+	name = "Delivery - NSS Exodus";
 	req_access_txt = "3"
 	},
 /obj/effect/spawner/random/exotic/technology,
@@ -2737,6 +2947,7 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Xr" = (
 /obj/effect/turf_decal/bot,
+/mob/living/simple_animal/hostile/giant_spider,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Xs" = (
@@ -2865,7 +3076,9 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Zu" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/radiation,
+/obj/structure/closet/crate/radiation{
+	name = "Delivery - NSV Dagon"
+	},
 /obj/effect/spawner/random/engineering/material,
 /obj/effect/spawner/random/engineering/material,
 /obj/effect/spawner/random/engineering/material_rare,
@@ -3232,7 +3445,7 @@ Zy
 Zy
 Zy
 Zy
-hP
+Bb
 Bb
 Bb
 Bb
@@ -3351,7 +3564,7 @@ Ta
 SQ
 XB
 Wl
-Wl
+PO
 Ta
 Wl
 pc
@@ -3372,7 +3585,7 @@ Zy
 Zy
 Zy
 Qc
-hP
+Bb
 Bb
 Bb
 Bb
@@ -3414,7 +3627,7 @@ Bb
 YD
 SF
 Bb
-XU
+uU
 Vs
 jo
 Wh
@@ -3477,7 +3690,7 @@ Zy
 Zy
 OP
 OP
-hP
+Bb
 Bb
 Bb
 Bb
@@ -3582,7 +3795,7 @@ Zy
 Zy
 Zy
 Zy
-hP
+Bb
 Bb
 Bb
 Bb
@@ -3637,7 +3850,7 @@ ZN
 Ws
 Qo
 Bb
-aH
+DL
 Yy
 Bb
 Jj
@@ -3687,7 +3900,7 @@ Zy
 Zy
 Zy
 Zy
-hP
+Bb
 Bb
 Bb
 Bb
@@ -3707,7 +3920,7 @@ JZ
 ZN
 SZ
 Bb
-Zn
+Np
 Zl
 Bb
 qU
@@ -3768,7 +3981,7 @@ XU
 Vs
 qW
 Bb
-ZB
+zU
 ZB
 GA
 ZB
@@ -3792,11 +4005,11 @@ Zy
 OP
 OP
 Zy
-hP
 Bb
 Bb
 Bb
-IA
+Bb
+Oj
 IA
 Km
 Zn
@@ -3813,8 +4026,8 @@ YD
 YD
 Ax
 Zn
-Zl
-Bb
+yl
+Mp
 Sc
 ML
 ML
@@ -3850,7 +4063,7 @@ Ax
 Zn
 Zl
 Bb
-Sc
+pe
 YK
 YK
 YK
@@ -3869,7 +4082,7 @@ Dg
 IA
 Vu
 Bb
-XU
+uZ
 Vs
 Zl
 Mz
@@ -3990,7 +4203,7 @@ Ax
 aH
 JV
 Bb
-er
+Sc
 YK
 YK
 YK
@@ -4025,7 +4238,7 @@ AM
 Zn
 Zl
 Bb
-Ml
+bo
 FY
 uj
 sA
@@ -4058,9 +4271,9 @@ Wl
 Wl
 Wl
 vi
-yl
-Mp
-ML
+Zl
+Bb
+YK
 rE
 pu
 pu
@@ -4097,10 +4310,10 @@ Zl
 Bb
 ns
 Bb
-hP
-hP
-hP
-hP
+Bb
+Bb
+Bb
+Bb
 Zy
 "}
 (35,1,1) = {"
@@ -4113,7 +4326,7 @@ sa
 sa
 ND
 Bb
-iC
+XU
 XS
 XS
 Vs
@@ -4167,10 +4380,10 @@ Wh
 Wh
 Wh
 Ba
-hP
-hP
-hP
-hP
+Bb
+Bb
+Bb
+Bb
 Zy
 "}
 (37,1,1) = {"
@@ -4216,7 +4429,7 @@ Gi
 hP
 sF
 Er
-Er
+js
 Xs
 Er
 XS
@@ -4249,7 +4462,7 @@ Zy
 Zy
 Zy
 hP
-sF
+aC
 EH
 Vs
 Vs
@@ -4265,7 +4478,7 @@ EO
 Vs
 XS
 XS
-dq
+RA
 Bb
 MN
 Xn
@@ -4432,7 +4645,7 @@ XS
 Ff
 Er
 NX
-hP
+Bb
 mf
 mf
 Bb
@@ -4478,9 +4691,9 @@ Vs
 MK
 CK
 wm
+wB
 XS
-XS
-RA
+SS
 hP
 Zy
 OP
@@ -4494,13 +4707,13 @@ OP
 OP
 OP
 hP
-hP
+Bb
 Mz
 Mz
 Mz
 Mz
 Mz
-hP
+Bb
 hP
 YA
 jh
@@ -4514,7 +4727,7 @@ Sl
 VN
 wm
 XS
-dq
+RA
 Eh
 hP
 Zy
@@ -4581,7 +4794,7 @@ hP
 qi
 QU
 RA
-RA
+hl
 RA
 hr
 Bb


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ok so as it turns out, I forgot air alarms and quite a few things about the cargodise ruin were a bit messed up. This PR will fix those. Basically air alarms and fire alarms are added, the minebots that were SUPPOSED to be hostile are replaced with spiders, and the blast doors will now respond to buttons. I also added Delivery labels to most of the crates in the cargo hold, some memey, some more serious.

## How This Contributes To The Skyrat Roleplay Experience

Fixing some oversights about the map

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed the lack of air alarms and blast doors on cargodise not working.
expansion: Added spider enemies and delivery labels to the crates for RP potential.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
