### PR TITLE
Lower power draw of flashlights

### DIFF
--- a/modular_skyrat/modules/cell_component/code/flashlight.dm
+++ b/modular_skyrat/modules/cell_component/code/flashlight.dm
@@ -4,7 +4,7 @@
 	/// Does this flashlight have a cell override?
 	var/cell_override
 	/// How much power(per process) does this flashlight use? If any.
-	power_use_amount = POWER_CELL_USE_VERY_LOW
+	power_use_amount = POWER_CELL_USE_MINIMUM
 	/// Flashlight mode, 0 = low, 1 = med, 2 = high
 	var/flashlight_mode = 0
 	///Does this flashlight have modes?
@@ -36,21 +36,21 @@
 	if(has_modes)
 		switch(flashlight_mode)
 			if(0)
-				power_use_amount = POWER_CELL_USE_VERY_LOW
+				power_use_amount = POWER_CELL_USE_MINIMUM
 				light_range = initial(light_range)
 				light_power = initial(light_power)
 				set_light_on(on)
 				flashlight_mode = 1
 				to_chat(user, "<span class='notice'>You set [src] to low.</span>")
 			if(1)
-				power_use_amount = POWER_CELL_USE_LOW
+				power_use_amount = POWER_CELL_USE_VERY_LOW
 				light_range = initial(light_range) + 2
 				light_power = initial(light_power) + 1
 				set_light_on(on)
 				flashlight_mode = 2
 				to_chat(user, "<span class='notice'>You set [src] to medium.</span>")
 			if(2)
-				power_use_amount = POWER_CELL_USE_NORMAL
+				power_use_amount = POWER_CELL_USE_LOW
 				light_range = initial(light_range) + 4
 				light_power = initial(light_power) + 2
 				set_light_on(on)


### PR DESCRIPTION
It makes absolutely no sense why a power cell capable of sustaining a BSA can't hack the output of a flashlight, so I've dropped the power draw of flashlights down a notch

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Literally just dropped the power draw of flashlights down a notch. I don't see how this changes game balance apart from making it so that flashlights are actually slightly useful and not such a constant annoyance.

## How This Contributes To The Skyrat Roleplay Experience

It makes the power cells in-game more believable, increasing everyone's fun.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: changed power draw of flashlights
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
