### PR TITLE
[Modular] Breastmilk production now consumes nutrition instead of adding it

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -191,11 +191,9 @@
 		if(breasts)
 			if(breasts.lactates == TRUE)
 				var/regen = ((owner.nutrition / (NUTRITION_LEVEL_WELL_FED/100))/100) * (breasts.internal_fluids.maximum_volume/11000) * interval
-				breasts.internal_fluids.add_reagent(/datum/reagent/consumable/milk/breast_milk, regen)
 				if(!breasts.internal_fluids.holder_full())
-					owner.adjust_nutrition(regen / 2)
-				else
-					regen = regen
+					owner.adjust_nutrition(-regen / 2)
+					breasts.internal_fluids.add_reagent(/datum/reagent/consumable/milk/breast_milk, regen)
 
 		if(vagina)
 			if(H.arousal >= AROUS_SYS_LITTLE)


### PR DESCRIPTION
## About The Pull Request

Breasts were supposed to decrease nutrition when regenning milk. Instead, it increased it, making people with huge breasts fat. Now it works properly!

Also moved the add-more-milk proc to inside the check to see if its full, cus honestly, why wasn't it there?

And removed an "else regen = regen" cus it did pretty much nothing at all.

## How This Contributes To The Skyrat Roleplay Experience

ur fat milkers dont make u fat anymore

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: breastmilk production no longer makes you fat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
