### PR TITLE
[NON-MODULAR] "Fixes" BZ Metabolites not draining Changeling's chemicals

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2442,7 +2442,7 @@
 		if(changeling)
 			//SKYRAT EDIT CHANGE BEGIN - BZ-BUFF-VS-LING
 			//changeling.chem_charges = max(changeling.chem_charges - (2 * REM * delta_time), 0) - SKYRAT EDIT - ORIGINAL
-			changeling.chem_charges = max(changeling.chem_charges - (6 * REM * delta_time), 0)
+			changeling.chem_charges = max(changeling.chem_charges - (4 * REM * delta_time), 0)
 			//SKYRAT EDIT CHANGE END - BZ-BUFF-VS-LING
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2440,7 +2440,10 @@
 	if(L.mind)
 		var/datum/antagonist/changeling/changeling = L.mind.has_antag_datum(/datum/antagonist/changeling)
 		if(changeling)
-			changeling.chem_charges = max(changeling.chem_charges - (2 * REM * delta_time), 0)
+			//SKYRAT EDIT CHANGE BEGIN - BZ-BUFF-VS-LING
+			//changeling.chem_charges = max(changeling.chem_charges - (2 * REM * delta_time), 0) - SKYRAT EDIT - ORIGINAL
+			changeling.chem_charges = max(changeling.chem_charges - (6 * REM * delta_time), 0)
+			//SKYRAT EDIT CHANGE END - BZ-BUFF-VS-LING
 	return ..()
 
 /datum/reagent/pax/peaceborg


### PR DESCRIPTION
## About The Pull Request
This PR "fixes" BZ Metabolites to drain Changeling's chemicals by buffing the reagent's drain value from "2" to "4".
#3393 buffed some values of Changelings, in which the chemicals regeneration rate is now tripled. BZ was left untouched which only slowed the chemical regeneration instead like shown in this clip.

https://streamable.com/ezug3p

Because of this, it made impossible to contain a conscious changeling without draining their abilities as even inside a containement cell filled with BZ, they could spam their abilities like EMP or Armblade. 

BZ is intended to drain chemicals as stated in the TG Wiki. To be sure about it, this is me testing on TG the BZ's properties on changelings. You can notice that the chemicals start to slowly be drained once I release the BZ.
https://streamable.com/esvhb3

~~Reason I've buffed to drain the chemical drain to "6" was : "if we triple the regen rate, we can triple the drain rate too".~~
Under request, I changed it to 4, so BZ drains 1 point per tick to be conform with TG's value. This will give lings more time to react and think about which abilities to spend before running out.
## How This Contributes To The Skyrat Roleplay Experience

- Restores an intended mechanic to properly contain a changeling.
- Server's policy discourages to round remove antagonists unless if it's necessary.
- RP and Policy wise, we are encouraged to capture a Changeling alive for studies.
- Makes it possible to contain a Changeling without comitting a soft round removal by putting it in an undestructable cage.
- Encourages science to be more involved in Changeling's capture and study if there is a reliable way to subdue them.
- Antag can still RP.
- Perhaps incentivizes other antagonists to break out the changeling if needed.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: BZ Metabolizes drains Changeling's chemicals again.
/:cl:

