### PR TITLE
Alltheworstcode - Rebalancing makeshift tools.

### DIFF
--- a/modular_skyrat/modules/cell_component/code/flashlight.dm
+++ b/modular_skyrat/modules/cell_component/code/flashlight.dm
@@ -4,7 +4,7 @@
 	/// Does this flashlight have a cell override?
 	var/cell_override
 	/// How much power(per process) does this flashlight use? If any.
-	power_use_amount = POWER_CELL_USE_VERY_LOW
+	power_use_amount = POWER_CELL_USE_MINIMUM
 	/// Flashlight mode, 0 = low, 1 = med, 2 = high
 	var/flashlight_mode = 0
 	///Does this flashlight have modes?
@@ -36,21 +36,21 @@
 	if(has_modes)
 		switch(flashlight_mode)
 			if(0)
-				power_use_amount = POWER_CELL_USE_VERY_LOW
+				power_use_amount = POWER_CELL_USE_MINIMUM
 				light_range = initial(light_range)
 				light_power = initial(light_power)
 				set_light_on(on)
 				flashlight_mode = 1
 				to_chat(user, "<span class='notice'>You set [src] to low.</span>")
 			if(1)
-				power_use_amount = POWER_CELL_USE_LOW
+				power_use_amount = POWER_CELL_USE_VERY_LOW
 				light_range = initial(light_range) + 2
 				light_power = initial(light_power) + 1
 				set_light_on(on)
 				flashlight_mode = 2
 				to_chat(user, "<span class='notice'>You set [src] to medium.</span>")
 			if(2)
-				power_use_amount = POWER_CELL_USE_NORMAL
+				power_use_amount = POWER_CELL_USE_LOW
 				light_range = initial(light_range) + 4
 				light_power = initial(light_power) + 2
 				set_light_on(on)

--- a/modular_skyrat/modules/modular_items/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/modular_skyrat/modules/modular_items/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -1,6 +1,5 @@
 /datum/crafting_recipe/makeshift/crowbar
 	name = "Makeshift Crowbar"
