### PR TITLE
Restaurant for Icebox, Delta and Tram - Chef Rework Part 2

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -1357,12 +1357,11 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "aot" = (
-/obj/effect/turf_decal/tile/red/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/large,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "aow" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3505,12 +3504,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aJT" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 4
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/large,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "aJY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4210,18 +4207,6 @@
 	icon_state = "damaged2"
 	},
 /area/icemoon/surface/outdoors)
-"aRu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Canteen"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_half{
-	dir = 1
-	},
-/area/service/kitchen/diner)
 "aRK" = (
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
@@ -5987,10 +5972,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bji" = (
-/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bjl" = (
@@ -10217,7 +10198,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/machinery/power/grounding_rod/anchored,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "bKr" = (
@@ -11543,13 +11524,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
-"bVX" = (
-/obj/structure/chair/greyscale{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/full,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "bWc" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table,
@@ -12211,15 +12185,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/execution/education)
-"caH" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_large,
-/area/service/kitchen/diner)
 "caK" = (
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
@@ -14426,16 +14391,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/command/meeting_room)
-"cGO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "cHd" = (
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/green,
@@ -14766,8 +14721,11 @@
 	},
 /area/science/misc_lab)
 "cLx" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/brown/corner,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "cLH" = (
 /obj/structure/grille/broken,
@@ -15458,13 +15416,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
-"dcO" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "dcQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -15766,11 +15717,11 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "dkG" = (
-/obj/structure/chair/greyscale{
-	dir = 1
+/obj/structure/table/wood/fancy/red,
+/obj/item/candle/infinite{
+	pixel_y = 7
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "dlC" = (
 /obj/structure/chair{
@@ -16075,6 +16026,15 @@
 "dyq" = (
 /turf/closed/wall,
 /area/cargo/office)
+"dyB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "dyC" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -16538,14 +16498,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"dLo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
 "dLV" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
@@ -17066,7 +17018,8 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
 "ebS" = (
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "ecj" = (
 /obj/structure/cable/multilayer/multiz,
@@ -17088,16 +17041,8 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "ecW" = (
-/obj/structure/chair/greyscale{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/large,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "ede" = (
 /obj/structure/cable,
@@ -17125,16 +17070,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "edS" = (
-/obj/structure/chair/greyscale{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 5
-	},
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding/brown,
+/obj/structure/decorative/shelf/soda,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "edV" = (
 /turf/open/floor/iron/dark,
@@ -17699,6 +17640,8 @@
 /area/hallway/primary/starboard)
 "evV" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "ewl" = (
@@ -17923,14 +17866,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eCM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "eDN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 5
@@ -18594,10 +18537,9 @@
 	},
 /area/maintenance/starboard/fore)
 "fbj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "fbm" = (
 /turf/open/floor/iron,
@@ -19062,18 +19004,23 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fnZ" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair/greyscale{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Service-Diner";
 	dir = 4
 	},
-/turf/open/floor/iron/large,
+/obj/structure/table/wood/fancy/red,
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "fog" = (
 /obj/structure/cable,
@@ -19302,6 +19249,7 @@
 "fvz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "fwq" = (
@@ -19411,10 +19359,8 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fyw" = (
-/obj/structure/chair/greyscale{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "fyz" = (
 /obj/structure/spider/stickyweb,
@@ -19434,17 +19380,17 @@
 	},
 /area/hallway/secondary/entry)
 "fyW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "fzn" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron,
@@ -19781,15 +19727,6 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
-"fJK" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "fJQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20088,11 +20025,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"fRP" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "fRW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
@@ -20575,10 +20507,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "geQ" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "geS" = (
 /obj/effect/turf_decal/siding/wood{
@@ -20912,14 +20844,6 @@
 	dir = 5
 	},
 /area/maintenance/port/aft)
-"gps" = (
-/obj/machinery/door/airlock/sandstone/glass{
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/freezer,
-/area/service/kitchen/coldroom)
 "gpv" = (
 /obj/machinery/camera{
 	c_tag = "Fitness Room South";
@@ -20947,20 +20871,12 @@
 /turf/open/floor/iron/dark/blue,
 /area/security/brig)
 "gpU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	id = "barbershopcurtains1"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	id = "commissaryshutter";
-	name = "Vacant Commissary Shutter"
-	},
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/turf/open/floor/plating,
+/area/service/salon)
 "gqr" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/table,
@@ -21148,39 +21064,32 @@
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "gvr" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair/greyscale,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
 /obj/machinery/light/directional/west,
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
-/turf/open/floor/iron/large,
+/obj/effect/turf_decal/siding/brown,
+/obj/structure/aquarium,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/box/aquarium_props,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "gvx" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
-"gvO" = (
-/obj/structure/table/greyscale,
-/obj/effect/turf_decal/siding/white{
+"gvJ" = (
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/brown{
 	dir = 8
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "gvP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -21702,24 +21611,16 @@
 /turf/closed/mineral/random/snow,
 /area/icemoon/surface/outdoors)
 "gMI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/vending/barbervend,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "gMR" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
@@ -21882,6 +21783,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"gRh" = (
+/obj/structure/hedge/opaque,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
+/area/service/kitchen/diner)
 "gRQ" = (
 /obj/structure/bed/dogbed/runtime,
 /mob/living/simple_animal/pet/cat/runtime,
@@ -21903,17 +21809,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/aft)
-"gSZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "gTp" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/disposalpipe/segment,
@@ -22250,22 +22145,12 @@
 	},
 /area/science/research)
 "hgp" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/button/door/directional/east{
-	id = "commissaryshutter";
-	name = "Commissary Shutter Control"
-	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "hgT" = (
 /obj/effect/landmark/start/librarian,
 /obj/structure/chair/office,
@@ -22529,14 +22414,10 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "hrd" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/hedge/opaque,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "hrk" = (
 /obj/item/crowbar/large,
@@ -22669,23 +22550,15 @@
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "huA" = (
-/obj/structure/table,
 /obj/machinery/firealarm/directional/north,
-/obj/item/stack/sheet/iron/five,
-/obj/item/circuitboard/machine/paystand,
-/obj/item/stack/cable_coil/five,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/bed/pod,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "huD" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -22826,14 +22699,6 @@
 /obj/item/food/grown/carrot,
 /turf/open/floor/iron/dark,
 /area/science/research)
-"hAX" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "hBg" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -22876,19 +22741,12 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "hCt" = (
-/obj/structure/table/greyscale,
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/large,
+/obj/effect/turf_decal/siding/brown{
+	dir = 10
+	},
+/obj/structure/table/rolling,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "hCF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -22963,6 +22821,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/fitness)
+"hDT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/service/kitchen/diner)
 "hDY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -23306,8 +23174,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "hQl" = (
 /obj/structure/table,
@@ -23429,21 +23299,18 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "hUE" = (
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/turf_decal/siding/white{
-	dir = 6
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "hUG" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Canteen"
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
 	},
-/turf/open/floor/iron/textured_half{
-	dir = 1
-	},
-/area/service/kitchen/diner)
+/obj/machinery/door/airlock/silver,
+/turf/open/floor/carpet/black,
+/area/hallway/secondary/service)
 "hUJ" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
@@ -23596,16 +23463,11 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter)
 "iad" = (
-/obj/structure/chair/greyscale{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/restaurant_portal/restaurant,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "iaE" = (
 /obj/machinery/light/directional/west,
@@ -23673,11 +23535,11 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "ibK" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/large,
+/obj/structure/table/wood/fancy,
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "ibP" = (
 /obj/machinery/door/airlock/external{
@@ -23928,11 +23790,15 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "ihH" = (
-/obj/item/wrench,
-/obj/item/screwdriver,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/commons/vacant_room/commissary)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/chair/barber_chair{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/service/salon)
 "ihM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 9
@@ -24047,11 +23913,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
-"ilv" = (
-/obj/structure/table/greyscale,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/smooth_large,
-/area/service/kitchen/diner)
 "ilw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -25094,24 +24955,26 @@
 /turf/open/floor/wood,
 /area/service/library)
 "iUM" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/button/curtain{
+	id = "barbershopcurtains";
+	pixel_x = 25;
+	pixel_y = -24
+	},
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "iUO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26138,7 +26001,7 @@
 "jCM" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "jCV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -26256,7 +26119,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/textured_half,
 /area/hallway/secondary/service)
 "jFb" = (
@@ -26297,19 +26159,18 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "jFS" = (
-/obj/machinery/door/airlock{
-	id_tag = "commissarydoor";
-	name = "Commissary"
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/iron/dark,
-/area/commons/vacant_room/commissary)
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	id = "barbershopcurtains"
+	},
+/turf/open/floor/plating,
+/area/service/salon)
 "jGf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -26318,10 +26179,16 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "jGw" = (
-/obj/structure/table/greyscale,
-/obj/effect/turf_decal/tile/red/full,
-/obj/item/clothing/head/fedora,
-/turf/open/floor/iron/large,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "jGR" = (
 /obj/machinery/disposal/bin,
@@ -26495,22 +26362,12 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "jOb" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/table/greyscale,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
 /obj/machinery/light/directional/west,
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
-/turf/open/floor/iron/large,
+/obj/structure/hedge/opaque,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "jOk" = (
 /obj/machinery/light/directional/north,
@@ -26715,12 +26572,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jUa" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/bed/pod,
+/obj/structure/window,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "jUs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -27112,9 +26971,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/iron/half{
 	dir = 1
 	},
@@ -28275,16 +28131,6 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "kMq" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28292,8 +28138,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "kMK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28864,24 +28717,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "lhr" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/button/door/directional/east{
-	id = "commissarydoor";
-	name = "Commissary Door Lock";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "lhu" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -29372,6 +29213,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"lwU" = (
+/obj/structure/table/wood/fancy/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "lxr" = (
 /obj/structure/table,
 /obj/item/assembly/prox_sensor{
@@ -29827,10 +29678,19 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "lHp" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/structure/window,
+/obj/structure/window{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "lIn" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm4";
@@ -31281,14 +31141,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"mzt" = (
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/turf_decal/siding/white{
-	dir = 5
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/smooth_large,
-/area/service/kitchen/diner)
 "mzA" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "miner-passthrough"
@@ -32660,12 +32512,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
-"nhZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/service/kitchen/diner)
 "nid" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33397,6 +33243,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"nDl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron,
+/area/service/salon)
 "nDB" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -33610,11 +33464,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "nIT" = (
-/obj/structure/chair/greyscale,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
+/obj/structure/chair/sofa{
+	dir = 1
 	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "nJf" = (
 /obj/machinery/power/apc/auto_name/north,
@@ -33792,9 +33645,6 @@
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/half{
@@ -33950,13 +33800,6 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"nTS" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "nUo" = (
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
@@ -34158,6 +34001,18 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"obl" = (
+/obj/item/radio/intercom/directional/west,
+/obj/structure/table/reinforced/rglass,
+/obj/item/reagent_containers/dropper/precision{
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/spray/quantum_hair_dye{
+	pixel_x = 6
+	},
+/obj/item/lipstick/random,
+/turf/open/floor/iron,
+/area/service/salon)
 "obw" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/bot,
@@ -34231,8 +34086,13 @@
 /turf/open/openspace,
 /area/commons/storage/mining)
 "odG" = (
-/obj/effect/turf_decal/tile/red/full,
-/turf/open/floor/iron/large,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "oeD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -34564,14 +34424,8 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "orh" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "orn" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -34624,7 +34478,12 @@
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "orS" = (
-/obj/effect/turf_decal/delivery,
+/obj/structure/sign/barber{
+	pixel_x = -13
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
 "osi" = (
@@ -35410,18 +35269,13 @@
 /turf/open/floor/iron/dark,
 /area/brigofficer)
 "oOd" = (
-/obj/structure/table/greyscale,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/door/window/eastleft,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "oOi" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
@@ -35698,6 +35552,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
+"oYZ" = (
+/obj/structure/mirror/directional/west,
+/obj/structure/table/reinforced/rglass,
+/obj/item/razor{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/spray/barbers_aid{
+	pixel_x = 6
+	},
+/turf/open/floor/iron,
+/area/service/salon)
 "oZj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -35976,9 +35841,8 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "piZ" = (
-/obj/structure/table/greyscale,
-/obj/item/clothing/mask/cigarette/cigar,
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/hedge/opaque,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "pjk" = (
 /obj/structure/cable,
@@ -36069,26 +35933,22 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "pmn" = (
-/obj/structure/table,
 /obj/machinery/newscaster/directional/north,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 4
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/chair/office/light{
+	dir = 4
 	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/window{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light/directional/north,
+/obj/machinery/camera{
+	c_tag = "Salon"
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "pmp" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -36730,6 +36590,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
+"pzT" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/half{
+	dir = 1
+	},
+/area/hallway/secondary/service)
 "pAh" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Chemistry Lab Utilities";
@@ -36748,14 +36619,14 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "pAI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "pAR" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -37088,14 +36959,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
-"pJj" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair/greyscale{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "pJI" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -37143,12 +37006,6 @@
 /obj/vehicle/ridden/janicart,
 /turf/open/floor/iron,
 /area/service/janitor)
-"pKP" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "pLn" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -37468,8 +37325,8 @@
 "pTs" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/duct,
-/obj/structure/sign/poster/random{
-	pixel_y = 32
+/obj/machinery/airalarm/kitchen_cold_room{
+	pixel_y = 24
 	},
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
@@ -37491,25 +37348,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "pUg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Vacant Commissary";
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "pUi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
@@ -38099,9 +37946,13 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "qmL" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "qnw" = (
 /obj/machinery/power/apc/auto_name/south,
@@ -38219,8 +38070,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/commons/vacant_room/commissary)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/barber,
+/turf/open/floor/iron,
+/area/service/salon)
 "qpn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38446,7 +38302,9 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "qyN" = (
-/obj/effect/turf_decal/bot,
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
 "qyX" = (
@@ -38644,8 +38502,19 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "qEX" = (
-/turf/closed/wall,
-/area/commons/vacant_room/commissary)
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	id = "barbershopcurtains"
+	},
+/turf/open/floor/plating,
+/area/service/salon)
+"qFk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/silver,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "qFz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -38879,8 +38748,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qMP" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
 "qMQ" = (
@@ -39191,16 +39058,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"qVA" = (
-/obj/structure/chair/greyscale{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "qVL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -40001,8 +39858,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
@@ -40270,19 +40127,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "rCr" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/chair/barber_chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/west,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "rCB" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -40378,8 +40232,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/cook,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "rEn" = (
 /obj/machinery/space_heater,
@@ -41301,6 +41155,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/noticeboard/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "sgv" = (
@@ -41359,7 +41214,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/machinery/power/tesla_coil/anchored,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "shq" = (
@@ -41412,13 +41267,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"sir" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/rack,
-/obj/item/poster/random_contraband,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "sis" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -41660,14 +41508,8 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "sob" = (
-/obj/structure/chair/greyscale{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 10
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/chair/sofa,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "sol" = (
 /obj/structure/rack,
@@ -41807,13 +41649,14 @@
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
 "ssV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "stc" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
@@ -41907,11 +41750,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"svV" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair/greyscale,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "swc" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/iron/grimy,
@@ -41986,7 +41824,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/machinery/power/tesla_coil/anchored,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "syO" = (
@@ -42453,20 +42291,14 @@
 /area/ai_monitored/turret_protected/ai)
 "sMx" = (
 /obj/machinery/airalarm/directional/north,
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/item/storage/secure/briefcase,
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/light/warm/directional/north,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "sMI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -42710,15 +42542,6 @@
 /obj/item/key/janitor,
 /turf/open/floor/iron,
 /area/service/janitor)
-"sTF" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/holopad,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "sTP" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Mix to Port"
@@ -43262,20 +43085,14 @@
 	},
 /area/maintenance/aft)
 "tju" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/newspaper,
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/table/reinforced/rglass,
+/obj/item/hairbrush,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "tjz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -43607,14 +43424,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "tqk" = (
-/obj/structure/chair/greyscale{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/paper_bin,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "tqF" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -43727,17 +43541,11 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "tus" = (
-/obj/structure/chair/greyscale{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/iron/large,
+/obj/structure/chair/wood,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "tuy" = (
 /obj/structure/disposalpipe/segment,
@@ -44060,9 +43868,8 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "tDS" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white/corner,
-/turf/open/floor/iron/large,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "tEp" = (
 /obj/structure/cable,
@@ -44233,14 +44040,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"tJC" = (
-/obj/structure/table,
-/obj/machinery/airalarm/kitchen_cold_room{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/iron/freezer,
-/area/service/kitchen/coldroom)
 "tJF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44581,6 +44380,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"tSV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "tSY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44696,14 +44504,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "tWh" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 6
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "tWx" = (
 /obj/structure/closet/secure_closet/personal{
@@ -44747,18 +44550,18 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "tXN" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/landmark/start/barber,
+/obj/machinery/button/curtain{
+	id = "barbershopcurtains1";
+	pixel_x = 25;
+	pixel_y = 24
 	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "tXP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -45369,18 +45172,16 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "umQ" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/table/reinforced/rglass,
+/obj/structure/window,
+/obj/item/hairbrush,
+/obj/item/lipstick/random,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "umY" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/vending/wardrobe/science_wardrobe,
@@ -45488,8 +45289,18 @@
 "uqs" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/plating,
-/area/commons/vacant_room/commissary)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/dryer{
+	dir = 4;
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/turf/open/floor/iron,
+/area/service/salon)
 "uqG" = (
 /obj/machinery/door/window/eastright{
 	dir = 1;
@@ -45617,9 +45428,13 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "usW" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/large,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "utL" = (
 /turf/closed/wall,
@@ -46319,17 +46134,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"uLp" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/half{
-	dir = 1
-	},
-/area/hallway/secondary/service)
 "uLr" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -46338,10 +46142,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uLC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/brown{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "uLQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46561,10 +46368,6 @@
 "uUP" = (
 /turf/open/floor/carpet,
 /area/maintenance/space_hut/cabin)
-"uVg" = (
-/obj/item/trash/energybar,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "uVv" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Fuel Pipe"
@@ -46837,6 +46640,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/half{
 	dir = 1
 	},
@@ -46933,11 +46739,11 @@
 /turf/closed/wall,
 /area/service/bar/atrium)
 "vhG" = (
-/obj/machinery/restaurant_portal/restaurant,
-/obj/effect/turf_decal/siding/white{
-	dir = 10
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "vhK" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
@@ -47066,29 +46872,22 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/service/hydroponics/garden)
-"vkk" = (
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
+"vke" = (
+/obj/structure/mirror/directional/west,
+/obj/structure/table/reinforced/rglass,
+/obj/item/hairbrush/comb{
+	pixel_y = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_large,
-/area/service/kitchen/diner)
+/obj/item/reagent_containers/dropper,
+/obj/machinery/dryer{
+	pixel_y = 14
+	},
+/turf/open/floor/iron,
+/area/service/salon)
 "vkz" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/command/meeting_room)
-"vkK" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/public/glass{
-	name = "Canteen"
-	},
-/turf/open/floor/iron,
-/area/service/kitchen/diner)
 "vld" = (
 /obj/machinery/light/directional/south,
 /turf/open/openspace,
@@ -47218,6 +47017,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/commons/fitness)
+"vqL" = (
+/turf/closed/wall,
+/area/service/salon)
 "vqN" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -47719,6 +47521,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"vDL" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/service/salon)
 "vDO" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/plating,
@@ -48529,12 +48339,14 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "wbq" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/large,
+/obj/structure/table/wood/fancy,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "wbB" = (
 /obj/machinery/camera{
@@ -49111,12 +48923,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "wpy" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/brown/corner,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "wpH" = (
 /obj/effect/turf_decal/bot,
@@ -49616,17 +49425,12 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "wFL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "wGa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
@@ -49721,7 +49525,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/machinery/power/grounding_rod/anchored,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "wJm" = (
@@ -49878,13 +49682,13 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "wOC" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "wOE" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
@@ -50051,13 +49855,6 @@
 /obj/structure/cable,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
-"wRZ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
 "wSa" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/blue,
@@ -50251,8 +50048,14 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
 "wVv" = (
-/obj/structure/chair/greyscale,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding/brown,
+/obj/structure/aquarium,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/box/aquarium_props,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "wVA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50366,21 +50169,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "wZs" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/rack,
-/obj/item/crowbar,
-/obj/item/wirecutters,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/landmark/start/barber,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "wZJ" = (
 /obj/structure/table/glass,
 /obj/item/restraints/handcuffs/cable/zipties,
@@ -51172,6 +50967,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"xtP" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/half{
+	dir = 1
+	},
+/area/hallway/secondary/service)
 "xtW" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white/side{
@@ -51352,19 +51159,16 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "xzs" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light_switch/directional/west,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
 	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/salon)
 "xzt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -51917,14 +51721,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
-"xRW" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "xSX" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
@@ -52169,12 +51965,30 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ybY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall,
-/area/commons/vacant_room/commissary)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Barbershop"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/service/salon)
 "ybZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/table/wood/fancy/red,
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "yca" = (
 /obj/machinery/door/firedoor,
@@ -52469,11 +52283,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/research)
-"yjm" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/table/greyscale,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "yjw" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/disposal/bin,
@@ -74842,11 +74651,11 @@ aPL
 ldi
 upj
 wtM
-aPz
-bji
-sir
-uVg
-aSg
+vqL
+vqL
+vqL
+vqL
+vqL
 jUV
 wZp
 aPz
@@ -75099,14 +74908,14 @@ rBh
 ldi
 sSi
 pEo
-aPz
-aPz
-aPz
-aPz
-aPz
-xrz
-aPz
-aPz
+vqL
+vke
+obl
+oYZ
+vqL
+dyB
+vqL
+vqL
 fQM
 tel
 fQM
@@ -75356,7 +75165,7 @@ oZI
 oZI
 oZI
 oZI
-qEX
+vqL
 ihH
 wZs
 rCr
@@ -75613,14 +75422,14 @@ oZI
 ykY
 mzO
 fQp
-qEX
+vqL
 sMx
 wOC
-ssV
+nDl
 ssV
 fyW
 gMI
-qEX
+vqL
 qos
 lfk
 kRL
@@ -75870,14 +75679,14 @@ oMA
 ewl
 jIw
 flW
-qEX
+vqL
 pmn
-jUa
+hgp
 lHp
-dLo
+lhr
 pAI
 qpl
-qEX
+vqL
 pPD
 xxr
 roq
@@ -76127,14 +75936,14 @@ xkf
 qra
 iZJ
 xkS
-qEX
+vqL
 huA
+vDL
 jUa
-jUa
-wRZ
+lhr
 eCM
 kMq
-qEX
+vqL
 jJX
 kHP
 kIT
@@ -76384,14 +76193,14 @@ oMA
 wVe
 fNY
 qMs
-qEX
+vqL
 tju
 tXN
 umQ
 hgp
 lhr
 iUM
-qEX
+vqL
 emT
 lFU
 kIT
@@ -76641,10 +76450,10 @@ oZI
 pDc
 jNa
 pBs
-qEX
-qEX
+vqL
+vqL
 gpU
-gpU
+vqL
 qEX
 ybY
 jFS
@@ -76898,14 +76707,14 @@ oZI
 oMA
 oMA
 oMA
-qEX
+vqL
 bCA
-orS
+qMP
 orS
 qyN
 qMP
 pvr
-qEX
+vqL
 tel
 tel
 nRi
@@ -88714,8 +88523,8 @@ kSl
 oTg
 cVb
 pNr
-uLp
-fqI
+wcT
+xtP
 vhz
 agG
 agG
@@ -88971,8 +88780,8 @@ eyi
 qJF
 cVb
 pNr
-uLp
 wcT
+pzT
 std
 agG
 agG
@@ -89228,7 +89037,7 @@ oHg
 cVb
 liL
 liL
-aRu
+hUG
 hUG
 std
 uCZ
@@ -89488,13 +89297,13 @@ tqk
 orh
 geQ
 gvr
-gvO
+piZ
 fnZ
 nIT
 jOb
 sob
 ybZ
-lML
+liL
 aYV
 aYV
 oOF
@@ -89743,15 +89552,15 @@ cVb
 oOd
 jGw
 wFL
-fRP
+geQ
 wVv
-yjm
-dkG
-svV
 piZ
-pJj
-ybZ
-lML
+dkG
+nIT
+piZ
+sob
+lwU
+liL
 aYV
 aYV
 oOF
@@ -90002,12 +89811,12 @@ fyw
 wpy
 uLC
 usW
-ebS
+gvJ
 odG
 cLx
-nTS
 qmL
-liL
+qmL
+hDT
 liL
 bcq
 bcq
@@ -90255,14 +90064,14 @@ yaB
 xLr
 cVb
 iad
-bVX
 wFL
-pKP
+gRh
+tSV
 rDR
-sTF
+tSV
 hPX
 aot
-fbj
+tSV
 gvx
 vhG
 liL
@@ -90512,19 +90321,19 @@ qVL
 rwz
 cVb
 hCt
-ilv
-dcO
-nhZ
+wFL
+gRh
+ibK
 tDS
-caH
+ibK
 aJT
 ebS
 ibK
 fbj
 wbq
-vkK
-qtw
-qtw
+liL
+aYV
+aYV
 oOF
 aYV
 bfK
@@ -90769,17 +90578,17 @@ rHC
 vdx
 cVb
 edS
-qVA
+wFL
 hrd
-xRW
-tWh
-liL
-mzt
-hAX
-vkk
-fJK
 hUE
-ybZ
+tWh
+hUE
+aJT
+ebS
+hUE
+gvx
+hUE
+liL
 aYV
 mju
 oOF
@@ -91028,14 +90837,14 @@ uZT
 uZT
 uZT
 uZT
-gps
+uZT
 uZT
 uZT
 nIh
 xev
-gSZ
-xev
-cGO
+mjA
+qFk
+mjA
 mjA
 dmC
 sWR
@@ -91282,7 +91091,7 @@ mdB
 rHC
 eyi
 kNx
-tJC
+heF
 mJO
 dbo
 fdr

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -1131,8 +1131,10 @@
 /turf/open/floor/engine/cult,
 /area/service/library)
 "aeH" = (
-/obj/structure/table,
-/turf/open/floor/glass,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "aeK" = (
 /turf/open/floor/wood,
@@ -1308,15 +1310,14 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "afA" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchencounter";
-	name = "Kitchen Counter Shutters"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen";
+	req_access_txt = "28"
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "afB" = (
@@ -1860,8 +1861,10 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "ahF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2009,11 +2012,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/service)
-"aid" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "aie" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -2499,6 +2497,9 @@
 "ake" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
+	},
+/obj/structure/table/rolling{
+	name = "a la carte"
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -4137,9 +4138,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "apN" = (
@@ -4298,9 +4296,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "aqh" = (
@@ -4425,9 +4420,6 @@
 	},
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
@@ -5727,13 +5719,9 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "auf" = (
-/obj/structure/chair/sofa/corner{
-	dir = 1
-	},
-/obj/structure/railing,
 /obj/machinery/light/directional/west,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "aug" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -6267,8 +6255,10 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "awj" = (
 /obj/effect/spawner/structure/window,
@@ -6907,10 +6897,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
 "ays" = (
-/obj/structure/railing{
-	dir = 4
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "ayt" = (
 /turf/open/openspace,
@@ -6932,10 +6922,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "ayy" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -7898,11 +7885,8 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "aBZ" = (
-/obj/structure/railing,
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "aCa" = (
 /turf/closed/wall,
@@ -7950,10 +7934,8 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "aCo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/sofa,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "aCs" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -10074,8 +10056,7 @@
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 1
 	},
-/obj/structure/railing/corner,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "aLl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -10526,8 +10507,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aOx" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "aOy" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -11228,7 +11208,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 9
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "aSJ" = (
 /obj/structure/table/wood,
@@ -11277,12 +11257,15 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "aTu" = (
-/obj/structure/railing,
-/obj/structure/chair/sofa/left{
+/obj/structure/window{
 	dir = 1
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/effect/turf_decal/siding/brown{
+	dir = 9
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "aTB" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -11312,11 +11295,10 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "aTJ" = (
-/obj/structure/chair,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 6
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "aTM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11355,10 +11337,13 @@
 /turf/closed/wall/r_wall,
 /area/engineering/engine_smes)
 "aUc" = (
-/obj/structure/railing{
+/obj/effect/turf_decal/siding/brown{
 	dir = 8
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "aUe" = (
 /obj/structure/sign/poster/official/bless_this_spess{
@@ -11449,9 +11434,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
-"aUE" = (
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "aUL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -11655,13 +11637,10 @@
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
 	},
-/obj/structure/railing/corner{
+/obj/effect/turf_decal/siding/brown/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "aWt" = (
 /obj/structure/toilet/greyscale{
@@ -13694,12 +13673,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"bKP" = (
-/obj/structure/chair/sofa{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "bKS" = (
 /obj/structure/bed/dogbed/mcgriff,
 /obj/structure/cable,
@@ -14805,16 +14778,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"cjB" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "cjP" = (
 /obj/structure/mirror/directional/north,
 /obj/structure/sink{
@@ -16286,10 +16249,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "cSm" = (
 /turf/closed/wall/r_wall,
@@ -16925,6 +16885,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"dfu" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/service/kitchen/diner)
 "dgb" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
@@ -17982,11 +17952,19 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "dBw" = (
-/obj/structure/chair/sofa/corner{
-	dir = 1
+/obj/structure/table/wood/fancy,
+/obj/item/candle/infinite{
+	pixel_y = 7
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "dBC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -18000,7 +17978,6 @@
 	name = "Service Wing Hallway"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "dBH" = (
@@ -18938,6 +18915,16 @@
 	dir = 5
 	},
 /area/science/breakroom)
+"dTH" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/service/kitchen/diner)
 "dTU" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -20365,10 +20352,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
-"ewR" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "ewS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
@@ -22211,7 +22194,8 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "foG" = (
-/turf/open/openspace,
+/obj/structure/decorative/shelf/soda,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "foH" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -22802,12 +22786,12 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "fCR" = (
-/obj/structure/railing,
-/obj/structure/chair/sofa/corner{
-	dir = 8
-	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/door/window/northleft,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "fCU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24296,6 +24280,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"giZ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "gjg" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -24646,6 +24638,12 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
+"grH" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "grQ" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -24957,7 +24955,12 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "gyC" = (
-/turf/open/floor/glass,
+/obj/structure/aquarium,
+/obj/item/storage/box/aquarium_props,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/fish_case/random,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "gyG" = (
 /obj/structure/chair{
@@ -26396,6 +26399,14 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"hcx" = (
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "hcz" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/table,
@@ -27013,10 +27024,9 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "hmt" = (
 /obj/item/chair,
@@ -29925,11 +29935,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "izJ" = (
-/obj/structure/table,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "izK" = (
 /obj/structure/closet/firecloset,
@@ -30681,10 +30693,6 @@
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"iMx" = (
-/obj/structure/chair/sofa/right,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "iMI" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -30697,12 +30705,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"iMU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "iMV" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Office";
@@ -32360,7 +32362,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "jya" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/glass,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "jyl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32736,16 +32738,14 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "jGO" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "jHg" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -33064,6 +33064,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/navbeacon/wayfinding/kitchen,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "jOk" = (
@@ -33827,7 +33828,8 @@
 	dir = 6;
 	network = list("ss13","Service")
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/sofa,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "kbY" = (
 /obj/structure/mirror/directional/north,
@@ -34455,11 +34457,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "kmk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/structure/chair/sofa{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "kmq" = (
 /obj/effect/turf_decal/delivery,
@@ -34579,11 +34580,19 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kow" = (
-/obj/structure/chair/sofa/corner{
-	dir = 8
+/obj/structure/table/wood/fancy,
+/obj/item/candle/infinite{
+	pixel_y = 7
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 7;
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "koT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
@@ -35820,12 +35829,11 @@
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "kNC" = (
-/obj/structure/chair/sofa/right{
-	dir = 8
-	},
 /obj/item/radio/intercom/directional/east,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "kNK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36321,7 +36329,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "kYv" = (
-/obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -36528,10 +36535,14 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "lcC" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
+/obj/structure/table/wood/fancy,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "lcH" = (
 /obj/effect/turf_decal/tile/blue{
@@ -37327,7 +37338,10 @@
 "ltP" = (
 /obj/effect/turf_decal/siding/thinplating/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "ltT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -38242,9 +38256,6 @@
 	pixel_x = -8;
 	req_access_txt = "28"
 	},
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 8
-	},
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 11
@@ -38704,8 +38715,13 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "lWV" = (
-/obj/structure/table,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "lXA" = (
 /turf/open/floor/iron,
@@ -38929,6 +38945,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"mfe" = (
+/obj/structure/noticeboard{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/service/kitchen)
 "mfo" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/mouse/brown/tom,
@@ -39589,8 +39611,9 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/restaurant_portal/restaurant,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "msm" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -40580,18 +40603,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"mOT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/left)
 "mOW" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 8
@@ -41024,9 +41035,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "mZQ" = (
@@ -41378,17 +41386,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/iron/white,
 /area/science/research)
-"ngI" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "ngN" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -43348,14 +43345,14 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "oaV" = (
-/obj/structure/chair/sofa/left{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/west,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/table/rolling{
+	name = "a la carte"
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "obu" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -44495,12 +44492,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
-"ozV" = (
-/obj/structure/chair/sofa/left,
-/obj/effect/landmark/start/hangover,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "ozW" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/button/elevator{
@@ -45964,10 +45955,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"pco" = (
-/obj/machinery/restaurant_portal/restaurant,
-/turf/open/floor/glass,
-/area/service/kitchen/diner)
 "pcp" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -46626,13 +46613,15 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "prO" = (
-/obj/item/kirbyplants/random,
 /obj/machinery/camera{
 	c_tag = "Service - Kitchen Diner South";
 	dir = 5;
 	network = list("ss13","Service")
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/sofa{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "pss" = (
 /obj/structure/industrial_lift/tram{
@@ -47276,13 +47265,13 @@
 /turf/closed/wall,
 /area/cargo/sorting)
 "pEz" = (
-/obj/machinery/smartfridge/food,
+/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchencounter";
 	name = "Kitchen Counter Shutters"
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/closed/wall,
 /area/service/kitchen)
 "pED" = (
 /obj/effect/spawner/random/structure/crate,
@@ -48788,10 +48777,6 @@
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"qmT" = (
-/obj/structure/chair,
-/turf/open/floor/glass,
-/area/service/kitchen/diner)
 "qnn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -49306,10 +49291,10 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qyo" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/hallway/primary/port)
 "qyp" = (
 /obj/structure/fluff/tram_rail/anchor,
@@ -50351,14 +50336,11 @@
 /turf/open/floor/plating,
 /area/command/bridge)
 "qVG" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/structure/chair/stool/bar/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown/corner,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "qVO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
@@ -50926,11 +50908,14 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
 "rhU" = (
-/obj/structure/chair/sofa/right{
-	dir = 1
+/obj/structure/table/wood/fancy,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/cafeteria,
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "riv" = (
 /obj/effect/turf_decal/tile/bar,
@@ -51412,11 +51397,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"rrR" = (
-/obj/structure/chair/sofa/corner,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "rrW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -54025,6 +54005,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"swH" = (
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "swK" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
@@ -55490,9 +55473,6 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "tfL" = (
@@ -55616,7 +55596,6 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "thq" = (
-/obj/effect/turf_decal/siding/thinplating,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -56324,6 +56303,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"trL" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "trQ" = (
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/iron/dark/telecomms,
@@ -56695,7 +56681,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "tzc" = (
 /obj/structure/grille,
@@ -59043,6 +59032,13 @@
 "uwx" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"uxc" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "uxe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -59151,11 +59147,8 @@
 /area/security/prison)
 "uzl" = (
 /obj/machinery/newscaster/directional/west,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/sofa,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "uzM" = (
 /obj/structure/sign/poster/official/do_not_question{
@@ -59303,6 +59296,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"uDP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/hallway/primary/port)
 "uDV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -60045,13 +60044,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint)
-"uTG" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/machinery/navbeacon/wayfinding/kitchen,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "uTR" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -60612,20 +60604,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"vgw" = (
-/obj/structure/chair/sofa/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
-"vgx" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "vgz" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -62446,9 +62424,11 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "vRv" = (
 /obj/effect/turf_decal/trimline/red/corner{
@@ -63393,12 +63373,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/library)
-"wlQ" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "wlV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63527,10 +63501,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "wnY" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/glass,
+/obj/structure/hedge,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "wnZ" = (
 /obj/effect/turf_decal/stripes/line,
@@ -63943,9 +63915,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
@@ -64373,11 +64342,10 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "wDL" = (
-/obj/structure/chair,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 10
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "wEc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -65855,11 +65823,9 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/thinplating/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "xif" = (
 /obj/structure/cable,
@@ -66266,10 +66232,8 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "xrp" = (
-/obj/structure/chair/sofa{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/hedge/opaque,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "xry" = (
 /obj/structure/stairs/south,
@@ -67159,15 +67123,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"xJr" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/tram/left)
 "xJs" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -67930,11 +67885,9 @@
 "xWZ" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 1
-	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "xXg" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -153602,7 +153555,7 @@ acL
 acL
 qxD
 meV
-alV
+uDP
 cbU
 anG
 acE
@@ -153860,7 +153813,7 @@ uUv
 uUv
 thr
 qyo
-xQj
+giZ
 dBC
 apM
 asf
@@ -154368,9 +154321,9 @@ tge
 ake
 anZ
 anZ
-afy
-afy
-afy
+anZ
+anZ
+anZ
 anZ
 anZ
 aje
@@ -154625,7 +154578,7 @@ aGY
 anZ
 anZ
 uzl
-vgw
+dBw
 xrp
 dBw
 prO
@@ -154882,14 +154835,14 @@ rOV
 aGY
 msi
 aCo
-ozV
-ngI
+rhU
+xrp
 rhU
 kmk
 oaV
 auf
 foG
-foG
+anZ
 tfE
 auY
 awK
@@ -155139,15 +155092,15 @@ axQ
 abq
 vRt
 ltP
-ahD
-ahD
-ahD
+dfu
+dfu
+dfu
 ahD
 izJ
 aBZ
 foG
-foG
-mOT
+anZ
+aDZ
 ava
 anG
 axX
@@ -155396,10 +155349,10 @@ axa
 abq
 xie
 aTJ
-aeH
-wnY
-gyC
-gyC
+swH
+swH
+swH
+swH
 ayx
 aWs
 aUc
@@ -155652,16 +155605,16 @@ apq
 axQ
 abq
 hmf
-gyC
-gyC
-gyC
-qmT
+wnY
+aeH
+swH
+swH
 aeH
 wnY
 cSb
 aOx
-aid
-xJr
+aDI
+aDk
 edA
 kUi
 axX
@@ -155908,15 +155861,15 @@ jOh
 tZi
 axa
 pEz
-vgx
+hmf
 gyC
-gyC
-pco
+uxc
+swH
 jya
+uxc
 gyC
-gyC
-uTG
-aUE
+cSb
+aOx
 aDI
 auX
 avd
@@ -156164,16 +156117,16 @@ acW
 aqp
 ccu
 axQ
-abq
+pEz
 hmf
-gyC
-gyC
-gyC
-qmT
-aeH
 wnY
-wlQ
-aUE
+grH
+swH
+swH
+grH
+wnY
+cSb
+aOx
 aDI
 aKw
 avc
@@ -156421,13 +156374,13 @@ abv
 plM
 aKQ
 kYv
-abq
+mfe
 jGO
 wDL
-aeH
-wnY
-gyC
-gyC
+swH
+swH
+swH
+swH
 aSF
 aLf
 ays
@@ -156681,14 +156634,14 @@ thq
 afA
 qVG
 tzb
-awi
-awi
-awi
+dTH
+dTH
+dTH
 awi
 lWV
 aTu
-foG
-foG
+hcx
+anZ
 aqC
 avf
 anG
@@ -156937,15 +156890,15 @@ aby
 lML
 aGY
 xWZ
-aUE
-iMx
-cjB
+aCo
 lcC
-iMU
+xrp
+lcC
+kmk
 kNC
 fCR
-foG
-foG
+trL
+anZ
 aDZ
 avc
 awT
@@ -157195,10 +157148,10 @@ aGY
 anZ
 anZ
 kbX
-rrR
-bKP
 kow
-ewR
+xrp
+kow
+kmk
 anZ
 anZ
 anZ
@@ -157452,9 +157405,9 @@ gOG
 kVh
 anZ
 anZ
-afy
-afy
-afy
+anZ
+anZ
+anZ
 anZ
 anZ
 ajg


### PR DESCRIPTION
## About The Pull Request

As part of my plans for chef, I mean to give them a restaurant to manage, cooking meals, taking orders, and generally giving better opportunities for roleplay. This does the mapping part of that - it will be a proof of concept for having a restaurant as a viable replacement to current chef balance and theme. Also it's cute as hell, like, damn just look at those screenshots.

## How This Contributes To The Skyrat Roleplay Experience

This, paired with the MRE PR #8860 gives chefs a different role in the station, that of slower paced roleplay and cooking to order for involved, interested customers rather than hectic highpop food spam for people who are neither interested in what they're cooking nor interested in RP.

The intended flow of this is for customers to come in, be seated by the server, who will write down their order and give it to the chef on a piece of paper, to be pinned to the bulletin board for the chef to keep track of tickets. While the food cooks, customers can sit and chat all they like, and in the lower pressure environment, the chef may have time to go out and chat with them. The server will make sure that everyone is happy and has what they need, as well as serving drinks from the bar, creating cooperation. There is also a rolling table to offer customers à la carte desserts.

## Changelog

:cl:
add: Replaces the existing dining areas on Icebox, Delta, and Tram with a new restaurant.
/:cl:

## Delta
![unknown](https://user-images.githubusercontent.com/58074918/137822569-35614456-3385-4d03-8f0e-b7e1439fdb60.png)


## Icemoon
![unknown](https://user-images.githubusercontent.com/58074918/137802843-edae2d0f-ea27-4735-a0bc-05faa8f5308c.png)

## Tram
![unknown2](https://user-images.githubusercontent.com/58074918/137802863-2e5907e3-ce4a-4bec-905c-3e52a3e21a7d.png)
