### PR TITLE
[NON-MODULAR][FIX]Hypovials fit inside medical belts again

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -184,6 +184,7 @@
 		/obj/item/surgical_drapes, //for true paramedics
 		/obj/item/clothing/suit/toggle/labcoat/hospitalgown,	//SKYRAT EDIT ADDITION - adds surgery gowns to belts
 		/obj/item/weaponcell/medical, //SKYRAT EDIT MEDIGUNS
+		/obj/item/reagent_containers/glass/vial, //SKYRAT EDIT HYPOSPRAYS
 		/obj/item/scalpel,
 		/obj/item/circular_saw,
 		/obj/item/bonesetter,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This fixes the same issue that happened with medical bandoliers https://github.com/Skyrat-SS13/Skyrat-tg/pull/8921, please read over that PR for the exact explanation of this issue. In short, hypovials were previously a subtype of bottles, they are no longer a subtype anymore meaning that they no longer fit inside of medical belts. This PR should allow them to fit inside medical belts again.
If there are any other issues like this, please PM me on discord at Bunny#5839
## How This Contributes To The Skyrat Roleplay Experience
This restores the intended behavior of hypovials being able to fit inside of belts.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Hypovials now fit inside of medical belts again. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