-	tool_paths = list(/obj/item/hammer/makeshift)
 	result = /obj/item/crowbar/makeshift
 	reqs = list(/obj/item/stack/sheet/iron = 4,
 				/obj/item/stack/sheet/cloth = 1,
@@ -8,18 +7,9 @@
 	time = 120
 	category = CAT_MISC
 
-/datum/crafting_recipe/makeshift/hammer
-	name = "Makeshift Hammer"
-	result = /obj/item/hammer/makeshift
-	reqs = list(/obj/item/stack/cable_coil = 1,
-				/obj/item/stack/rods = 2,
-				/obj/item/stack/sheet/iron = 2)
-	time = 80
-	category = CAT_MISC
-
 /datum/crafting_recipe/makeshift/screwdriver
 	name = "Makeshift Screwdriver"
-	tool_paths = list(/obj/item/hammer/makeshift)
+	tool_paths = list(/datum/crafting_recipe/makeshift/crowbar)
 	result = /obj/item/screwdriver/makeshift
 	reqs = list(/obj/item/stack/cable_coil = 1,
 				/obj/item/stack/sheet/cloth = 2,
@@ -29,7 +19,7 @@
 
 /datum/crafting_recipe/makeshift/welder
 	name = "Makeshift Welder"
-	tool_paths = list(/obj/item/hammer/makeshift)
+	tool_paths = list(/datum/crafting_recipe/makeshift/crowbar)
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	result = /obj/item/weldingtool/makeshift
 	reqs = list(/obj/item/tank/internals/emergency_oxygen = 1,
@@ -41,7 +31,7 @@
 
 /datum/crafting_recipe/makeshift/wirecutters
 	name = "Makeshift Wirecutters"
-	tool_paths = list(/obj/item/hammer/makeshift)
+	tool_paths = list(/datum/crafting_recipe/makeshift/crowbar)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	result = /obj/item/wirecutters/makeshift
 	reqs = list(/obj/item/stack/cable_coil = 2,
@@ -51,7 +41,7 @@
 
 /datum/crafting_recipe/makeshift/wrench
 	name = "Makeshift Wrench"
-	tool_paths = list(/obj/item/hammer/makeshift)
+	tool_paths = list(/datum/crafting_recipe/makeshift/crowbar)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	result = /obj/item/wrench/makeshift
 	reqs = list(/obj/item/stack/cable_coil = 1,

--- a/modular_skyrat/modules/modular_items/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/modular_skyrat/modules/modular_items/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -13,7 +13,7 @@
 	result = /obj/item/hammer/makeshift
 	reqs = list(/obj/item/stack/cable_coil = 1,
 				/obj/item/stack/rods = 2,
-				/obj/item/kitchen/rollingpin = 2)
+				/obj/item/stack/sheet/iron = 2)
 	time = 80
 	category = CAT_MISC
 

--- a/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
@@ -1,12 +1,3 @@
-/obj/item/hammer/makeshift
-	name = "makeshift hammer"
-	desc = "A makeshift hammer, flimsily constructed with miscellaneous parts."
-	icon = 'modular_skyrat/modules/modular_items/icons/obj/items/tools.dmi'
-	icon_state = "makeshift_hammer"
-	force = 2
-	throwforce = 3
-	w_class = WEIGHT_CLASS_NORMAL
-
 //loot
 /obj/item/bloodcrawlbottle
 	name = "bloodlust in a bottle"

--- a/modular_skyrat/modules/modular_items/code/game/objects/items/tools/makeshift.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/tools/makeshift.dm
@@ -2,12 +2,12 @@
 
 /obj/item/crowbar/makeshift
 	name = "makeshift crowbar"
-	desc = "A makeshift crowbar, flimsily constructed with miscellaneous parts. It's too messed up to fit in a backpack."
+	desc = "A makeshift crowbar, flimsily constructed with miscellaneous parts."
 	icon = 'modular_skyrat/modules/modular_items/icons/obj/items/tools.dmi'
 	icon_state = "makeshift_crowbar"
 	force = 2
 	throwforce = 2
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	toolspeed = 2
 
 /obj/item/screwdriver/makeshift

--- a/modular_skyrat/modules/modular_items/code/game/objects/items/tools/makeshift.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/tools/makeshift.dm
@@ -2,7 +2,7 @@
 
 /obj/item/crowbar/makeshift
 	name = "makeshift crowbar"
-	desc = "A makeshift crowbar, flimsily constructed with miscellaneous parts."
+	desc = "A makeshift crowbar, flimsily constructed with miscellaneous parts. The only good thing about it is the nasty-looking hammerhead on one end."
 	icon = 'modular_skyrat/modules/modular_items/icons/obj/items/tools.dmi'
 	icon_state = "makeshift_crowbar"
 	force = 2

--- a/modular_skyrat/modules/modular_items/code/game/objects/items/tools/makeshift.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/tools/makeshift.dm
@@ -8,7 +8,7 @@
 	force = 2
 	throwforce = 2
 	w_class = WEIGHT_CLASS_NORMAL
-	toolspeed = 2
+	toolspeed = 1.5
 
 /obj/item/screwdriver/makeshift
 	name = "makeshift screwdriver"
@@ -19,7 +19,7 @@
 	force = 1
 	throwforce = 1
 	w_class = WEIGHT_CLASS_NORMAL
-	toolspeed = 2
+	toolspeed = 1.5
 
 /obj/item/weldingtool/makeshift
 	name = "makeshift welder"
@@ -28,9 +28,9 @@
 	icon_state = "makeshift_welder"
 	force = 1
 	throwforce = 2
-	toolspeed = 2
+	toolspeed = 1.5
 	w_class = WEIGHT_CLASS_NORMAL
-	max_fuel = 5
+	max_fuel = 12
 	heat = 1800
 
 /obj/item/wirecutters/makeshift
@@ -42,7 +42,7 @@
 	force = 3
 	throwforce = 2
 	w_class = WEIGHT_CLASS_NORMAL
-	toolspeed = 2
+	toolspeed = 1.5
 
 /obj/item/wrench/makeshift
 	name = "makeshift wrench"
@@ -52,4 +52,4 @@
 	force = 2
 	throwforce = 2
 	w_class = WEIGHT_CLASS_NORMAL
-	toolspeed = 2
+	toolspeed = 1.5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rebalances makeshift tools to not be hot rubbish

## How This Contributes To The Skyrat Roleplay Experience

Makeshift tools have been a complete joke up until now, with them being annoying to carry, convoluted to get the parts for, and far too slow to be of any use. This PR will change them to become a still inferior, but actually usable alternative to breaking into the nearest lathe. I'm hoping this'll reward players for looking into the crafting menu, as they find something that can actually be used to some affect if (for example) the QM's being a puritan and has set up an exclusion zone around the cargo autolathe.

(also, sidenote, please ignore the thing about flashlights. That was merged yesterday, I was just a smoothbrain who didn't change branch to do my next idea.)
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: made makeshift hammer use iron plates instead of (for some reason) rolling pins
balance: made makeshift tools faster
balance: made makeshift welding tool hold 12 units of fuel instead of a pathetic 5
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
