### PR TITLE
[MOSTLY MODULAR] Fixes Hypovial Texture

### DIFF
--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -77,11 +77,11 @@
 			stored_products += P
 		//SKYRAT EDIT HYPOVIALS
 		else if (product == "vial")
-			var/obj/item/reagent_containers/glass/bottle/vial/small/P = new(src)
+			var/obj/item/reagent_containers/glass/vial/small/P = new(src)
 			reagents.trans_to(P, current_volume)
 			P.name = trim("[product_name] vial")
 			stored_products += P
-		//SKYRAT EDIT HYPOVIALS END 
+		//SKYRAT EDIT HYPOVIALS END
 	if(stored_products.len)
 		var/pill_amount = 0
 		for(var/thing in loc)

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -398,9 +398,9 @@
 				reagents.trans_to(P, vol_each, transfered_by = usr)
 		//SKYRAT EDIT ADDTION HYPOVIALS START
 		if(item_type == "vial")
-			var/obj/item/reagent_containers/glass/bottle/vial/small/P
+			var/obj/item/reagent_containers/glass/vial/small/P
 			for(var/i = 0; i < amount; i++)
-				P = new/obj/item/reagent_containers/glass/bottle/vial/small(drop_location())
+				P = new/obj/item/reagent_containers/glass/vial/small(drop_location())
 				P.name = trim("[name] vial")
 				adjust_item_drop_location(P)
 				reagents.trans_to(P, vol_each, transfered_by = usr)

--- a/modular_skyrat/modules/customization/modules/clothing/suits/trek.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/suits/trek.dm
@@ -20,7 +20,7 @@
 				/obj/item/hypospray,
 				/obj/item/healthanalyzer,
 				/obj/item/reagent_containers/syringe,
-				/obj/item/reagent_containers/glass/bottle/vial,
+				/obj/item/reagent_containers/glass/vial,
 				/obj/item/reagent_containers/glass/beaker,
 				/obj/item/storage/pill_bottle,
 				/obj/item/taperecorder)
@@ -84,7 +84,7 @@
 			/obj/item/hypospray,
 			/obj/item/healthanalyzer,
 			/obj/item/reagent_containers/syringe,
-			/obj/item/reagent_containers/glass/bottle/vial,
+			/obj/item/reagent_containers/glass/vial,
 			/obj/item/reagent_containers/glass/beaker,
 			/obj/item/storage/pill_bottle,
 			/obj/item/taperecorder)

--- a/modular_skyrat/modules/hyposprays/code/game/autolathe_designs.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/autolathe_designs.dm
@@ -3,7 +3,7 @@
 	id = "large_hypovial"
 	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(/datum/material/iron = 2500)
-	build_path = /obj/item/reagent_containers/glass/bottle/vial/large
+	build_path = /obj/item/reagent_containers/glass/vial/large
 	category = list("initial","Medical","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 

--- a/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hypospray_kits.dm
@@ -26,7 +26,7 @@
 	stored.max_items = 12
 	stored.can_hold = typecacheof(list(
 		/obj/item/hypospray/mkii,
-		/obj/item/reagent_containers/glass/bottle/vial
+		/obj/item/reagent_containers/glass/vial
 	))
 	update_icon_state()
 	update_icon()
@@ -80,9 +80,9 @@
 	if(empty)
 		return
 	new /obj/item/hypospray/mkii(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/small(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/small(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/small(src)
+	new /obj/item/reagent_containers/glass/vial/small(src)
+	new /obj/item/reagent_containers/glass/vial/small(src)
+	new /obj/item/reagent_containers/glass/vial/small(src)
 
 /obj/item/storage/hypospraykit/cmo
 	name = "deluxe hypospray kit"
@@ -95,16 +95,16 @@
 	if(empty)
 		return
 	new /obj/item/hypospray/mkii/CMO(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/large/multiver(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/large/salglu(src)
-	new /obj/item/reagent_containers/glass/bottle/vial/large/synthflesh(src)
+	new /obj/item/reagent_containers/glass/vial/large/multiver(src)
+	new /obj/item/reagent_containers/glass/vial/large/salglu(src)
+	new /obj/item/reagent_containers/glass/vial/large/synthflesh(src)
 
 /obj/item/storage/box/vials
 	name = "box of hypovials"
 
 /obj/item/storage/box/vials/PopulateContents()
 	for(var/i in 1 to 7)
-		new /obj/item/reagent_containers/glass/bottle/vial/small( src )
+		new /obj/item/reagent_containers/glass/vial/small( src )
 
 /obj/item/storage/box/hypospray
 	name = "box of hypospray kits"

--- a/modular_skyrat/modules/hyposprays/code/game/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hyposprays_II.dm
@@ -22,11 +22,11 @@
 	icon = 'modular_skyrat/modules/hyposprays/icons/hyposprays.dmi'
 	desc = "A new development from DeForest Medical, this hypospray takes 60-unit vials as the drug supply for easy swapping."
 	w_class = WEIGHT_CLASS_TINY
-	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/bottle/vial/small)
+	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/vial/small)
 	//Inject or spray?
 	var/mode = HYPO_INJECT
-	var/obj/item/reagent_containers/glass/bottle/vial/vial
-	var/start_vial = /obj/item/reagent_containers/glass/bottle/vial/small
+	var/obj/item/reagent_containers/glass/vial/vial
+	var/start_vial = /obj/item/reagent_containers/glass/vial/small
 	var/spawnwithvial = TRUE
 
 	//Time taken to inject others
@@ -45,11 +45,11 @@
 
 /obj/item/hypospray/mkii/CMO
 	name = "hypospray mk.II deluxe"
-	allowed_containers = list(/obj/item/reagent_containers/glass/bottle/vial/small, /obj/item/reagent_containers/glass/bottle/vial/large)
+	allowed_containers = list(/obj/item/reagent_containers/glass/vial/small, /obj/item/reagent_containers/glass/vial/large)
 	icon_state = "cmo2"
 	desc = "The deluxe hypospray can take larger 120-unit vials. It also acts faster and can deliver more reagents per spray."
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-	start_vial = /obj/item/reagent_containers/glass/bottle/vial/large/deluxe
+	start_vial = /obj/item/reagent_containers/glass/vial/large/deluxe
 	inject_wait = DELUXE_WAIT_INJECT
 	spray_wait = DELUXE_WAIT_SPRAY
 	spray_self = DELUXE_SELF_SPRAY
@@ -71,7 +71,7 @@
 	if(!vial.reagents.total_volume)
 		return
 	var/vial_spritetype = "chem-color"
-	if(/obj/item/reagent_containers/glass/bottle/vial/large in allowed_containers)
+	if(/obj/item/reagent_containers/glass/vial/large in allowed_containers)
 		vial_spritetype += "-cmo"
 	var/mutable_appearance/chem_loaded = mutable_appearance('modular_skyrat/modules/hyposprays/icons/hyposprays.dmi', vial_spritetype)
 	chem_loaded.color = vial.chem_color
@@ -94,8 +94,8 @@
 	. += "[src] is set to [mode ? "Inject" : "Spray"] contents on application."
 
 /obj/item/hypospray/mkii/proc/unload_hypo(obj/item/hypo, mob/user)
-	if((istype(hypo, /obj/item/reagent_containers/glass/bottle/vial)))
-		var/obj/item/reagent_containers/glass/bottle/vial/container = hypo
+	if((istype(hypo, /obj/item/reagent_containers/glass/vial)))
+		var/obj/item/reagent_containers/glass/vial/container = hypo
 		container.forceMove(user.loc)
 		user.put_in_hands(container)
 		to_chat(user, span_notice("You remove [vial] from [src]."))
@@ -107,12 +107,12 @@
 		return
 
 /obj/item/hypospray/mkii/proc/insert_vial(obj/item/new_vial, mob/living/user, obj/item/current_vial)
-	var/obj/item/reagent_containers/glass/bottle/vial/container = new_vial
+	var/obj/item/reagent_containers/glass/vial/container = new_vial
 	if(!is_type_in_list(container, allowed_containers))
 		to_chat(user, span_notice("[src] doesn't accept this type of vial."))
 		return FALSE
 	if(current_vial)
-		var/obj/item/reagent_containers/glass/bottle/vial/old_container = current_vial
+		var/obj/item/reagent_containers/glass/vial/old_container = current_vial
 		old_container.forceMove(drop_location())
 	if(!user.transferItemToLoc(container, src))
 		return FALSE
@@ -124,7 +124,7 @@
 		user.put_in_hands(current_vial)
 
 /obj/item/hypospray/mkii/attackby(obj/item/used_item, mob/living/user)
-	if((istype(used_item, /obj/item/reagent_containers/glass/bottle/vial) && vial != null))
+	if((istype(used_item, /obj/item/reagent_containers/glass/vial) && vial != null))
 		if(!quickload)
 			to_chat(user, span_warning("[src] can not hold more than one vial!"))
 			return FALSE
@@ -132,7 +132,7 @@
 			insert_vial(used_item, user, vial)
 			return TRUE
 
-	if((istype(used_item, /obj/item/reagent_containers/glass/bottle/vial)))
+	if((istype(used_item, /obj/item/reagent_containers/glass/vial)))
 		insert_vial(used_item, user)
 		return TRUE
 
@@ -164,7 +164,7 @@
 	return
 
 /obj/item/hypospray/mkii/afterattack(atom/target, mob/living/user, proximity)
-	if((istype(target, /obj/item/reagent_containers/glass/bottle/vial)))
+	if((istype(target, /obj/item/reagent_containers/glass/vial)))
 		insert_vial(target, user, vial)
 		return TRUE
 

--- a/modular_skyrat/modules/hyposprays/code/game/hypovials.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hypovials.dm
@@ -1,4 +1,4 @@
-/obj/item/reagent_containers/glass/bottle/vial
+/obj/item/reagent_containers/glass/vial
 	name = "broken hypovial"
 	desc = "You probably shouldn't be seeing this. Shout at a coder."
 	icon = 'modular_skyrat/modules/hyposprays/icons/vials.dmi'
@@ -8,7 +8,7 @@
 	possible_transfer_amounts = list(1,2,5,10)
 	var/chem_color //Used for hypospray overlay
 
-/obj/item/reagent_containers/glass/bottle/vial/update_overlays()
+/obj/item/reagent_containers/glass/vial/update_overlays()
     . = ..()
     if(!fill_icon_thresholds)
         return
@@ -32,22 +32,22 @@
         chem_color = filling.color
         . += filling
 
-/obj/item/reagent_containers/glass/bottle/vial/Initialize()
+/obj/item/reagent_containers/glass/vial/Initialize()
 	. = ..()
 	update_icon()
 
-/obj/item/reagent_containers/glass/bottle/vial/on_reagent_change()
+/obj/item/reagent_containers/glass/vial/on_reagent_change()
 	update_icon()
 
 //Fit in all hypos
-/obj/item/reagent_containers/glass/bottle/vial/small
+/obj/item/reagent_containers/glass/vial/small
 	name = "hypovial"
 	desc = "A small, 60u capacity vial compatible with most hyposprays."
 	volume = 60
 	possible_transfer_amounts = list(1,2,5,10,20,30,40,50,60)
 
 //Fit in CMO hypo only
-/obj/item/reagent_containers/glass/bottle/vial/large
+/obj/item/reagent_containers/glass/vial/large
 	name = "large hypovial"
 	icon_state = "hypoviallarge"
 	desc = "A large, 120u capacity vial that fits only in the most deluxe hyposprays."
@@ -55,18 +55,18 @@
 	possible_transfer_amounts = list(1,2,5,10,20,30,40,50,100,120)
 
 //Hypos that are in the CMO's kit round start
-/obj/item/reagent_containers/glass/bottle/vial/large/deluxe
+/obj/item/reagent_containers/glass/vial/large/deluxe
 	name = "deluxe hypovial"
 	list_reagents = list(/datum/reagent/medicine/omnizine = 20, /datum/reagent/medicine/leporazine = 20, /datum/reagent/medicine/atropine = 20)
 
-/obj/item/reagent_containers/glass/bottle/vial/large/salglu
+/obj/item/reagent_containers/glass/vial/large/salglu
 	name = "large green hypovial (salglu)"
 	list_reagents = list(/datum/reagent/medicine/salglu_solution = 60)
 
-/obj/item/reagent_containers/glass/bottle/vial/large/synthflesh
+/obj/item/reagent_containers/glass/vial/large/synthflesh
 	name = "large orange hypovial (synthflesh)"
 	list_reagents = list(/datum/reagent/medicine/c2/synthflesh = 60)
 
-/obj/item/reagent_containers/glass/bottle/vial/large/multiver
+/obj/item/reagent_containers/glass/vial/large/multiver
 	name = "large black hypovial (multiver)"
 	list_reagents = list(/datum/reagent/medicine/c2/multiver = 60)

--- a/modular_skyrat/modules/hyposprays/code/game/hypovials.dm
+++ b/modular_skyrat/modules/hyposprays/code/game/hypovials.dm
@@ -6,6 +6,7 @@
 	spillable = FALSE
 	volume = 10
 	possible_transfer_amounts = list(1,2,5,10)
+	fill_icon_thresholds = list(10, 25, 50, 75, 100)
 	var/chem_color //Used for hypospray overlay
 
 /obj/item/reagent_containers/glass/vial/update_overlays()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Repaths hypovials to not be a child of bottles, making it so that the bottle overlay does not apply to them. From what I've tested, this shouldn't have any effect on how hypovials actually function. Gives hyposprays fill_icon_thresholds, allowing them to add textures.

The end result is that hypovials properly display their overlays instead of the bottle overlay. 
![image](https://user-images.githubusercontent.com/68373373/136706965-8bba55a1-85ff-458d-90b6-7852998a2960.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Glitched textures are unrealistic and LRP
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Hypovials now properly display their intended overlay texture, instead of the chemical overlay textures from bottles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
