### PR TITLE
[FIX][CI][MDB IGNORE] Updating Stations to NT Safety Standard 35489-A1

### DIFF
--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -9997,8 +9997,7 @@
 "aPv" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1";
-	safety_mode = 1
+	name = "Port Docking Bay 1"
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -11059,8 +11058,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "Escape Airlock";
-	safety_mode = 1
+	name = "Escape Airlock"
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
@@ -11286,8 +11284,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1";
-	safety_mode = 1
+	name = "Port Docking Bay 1"
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -12494,8 +12491,7 @@
 /area/security/execution/transfer)
 "aXI" = (
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1";
-	safety_mode = 1
+	name = "Port Docking Bay 1"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -33862,8 +33858,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock";
-	req_access_txt = "2";
-	safety_mode = 1
+	req_access_txt = "2"
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/escape)
@@ -33887,8 +33882,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "Cargo Escape Airlock";
-	safety_mode = 1
+	name = "Cargo Escape Airlock"
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
@@ -39549,8 +39543,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1";
-	safety_mode = 1
+	name = "Port Docking Bay 1"
 	},
 /obj/machinery/navbeacon/wayfinding{
 	location = "Arrival Shuttle"
@@ -40578,8 +40571,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "Escape Airlock";
-	safety_mode = 1
+	name = "Escape Airlock"
 	},
 /obj/machinery/navbeacon/wayfinding{
 	location = "Escape"
@@ -46394,8 +46386,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "Cargo Escape Airlock";
-	safety_mode = 1
+	name = "Cargo Escape Airlock"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47508,8 +47499,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock";
-	req_access_txt = "2";
-	safety_mode = 1
+	req_access_txt = "2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -57909,8 +57899,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "Escape Airlock";
-	safety_mode = 1
+	name = "Escape Airlock"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -561,7 +561,8 @@
 "acU" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
-	req_access_txt = "63"
+	req_access_txt = "63";
+	space_dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -910,7 +911,8 @@
 /area/security/office)
 "afo" = (
 /obj/machinery/door/airlock/external{
-	name = "Escape Pod Three"
+	name = "Escape Pod Three";
+	space_dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -1785,7 +1787,8 @@
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
 	req_access_txt = "2";
-	shuttledocked = 1
+	shuttledocked = 1;
+	space_dir = 8
 	},
 /turf/open/floor/plating,
 /area/security/processing)
@@ -2338,7 +2341,8 @@
 /area/maintenance/port/fore)
 "anN" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+	dir = 4;
+	late = 8
 	},
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -2919,7 +2923,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
 	name = "External Access";
-	req_access_txt = "13"
+	req_access_txt = "13";
+	space_dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -3053,7 +3058,8 @@
 /area/holodeck/rec_center)
 "arp" = (
 /obj/machinery/door/airlock/external{
-	req_access_txt = "13"
+	req_access_txt = "13";
+	space_dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -4180,7 +4186,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	req_access_txt = "13"
+	req_access_txt = "13";
+	space_dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -6935,7 +6942,8 @@
 "aEQ" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10; 13";
+	space_dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
@@ -7020,7 +7028,8 @@
 /area/maintenance/fore)
 "aFh" = (
 /obj/machinery/door/airlock/external{
-	name = "Escape Pod One"
+	name = "Escape Pod One";
+	space_dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -8961,7 +8970,8 @@
 /area/hallway/secondary/entry)
 "aLD" = (
 /obj/machinery/door/airlock/external{
-	name = "Common Mining Shuttle Bay"
+	name = "Common Mining Shuttle Bay";
+	space_dir = 2
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -12491,7 +12501,8 @@
 /area/security/execution/transfer)
 "aXI" = (
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
+	name = "Port Docking Bay 1";
+	space_dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -18535,7 +18546,8 @@
 "bpr" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock";
-	req_access_txt = "48"
+	req_access_txt = "48";
+	space_dir = 8
 	},
 /turf/open/floor/plating,
 /area/cargo/miningdock)
@@ -19384,7 +19396,8 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
-	req_access_txt = "31"
+	req_access_txt = "31";
+	space_dir = 8
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
@@ -20448,7 +20461,8 @@
 "bus" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
-	req_access_txt = "24"
+	req_access_txt = "24";
+	space_dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -22351,7 +22365,8 @@
 "bBF" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
-	req_access_txt = "24"
+	req_access_txt = "24";
+	space_dir = 2
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -28454,7 +28469,8 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "External Access";
-	req_access_txt = "13"
+	req_access_txt = "13";
+	space_dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -30844,7 +30860,8 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10; 13";
+	space_dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -32315,7 +32332,8 @@
 /area/engineering/supermatter)
 "cry" = (
 /obj/machinery/door/airlock/external{
-	name = "Construction Zone"
+	name = "Construction Zone";
+	space_dir = 8
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
@@ -32413,7 +32431,8 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
-	req_one_access_txt = "10;24"
+	req_one_access_txt = "10;24";
+	space_dir = 2
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -32515,7 +32534,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "cta" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+	dir = 4;
+	late = 8
 	},
 /obj/machinery/door/airlock/external{
 	name = "MiniSat External Access";
@@ -33798,7 +33818,8 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10; 13";
+	space_dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -33891,7 +33912,8 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 4"
+	name = "Port Docking Bay 4";
+	space_dir = 2
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -33900,7 +33922,8 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 3"
+	name = "Port Docking Bay 3";
+	space_dir = 2
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -33909,7 +33932,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	req_access_txt = "13"
+	req_access_txt = "13";
+	space_dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -33966,7 +33990,8 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10; 13";
+	space_dir = 2
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -33991,7 +34016,8 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Four";
-	shuttledocked = 1
+	shuttledocked = 1;
+	space_dir = 4
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -35988,7 +36014,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	req_access_txt = "13"
+	req_access_txt = "13";
+	space_dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -36281,7 +36308,8 @@
 /area/engineering/main)
 "cTE" = (
 /obj/machinery/door/airlock/external{
-	name = "Escape Pod One"
+	name = "Escape Pod One";
+	space_dir = 8
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -36515,6 +36543,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"dee" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13";
+	space_dir = 2
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "deg" = (
 /obj/machinery/camera{
 	c_tag = "Prison - Visition (Visitor)";
@@ -43958,6 +43994,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"klH" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1";
+	space_dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "klV" = (
 /obj/machinery/smartfridge/organ,
 /turf/closed/wall,
@@ -44450,6 +44494,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"kDi" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13";
+	space_dir = 2
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "kDo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -45797,7 +45849,8 @@
 "lWA" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
-	req_access_txt = "13"
+	req_access_txt = "13";
+	space_dir = 2
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -46386,7 +46439,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "Cargo Escape Airlock"
+	name = "Cargo Escape Airlock";
+	space_dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47499,7 +47553,8 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock";
-	req_access_txt = "2"
+	req_access_txt = "2";
+	space_dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -52582,6 +52637,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"sDN" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1";
+	space_dir = 2
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "sDW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57899,7 +57964,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
+	name = "Escape Airlock";
+	space_dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -58153,7 +58219,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 3"
+	name = "Port Docking Bay 3";
+	space_dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/hallway/secondary/entry)
@@ -68438,7 +68505,7 @@ awZ
 ayk
 aPv
 auP
-aUl
+sDN
 uRx
 xzh
 xzh
@@ -70494,7 +70561,7 @@ aAH
 aOh
 aPv
 auP
-aUl
+sDN
 uRx
 xzh
 xzh
@@ -70502,7 +70569,7 @@ xzh
 xzh
 xzh
 uRx
-aPv
+klH
 auP
 gfa
 jly
@@ -100375,7 +100442,7 @@ feO
 cfn
 bAw
 bAw
-cfn
+kDi
 cng
 xzh
 xzh
@@ -103981,7 +104048,7 @@ mtK
 jdH
 keQ
 cOe
-cqu
+dee
 uRx
 xzh
 xzh

--- a/_maps/map_files/WaterKiloStation/WaterKiloStation.dmm
+++ b/_maps/map_files/WaterKiloStation/WaterKiloStation.dmm
@@ -40817,8 +40817,7 @@
 /area/maintenance/starboard)
 "ceU" = (
 /obj/machinery/door/airlock/external{
-	name = "Arrival Shuttle Airlock";
-	safety_mode = 1
+	name = "Arrival Shuttle Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/navbeacon/wayfinding,
@@ -49043,8 +49042,7 @@
 /area/hallway/secondary/entry)
 "cCm" = (
 /obj/machinery/door/airlock/external{
-	name = "Arrival Shuttle Airlock";
-	safety_mode = 1
+	name = "Arrival Shuttle Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1

--- a/_maps/map_files/WaterKiloStation/WaterKiloStation.dmm
+++ b/_maps/map_files/WaterKiloStation/WaterKiloStation.dmm
@@ -2080,7 +2080,8 @@
 "aee" = (
 /obj/machinery/door/airlock/external{
 	name = "Satellite External Airlock";
-	req_one_access_txt = "32;19"
+	req_one_access_txt = "32;19";
+	space_dir = 2
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -2361,7 +2362,8 @@
 /area/hallway/secondary/entry)
 "aeV" = (
 /obj/machinery/door/airlock/external{
-	name = "Abandoned External Airlock"
+	name = "Abandoned External Airlock";
+	space_dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/disposalpipe/segment,
@@ -3822,7 +3824,8 @@
 /area/maintenance/fore)
 "ahY" = (
 /obj/machinery/door/airlock/external{
-	name = "Abandoned External Airlock"
+	name = "Abandoned External Airlock";
+	space_dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron/dark,
@@ -6430,7 +6433,8 @@
 "any" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10; 13";
+	space_dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -8370,7 +8374,8 @@
 "asd" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10; 13";
+	space_dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -14010,7 +14015,8 @@
 /area/maintenance/starboard)
 "aKn" = (
 /obj/machinery/door/airlock/external{
-	name = "Cargo Escape Pod"
+	name = "Cargo Escape Pod";
+	space_dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -25033,7 +25039,8 @@
 "bge" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
-	req_access_txt = "13"
+	req_access_txt = "13";
+	space_dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -26848,7 +26855,8 @@
 /area/ai_monitored/turret_protected/aisat/atmos)
 "bmI" = (
 /obj/machinery/door/airlock/external{
-	name = "Medical Escape Pod"
+	name = "Medical Escape Pod";
+	space_dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -27838,7 +27846,8 @@
 "bqZ" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
-	req_access_txt = "13"
+	req_access_txt = "13";
+	space_dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -34604,7 +34613,8 @@
 "bRw" = (
 /obj/machinery/door/airlock/external{
 	name = "Prison External Airlock";
-	req_access_txt = "2"
+	req_access_txt = "2";
+	space_dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -35182,7 +35192,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "Brig Shuttle Airlock";
-	req_one_access_txt = "63"
+	req_one_access_txt = "63";
+	space_dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -36174,7 +36185,8 @@
 "bVk" = (
 /obj/machinery/door/airlock/external{
 	name = "Prison External Airlock";
-	req_access_txt = "2"
+	req_access_txt = "2";
+	space_dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -37179,7 +37191,8 @@
 "bXe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
-	name = "Departure Shuttle Airlock"
+	name = "Departure Shuttle Airlock";
+	space_dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -45170,7 +45183,8 @@
 "cqN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
-	name = "Ferry Shuttle Airlock"
+	name = "Ferry Shuttle Airlock";
+	space_dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -45464,7 +45478,8 @@
 /area/security/warden)
 "crD" = (
 /obj/machinery/door/airlock/external{
-	name = "Security Escape Pod"
+	name = "Security Escape Pod";
+	space_dir = 2
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/port/aft)
@@ -46742,7 +46757,8 @@
 "cuU" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10; 13";
+	space_dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -47643,7 +47659,8 @@
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
 	req_access_txt = "2";
-	shuttledocked = 1
+	shuttledocked = 1;
+	space_dir = 2
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -47737,7 +47754,8 @@
 "cxz" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
-	shuttledocked = 1
+	shuttledocked = 1;
+	space_dir = 2
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -49031,18 +49049,10 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/ocean,
 /area/hallway/secondary/entry)
-"cCk" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Shuttle Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/hallway/secondary/entry)
 "cCm" = (
 /obj/machinery/door/airlock/external{
-	name = "Arrival Shuttle Airlock"
+	name = "Arrival Shuttle Airlock";
+	space_dir = 2
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -49497,8 +49507,8 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Eng1"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -50547,7 +50557,8 @@
 "cGF" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "10; 13";
+	space_dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -50857,7 +50868,8 @@
 "cHH" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
-	req_access_txt = "13"
+	req_access_txt = "13";
+	space_dir = 2
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -65373,7 +65385,8 @@
 "jRb" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
-	req_access_txt = "31"
+	req_access_txt = "31";
+	space_dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -65541,7 +65554,8 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock";
-	req_access_txt = "48"
+	req_access_txt = "48";
+	space_dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -67106,8 +67120,8 @@
 	name = "Gravity Generator Access";
 	req_one_access_txt = "10"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Eng1"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -68806,8 +68820,8 @@
 	name = "Atmospherics External Airlock";
 	req_access_txt = "24"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Eng2"
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
@@ -71345,7 +71359,8 @@
 "mLz" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
-	req_access_txt = "24"
+	req_access_txt = "24";
+	space_dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -76541,7 +76556,9 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Eng1"
+	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -81831,8 +81848,8 @@
 	name = "Engineering External Airlock";
 	req_access_txt = "10"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Eng2"
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
@@ -83273,7 +83290,8 @@
 "tlv" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
-	req_access_txt = "31"
+	req_access_txt = "31";
+	space_dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -91272,8 +91290,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Eng1"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -91946,7 +91964,8 @@
 "xSr" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
-	req_access_txt = "24"
+	req_access_txt = "24";
+	space_dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -92365,7 +92384,11 @@
 "ycC" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Airlock";
-	req_one_access_txt = "10;24"
+	req_one_access_txt = "10;24";
+	space_dir = 2
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Eng2"
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
@@ -132208,7 +132231,7 @@ aSD
 jGo
 cCi
 cbu
-cCk
+cCm
 bUN
 bUN
 bUN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Updates Skyrat maps to be compliant with external access upstream update

## How This Contributes To The Skyrat Roleplay Experience

Fix CI Failures

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The Following Stations are now in compliance with NT EVA Safety Protocols Submerged Kilo Station, NSS Journey and Blueshift
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
