### PR TITLE
[modular] fixes a runtime with loadout outfit helper

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
@@ -18,6 +18,9 @@
  * preference_source - the preferences of the thing we're equipping
  */
 /mob/living/carbon/human/proc/equip_outfit_and_loadout(datum/outfit/outfit, datum/preferences/preference_source, visuals_only = FALSE, datum/job/equipping_job)
+	if (!preference_source)
+		return FALSE
+
 	var/datum/outfit/equipped_outfit
 
 	if(ispath(outfit))


### PR DESCRIPTION
## About The Pull Request

cannot execute null.read_preference because someone forgot to include a check, considering that the only proc that calls this is a tg proc which doesn't normally send prefs to it

## How This Contributes To The Skyrat Roleplay Experience

runtime fix

## Changelog
not noticeable