### PR TITLE
Fixes most if not all space ruins with wrong paths

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -261,6 +261,7 @@
 /area/ruin/unpowered/syndicate_lava_base/medbay)
 "cB" = (
 /obj/structure/flora/ausbushes/brflowers,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/grass,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
 "cC" = (
@@ -3350,6 +3351,7 @@
 /area/ruin/unpowered/syndicate_lava_base/testlab)
 "OX" = (
 /obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/grass,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
 "Pd" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -924,6 +924,7 @@
 /obj/machinery/door/poddoor{
 	id = "interdynebar"
 	},
+/obj/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "kV" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/alientoollab.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/alientoollab.dmm
@@ -291,7 +291,7 @@
 	dir = 1
 	},
 /obj/structure/table/abductor,
-/obj/effect/spawner/lootdrop/space/fancytool,
+/obj/effect/spawner/random/exotic/tool,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/powered)
 "U" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/blackmarket.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/blackmarket.dmm
@@ -94,11 +94,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
-"gN" = (
-/obj/effect/spawner/scatter/grime,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "hk" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -653,8 +648,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/spawner/random/prison_contraband,
-/obj/effect/spawner/lootdrop/armory_contraband/metastation,
+/obj/effect/spawner/random/contraband/prison,
+/obj/effect/spawner/random/contraband/armory,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
@@ -919,7 +914,7 @@ wq
 Wi
 Zh
 tC
-gN
+Hq
 qJ
 OC
 Zh

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/codealpha.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/codealpha.dmm
@@ -4,7 +4,7 @@
 /area/ruin/space/has_grav)
 "bR" = (
 /obj/structure/table/bronze,
-/obj/effect/spawner/lootdrop/space/cashmoney,
+/obj/item/stack/spacecash/c1000,
 /turf/open/floor/bronze,
 /area/ruin/space/has_grav)
 "dz" = (
@@ -105,7 +105,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/space/rareseed,
+/obj/effect/spawner/random/food_or_drink/seed_rare,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav)
 "rL" = (
@@ -178,7 +178,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav)
 "AM" = (
-/obj/effect/spawner/lootdrop/space/material,
+/obj/effect/spawner/random/engineering/material_rare,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav)
 "Bl" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -1429,7 +1429,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/spawner/randomcolavend,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav)
 "yT" = (
@@ -1659,7 +1658,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/space/fancytech,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav)
 "BN" = (
@@ -1803,6 +1801,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/item/disk/tech_disk/major,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav)
 "DY" = (
@@ -2668,7 +2667,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/space/fancytech,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav)
 "RU" = (
@@ -2750,6 +2748,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
 	},
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav)
 "TD" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/derelictferry.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/derelictferry.dmm
@@ -12,7 +12,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/ruin/space)
 "e" = (
-/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ruin/space)
 "f" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/ghostship.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/ghostship.dmm
