### PR TITLE
[MODULAR][FIX] Medical Bandoliers can carry Hypovials again

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
@@ -160,5 +160,6 @@
 		/obj/item/reagent_containers/medigel,
 		/obj/item/storage/pill_bottle,
 		/obj/item/implanter,
+		/obj/item/reagent_containers/glass/vial,
 		/obj/item/weaponcell/medical
 		))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows Medical bandoliers to carry hypovials again. They were intended to do so originally https://github.com/Skyrat-SS13/Skyrat-tg/pull/7738. The issue occurred when I swapped hypovials to not be a subtype of bottles in https://github.com/Skyrat-SS13/Skyrat-tg/pull/8745, meaning that the bandolier would no longer hold them. This PR restores hypovials back to the allowed containers list for medical bandoliers. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Reinstates intended behavior for medical bandoliers that was screwed up after the hypovial refactor. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: medical bandoliers can now hold hypovials again. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
