### PR TITLE
[modular] stops tgui from migrating prefs when it shouldn't be and thus causing bad things when making new characters

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences.dm
@@ -48,7 +48,7 @@
 	var/list/alt_job_titles = list()
 
 	//Determines if the player has undergone TGUI preferences migration, if so, this will prevent constant loading.
-	var/tgui_prefs_migration = FALSE
+	var/tgui_prefs_migration = TRUE
 
 /datum/preferences/proc/species_updated(species_type)
 	all_quirks = list()

--- a/modular_skyrat/master_files/code/modules/client/preferences_savefile.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences_savefile.dm
@@ -74,6 +74,7 @@
 	WRITE_FILE(S["exploitable_info"] , exploitable_info)
 	WRITE_FILE(S["alt_job_titles"], alt_job_titles)
 	WRITE_FILE(S["languages"] , languages)
+	WRITE_FILE(S["tgui_prefs_migration"] , tgui_prefs_migration)
 
 /datum/preferences/proc/update_mutant_bodyparts(datum/preference/preference)
 	if (!preference.relevant_mutant_bodypart)


### PR DESCRIPTION
## About The Pull Request

title

## How This Contributes To The Skyrat Roleplay Experience

it doesn't

## Changelog

:cl:
fix: stops tgui from migrating prefs when it shouldn't be
/:cl: