### PR TITLE
Fixed Internals for Lizards(And other races too!)

### DIFF
--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -159,7 +159,10 @@
 	icon_state = passed_string
 
 /obj/item/organ/genital/testicles/get_description_string(datum/sprite_accessory/genital/gas)
-	return "You see a pair of testicles, they look [lowertext(balls_size_to_description(genital_size))]."
+	if(genital_name == "Internal") //Checks if Testicles are of Internal Variety
+		visibility_preference = GENITAL_SKIP_VISIBILITY //Removes visibility if yes.
+	else
+		return "You see a pair of testicles, they look [lowertext(balls_size_to_description(genital_size))]."
 
 /obj/item/organ/genital/testicles/build_from_dna(datum/dna/DNA, associated_key)
 	..()

--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -159,9 +159,9 @@
 	icon_state = passed_string
 
 /obj/item/organ/genital/testicles/get_description_string(datum/sprite_accessory/genital/gas)
-	if(genital_name == "Internal") //Checks if Testicles are of Internal Variety
-		visibility_preference = GENITAL_SKIP_VISIBILITY //Removes visibility if yes.
-	else
+	if(genital_name == "Internal") //SKYRAT EDIT ADD  - Checks if Testicles are of Internal Variety
+		visibility_preference = GENITAL_SKIP_VISIBILITY //SKYRAT EDIT ADD  - Removes visibility if yes.
+	else //SKYRAT EDIT ADD
 		return "You see a pair of testicles, they look [lowertext(balls_size_to_description(genital_size))]."
 
 /obj/item/organ/genital/testicles/build_from_dna(datum/dna/DNA, associated_key)

--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -159,9 +159,9 @@
 	icon_state = passed_string
 
 /obj/item/organ/genital/testicles/get_description_string(datum/sprite_accessory/genital/gas)
-	if(genital_name == "Internal") //SKYRAT EDIT ADD  - Checks if Testicles are of Internal Variety
-		visibility_preference = GENITAL_SKIP_VISIBILITY //SKYRAT EDIT ADD  - Removes visibility if yes.
-	else //SKYRAT EDIT ADD
+	if(genital_name == "Internal") //Checks if Testicles are of Internal Variety
+		visibility_preference = GENITAL_SKIP_VISIBILITY //Removes visibility if yes.
+	else
 		return "You see a pair of testicles, they look [lowertext(balls_size_to_description(genital_size))]."
 
 /obj/item/organ/genital/testicles/build_from_dna(datum/dna/DNA, associated_key)


### PR DESCRIPTION
## About The Pull Request
This checks your testicles for internal status and if so, prevents them from being shown or able to be exposed.
If not, it simply returns the normal external testicle description.
This removes their visibility and ability to be exposed, while allowing them to function properly.

## How This Contributes To The Skyrat Roleplay Experience
Internals Testicles have been bugged for a long time now. If you had them you had to go to the expose/hide option and hide your testicles at round start every round. Otherwise your testicles would by default be exposed when unclothed, and the genital description would describe an external pair of testicles that you shouldn't have.
This is good because it'll take a minor inconvenience off the board
## Changelog

:cl: Deek-Za
fix: fixes Internal testicles