@@ -249,6 +249,7 @@
 	},
 /obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/disk/tech_disk/spaceloot,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "mW" = (
@@ -504,7 +505,7 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "Ga" = (
-/obj/machinery/portable_atmospherics/canister/toxins{
+/obj/machinery/portable_atmospherics/canister/plasma{
 	desc = "Plasma gas. Highly fuel efficient. Highly volatile. Highly toxic.";
 	name = "Fuel canister"
 	},
@@ -650,7 +651,7 @@
 /area/ruin/unpowered)
 "Pr" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/crate_spawner,
+/obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "Qc" = (
@@ -702,7 +703,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet,
 /obj/effect/decal/fakelattice,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "Ta" = (
@@ -761,7 +762,7 @@
 /area/ruin/unpowered)
 "Vv" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/portable_atmospherics/canister/toxins{
+/obj/machinery/portable_atmospherics/canister/plasma{
 	desc = "Plasma gas. Highly fuel efficient. Highly volatile. Highly toxic.";
 	name = "Fuel canister"
 	},
@@ -796,7 +797,6 @@
 /area/ruin/unpowered)
 "YN" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/space/fancytech,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/outoftime.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/outoftime.dmm
@@ -582,7 +582,7 @@
 	},
 /area/ruin/space/has_grav/powered)
 "VI" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating{
 	icon = 'icons/turf/floors.dmi'
 	},

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/posterpandamonium.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/posterpandamonium.dmm
@@ -81,7 +81,7 @@
 	name = "Unexplored Location"
 	})
 "m" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered{
 	name = "Unexplored Location"

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/prisonshuttle.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/prisonshuttle.dmm
@@ -55,7 +55,7 @@
 	name = "Unexplored Location"
 	})
 "io" = (
-/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/powered{
 	name = "Unexplored Location"
@@ -119,7 +119,7 @@
 	name = "Unexplored Location"
 	})
 "nF" = (
-/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered{
 	name = "Unexplored Location"
@@ -195,7 +195,7 @@
 	name = "Unexplored Location"
 	})
 "xj" = (
-/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered{

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/salvagepost.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/salvagepost.dmm
@@ -516,7 +516,7 @@
 "wu" = (
 /obj/effect/turf_decal/box/white,
 /obj/effect/turf_decal/trimline/blue,
-/obj/machinery/portable_atmospherics/canister/toxins{
+/obj/machinery/portable_atmospherics/canister/plasma{
 	anchored = 1;
 	desc = "Plasma gas. Highly fuel efficient. Highly volatile. Highly toxic.";
 	name = "Fuel canister"
@@ -656,8 +656,8 @@
 "Eb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack/shelf,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/item/reagent_containers/food/drinks/waterbottle/large,
 /obj/item/reagent_containers/food/drinks/waterbottle/large,
 /obj/item/reagent_containers/food/drinks/waterbottle/large,
@@ -675,7 +675,7 @@
 /turf/template_noop,
 /area/template_noop)
 "EE" = (
-/obj/machinery/portable_atmospherics/canister/toxins{
+/obj/machinery/portable_atmospherics/canister/plasma{
 	anchored = 1;
 	desc = "Plasma gas. Highly fuel efficient. Highly volatile. Highly toxic.";
 	name = "Fuel canister"
@@ -698,7 +698,7 @@
 "EQ" = (
 /obj/effect/turf_decal/box/white,
 /obj/effect/turf_decal/trimline/blue,
-/obj/effect/spawner/lootdrop/crate_spawner,
+/obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/mech_bay_recharge_floor{
 	desc = "Commonly used in cargo ships to secure external cargo";
 	name = "magnetic floor"
@@ -865,7 +865,7 @@
 "Ni" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/refreshing_beverage{
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage{
 	pixel_x = -3;
 	pixel_y = 6
 	},
@@ -1100,7 +1100,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/toxins{
+/obj/machinery/portable_atmospherics/canister/plasma{
 	desc = "Plasma gas. Highly fuel efficient. Highly volatile. Highly toxic.";
 	name = "Fuel canister"
 	},

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/shuttle8532.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/shuttle8532.dmm
@@ -197,7 +197,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/effect/spawner/random/food_or_drink/three_course_meal,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "eb" = (
@@ -250,8 +250,8 @@
 	dir = 1;
 	icon_state = "tube"
 	},
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/space/syndiecosmetic,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/spawner/random/clothing/syndie,
 /obj/item/wrench/advanced,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
@@ -335,7 +335,7 @@
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "fW" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/random/maintenance,
 /obj/machinery/light/dim,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
@@ -679,7 +679,7 @@
 /area/ruin/space/has_grav/shuttle8532engineering)
 "oh" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/effect/spawner/random/food_or_drink/three_course_meal,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "ol" = (
@@ -724,7 +724,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "pe" = (
@@ -1210,7 +1210,9 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/space/fancytech,
+/obj/item/disk/tech_disk/spaceloot,
+/obj/item/stack/spacecash/c1000,
+/obj/item/raw_anomaly_core/random,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "yW" = (
@@ -1219,6 +1221,7 @@
 /area/ruin/space/has_grav/shuttle8532engineering)
 "zg" = (
 /obj/structure/table/reinforced,
+/obj/item/disk/tech_disk/spaceloot,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "zi" = (
@@ -1474,7 +1477,7 @@
 "CG" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/cable,
-/obj/effect/spawner/lootdrop/maint_drugs,
+/obj/effect/spawner/random/entertainment/drugs,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "CH" = (
@@ -1604,7 +1607,7 @@
 "EQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/effect/spawner/random/food_or_drink/three_course_meal,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "ER" = (
@@ -1628,7 +1631,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/effect/spawner/random/food_or_drink/three_course_meal,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "Ff" = (
@@ -1653,7 +1656,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/space/syndiecosmetic,
+/obj/effect/spawner/random/clothing/syndie,
 /obj/effect/turf_decal/raven{
 	dir = 8
 	},
@@ -1763,7 +1766,7 @@
 /obj/effect/turf_decal/raven{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/space/syndiecosmetic,
+/obj/effect/spawner/random/clothing/syndie,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532cargohall)
 "Iu" = (
@@ -1882,7 +1885,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/cable,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "Ly" = (
@@ -2025,7 +2028,7 @@
 /area/ruin/space/has_grav/shuttle8532engineering)
 "OK" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/maint_drugs,
+/obj/effect/spawner/random/entertainment/drugs,
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "OQ" = (
@@ -2061,7 +2064,6 @@
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "PI" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/space/fancytech,
 /obj/structure/table/reinforced,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532researchbay)
@@ -2218,7 +2220,7 @@
 /area/ruin/space/has_grav/shuttle8532cargohall)
 "Sw" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/random/maintenance,
 /obj/machinery/light/dim,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
@@ -2357,7 +2359,7 @@
 "VF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "VH" = (
@@ -2466,9 +2468,8 @@
 	dir = 1;
 	icon_state = "tube"
 	},
-/obj/effect/spawner/random/prison_contraband,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/syndiecosmetic,
+/obj/effect/spawner/random/contraband/prison,
+/obj/effect/spawner/random/clothing/syndie,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "XC" = (
@@ -2491,7 +2492,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532cargohall)
 "XE" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "XI" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/smugglies.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/smugglies.dmm
@@ -60,7 +60,7 @@
 /area/ruin/space/has_grav/powered/skyrat/smugglies)
 "y" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/space/cashmoney,
+/obj/item/stack/spacecash,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/skyrat/smugglies)
 "z" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/vaulttango.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/vaulttango.dmm
@@ -50,8 +50,8 @@
 	dir = 6
 	},
 /obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
+/obj/item/stack/spacecash,
+/obj/item/stack/spacecash,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/vaulttango)
 "bZ" = (
@@ -342,7 +342,7 @@
 "jw" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/rack/shelf,
-/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/item/ammo_box/magazine/m9mm,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/vaulttango)
@@ -358,7 +358,7 @@
 "jI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/rack/shelf,
-/obj/effect/spawner/lootdrop/space/syndiecosmetic,
+/obj/effect/spawner/random/clothing/syndie,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/vaulttango)
 "jY" = (
@@ -637,7 +637,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/vaulttango)
 "tZ" = (
-/turf/closed/wall/mineral/plastitanium/interior,
+/turf/closed/wall/mineral/plastitanium,
 /area/ruin/space/has_grav/vaulttango)
 "ut" = (
 /obj/structure/cable,
@@ -790,7 +790,7 @@
 "By" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/random/maintenance,
 /turf/template_noop,
 /area/template_noop)
 "BK" = (
@@ -814,7 +814,7 @@
 "Cc" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/north,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/vaulttango)
 "Cl" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/waypointstation.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/waypointstation.dmm
@@ -159,7 +159,7 @@
 	name = "Abandoned Station"
 	})
 "fQ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav{
 	name = "Abandoned Station"
@@ -355,7 +355,8 @@
 	})
 "oa" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/space/fancytech,
+/obj/item/disk/tech_disk/spaceloot,
+/obj/item/disk/tech_disk/spaceloot,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav{
 	name = "Abandoned Station"
@@ -404,7 +405,7 @@
 	})
 "pG" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/space/cashmoney,
+/obj/item/stack/spacecash,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav{
 	name = "Abandoned Station"
@@ -594,7 +595,7 @@
 	})
 "uK" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/space/cashmoney,
+/obj/item/stack/spacecash,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav{
 	name = "Abandoned Station"
@@ -634,7 +635,7 @@
 	name = "Abandoned Station"
 	})
 "xw" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
@@ -873,7 +874,7 @@
 	name = "Abandoned Station"
 	})
 "Ff" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav{
 	name = "Abandoned Shuttle"
@@ -888,7 +889,7 @@
 /turf/closed/mineral/bananium,
 /area/ruin/space)
 "Gh" = (
-/obj/effect/spawner/randomcolavend,
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav{
 	name = "Abandoned Station"
@@ -1079,7 +1080,7 @@
 /obj/machinery/light/broken{
 	dir = 1
 	},
-/obj/effect/spawner/randomsnackvend,
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav{
 	name = "Abandoned Station"

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/wreckedhomestead.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/wreckedhomestead.dmm
@@ -5,7 +5,7 @@
 /turf/open/floor/iron/dark/airless,
 /area/ruin/unpowered)
 "aW" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered)
 "bQ" = (
@@ -191,7 +191,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/unpowered)
 "Cl" = (
-/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered)
 "Dh" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does what it says on the tin, fixes the wrong paths in Skyrat specific space ruins, as TG already fixed their paths on their specific ruins.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Fixes are cool.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Space ruins should spawn properly and not be missing parts and pieces of themselves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
