### PR TITLE
skills for fishing, ceramics, and glassblowing (and more)

### DIFF
--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -3,6 +3,7 @@
 	desc = "Vends things that the Captain and Head of Personnel are probably not going to appreciate you fiddling with instead of your job..."
 	product_ads = "Escape to a fantasy world!;Fuel your gambling addiction!;Ruin your friendships!;Roll for initiative!;Elves and dwarves!;Paranoid computers!;Totally not satanic!;Fun times forever!"
 	icon_state = "games"
+	//SKYRAT EDIT: Adds Ceramic, Glassblowing, and Fishing Skillchips
 	products = list(
 		/obj/item/toy/cards/deck = 5,
 		/obj/item/storage/dice = 10,
@@ -22,9 +23,13 @@
 		/obj/item/skillchip/wine_taster=2,
 		/obj/item/skillchip/light_remover=2,
 		/obj/item/skillchip/useless_adapter=5,
+		/obj/item/skillchip/ceramic_master = 2,
+		/obj/item/skillchip/glassblowing_master = 2,
+		/obj/item/skillchip/fishing_master = 2,
 		/obj/item/dyespray=3,
 		/obj/item/razor=3,
 	)
+	//SKYRAT EDIT: Adds Ceramic, Glassblowing, and Fishing Skillchips
 	contraband = list(
 		/obj/item/dice/fudge = 9,
 		/obj/item/clothing/shoes/wheelys/skishoes=4,

--- a/modular_skyrat/master_files/code/_globalvars/maint_loot_uncommon.dm
+++ b/modular_skyrat/master_files/code/_globalvars/maint_loot_uncommon.dm
@@ -7,6 +7,9 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/skillchip/job/engineer = 10,
 		/obj/item/skillchip/job/roboticist = 10,
 		/obj/item/skillchip/light_remover = 10,
+		/obj/item/skillchip/ceramic_master = 10,
+		/obj/item/skillchip/glassblowing_master = 10,
+		/obj/item/skillchip/fishing_master = 10,
 		/obj/item/skillchip/useless_adapter = 25,
 		/obj/item/skillchip/wine_taster = 50
 	) = 50,

--- a/modular_skyrat/modules/fishing/code/fishing.dm
+++ b/modular_skyrat/modules/fishing/code/fishing.dm
@@ -9,6 +9,18 @@ GLOBAL_LIST_INIT(fishing_weights, list(
 	/obj/item/xenoarch/strange_rock = 5,
 ))
 
+#define TRAIT_FISHING_MASTER "fishing_master"
+
+/obj/item/skillchip/fishing_master
+	name = "Fishing Master skillchip"
+	desc = "A master of fishing, capable of wrangling the whole ocean if we must."
+	auto_traits = list(TRAIT_FISHING_MASTER)
+	skill_name = "Fishing Master"
+	skill_description = "Master the ability to use fish."
+	skill_icon = "certificate"
+	activate_message = "<span class='notice'>The fish and junk become far more visible beneath the surface.</span>"
+	deactivate_message = "<span class='notice'>The surface begins to cloud up, making it hard to see beneath.</span>"
+
 /turf/open
 	///If fishes are able to be fished from this open turf
 	var/fishspawn_possible = FALSE
@@ -35,9 +47,15 @@ GLOBAL_LIST_INIT(fishing_weights, list(
 	var/list/allowed_fishing_turfs = list()
 	///the current turf in which the fishing rod is after
 	var/turf/open/fishing_spot
+	///the time to allow fishing
 	var/allowed_fishing
+	///the mob that the rod is listening to signal wise
 	var/mob/listening_to
+	///the linked, spawned bobber
 	var/obj/effect/fishing_bobber/spawned_bobber
+	///whether its in a water basin, so it chooses fish only
+	var/water_basined = FALSE
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/fishing_rod/Destroy()
 	if(fishing_spot)
@@ -81,6 +99,7 @@ GLOBAL_LIST_INIT(fishing_weights, list(
 	icon = 'modular_skyrat/modules/fishing/icons/fishing.dmi'
 	icon_state = "bobber"
 	var/timed_fishing
+	var/obj/item/fishing_rod/connected_rod
 
 /obj/effect/fishing_bobber/Initialize(mapload)
 	. = ..()
@@ -88,11 +107,15 @@ GLOBAL_LIST_INIT(fishing_weights, list(
 
 /obj/effect/fishing_bobber/Destroy(force)
 	STOP_PROCESSING(SSobj, src)
+	connected_rod = null
 	. = ..()
 
 /obj/effect/fishing_bobber/process(delta_time)
-	if(world.time > timed_fishing && world.time < timed_fishing + 2 SECONDS)
-		pixel_y = pick(-2,2)
+	if(world.time > timed_fishing && world.time < timed_fishing + 3 SECONDS)
+		playsound(src, 'sound/machines/ping.ogg', 30, TRUE)
+	if(world.time > timed_fishing + 4 SECONDS)
+		timed_fishing = world.time + 4 SECONDS
+		connected_rod.allowed_fishing = world.time + 4 SECONDS
 
 /obj/item/fishing_rod/equipped(mob/user, slot, initial)
 	. = ..()
@@ -132,21 +155,40 @@ GLOBAL_LIST_INIT(fishing_weights, list(
 			QDEL_NULL(spawned_bobber)
 			return
 		to_chat(user, span_notice("You reel back [src], catching something..."))
-		if(fishing_spot.fishspawn_possible)
-			var/pick_choose = rand(1, 3)
-			switch(pick_choose)
-				if(1)
-					generate_fish(get_turf(user), random_fish_type())
-				if(2 to 3)
-					var/obj/spawn_objone = pickweight(GLOB.fishing_weights)
-					new spawn_objone(get_turf(user))
-			fishing_spot = null
-			QDEL_NULL(spawned_bobber)
-			return
-		var/obj/spawn_objtwo = pickweight(GLOB.fishing_weights)
-		new spawn_objtwo(get_turf(user))
+		var/repeat_code = 1
+		if(HAS_TRAIT(user, TRAIT_FISHING_MASTER))
+			repeat_code = 2
+		for(var/multiple_times in 1 to repeat_code)
+			if(fishing_spot.fishspawn_possible || water_basined)
+				var/pick_choose = rand(1, 3)
+				switch(pick_choose)
+					if(1 to 2)
+						generate_fish(get_turf(user), random_fish_type())
+					if(3)
+						var/obj/spawn_objone = pickweight(GLOB.fishing_weights)
+						new spawn_objone(get_turf(user))
+			else
+				var/obj/spawn_objtwo = pickweight(GLOB.fishing_weights)
+				new spawn_objtwo(get_turf(user))
+		water_basined = FALSE
 		fishing_spot = null
 		QDEL_NULL(spawned_bobber)
+		return
+	if(istype(target, /obj/structure/reagent_water_basin))
+		var/obj/structure/reagent_water_basin/target_basin = target
+		if(!target_basin.bluespaced)
+			to_chat(user, span_warning("[target_basin] is not connected to another ocean... perhaps using a bluespace crystal will do so?"))
+			return
+		var/turf/open/basin_turf = get_turf(target_basin)
+		if(get_dist(target, user) >= 4) //not using proximity because I want you to be able to cast the line
+			return
+		to_chat(user, span_notice("You throw out the line to [basin_turf]..."))
+		var/choose_timer = (rand(3, 7)) SECONDS
+		allowed_fishing = world.time + choose_timer
+		fishing_spot = basin_turf
+		spawned_bobber =  new /obj/effect/fishing_bobber(basin_turf)
+		spawned_bobber.timed_fishing = allowed_fishing
+		water_basined = TRUE
 		return
 	if(!is_type_in_list(target, allowed_fishing_turfs))
 		return
@@ -159,3 +201,4 @@ GLOBAL_LIST_INIT(fishing_weights, list(
 	fishing_spot = open_turf
 	spawned_bobber =  new /obj/effect/fishing_bobber(open_turf)
 	spawned_bobber.timed_fishing = allowed_fishing
+	spawned_bobber.connected_rod = src

--- a/modular_skyrat/modules/primitive_fun/code/ceramics.dm
+++ b/modular_skyrat/modules/primitive_fun/code/ceramics.dm
@@ -1,3 +1,15 @@
+#define TRAIT_CERAMIC_MASTER "ceramic_master"
+
+/obj/item/skillchip/ceramic_master
+	name = "Ceramic Master skillchip"
+	desc = "A master of clay, perhaps even capable of creating life from clay and fire."
+	auto_traits = list(TRAIT_CERAMIC_MASTER)
+	skill_name = "Ceramic Master"
+	skill_description = "Master the ability to use clay within ceramics."
+	skill_icon = "certificate"
+	activate_message = "<span class='notice'>The faults within the clay are now to be seen.</span>"
+	deactivate_message = "<span class='notice'>Clay becomes more obscured.</span>"
+
 /obj/structure/water_source/puddle/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/stack/ore/glass))
 		var/obj/item/stack/ore/glass/glass_item = O
@@ -47,6 +59,7 @@
 	name = "clay"
 	desc = "A pile of clay that can be used to create ceramic artwork."
 	icon_state = "clay"
+	w_class = WEIGHT_CLASS_SMALL
 
 /datum/export/ceramics
 	cost = 1000
@@ -60,29 +73,34 @@
 	desc = "A piece of clay that is flat, in the shape of a plate."
 	icon_state = "clay_plate"
 	forge_item = /obj/item/plate/ceramic
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/plate/ceramic
 	name = "ceramic plate"
 	icon = 'modular_skyrat/modules/primitive_fun/icons/prim_fun.dmi'
 	icon_state = "clay_plate"
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ceramic/bowl
 	name =  "ceramic bowl"
 	desc = "A piece of clay with a raised lip, in the shape of a bowl."
 	icon_state = "clay_bowl"
 	forge_item = /obj/item/reagent_containers/glass/bowl/ceramic
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/reagent_containers/glass/bowl/ceramic
 	name = "ceramic bowl"
 	icon = 'modular_skyrat/modules/primitive_fun/icons/prim_fun.dmi'
 	icon_state = "clay_bowl"
 	custom_materials = null
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ceramic/cup
 	name = "ceramic cup"
 	desc = "A piece of clay with high walls, in the shape of a cup. It can hold 120 units."
 	icon_state = "clay_cup"
 	forge_item = /obj/item/reagent_containers/glass/beaker/large/ceramic
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/reagent_containers/glass/beaker/large/ceramic
 	name = "ceramic cup"
@@ -90,6 +108,7 @@
 	icon = 'modular_skyrat/modules/primitive_fun/icons/prim_fun.dmi'
 	icon_state = "clay_cup"
 	custom_materials = null
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/structure/throwing_wheel
 	name = "throwing wheel"
@@ -103,6 +122,9 @@
 
 /obj/structure/throwing_wheel/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/ceramic/clay))
+		spinning_speed = 4 SECONDS
+		if(HAS_TRAIT(user, TRAIT_CERAMIC_MASTER))
+			spinning_speed = 2 SECONDS
 		if(length(contents) >= 1)
 			return
 		if(!do_after(user, spinning_speed, target = src))
@@ -120,6 +142,9 @@
 	return ..()
 
 /obj/structure/throwing_wheel/proc/use_clay(spawn_type, mob/user)
+	spinning_speed = 4 SECONDS
+	if(HAS_TRAIT(user, TRAIT_CERAMIC_MASTER))
+		spinning_speed = 2 SECONDS
 	var/given_message = list(
 		"You slowly start spinning the throwing wheel...",
 		"You place your hands on the clay, slowly shaping it...",
@@ -144,6 +169,9 @@
 	if(in_use)
 		return
 	in_use = TRUE
+	spinning_speed = 4 SECONDS
+	if(HAS_TRAIT(user, TRAIT_CERAMIC_MASTER))
+		spinning_speed = 2 SECONDS
 	if(length(contents) >= 1)
 		var/user_input = tgui_alert(user, "What would you like to do?", "Choice Selection", list("Create", "Remove"))
 		if(!user_input)

--- a/modular_skyrat/modules/primitive_fun/code/glassblowing.dm
+++ b/modular_skyrat/modules/primitive_fun/code/glassblowing.dm
@@ -1,13 +1,26 @@
+#define TRAIT_GLASSBLOWING_MASTER "glassblowing_master"
+
+/obj/item/skillchip/glassblowing_master
+	name = "Glassblowing Master skillchip"
+	desc = "A master of glass, perhaps even capable of creating life from glass and fire."
+	auto_traits = list(TRAIT_GLASSBLOWING_MASTER)
+	skill_name = "Glass-Blowing Master"
+	skill_description = "Master the ability to use glass within glassblowing."
+	skill_icon = "certificate"
+	activate_message = "<span class='notice'>The faults within the glass are now to be seen.</span>"
+	deactivate_message = "<span class='notice'>Glass becomes more obscured.</span>"
+
 /obj/item/glassblowing
 	icon = 'modular_skyrat/modules/primitive_fun/icons/prim_fun.dmi'
 
 /obj/item/glassblowing/glass_globe
 	name = "glass globe"
-	desc = "A glass bowl that is capable of carrying things."
-	icon_state = "glass_bowl"
+	desc = "A glass globe that may eventually hold liquids."
+	icon_state = "glass_globe"
+	w_class = WEIGHT_CLASS_SMALL
 
 /datum/export/glassblowing
-	cost = 1000
+	cost = 3000
 	unit_name = "glassblowing product"
 	export_types = list(/obj/item/glassblowing/glass_lens,
 						/obj/item/glassblowing/glass_globe,
@@ -20,14 +33,16 @@
 
 /obj/item/glassblowing/glass_lens
 	name = "glass lens"
-	desc = "A glass bowl that is capable of carrying things."
-	icon_state = "glass_bowl"
+	desc = "A glass lens that can magnify."
+	icon_state = "glass_lens"
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/reagent_containers/glass/bowl/blowing_glass
 	name = "glass bowl"
 	desc = "A glass bowl that is capable of carrying things."
 	icon = 'modular_skyrat/modules/primitive_fun/icons/prim_fun.dmi'
 	icon_state = "glass_bowl"
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/reagent_containers/glass/beaker/large/blowing_glass
 	name = "glass cup"
@@ -35,12 +50,14 @@
 	icon = 'modular_skyrat/modules/primitive_fun/icons/prim_fun.dmi'
 	icon_state = "glass_cup"
 	custom_materials = null
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/plate/blowing_glass
 	name = "glass plate"
 	desc = "A glass plate that is capable of carrying things."
 	icon = 'modular_skyrat/modules/primitive_fun/icons/prim_fun.dmi'
 	icon_state = "glass_plate"
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/glassblowing/molten_glass
 	name = "molten glass"
@@ -51,6 +68,7 @@
 	var/list/required_actions = list(0,0,0,0,0) //blowing, spinning, paddles, shears, jacks
 	var/list/current_actions = list(0,0,0,0,0)
 	var/chosen_item
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/glassblowing/molten_glass/Initialize()
 	. = ..()
@@ -92,6 +110,7 @@
 	desc = "A tool that is used to hold the molten glass as well as help shape it."
 	icon_state = "blow_pipe_empty"
 	var/in_use = FALSE
+	w_class = WEIGHT_CLASS_SMALL
 
 /datum/crafting_recipe/glass_blowing_rod
 	name = "Glass-blowing Blowing Rod"
@@ -142,7 +161,9 @@
 
 /obj/item/glassblowing/blowing_rod/attackby(obj/item/I, mob/living/user, params)
 	var/obj/item/glassblowing/molten_glass/find_glass = locate() in contents
-
+	var/actions_time = 5 SECONDS
+	if(HAS_TRAIT(user, TRAIT_GLASSBLOWING_MASTER))
+		actions_time = 2 SECONDS
 	if(istype(I, /obj/item/glassblowing/molten_glass))
 		if(find_glass)
 			to_chat(user, span_warning("[src] already has some glass on it still!"))
@@ -161,7 +182,7 @@
 			in_use = FALSE
 			return
 		to_chat(user, span_notice("You begin using [I] on [src]."))
-		if(!do_after(user, 5 SECONDS, target = src))
+		if(!do_after(user, actions_time, target = src))
 			to_chat(user, span_warning("You interrupt an action!"))
 			in_use = FALSE
 			return
@@ -183,7 +204,7 @@
 			in_use = FALSE
 			return
 		to_chat(user, span_notice("You begin using [I] on [src]."))
-		if(!do_after(user, 5 SECONDS, target = src))
+		if(!do_after(user, actions_time, target = src))
 			to_chat(user, span_warning("You interrupt an action!"))
 			in_use = FALSE
 			return
@@ -205,7 +226,7 @@
 			in_use = FALSE
 			return
 		to_chat(user, span_notice("You begin using [I] on [src]."))
-		if(!do_after(user, 5 SECONDS, target = src))
+		if(!do_after(user, actions_time, target = src))
 			to_chat(user, span_warning("You interrupt an action!"))
 			in_use = FALSE
 			return
@@ -222,6 +243,9 @@
 
 /obj/item/glassblowing/blowing_rod/attack_self(mob/user, modifiers)
 	var/obj/item/glassblowing/molten_glass/find_glass = locate() in contents
+	var/actions_time = 5 SECONDS
+	if(HAS_TRAIT(user, TRAIT_GLASSBLOWING_MASTER))
+		actions_time = 2 SECONDS
 	if(find_glass)
 		if(find_glass.world_molten < world.time)
 			to_chat(user, span_warning("The glass has cooled down far too much to be handled..."))
@@ -265,7 +289,7 @@
 						in_use = FALSE
 						return
 					to_chat(user, span_notice("You begin blowing [src]."))
-					if(!do_after(user, 5 SECONDS, target = src))
+					if(!do_after(user, actions_time, target = src))
 						to_chat(user, span_warning("You interrupt an action!"))
 						in_use = FALSE
 						return
@@ -281,7 +305,7 @@
 						in_use = FALSE
 						return
 					to_chat(user, span_notice("You begin spinning [src]."))
-					if(!do_after(user, 5 SECONDS, target = src))
+					if(!do_after(user, actions_time, target = src))
 						to_chat(user, span_warning("You interrupt an action!"))
 						in_use = FALSE
 						return
@@ -325,6 +349,7 @@
 	name = "jacks"
 	desc = "A tool that helps shape glass during the art process."
 	icon_state = "jacks"
+	w_class = WEIGHT_CLASS_SMALL
 
 /datum/crafting_recipe/glass_jack
 	name = "Glass-blowing Jacks"
@@ -336,6 +361,7 @@
 	name = "paddle"
 	desc = "A tool that helps shape glass during the art process."
 	icon_state = "paddle"
+	w_class = WEIGHT_CLASS_SMALL
 
 /datum/crafting_recipe/glass_paddle
 	name = "Glass-blowing Paddle"
@@ -347,6 +373,7 @@
 	name = "shears"
 	desc = "A tool that helps shape glass during the art process."
 	icon_state = "shears"
+	w_class = WEIGHT_CLASS_SMALL
 
 /datum/crafting_recipe/glass_shears
 	name = "Glass-blowing Shears"
@@ -359,6 +386,7 @@
 	desc = "A tool that helps shape glass during the art process."
 	icon_state = "metal_cup_empty"
 	var/has_sand = FALSE
+	w_class = WEIGHT_CLASS_SMALL
 
 /datum/crafting_recipe/glass_metal_cup
 	name = "Glass-blowing Metal Cup"

--- a/modular_skyrat/modules/reagent_forging/code/modules/reagent_forging/forge.dm
+++ b/modular_skyrat/modules/reagent_forging/code/modules/reagent_forging/forge.dm
@@ -501,7 +501,10 @@
 			to_chat(user, span_warning("You feel that setting [ceramic_item] would not yield anything useful!"))
 			return
 		to_chat(user, span_notice("You start setting [ceramic_item]..."))
-		if(!do_after(user, 5 SECONDS, target = src))
+		var/set_time = 5 SECONDS
+		if(HAS_TRAIT(user, TRAIT_CERAMIC_MASTER))
+			set_time = 2 SECONDS
+		if(!do_after(user, set_time, target = src))
 			to_chat(user, span_warning("You stop setting [ceramic_item]!"))
 			return
 		to_chat(user, span_notice("You finish setting [ceramic_item]..."))
@@ -525,13 +528,20 @@
 			to_chat(user, span_warning("[blowing_item] does not have any glass to heat up."))
 			in_use = FALSE
 			return
+		var/looping_amount = 5
+		var/looping_time = 2 SECONDS
+		var/added_molten = 25 SECONDS
+		if(HAS_TRAIT(user, TRAIT_GLASSBLOWING_MASTER))
+			looping_amount = 3
+			looping_time = 1 SECONDS
+			added_molten = 40 SECONDS
 		to_chat(user, span_notice("You begin heating up [blowing_item]."))
-		for(var/do_loop in 1 to 5) //I really want 10 seconds, but not all at "once," this makes it feel like less time
-			if(!do_after(user, 2 SECONDS, target = src))
+		for(var/do_loop in 1 to looping_amount) //I really want 10 seconds, but not all at "once," this makes it feel like less time
+			if(!do_after(user, looping_time, target = src))
 				to_chat(user, span_warning("[blowing_item] is interrupted in its heating process."))
 				in_use = FALSE
 				return
-		find_glass.world_molten = world.time + 25 SECONDS
+		find_glass.world_molten = world.time + added_molten
 		to_chat(user, span_notice("You finish heating up [blowing_item]."))
 		in_use = FALSE
 		return
@@ -550,13 +560,18 @@
 			to_chat(user, span_warning("You need to be able to use [glass_item]!"))
 			in_use = FALSE
 			return
-		if(!do_after(user, 5 SECONDS, target = src))
+		var/doing_time = 5 SECONDS
+		var/added_molten = 25 SECONDS
+		if(HAS_TRAIT(user, TRAIT_GLASSBLOWING_MASTER))
+			doing_time = 2 SECONDS
+			added_molten = 40 SECONDS
+		if(!do_after(user, doing_time, target = src))
 			to_chat(user, span_warning("You stop heating up [glass_item]!"))
 			in_use = FALSE
 			return
 		in_use = FALSE
 		var/obj/item/glassblowing/molten_glass/spawned_glass = new /obj/item/glassblowing/molten_glass(get_turf(src))
-		spawned_glass.world_molten = world.time + 25 SECONDS
+		spawned_glass.world_molten = world.time + added_molten
 		return
 
 	if(istype(I, /obj/item/glassblowing/metal_cup))
@@ -573,7 +588,12 @@
 			to_chat(user, span_warning("There is no sand within [metal_item]!"))
 			in_use = FALSE
 			return
-		if(!do_after(user, 5 SECONDS, target = src))
+		var/doing_time = 5 SECONDS
+		var/added_molten = 25 SECONDS
+		if(HAS_TRAIT(user, TRAIT_GLASSBLOWING_MASTER))
+			doing_time = 2 SECONDS
+			added_molten = 40 SECONDS
+		if(!do_after(user, doing_time, target = src))
 			to_chat(user, span_warning("You stop heating up [metal_item]!"))
 			in_use = FALSE
 			return
@@ -581,7 +601,7 @@
 		metal_item.has_sand = FALSE
 		metal_item.icon_state = "metal_cup_empty"
 		var/obj/item/glassblowing/molten_glass/spawned_glass = new /obj/item/glassblowing/molten_glass(get_turf(src))
-		spawned_glass.world_molten = world.time + 25 SECONDS
+		spawned_glass.world_molten = world.time + added_molten
 		return
 
 	return ..()

--- a/modular_skyrat/modules/reagent_forging/code/modules/reagent_forging/water_basin.dm
+++ b/modular_skyrat/modules/reagent_forging/code/modules/reagent_forging/water_basin.dm
@@ -6,12 +6,24 @@
 	anchored = TRUE
 	density = TRUE
 
+	var/bluespaced = FALSE
+
 /obj/structure/reagent_water_basin/Initialize()
 	. = ..()
 	if(is_mining_level(z))
 		icon_state = "primitive_water_basin"
 
 /obj/structure/reagent_water_basin/attackby(obj/item/I, mob/living/user, params)
+	if(istype(I, /obj/item/stack/ore/bluespace_crystal))
+		if(bluespaced)
+			to_chat(user, span_warning("[src] has already been connected to another ocean, it does not require this again!"))
+			return
+		var/obj/item/stack/try_stack = I
+		if(!try_stack.use(1))
+			to_chat(user, span_warning("[try_stack] is unable to be added to [src], there is an issue!"))
+			return
+		bluespaced = TRUE
+		return
 	if(istype(I, /obj/item/forging/tongs))
 		var/obj/item/forging/incomplete/searchIncomplete = locate(/obj/item/forging/incomplete) in I.contents
 		if(searchIncomplete?.times_hit < searchIncomplete.average_hits)
@@ -30,6 +42,8 @@
 	if(I.tool_behaviour == TOOL_WRENCH)
 		for(var/i in 1 to 5)
 			new /obj/item/stack/sheet/mineral/wood(get_turf(src))
+		if(bluespaced)
+			new /obj/item/stack/ore/bluespace_crystal(get_turf(src))
 		qdel(src)
 		return
 	if(istype(I, /obj/item/stack/ore/glass))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
different weighting for fishing, ceramic, and glassblowing items

created a fishing skill
gives you 2x the rewards for fishing

Water basins if a bluespace crystal is used on it will "link it to a random ocean," allowing you to fish from it

fishing bobbers will now just make a sound, rather than move (the moving was not too good)
fishing bobbers will allow you to reel in at a later time as well, as it loops now (every four seconds)

created a ceramic skill
it takes less time to do ceramics

created a glassblowing skill
it takes less time to do glassblowing
glass stays hot for longer

glass lens and globe are fixed icon and desc

glassblowing items are sold for three times more to balance it against ceramics
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
QoL for fishing, ceramics, and glassblowing... additionally connecting content to content
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: added fishing skillchip
add: added ceramics skillchip
add: added glassblowing skillchip
add: added the ability to fish from water basins (forging) if bluespace crystal'd
balance: fishing bobbers make a sound rather than move
balance: fishing bobbers can now loop, rather than one-time only
balance: fishing, ceramics, and glassblowing items have some different weights
balance: glassblowing is sold for 3x more
fix: glass lens and globe icon and desc is fixed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
