### PR TITLE
Returns the Knockdown to security batons.

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -523,7 +523,7 @@
 	if(!target.IsKnockdown())
 		to_chat(target, span_warning("Your muscles seize, making you collapse [trait_check ? ", but your body quickly recovers..." : "!"]"))
 
-	//target.Knockdown(knockdown_time * (trait_check ? 0.1 : 1)) // SKYRAT EDIT DISABLE
+	target.Knockdown(knockdown_time * (trait_check ? 0.1 : 1))
 
 /obj/item/melee/baton/security/get_wait_description()
 	return span_danger("The baton is still charging!")


### PR DESCRIPTION
I had made this change late in the GoofSec dev cycle and it didn't get enough time to marinate before it was merged, and upon retrospection, bad change.
## Changelog

:cl:
balance: Batons now knockdown again.
/:cl: