### PR TITLE
Disable Regained Tail Trauma

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2135,10 +2135,14 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	else
 		SEND_SIGNAL(tail_owner, COMSIG_ADD_MOOD_EVENT, "wrong_tail_regained", /datum/mood_event/tail_regained_wrong)
 	*/
+	//SKYRAT EDIT TAIL TRAUMA BEGIN
+	/* Temporarily disabling until fixed upon player spawm
 	if(tail_owner.dna.mutant_bodyparts["tail"][MUTANT_INDEX_NAME] == mutant_bodyparts["tail"][MUTANT_INDEX_NAME]) //mutant_bodyparts["tail"] should exist here
 		SEND_SIGNAL(tail_owner, COMSIG_ADD_MOOD_EVENT, "right_tail_regained", /datum/mood_event/tail_regained_right)
 	else
 		SEND_SIGNAL(tail_owner, COMSIG_ADD_MOOD_EVENT, "wrong_tail_regained", /datum/mood_event/tail_regained_wrong)
+	*/
+	//SKYRAT EDIT TAIL TRAUMA END
 	//SKYRAT EDIT CHANGE END
 
 /*


### PR DESCRIPTION
## About The Pull Request

Disables the Tail Trauma event

## How This Contributes To The Skyrat Roleplay Experience
_My tail is back, but that was traumatic..._

The regained your tail trauma moodlet debuff fires off on **Spawn**(Both roundstart and latejoin) if you have any sort of tail due to changes with how we handle the tails on SR. This negatively impacts the beginning of play for sizeable chunk of people due to it being a furry server. It's also rarely used in a legitimate way during any given round. 

Proposed change until a proper fix is issued since it makes a rougher round start for so many people and this has been an issue for several months.

## Changelog



:cl: Deek-Za
del: Disabled Tail Trauma
qol: Less troubling start for tailed individuals.
/:cl: