### PR TITLE
Allows OOC examine at all times

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -468,10 +468,9 @@
 				if(!(G.is_hidden(src)))
 					. += "<span class='notice'>[t_He] has exposed genitals... <a href='?src=[REF(src)];lookup_info=genitals'>Look closer...</a></span>"
 					break
-	if(!skipface)
-		var/line = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
-		if(line)
-			. += line
+	var/line = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
+	if(line)
+		. += line
 	if(client)
 		var/erp_status_pref = client.prefs.read_preference(/datum/preference/choiced/erp_status)
 		if(erp_status_pref && erp_status_pref != "disabled")

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -37,24 +37,24 @@
 
 	var/datum/preferences/preferences = holder.client?.prefs
 
-	var/skipface = (holder.wear_mask && (holder.wear_mask.flags_inv & HIDEFACE)) || (holder.head && (holder.head.flags_inv & HIDEFACE))
-	var/name = skipface ? "Unknown" : holder.name
-	var/flavor_text = skipface ? "Obscured" :  holder.dna.features["flavor_text"]
-	var/custom_species = skipface ? "Obscured" : holder.dna.features["custom_species"]
-	var/custom_species_lore = skipface ? "Obscured" : holder.dna.features["custom_species_lore"]
+	var/obscured = (holder.wear_mask && (holder.wear_mask.flags_inv & HIDEFACE)) || (holder.head && (holder.head.flags_inv & HIDEFACE))
+	var/name = obscured ? "Unknown" : holder.name
+	var/flavor_text = obscured ? "Obscured" :  holder.dna.features["flavor_text"]
+	var/custom_species = obscured ? "Obscured" : holder.dna.features["custom_species"]
+	var/custom_species_lore = obscured ? "Obscured" : holder.dna.features["custom_species_lore"]
 
 	var/e_prefs
 	var/e_prefs_nc
-	var/list/ooc_notes = list()
+	var/ooc_notes = ""
 
 	if(preferences)
 		e_prefs = preferences.read_preference(/datum/preference/choiced/erp_status)
 		e_prefs_nc = preferences.read_preference(/datum/preference/choiced/erp_status_nc)
-		ooc_notes += "ERP PREFERENCES: ERP - [e_prefs] | Non-conforming - [e_prefs_nc]<br>"
+		ooc_notes += "ERP PREFERENCES: ERP - [e_prefs] | Non-conforming - [e_prefs_nc]\n"
 
 	ooc_notes += holder.dna.features["ooc_notes"]
 
-	data["obscured"] = skipface ? TRUE : FALSE
+	data["obscured"] = obscured ? TRUE : FALSE
 	data["character_name"] = name
 	data["assigned_map"] = examine_panel_screen.assigned_map
 	data["flavor_text"] = flavor_text

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -43,14 +43,17 @@
 	var/custom_species = obscured ? "Obscured" : holder.dna.features["custom_species"]
 	var/custom_species_lore = obscured ? "Obscured" : holder.dna.features["custom_species_lore"]
 
-	var/e_prefs
-	var/e_prefs_nc
 	var/ooc_notes = ""
 
-	if(preferences)
-		e_prefs = preferences.read_preference(/datum/preference/choiced/erp_status)
-		e_prefs_nc = preferences.read_preference(/datum/preference/choiced/erp_status_nc)
-		ooc_notes += "ERP PREFERENCES: ERP - [e_prefs] | Non-conforming - [e_prefs_nc]\n"
+	if(preferences && preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
+		var/e_prefs = preferences.read_preference(/datum/preference/choiced/erp_status)
+		var/e_prefs_nc = preferences.read_preference(/datum/preference/choiced/erp_status_nc)
+		var/e_prefs_v = preferences.read_preference(/datum)
+		ooc_notes += "ERP PREFERENCES:\n"
+		ooc_notes += "ERP - [e_prefs]\n"
+		ooc_notes += "Non-conforming - [e_prefs_nc]\n"
+		ooc_notes += "VR - [e_prefs_v]\n"
+		ooc_notes += "\n"
 
 	ooc_notes += holder.dna.features["ooc_notes"]
 

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -34,10 +34,31 @@
 
 /datum/examine_panel/ui_data(mob/user)
 	var/list/data = list()
-	data["character_name"] = holder.name
+
+	var/datum/preferences/preferences = holder.client?.prefs
+
+	var/skipface = (holder.wear_mask && (holder.wear_mask.flags_inv & HIDEFACE)) || (holder.head && (holder.head.flags_inv & HIDEFACE))
+	var/name = skipface ? "Unknown" : holder.name
+	var/flavor_text = skipface ? "Obscured" :  holder.dna.features["flavor_text"]
+	var/custom_species = skipface ? "Obscured" : holder.dna.features["custom_species"]
+	var/custom_species_lore = skipface ? "Obscured" : holder.dna.features["custom_species_lore"]
+
+	var/e_prefs
+	var/e_prefs_nc
+	var/list/ooc_notes = list()
+
+	if(preferences)
+		e_prefs = preferences.read_preference(/datum/preference/choiced/erp_status)
+		e_prefs_nc = preferences.read_preference(/datum/preference/choiced/erp_status_nc)
+		ooc_notes += "ERP PREFERENCES: ERP - [e_prefs] | Non-conforming - [e_prefs_nc]<br>"
+
+	ooc_notes += holder.dna.features["ooc_notes"]
+
+	data["obscured"] = skipface ? TRUE : FALSE
+	data["character_name"] = name
 	data["assigned_map"] = examine_panel_screen.assigned_map
-	data["flavor_text"] = holder.dna.features["flavor_text"]
-	data["ooc_notes"] = holder.dna.features["ooc_notes"]
-	data["custom_species"] = holder.dna.features["custom_species"]
-	data["custom_species_lore"] = holder.dna.features["custom_species_lore"]
+	data["flavor_text"] = flavor_text
+	data["ooc_notes"] = ooc_notes
+	data["custom_species"] = custom_species
+	data["custom_species_lore"] = custom_species_lore
 	return data

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -49,7 +49,7 @@
 		var/e_prefs = preferences.read_preference(/datum/preference/choiced/erp_status)
 		var/e_prefs_nc = preferences.read_preference(/datum/preference/choiced/erp_status_nc)
 		var/e_prefs_v = preferences.read_preference(/datum/preference/choiced/erp_status_v)
-		ooc_notes += "ERP PREFERENCES: [e_prefs]\n"
+		ooc_notes += "ERP: [e_prefs]\n"
 		ooc_notes += "Non-conforming - [e_prefs_nc]\n"
 		ooc_notes += "VR - [e_prefs_v]\n"
 		ooc_notes += "\n"

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -48,9 +48,8 @@
 	if(preferences && preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
 		var/e_prefs = preferences.read_preference(/datum/preference/choiced/erp_status)
 		var/e_prefs_nc = preferences.read_preference(/datum/preference/choiced/erp_status_nc)
-		var/e_prefs_v = preferences.read_preference(/datum)
-		ooc_notes += "ERP PREFERENCES:\n"
-		ooc_notes += "ERP - [e_prefs]\n"
+		var/e_prefs_v = preferences.read_preference(/datum/preference/choiced/erp_status_v)
+		ooc_notes += "ERP PREFERENCES: [e_prefs]\n"
 		ooc_notes += "Non-conforming - [e_prefs_nc]\n"
 		ooc_notes += "VR - [e_prefs_v]\n"
 		ooc_notes += "\n"

--- a/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
@@ -91,3 +91,33 @@
 
 /datum/preference/choiced/erp_status/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE
+
+/datum/preference/choiced/erp_status_nc
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "erp_status_pref_nc"
+
+/datum/preference/choiced/erp_status_nc/init_possible_values()
+	return list("Yes", "Ask", "No")
+
+/datum/preference/choiced/erp_status_nc/create_default_value()
+	return "Ask"
+
+/datum/preference/choiced/erp_status_nc/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	if(CONFIG_GET(flag/disable_erp_preferences))
+		return FALSE
+
+	return preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
+
+/datum/preference/choiced/erp_status_nc/deserialize(input, datum/preferences/preferences)
+	if(CONFIG_GET(flag/disable_erp_preferences))
+		return "disabled"
+	if(!preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
+		return "disabled"
+	. = ..()
+
+/datum/preference/choiced/erp_status_nc/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE

--- a/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
@@ -121,3 +121,33 @@
 
 /datum/preference/choiced/erp_status_nc/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE
+
+/datum/preference/choiced/erp_status_v
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "erp_status_pref_v"
+
+/datum/preference/choiced/erp_status_v/init_possible_values()
+	return list("Yes", "Ask", "No")
+
+/datum/preference/choiced/erp_status_v/create_default_value()
+	return "Ask"
+
+/datum/preference/choiced/erp_status_v/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	if(CONFIG_GET(flag/disable_erp_preferences))
+		return FALSE
+
+	return preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
+
+/datum/preference/choiced/erp_status_v/deserialize(input, datum/preferences/preferences)
+	if(CONFIG_GET(flag/disable_erp_preferences))
+		return "disabled"
+	if(!preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
+		return "disabled"
+	. = ..()
+
+/datum/preference/choiced/erp_status_v/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE

--- a/tgui/packages/tgui/interfaces/ExaminePanel.js
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.js
@@ -6,6 +6,7 @@ export const ExaminePanel = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     character_name,
+    obscured,
     assigned_map,
     flavor_text,
     ooc_notes,
@@ -22,14 +23,18 @@ export const ExaminePanel = (props, context) => {
         <Stack fill>
           <Stack.Item grow>
             <Section fill title="Character Preview">
-              <ByondUi
-                height="100%"
-                width="100%"
-                className="ExaminePanel__map"
-                params={{
-                  id: assigned_map,
-                  type: 'map',
-                }} />
+              {!obscured
+              && (
+                <ByondUi
+                  height="100%"
+                  width="100%"
+                  className="ExaminePanel__map"
+                  params={{
+                    id: assigned_map,
+                    type: 'map',
+                  }} />
+              )}
+
             </Section>
           </Stack.Item>
           <Stack.Item grow>

--- a/tgui/packages/tgui/interfaces/ExaminePanel.js
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.js
@@ -34,7 +34,6 @@ export const ExaminePanel = (props, context) => {
                     type: 'map',
                   }} />
               )}
-
             </Section>
           </Stack.Item>
           <Stack.Item grow>

--- a/tgui/packages/tgui/interfaces/ExaminePanel.js
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.js
@@ -21,7 +21,7 @@ export const ExaminePanel = (props, context) => {
       theme="admin">
       <Window.Content>
         <Stack fill>
-          <Stack.Item grow>
+          <Stack.Item width="30%">
             <Section fill title="Character Preview">
               {!obscured
               && (

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/cursed_shit.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/cursed_shit.tsx
@@ -124,3 +124,8 @@ export const erp_status_pref_nc: FeatureChoiced = {
   name: "ERP Non-conforming Status",
   component: FeatureDropdownInput,
 };
+
+export const erp_status_pref_v: FeatureChoiced = {
+  name: "ERP VR Status",
+  component: FeatureDropdownInput,
+};

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/cursed_shit.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/cursed_shit.tsx
@@ -119,3 +119,8 @@ export const erp_status_pref: FeatureChoiced = {
   name: "ERP Status",
   component: FeatureDropdownInput,
 };
+
+export const erp_status_pref_nc: FeatureChoiced = {
+  name: "ERP Non-conforming Status",
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
## About The Pull Request

You can now view OOC notes at any time regardless if someone's face is obscured.

## Changelog

:cl:
qol:  You can now view someone's OOC notes at any time regardless of if their face is obscured.
/:cl:

