### PR TITLE
Nature & Wildlife preservation measure(s)

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -934,6 +934,7 @@
 "qq" = (
 /obj/machinery/door/airlock/science,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav)
 "qE" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Locks a door in a ruin to save a kiwi, literally nothing else
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
think of the kiwis!! otherwise its just because the kiwi kills itself due to a large wander range removing the ability to have it as a pet or save it from the zombies, the ruin is also unmarked so there's no possibility to save it as its luck only
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Added a locked door inside of a dangerous research facility, to prevent an unnecessary casualty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
