### PR TITLE
[nonmodular] fixes a runtime with rods when melting them down to nothing

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 			if (!R && replace)
 				user.put_in_hands(new_item)
 	// SKYRAT EDIT ADDITION BEGIN: Reagent Forging
-	if(istype(W, /obj/item/forging/tongs))
+	else if(istype(W, /obj/item/forging/tongs))
 		var/obj/searchObj = locate(/obj) in W.contents
 		if(searchObj)
 			to_chat(user, span_warning("The tongs are already holding something, make room."))


### PR DESCRIPTION
## About The Pull Request

title

I'm starting to think I should have done all this in one PR but oh well

## How This Contributes To The Skyrat Roleplay Experience

it doesn't

## Changelog

:cl:
fix: welding rods down to nothing will no longer cause a runtime
/:cl: