### PR TITLE
[MODULAR] Disables a certain emote when a Server Toggle is thrown

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -799,10 +799,12 @@
 	cooldown = 30 SECONDS
 
 /datum/emote/living/cum/run_emote(mob/living/user, params, type_override, intentional)
+	if(CONFIG_GET(flag/disable_erp_preferences))
+		to_chat(user, span_warning("ERP is Disabled on this server"))
+		return
 	. = ..()
 	if(!.)
 		return
-
 
 	var/obj/item/coomer = new /obj/item/coom(user)
 	var/mob/living/carbon/human/H = user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Its a rough and dirty way to disable it but it hooks into the server wide toggle for exotic content. Ideally this would be eliminating it completely from the keybind menu but that is beyond my skill and have been told it is very difficult and would require /tg/ core file edits

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
code: hooked a certain emote to the server wide disable
admin: Non-ERP enabled server admins may see an increase in boinks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
