### PR TITLE
Minor change/fix to Hollow Bone drink ingredients

### DIFF
--- a/modular_skyrat/modules/customization/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/modular_skyrat/modules/customization/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -141,7 +141,7 @@
 
 /datum/chemical_reaction/drink/hollow_bone
 	results = list(/datum/reagent/consumable/ethanol/hollow_bone = 10)
-	required_reagents = list(/datum/reagent/toxin/bonehurtingjuice = 10,  /datum/reagent/consumable/milk = 15)
+	required_reagents = list(/datum/reagent/toxin/bonehurtingjuice = 10,  /datum/reagent/consumable/soymilk = 15)//Skeletons love milk, and will find soymilk disgusting!
 
 /datum/chemical_reaction/drink/jell_wyrm
 	results = list(/datum/reagent/consumable/ethanol/jell_wyrm = 2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I was asked on discord to change the recipe of this so it didn't sometimes break automation of Bone Hurting Juice in fermichem. Basically the issue was that BHJ requires milk, and BHJ + Milk is Hollow Bone, meaning if you tried to make too much of it it would turn into the liquor and not the chemical you wanted.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

This is a change to make a greater mechanical separation between a chem recipe and a fluff drink recipe to prevent ruining factory chems by mistake.

My reasoning for changing milk to soymilk is because the drink causes 30 disgust to skeletons, meaning they think it tastes awful. I figure soymilk is a bad imitation of the real thing, and even though the drink is no longer toxic it's nasty.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Changed Hollow Bone to use Soy Milk instead of Milk, making it harder to accidentally ruin your batch of Bone Hurting Juice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
