### PR TITLE
Fixes ambience being cut short after one minute of playing

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -92,7 +92,7 @@
 	///Used to decide what the minimum time between ambience is
 	var/min_ambience_cooldown = 30 SECONDS
 	///Used to decide what the maximum time between ambience is
-	var/max_ambience_cooldown = 60 SECONDS //SKYRAT EDIT CHANGE - ORIGINAL: 90
+	var/max_ambience_cooldown = 90 SECONDS
 
 	var/list/air_vent_info = list()
 	var/list/air_scrub_info = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The value was lowered without taking into account the fact that some of our ambience was still going near 90 seconds long. This reverts it to the /tg/ value to fix that bug where they're cut short for another track to play.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Not hearing your music being cut in the middle of your space exploration makes it less immersive, and it just sounds better.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: GoldenAlpharex
fix: Ambience music should now be cut a lot less often.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
