### PR TITLE
[MODULAR] Turns the Irish tactical sweater into the Sol tactical sweater, and fixes it in the loadout [option 1]

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/under/misc.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/under/misc.dm
@@ -67,9 +67,9 @@
 	icon_state = "royalkilt"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 
-/obj/item/clothing/under/misc/tactical1
-	name = "irish tactical uniform"
-	desc = "The SAM missiles are in the sky! Faint whiffs of cheap booze and Libyan semtex come off this getup, someone was so kind as to leave a book in one of the pockets, too bad it's all in Gaelic!"
+/obj/item/clothing/under/misc/soltactical
+	name = "Sol tactical uniform"
+	desc = "The SAM missiles are in the sky! Faint whiffs of cheap booze and cheaper semtex come off this getup, someone was so kind as to leave a book in one of the pockets, too bad it's all in Uncommon!"
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/uniforms.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/uniform.dmi'
 	icon_state = "tactical1"

--- a/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -408,9 +408,9 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	name = "Villain Suit"
 	item_path = /obj/item/clothing/under/costume/villain
 
-/datum/loadout_item/under/miscellaneous/tactical_irish
-	name = "Irish Tactical Sweater"
-	item_path = /obj/item/clothing/under/misc/tactical1
+/datum/loadout_item/under/miscellaneous/tactical_sol
+	name = "Sol Tactical Sweater"
+	item_path = /obj/item/clothing/under/misc/soltactical
 
 /datum/loadout_item/under/miscellaneous/tactical_irish
 	name = "British Tactical Sweater"

--- a/modular_skyrat/modules/modular_vending/code/autodrobe.dm
+++ b/modular_skyrat/modules/modular_vending/code/autodrobe.dm
@@ -21,7 +21,7 @@
 		/obj/item/clothing/under/costume/dutch = 5,
 		/obj/item/clothing/under/costume/arthur = 5,
 		/obj/item/clothing/under/whiterussian = 5,
-		/obj/item/clothing/under/misc/tactical1 = 5,
+		/obj/item/clothing/under/misc/soltactical = 5,
 		/obj/item/clothing/under/uvf = 5,
 		/obj/item/clothing/under/doug_dimmadome = 5,
 		/obj/item/clothing/glasses/biker = 5, //remind me to give these an up state later


### PR DESCRIPTION


## About The Pull Request
Removes references to a certain based group from a loadout item, and instead, references Sol itself.
Also makes it actually work in the loadout lmao
## How This Contributes To The Skyrat Roleplay Experience

So humans can rep the homeland

## Changelog

:cl:
fix: Removes references to a specific irish group, and replaces it with Sol, also makes it available in the loadout.
/:cl:

