### PR TITLE
Mirrors funny-button changes ignored in #8572 and fixes SM windows

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -5903,6 +5903,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"aUH" = (
+/obj/structure/window/reinforced/plasma/spawner/west{
+	dir = 4
+	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "aUK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -36040,11 +36048,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"epN" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/west,
-/turf/open/floor/iron,
-/area/security/prison)
 "epP" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown{
@@ -37952,7 +37955,7 @@
 /area/service/library)
 "eTO" = (
 /obj/machinery/camera{
-	c_tag = "Engineering - Supermatter Room";
+	c_tag = "Engineering - Supermatter Room East";
 	dir = 8;
 	name = "engineering camera"
 	},
@@ -44813,7 +44816,7 @@
 /area/engineering/main)
 "hgA" = (
 /obj/machinery/camera{
-	c_tag = "Engineering - Supermatter Room";
+	c_tag = "Engineering - Supermatter Room West";
 	dir = 4;
 	name = "engineering camera"
 	},
@@ -53274,9 +53277,9 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "jJm" = (
-/obj/structure/window/reinforced/plasma/spawner/west,
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable,
+/obj/structure/window/reinforced/plasma/spawner/north,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "jJq" = (
@@ -73543,7 +73546,7 @@
 	req_one_access_txt = "10;24"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "engine-entrence"
+	cycle_id = "engine-entrance"
 	},
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
@@ -123720,9 +123723,9 @@ aTe
 rNb
 ezC
 qzf
-jJm
-jJm
-jJm
+aUH
+aUH
+aUH
 qzf
 qzf
 qzf
@@ -153989,7 +153992,7 @@ qYo
 qYo
 aaa
 kHZ
-epN
+aJA
 oWs
 oWs
 npH

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -13085,7 +13085,6 @@
 /area/maintenance/starboard/aft)
 "ceX" = (
 /obj/machinery/holopad,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -31540,14 +31539,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
-"mGC" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/research)
 "mGX" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -32638,9 +32629,6 @@
 /area/engineering/supermatter/room)
 "njb" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
@@ -40114,6 +40102,7 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "rAR" = (
+/obj/machinery/airalarm/directional/west,
 /obj/structure/table,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
@@ -41192,6 +41181,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"shj" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "shw" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/directional/south,
@@ -41688,7 +41686,6 @@
 	id = "rnd2";
 	name = "research lab shutters"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
@@ -41768,7 +41765,9 @@
 /area/engineering/supermatter/room)
 "syN" = (
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/reinforced/plasma,
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/engine,
@@ -49796,10 +49795,6 @@
 /obj/item/wirecutters,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"wZy" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/research)
 "wZJ" = (
 /obj/structure/table/glass,
 /obj/item/restraints/handcuffs/cable/zipties,
@@ -50915,7 +50910,6 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 24
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
 "xHC" = (
@@ -81470,9 +81464,9 @@ uHy
 hua
 mWg
 lPn
-syN
-syN
-syN
+shj
+shj
+shj
 hua
 cIT
 cfZ
@@ -98124,8 +98118,8 @@ blX
 wZe
 dhn
 bsZ
-wZy
-wZy
+bWr
+bWr
 ceX
 bvg
 bDm
@@ -98381,7 +98375,7 @@ bvx
 sxn
 bpX
 uIv
-bta
+bBD
 cnK
 bvH
 bvf
@@ -98895,8 +98889,8 @@ bpf
 iEK
 bpZ
 uIv
-bta
-mGC
+bBD
+gLd
 nhP
 sDW
 eja

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -54399,9 +54399,9 @@
 /area/hallway/primary/fore)
 "kVo" = (
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/reinforced/plasma,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/structure/window/reinforced/plasma/spawner/east,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
@@ -68808,9 +68808,9 @@
 /area/cargo/warehouse)
 "rzN" = (
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/reinforced/plasma,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/window/reinforced/plasma/spawner/west,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -500,12 +500,6 @@
 "aey" = (
 /turf/closed/wall,
 /area/security/range)
-"aeD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "aeG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1967,8 +1961,8 @@
 /area/maintenance/disposal/incinerator)
 "apX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/delivery,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "aqe" = (
@@ -9312,10 +9306,6 @@
 /area/maintenance/starboard)
 "bUL" = (
 /obj/machinery/telecomms/server/presets/security,
-/obj/machinery/camera{
-	dir = 1;
-	network = list("ss13","tcomms")
-	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bUR" = (
@@ -10623,6 +10613,7 @@
 "cjk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -19891,9 +19882,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "eIv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
-	},
 /turf/closed/wall,
 /area/service/janitor)
 "eII" = (
@@ -30335,10 +30323,9 @@
 /area/medical/storage)
 "iEU" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/drinkingglasses,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -30348,6 +30335,9 @@
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
@@ -32356,6 +32346,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/commons/dorms)
+"jut" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "jux" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -38229,6 +38229,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "lCs" = (
@@ -38896,7 +38899,9 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lPb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/closed/wall,
 /area/service/janitor)
 "lPh" = (
@@ -40564,9 +40569,6 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -41187,7 +41189,9 @@
 /area/commons/dorms)
 "mDk" = (
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/reinforced/plasma,
+/obj/structure/window/reinforced/plasma{
+	dir = 1
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
@@ -41899,9 +41903,8 @@
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "mPK" = (
@@ -43909,9 +43912,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/binary/thermomachine/heater{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "nyP" = (
@@ -45671,9 +45671,6 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -53015,10 +53012,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
-"qNi" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall,
-/area/service/janitor)
 "qNp" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -55529,6 +55522,10 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"rGE" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall,
+/area/maintenance/starboard)
 "rGR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57471,13 +57468,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"sqd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "sqe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -61172,10 +61162,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/security/brig)
-"tIw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/service/janitor)
 "tIU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63142,6 +63128,7 @@
 "uqX" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/random,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/construction/storage_wing)
 "urg" = (
@@ -68940,6 +68927,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "wqP" = (
@@ -72657,6 +72647,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"xGO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/thermomachine/heater{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "xGT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -89695,7 +89692,7 @@ hJT
 nxD
 hkv
 nEK
-yhM
+jut
 unu
 yhM
 qby
@@ -111765,7 +111762,7 @@ qMr
 uVa
 xVl
 dKp
-sqd
+tqJ
 lCj
 alq
 bvc
@@ -112051,7 +112048,7 @@ dww
 cFu
 dyc
 uce
-jIn
+hEi
 haC
 jIn
 jIn
@@ -113054,10 +113051,10 @@ evA
 teN
 apc
 lNs
-lNs
+rGE
 lPb
-qNi
-tIw
+eIv
+eIv
 eIv
 ovj
 arh
@@ -113312,8 +113309,8 @@ apc
 oCR
 lNs
 mKO
+xGO
 aaX
-aeD
 apX
 mPy
 ovj

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -15711,17 +15711,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"dps" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard/fore)
-"dpL" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/starboard/fore)
 "dpY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -19378,6 +19367,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"eAz" = (
+/obj/machinery/firealarm/directional/east,
+/obj/structure/chair/office/light,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "eAF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24150,6 +24148,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"gkl" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "gkr" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -24397,10 +24402,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "goq" = (
@@ -25472,6 +25476,15 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/dark,
 /area/commons/locker)
+"gHZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "gIf" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -31122,11 +31135,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "iVh" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
+/obj/machinery/power/terminal{
+	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "iVt" = (
@@ -35640,12 +35653,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "kFz" = (
-/obj/machinery/firealarm/directional/east,
-/obj/structure/chair/office/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "kGc" = (
@@ -36086,6 +36094,12 @@
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"kNe" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "kNi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -50319,6 +50333,14 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos)
+"pNZ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "pOl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -55071,11 +55093,11 @@
 /turf/open/floor/carpet,
 /area/command/corporate_showroom)
 "rxr" = (
-/obj/machinery/power/terminal,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "rxz" = (
@@ -55914,11 +55936,10 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/medical/coldroom)
 "rOi" = (
-/obj/machinery/power/port_gen/pacman,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "rOn" = (
@@ -60479,12 +60500,13 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "tuI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "tuP" = (
@@ -61731,6 +61753,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "tRI" = (
@@ -66659,6 +66682,14 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
+"vCx" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "vCy" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -68507,6 +68538,7 @@
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "wkv" = (
@@ -69400,6 +69432,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "wCc" = (
@@ -116304,7 +116337,7 @@ kEv
 goo
 tuI
 tRH
-jRw
+gHZ
 vDR
 rUg
 sKe
@@ -117331,7 +117364,7 @@ sKk
 kEv
 rOi
 kFz
-lud
+gkl
 dqT
 nkh
 dqT
@@ -117586,9 +117619,9 @@ rzR
 rzR
 rzR
 rzR
-rzR
-dqT
-dqT
+vCx
+kFz
+kNe
 dqT
 tIU
 dqT
@@ -117842,11 +117875,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-dni
-dps
-dpL
+kEv
+pNZ
+eAz
+lud
+dqT
 ogL
 dqT
 bfJ
@@ -118103,7 +118136,7 @@ apm
 apm
 dnh
 dnh
-dnR
+dnh
 ydL
 dqT
 wxb

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -35070,11 +35070,11 @@
 /area/engineering/supermatter)
 "cEv" = (
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/reinforced/plasma,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 8
 	},
+/obj/structure/window/reinforced/plasma/spawner/east,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "cEw" = (
@@ -35091,11 +35091,11 @@
 /area/engineering/supermatter)
 "cEy" = (
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/reinforced/plasma,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 4
 	},
+/obj/structure/window/reinforced/plasma/spawner/west,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "cEz" = (
@@ -35190,11 +35190,11 @@
 /area/engineering/main)
 "cFe" = (
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/reinforced/plasma,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 5
 	},
+/obj/structure/window/reinforced/plasma/spawner/east,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "cFf" = (
@@ -35206,11 +35206,11 @@
 /area/science/research)
 "cFh" = (
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/reinforced/plasma,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 9
 	},
+/obj/structure/window/reinforced/plasma/spawner/west,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "cFi" = (

--- a/_maps/map_files/WaterKiloStation/WaterKiloStation.dmm
+++ b/_maps/map_files/WaterKiloStation/WaterKiloStation.dmm
@@ -65370,11 +65370,11 @@
 /area/service/chapel/office)
 "jNZ" = (
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/window/reinforced/plasma/spawner/east,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
@@ -67760,11 +67760,11 @@
 /area/maintenance/port)
 "kVo" = (
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/structure/window/reinforced/plasma/spawner/east,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
@@ -71348,11 +71348,11 @@
 /area/engineering/atmos)
 "mKV" = (
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/window/reinforced/plasma/spawner/west,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
@@ -80274,11 +80274,11 @@
 /area/cargo/warehouse)
 "rzN" = (
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/structure/window/reinforced/plasma/spawner/west,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -31476,9 +31476,9 @@
 /area/maintenance/central/secondary)
 "jdd" = (
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/structure/cable,
+/obj/structure/window/reinforced/plasma/spawner/east,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "jdj" = (
@@ -44418,6 +44418,13 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
+"oyb" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/structure/cable,
+/obj/structure/window/reinforced/plasma/spawner/west,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "oyh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -99655,9 +99662,9 @@ wnZ
 wKG
 oAv
 nfK
-jdd
-jdd
-jdd
+oyb
+oyb
+oyb
 wKG
 knR
 pKQ


### PR DESCRIPTION
## About The Pull Request
• Mirrors some of the duplicate APC issues, missing air alarms and messed up piping in #8572 
• Fixes Metastation's gravgen as per #8572 
• Fixes supermatter on all map being hecked with the windows facing the wrong way. 

Lots of the camera changes in #8572 have not been mirrored due to mapdiffbot not being the best in indicating changes to stuff like that.

## Changelog
:cl:
fix: Supermatter fixed on all maps.
/:cl:
