### PR TITLE
First-Aid Contents fix, Icebox.

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -545,11 +545,11 @@
 "afG" = (
 /obj/structure/window/reinforced,
 /obj/structure/rack,
-/obj/item/storage/firstaid{
+/obj/item/storage/firstaid/regular{
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/brute{
 	pixel_x = -3;
 	pixel_y = -3


### PR DESCRIPTION
Fixes Sec Med's first aid boxes

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The first-aid boxes in the sec med's office on icebox currently spawn with no contents.
Just swapped them out to proper first aid kits.

## How This Contributes To The Skyrat Roleplay Experience
Well medic needs his medic things. Helps prevent people from having to raid medbay for more supplies since secmed only really starts with brute packs.

![image](https://user-images.githubusercontent.com/84706993/136763478-a00ac31e-ca30-4588-9de1-9d65c3839521.png)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Deek-Za
fix: Added contents to SecMed's office first-aid kits on Icebox
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
