### PR TITLE
[NON-MODULAR] Removes cargo exports elasticity, unleashes creativity

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -27,7 +27,7 @@ Then the player gets the profit from selling his own wasted time.
 	var/list/exported_atoms_ref = list() //if they're not deleted they go in here for use.
 
 // external_report works as "transaction" object, pass same one in if you're doing more than one export in single go
-/proc/export_item_and_contents(atom/movable/AM, apply_elastic = FALSE, delete_unsold = TRUE, dry_run=FALSE, datum/export_report/external_report) //skyrat edit
+/proc/export_item_and_contents(atom/movable/AM, apply_elastic = FALSE, delete_unsold = TRUE, dry_run=FALSE, datum/export_report/external_report) //SKYRAT EDIT
 	if(!GLOB.exports_list.len)
 		setupExports()
 

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -1,3 +1,5 @@
+//THIS FILE HAS BEEN EDITED BY SKYRAT EDIT
+
 /* How it works:
 The shuttle arrives at CentCom dock and calls sell(), which recursively loops through all the shuttle contents that are unanchored.
 

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -27,7 +27,7 @@ Then the player gets the profit from selling his own wasted time.
 	var/list/exported_atoms_ref = list() //if they're not deleted they go in here for use.
 
 // external_report works as "transaction" object, pass same one in if you're doing more than one export in single go
-/proc/export_item_and_contents(atom/movable/AM, apply_elastic = FALSE, delete_unsold = TRUE, dry_run=FALSE, datum/export_report/external_report)
+/proc/export_item_and_contents(atom/movable/AM, apply_elastic = FALSE, delete_unsold = TRUE, dry_run=FALSE, datum/export_report/external_report) //skyrat edit
 	if(!GLOB.exports_list.len)
 		setupExports()
 
@@ -105,7 +105,7 @@ Then the player gets the profit from selling his own wasted time.
 		cost = init_cost
 
 // Checks the cost. 0 cost items are skipped in export.
-/datum/export/proc/get_cost(obj/O, apply_elastic = FALSE)
+/datum/export/proc/get_cost(obj/O, apply_elastic = FALSE) //SKYRAT EDIT
 	var/amount = get_amount(O)
 	if(apply_elastic)
 		if(k_elasticity!=0)
@@ -121,7 +121,7 @@ Then the player gets the profit from selling his own wasted time.
 	return 1
 
 // Checks if the item is fit for export datum.
-/datum/export/proc/applies_to(obj/O, apply_elastic = FALSE)
+/datum/export/proc/applies_to(obj/O, apply_elastic = FALSE) //SKYRAT EDIT
 	if(!is_type_in_typecache(O, export_types))
 		return FALSE
 	if(include_subtypes && is_type_in_typecache(O, exclude_types))
@@ -140,7 +140,7 @@ Then the player gets the profit from selling his own wasted time.
  * get_cost, get_amount and applies_to do not neccesary mean a successful sale.
  *
  */
-/datum/export/proc/sell_object(obj/O, datum/export_report/report, dry_run = TRUE, apply_elastic = FALSE)
+/datum/export/proc/sell_object(obj/O, datum/export_report/report, dry_run = TRUE, apply_elastic = FALSE) //SKYRAT EDIT
 	///This is the value of the object, as derived from export datums.
 	var/the_cost = get_cost(O, apply_elastic)
 	///Quantity of the object in question.

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -27,7 +27,7 @@ Then the player gets the profit from selling his own wasted time.
 	var/list/exported_atoms_ref = list() //if they're not deleted they go in here for use.
 
 // external_report works as "transaction" object, pass same one in if you're doing more than one export in single go
-/proc/export_item_and_contents(atom/movable/AM, apply_elastic = TRUE, delete_unsold = TRUE, dry_run=FALSE, datum/export_report/external_report)
+/proc/export_item_and_contents(atom/movable/AM, apply_elastic = FALSE, delete_unsold = TRUE, dry_run=FALSE, datum/export_report/external_report)
 	if(!GLOB.exports_list.len)
 		setupExports()
 
@@ -105,7 +105,7 @@ Then the player gets the profit from selling his own wasted time.
 		cost = init_cost
 
 // Checks the cost. 0 cost items are skipped in export.
-/datum/export/proc/get_cost(obj/O, apply_elastic = TRUE)
+/datum/export/proc/get_cost(obj/O, apply_elastic = FALSE)
 	var/amount = get_amount(O)
 	if(apply_elastic)
 		if(k_elasticity!=0)
@@ -121,7 +121,7 @@ Then the player gets the profit from selling his own wasted time.
 	return 1
 
 // Checks if the item is fit for export datum.
-/datum/export/proc/applies_to(obj/O, apply_elastic = TRUE)
+/datum/export/proc/applies_to(obj/O, apply_elastic = FALSE)
 	if(!is_type_in_typecache(O, export_types))
 		return FALSE
 	if(include_subtypes && is_type_in_typecache(O, exclude_types))
@@ -140,7 +140,7 @@ Then the player gets the profit from selling his own wasted time.
  * get_cost, get_amount and applies_to do not neccesary mean a successful sale.
  *
  */
-/datum/export/proc/sell_object(obj/O, datum/export_report/report, dry_run = TRUE, apply_elastic = TRUE)
+/datum/export/proc/sell_object(obj/O, datum/export_report/report, dry_run = TRUE, apply_elastic = FALSE)
 	///This is the value of the object, as derived from export datums.
 	var/the_cost = get_cost(O, apply_elastic)
 	///Quantity of the object in question.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR disables the cargo export price elasticity by changing the apply_elastic variable. The cargo export price elasticity was a modifier on the export price that made the price of exports go down the more you exported them. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

While it was a good way to prevent cargo from making a million by themselves through miasma collecting (stacking a lot of monkey corpses in a single tile), easy miasma production is now gone and so are other exploits. 

Price elasticity harmed other means of money making and potential antagonism/roleplay opportunities. I'll take an exemple that happened in a recent round, in blueshift. 
I was an antag and basically the gimmick was to make an ungodly amount of cocaine and smuggling it in the shuttle. I made my factory, sold one crate to make a bit of start money to hire some assistants that needed to pay their medical bills (medical was charging money for treatments) and got around 5k for a full crate of bricks. Then I sent another one because I had some spare, almost got caught by the custom and gained 272 credits for the same amount of bricks.
Producing cocaine on an industrial level lost all its point since it wasn't worthy enough and I ended up not hiring anyone because I didn't needed to, I didn't sell anymore cocaine so the custom agent or security never found out and basically the absurd price elasticity harmed a whole antag gimmick .

This change would also help botanists, xenobiologist, space explorers, even security (prisoner plates are affected by price elasticity), make money by ways that include roleplay. 
Custom agent now has to look out for things that are being exported, else a lot of money will be made illegaly. With more money into play, departments will also be able to charge for things. Do note that this change doesn't remove the utility of bounties. In fact most crewmembers don't need a lot of money so they won't invest in making a lot of goods to export, they will just do bounties instead.
In conclusion that mechanic change will push for more interactions, more conflicts, enable some kind of antagonism and make the cargo job less boring. 

This change also need live testing, if there's new op ways to make money safely and easily I'll be happy to nerf them by hardcoding a low price to keep the other things balanced.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:

balance: Nanotrascen economist specialist deduced that a single station couldn't overflow a market by themselves, the export price elasticity has now been removed.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
