### PR TITLE
Buffing beef wellington

### DIFF
--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -1244,28 +1244,30 @@
 	//basic ingredients, but a lot of them. just covering costs here
 	venue_value = FOOD_PRICE_NORMAL
 
+// SKYRAT EDIT BEGIN - gives beef wellington more nutrition and slices earned from cutting it
 /obj/item/food/beef_wellington
 	name = "beef wellington"
 	desc = "A luxurious log of beef, covered in a fine mushroom duxelle and pancetta ham, then bound in puff pastry."
 	icon_state = "beef_wellington"
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 21, /datum/reagent/consumable/nutriment/vitamin = 6)
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 30, /datum/reagent/consumable/nutriment/vitamin = 24) // SKYRAT EDIT - CHANGED FROM 21 PROTEIN 6 VITAMIN TO 30 PROTEIN 24 VITAMIN
 	tastes = list("beef" = 3, "mushrooms" = 1, "pancetta" = 1)
 	foodtypes = MEAT | VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_NORMAL
 	venue_value = FOOD_PRICE_EXOTIC
 
 /obj/item/food/beef_wellington/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE,  /obj/item/food/beef_wellington_slice, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE,  /obj/item/food/beef_wellington_slice, 6, 60) // SKYRAT EDIT - CHANGED FROM 3 SLICES TO 6, 30 CUTTING TIME TO 60
 
 /obj/item/food/beef_wellington_slice
 	name = "beef wellington slice"
 	desc = "A slice of beef wellington, topped with a rich gravy. Simply delicious."
 	icon_state = "beef_wellington_slice"
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 7, /datum/reagent/consumable/nutriment/vitamin = 2)
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 5, /datum/reagent/consumable/nutriment/vitamin = 4) // SKYRAT EDIT - CHANGED FROM 7 PROTEIN 2 VITAMIN TO 5 PROTEIN 4 VITAMIN
 	tastes = list("beef" = 3, "mushrooms" = 1, "pancetta" = 1)
 	foodtypes = MEAT | VEGETABLES | GRAIN
 	w_class = WEIGHT_CLASS_SMALL
 	venue_value = FOOD_PRICE_NORMAL
+// SKYRAT EDIT END
 
 /obj/item/food/full_english
 	name = "full english breakfast"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Beef wellington is hard to make and contains a ton of ingredients, thus it should have a better payout and be more filling like it is in real life. When sliced, it turns into only 3 pieces that last 3 bites each, hardly making it worth the efforts. This change will increase the beef wellington protein from 21 to 30, the vitamin from 6 to 24, and cause it to produce 6 slices when cut that take double the time to do so.

This is pretty much by very first PR ever so if I messed anything up please tell me!

## How This Contributes To The Skyrat Roleplay Experience

Doing this will hopefully inspire more chefs to make it since one person can eat two whole logs before getting full, making the whole process of creating it underwhelming and discouraging.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Made beef wellington more nutritious and have larger proportions
/:cl: