### PR TITLE
makes roundstart podpeople not OP

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
@@ -23,3 +23,6 @@
 
 	learnable_languages = list(/datum/language/common, /datum/language/sylvan)
 	always_customizable = FALSE
+
+/datum/species/pod/podweak/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
+	return


### PR DESCRIPTION
## About The Pull Request
roundstart podpeople

## How This Contributes To The Skyrat Roleplay Experience
see title

## Changelog

:cl:
balance: roundstart podpeople don't heal anymore from light
/:cl: