### PR TITLE
Fixing the Sergeant's Hat.

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/security_sergeant/secseg_clothes.dm
+++ b/modular_skyrat/modules/sec_haul/code/security_sergeant/secseg_clothes.dm
@@ -4,6 +4,8 @@
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/hats.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/head.dmi'
 	icon_state = "peacekeeper_sergeant_cap"
+	mutant_variants = NONE
+	armor = list(MELEE = 40, BULLET = 30, LASER = 30,ENERGY = 40, BOMB = 25, BIO = 0, RAD = 0, FIRE = 20, ACID = 50, WOUND = 0)
 
 /obj/item/clothing/under/rank/security/peacekeeper/sergeant
 	name = "peacekeeper sergeant uniform"


### PR DESCRIPTION
Fixed the Sergeant's Hat

## About The Pull Request

Sergeant's hat got messed up. Won't show on certain anthro races and also no armor values, making it worse to wear then pretty much any sec hat you can buy out of the vendor.
Fixed visibility on certain races
Added armor values matching a peacekeeper beret.

## How This Contributes To The Skyrat Roleplay Experience

It makes things work properly for folk!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Deek-Za
balance: Sergeant's hat has armor added.
fix: Sergeant's hat is now visible on anthro races.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
