### PR TITLE
Update Data Theft ambition template

### DIFF
--- a/modular_skyrat/modules/ambitions/code/ambition_templates.dm
+++ b/modular_skyrat/modules/ambitions/code/ambition_templates.dm
@@ -28,8 +28,8 @@
 /datum/ambition_template/data_theft
 	name = "Data Theft"
 	narrative = "You have been selected out of Donk. Co's leagues of potential sleeper operatives for one particular task."
-	objectives = list("Steal the Blackbox.", "Steal at least 20 technology nodes from the research division.", "Escape on the emergency shuttle alive and out of custody.")
-	tips = list("You should add an objective on how you plan to go about this task.", "The Blackbox is located in Telecomms on most Stations.", "The Blackbox doesn't fit in most bags. You'd need a bag of holding to hide it!", "To steal technology we'll have to print a disk from science and sneak our way to a research console to download nodes on the disk!")
+	objectives = list("Steal the Blackbox.", "Steal the Project Goon hard drive from the Master R&D Server.", "Escape on the emergency shuttle alive and out of custody.")
+	tips = list("You should add an objective on how you plan to go about this task.", "The Blackbox is located in Telecomms on most Stations.", "The Blackbox doesn't fit in most bags. You'd need a bag of holding to hide it!", "The hard drive is located in the Research Server Room on most stations.", "Stealing the hard drive will permanantly cripple research speed!")
 	antag_whitelist = list("Traitor")
 
 //TODO: Changeling Ambition


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Updates an ambition template to match #8401
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Stealing the research is bonehead easy. Technically it's still possible to do but the hard drive has a real impact on the round and is much more interesting to steal.
Most objective items are boring, the server _permanently_ halves research speed which is crippling if done early enough (no you can't put the hard drive back in the server) and adds real weight to the antag's actions.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Data Theft ambition template now targets the R&D Master Server instead of boring tech node theft.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
