### PR TITLE
Makes Felinid tails stop wagging [Fix]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,4 +199,3 @@ Temporary Items
 
 # TGUI bundles - SKYRAT EDIT
 /tgui/public/tgui-common.bundle.js
-tgstation.dme

--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,4 @@ Temporary Items
 
 # TGUI bundles - SKYRAT EDIT
 /tgui/public/tgui-common.bundle.js
+tgstation.dme

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -49,7 +49,6 @@
 		mutant_bodyparts -= "tail_human"
 	H.update_body()
 
-
 /datum/species/human/felinid/stop_wagging_tail(mob/living/carbon/human/H)
 	if(mutant_bodyparts["waggingtail_human"])
 		mutant_bodyparts["tail_human"] = mutant_bodyparts["waggingtail_human"]

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -48,14 +48,16 @@
 		mutant_bodyparts["waggingtail_human"] = mutant_bodyparts["tail_human"]
 		mutant_bodyparts -= "tail_human"
 	H.update_body()
-*/
-//SKYRAT EDIT REMOVAL END
+
 
 /datum/species/human/felinid/stop_wagging_tail(mob/living/carbon/human/H)
 	if(mutant_bodyparts["waggingtail_human"])
 		mutant_bodyparts["tail_human"] = mutant_bodyparts["waggingtail_human"]
 		mutant_bodyparts -= "waggingtail_human"
 	H.update_body()
+
+	*/
+//SKYRAT EDIT REMOVAL END
 
 /datum/species/human/felinid/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	if(ishuman(C))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

(Fixes #8508)

Felinid tails now stop wagging when you type *wag again. The original coder of the skyrat wagging module forgot to comment out the last bit of old wagging code, so the game just got confused whenever you tried to stop wagging. I commented that part out and now it works.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

I love the felinids. I love the felinids. I love the felinids.

(Really though, this probably pissed a lot of people off when it wasn't working.)

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: As a felinid, typing *wag a second time will stop your tail from wagging as intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
