### PR TITLE
revokes stealth blob removal

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/alien_infestation
 	name = "Alien Infestation"
 	typepath = /datum/round_event/ghost_role/alien_infestation
-	weight = 0 //SKYRAT EDIT CHANGE
+	weight = 4 //SKYRAT EDIT CHANGE
 
 	min_players = 10
 

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -4,7 +4,7 @@
 	weight = 10
 	max_occurrences = 1 //SKYRAT EDIT CHANGE
 
-	min_players = 20
+	min_players = 60 // SKYRAT EDIT - No lowpop blob
 
 	dynamic_should_hijack = TRUE
 

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -2,7 +2,7 @@
 	name = "Blob"
 	typepath = /datum/round_event/ghost_role/blob
 	weight = 10
-	max_occurrences = 0 //SKYRAT EDIT CHANGE
+	max_occurrences = 1 //SKYRAT EDIT CHANGE
 
 	min_players = 20
 

--- a/code/modules/events/swarmer.dm
+++ b/code/modules/events/swarmer.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/spawn_swarmer
 	name = "Spawn Swarmer Beacon"
 	typepath = /datum/round_event/spawn_swarmer
-	weight = 10
+	weight = 5	// SKYRAT EDIT CHANGE - bit more rare
 	max_occurrences = 1 //Only once okay fam //SKYRAT EDIT CHANGE
 	min_players = 20
 	dynamic_should_hijack = TRUE

--- a/code/modules/events/swarmer.dm
+++ b/code/modules/events/swarmer.dm
@@ -2,7 +2,7 @@
 	name = "Spawn Swarmer Beacon"
 	typepath = /datum/round_event/spawn_swarmer
 	weight = 10
-	max_occurrences = 0 //Only once okay fam //SKYRAT EDIT CHANGE
+	max_occurrences = 1 //Only once okay fam //SKYRAT EDIT CHANGE
 	min_players = 20
 	dynamic_should_hijack = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

max_occurences was stealthily set to 0 in some PR without mention or discussion. Setting it back to 1 allows the random even spawner to actually roll it rarely once more. Additionally sets min players to 60.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Stealth removal bad, blob good. Lowpop blob bad though.

Also brings back swarmers and xenos, since they were all disabled. Of course admins can still cancel events when they roll, if they are deemed unfit for the current round!

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Blob, swarmer, and xeno events should roll naturally again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
