### PR TITLE
Rebalance makeshift tools, remove makeshift hammer

### DIFF
--- a/modular_skyrat/modules/modular_items/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/modular_skyrat/modules/modular_items/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -1,6 +1,5 @@
 /datum/crafting_recipe/makeshift/crowbar
 	name = "Makeshift Crowbar"
-	tool_paths = list(/obj/item/hammer/makeshift)
 	result = /obj/item/crowbar/makeshift
 	reqs = list(/obj/item/stack/sheet/iron = 4,
 				/obj/item/stack/sheet/cloth = 1,
@@ -8,18 +7,9 @@
 	time = 120
 	category = CAT_MISC
 
-/datum/crafting_recipe/makeshift/hammer
-	name = "Makeshift Hammer"
-	result = /obj/item/hammer/makeshift
-	reqs = list(/obj/item/stack/cable_coil = 1,
-				/obj/item/stack/rods = 2,
-				/obj/item/kitchen/rollingpin = 2)
-	time = 80
-	category = CAT_MISC
-
 /datum/crafting_recipe/makeshift/screwdriver
 	name = "Makeshift Screwdriver"
-	tool_paths = list(/obj/item/hammer/makeshift)
+	tool_paths = list(/obj/item/crowbar/makeshift)
 	result = /obj/item/screwdriver/makeshift
 	reqs = list(/obj/item/stack/cable_coil = 1,
 				/obj/item/stack/sheet/cloth = 2,
@@ -29,7 +19,7 @@
 
 /datum/crafting_recipe/makeshift/welder
 	name = "Makeshift Welder"
-	tool_paths = list(/obj/item/hammer/makeshift)
+	tool_paths = list(/obj/item/crowbar/makeshift)
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	result = /obj/item/weldingtool/makeshift
 	reqs = list(/obj/item/tank/internals/emergency_oxygen = 1,
@@ -41,7 +31,7 @@
 
 /datum/crafting_recipe/makeshift/wirecutters
 	name = "Makeshift Wirecutters"
-	tool_paths = list(/obj/item/hammer/makeshift)
+	tool_paths = list(/obj/item/crowbar/makeshift)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	result = /obj/item/wirecutters/makeshift
 	reqs = list(/obj/item/stack/cable_coil = 2,
@@ -51,7 +41,7 @@
 
 /datum/crafting_recipe/makeshift/wrench
 	name = "Makeshift Wrench"
-	tool_paths = list(/obj/item/hammer/makeshift)
+	tool_paths = list(/obj/item/crowbar/makeshift)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	result = /obj/item/wrench/makeshift
 	reqs = list(/obj/item/stack/cable_coil = 1,

--- a/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/miscellaneous.dm
@@ -1,12 +1,3 @@
-/obj/item/hammer/makeshift
-	name = "makeshift hammer"
-	desc = "A makeshift hammer, flimsily constructed with miscellaneous parts."
-	icon = 'modular_skyrat/modules/modular_items/icons/obj/items/tools.dmi'
-	icon_state = "makeshift_hammer"
-	force = 2
-	throwforce = 3
-	w_class = WEIGHT_CLASS_NORMAL
-
 //loot
 /obj/item/bloodcrawlbottle
 	name = "bloodlust in a bottle"

--- a/modular_skyrat/modules/modular_items/code/game/objects/items/tools/makeshift.dm
+++ b/modular_skyrat/modules/modular_items/code/game/objects/items/tools/makeshift.dm
@@ -2,13 +2,13 @@
 
 /obj/item/crowbar/makeshift
 	name = "makeshift crowbar"
-	desc = "A makeshift crowbar, flimsily constructed with miscellaneous parts. It's too messed up to fit in a backpack."
+	desc = "A makeshift crowbar, flimsily constructed with miscellaneous parts. It's got a strong head that looks like it could be used for hammering."
 	icon = 'modular_skyrat/modules/modular_items/icons/obj/items/tools.dmi'
 	icon_state = "makeshift_crowbar"
 	force = 2
 	throwforce = 2
-	w_class = WEIGHT_CLASS_BULKY
-	toolspeed = 2
+	w_class = WEIGHT_CLASS_NORMAL
+	toolspeed = 1.5
 
 /obj/item/screwdriver/makeshift
 	name = "makeshift screwdriver"
@@ -19,7 +19,7 @@
 	force = 1
 	throwforce = 1
 	w_class = WEIGHT_CLASS_NORMAL
-	toolspeed = 2
+	toolspeed = 1.5
 
 /obj/item/weldingtool/makeshift
 	name = "makeshift welder"
@@ -28,9 +28,9 @@
 	icon_state = "makeshift_welder"
 	force = 1
 	throwforce = 2
-	toolspeed = 2
+	toolspeed = 1.5
 	w_class = WEIGHT_CLASS_NORMAL
-	max_fuel = 5
+	max_fuel = 10
 	heat = 1800
 
 /obj/item/wirecutters/makeshift
@@ -42,7 +42,7 @@
 	force = 3
 	throwforce = 2
 	w_class = WEIGHT_CLASS_NORMAL
-	toolspeed = 2
+	toolspeed = 1.5
 
 /obj/item/wrench/makeshift
 	name = "makeshift wrench"
@@ -52,4 +52,4 @@
 	force = 2
 	throwforce = 2
 	w_class = WEIGHT_CLASS_NORMAL
-	toolspeed = 2
+	toolspeed = 1.5


### PR DESCRIPTION
Second time's the charm!

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For a long time makeshift tools have been in a sorry state. They are (currently) completely useless to everyone except prisoners, and even then most antags in jail have better ways to escape, and actual prisoners aren't allowed to use the tools to escape.
This PR is my attempt to rebalance makeshift tools into something that may actually see use in-game, improving their stats and making them easier to craft, as well as streamlining the process by removing the stupid, awful, bad, useless hammer from the face of the earth. The tools now provide a way to bypass the autolathe, providing for new and exciting gameplay chances!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

It somewhat assists the problem of people being forced to LRP and steal, borrow and beg for tools from one of the main departments. With that in mind, I expect this to be of most use to people in the service department, as they often struggle to find tools outside of the very limited tool storage and the dark, damp maint tunnels.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
del: Removed the makeshift hammer
balance: Increased makeshift welders fuel from 5 to 10, putting it imbetween the emergency welder and the actual welder
balance: Reduced the size of the crowbar from bulky to normal, allowing it to be placed into toolbelts
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
