### PR TITLE
Roleplay Friendly Fireplaces

### DIFF
--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -1,6 +1,6 @@
-#define LOG_BURN_TIMER 900 //SKYRAT EDIT original: 150
+#define LOG_BURN_TIMER 900 //SKYRAT EDIT original: #define LOG_BURN_TIMER 150
 #define PAPER_BURN_TIMER 5
-#define MAXIMUM_BURN_TIMER 18000 //SKYRAT EDIT original: 3000
+#define MAXIMUM_BURN_TIMER 18000 //SKYRAT EDIT original: #define MAXIMUM_BURN_TIMER 3000
 
 /obj/structure/fireplace
 	name = "fireplace"
@@ -75,15 +75,15 @@
 		return
 
 	switch(burn_time_remaining())
-		if(0 to 1800) //SKYRAT EDIT original: (0 to 500)
+		if(0 to 1800) //SKYRAT EDIT original: if(0 to 500)
 			. += "fireplace_fire0"
-		if(1800 to 4800) //SKYRAT EDIT original: (500 to 1000)
+		if(1800 to 4800) //SKYRAT EDIT original: if(500 to 1000)
 			. += "fireplace_fire1"
-		if(4800 to 8400) //SKYRAT EDIT original: (1000 to 1500)
+		if(4800 to 8400) //SKYRAT EDIT original: if(1000 to 1500)
 			. += "fireplace_fire2"
-		if(8400 to 12000) //SKYRAT EDIT original: (1500 to 2000)
+		if(8400 to 12000) //SKYRAT EDIT original: if(1500 to 2000)
 			. += "fireplace_fire3"
-		if(12000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: (2000 to MAXIMUM_BURN_TIMER)
+		if(12000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: if(2000 to MAXIMUM_BURN_TIMER)
 			. += "fireplace_fire4"
 	. += "fireplace_glow"
 
@@ -93,15 +93,15 @@
 		return
 
 	switch(burn_time_remaining())
-		if(0 to 1800) //SKYRAT EDIT original: (0 to 500)
+		if(0 to 1800) //SKYRAT EDIT original: if(0 to 500)
 			set_light(1)
-		if(1800 to 4800) //SKYRAT EDIT original: (500 to 1000)
+		if(1800 to 4800) //SKYRAT EDIT original: if(500 to 1000)
 			set_light(2)
-		if(4800 to 8400) //SKYRAT EDIT original: (1000 to 1500)
+		if(4800 to 8400) //SKYRAT EDIT original: if(1000 to 1500)
 			set_light(3)
-		if(8400 to 12000) //SKYRAT EDIT original: (1500 to 2000)
+		if(8400 to 12000) //SKYRAT EDIT original: if(1500 to 2000)
 			set_light(4)
-		if(12000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: (2000 to MAXIMUM_BURN_TIMER)
+		if(12000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: if(2000 to MAXIMUM_BURN_TIMER)
 			set_light(6)
 
 /obj/structure/fireplace/process(delta_time)

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -1,6 +1,6 @@
-#define LOG_BURN_TIMER 150
+#define LOG_BURN_TIMER 900 //SKYRAT EDIT original: 150
 #define PAPER_BURN_TIMER 5
-#define MAXIMUM_BURN_TIMER 3000
+#define MAXIMUM_BURN_TIMER 18000 //SKYRAT EDIT original: 3000
 
 /obj/structure/fireplace
 	name = "fireplace"
@@ -75,15 +75,15 @@
 		return
 
 	switch(burn_time_remaining())
-		if(0 to 500)
+		if(0 to 1800) //SKYRAT EDIT original: (0 to 500)
 			. += "fireplace_fire0"
-		if(500 to 1000)
+		if(1800 to 4800) //SKYRAT EDIT original: (500 to 1000)
 			. += "fireplace_fire1"
-		if(1000 to 1500)
+		if(4800 to 8400) //SKYRAT EDIT original: (1000 to 1500)
 			. += "fireplace_fire2"
-		if(1500 to 2000)
+		if(8400 to 12000) //SKYRAT EDIT original: (1500 to 2000)
 			. += "fireplace_fire3"
-		if(2000 to MAXIMUM_BURN_TIMER)
+		if(12000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: (2000 to MAXIMUM_BURN_TIMER)
 			. += "fireplace_fire4"
 	. += "fireplace_glow"
 
@@ -93,15 +93,15 @@
 		return
 
 	switch(burn_time_remaining())
-		if(0 to 500)
+		if(0 to 1800) //SKYRAT EDIT original: (0 to 500)
 			set_light(1)
-		if(500 to 1000)
+		if(1800 to 4800) //SKYRAT EDIT original: (500 to 1000)
 			set_light(2)
-		if(1000 to 1500)
+		if(4800 to 8400) //SKYRAT EDIT original: (1000 to 1500)
 			set_light(3)
-		if(1500 to 2000)
+		if(8400 to 12000) //SKYRAT EDIT original: (1500 to 2000)
 			set_light(4)
-		if(2000 to MAXIMUM_BURN_TIMER)
+		if(12000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: (2000 to MAXIMUM_BURN_TIMER)
 			set_light(6)
 
 /obj/structure/fireplace/process(delta_time)


### PR DESCRIPTION
My friends, today we're going to have a quick fireside chat about fireplaces.
![image](https://i.imgur.com/ORHlIsr.gif)

## About The Pull Request
Increases the Burn timer for wood from 15 seconds to 1.5 minutes
Increases the max fuel capacity for the fireplace from 5 minutes to 30 minutes.
Adjusted animation/lighting phase timers.

## How This Contributes To The Skyrat Roleplay Experience
Fireplaces are pretty cool. But with our server having a higher RP focus and a much more likelihood to stop and sit at certain scenes longer, I think it's a better adjustment for Skyrat.
This is a gripe I see pretty regularly with fireplaces and them burning through fuel super quickly. One wood burns up in 15 seconds. And if you store enough fuel(20 Wood) to cap it out you get a grand total of.. five minutes.
Honestly some of our lengthy based RP'rs would burn through a full capacity before it's their turn to RP post again!
You basically have to keep feeding in logs as you go and I see/hear semi-regular complaints about this. Plus someone getting up every couple of minutes to throw wood in the fire is a real mood killer.

## Changelog

:cl: Deek-Za
qol: Fireplaces now burn longer and have better fuel efficiency.
/:cl:

