### PR TITLE
[nonmodular] runtime fix for cryopods and shoes

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -322,7 +322,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 			if(istype(item_content, /obj/item/pda))
 				var/obj/item/pda/pda = item_content
 				pda.toff = TRUE
-			item_content.dropped()
+			item_content.dropped(mob_occupant)
 			mob_occupant.transferItemToLoc(item_content, control_computer, force = TRUE, silent = TRUE)
 			control_computer.frozen_item += item_content
 		else mob_occupant.transferItemToLoc(item_content, drop_location(), force = TRUE, silent = TRUE)


### PR DESCRIPTION
## About The Pull Request

*Runtime in _shoes.dm, line 92: Cannot execute null.clear alert().*

## How This Contributes To The Skyrat Roleplay Experience

it doesn't

## Changelog
N/A