### PR TITLE
[nonmodular]adds the modern glasses to the glasses selection

### DIFF
--- a/code/_globalvars/lists/quirks.dm
+++ b/code/_globalvars/lists/quirks.dm
@@ -1,4 +1,4 @@
 ///Lists related to quirk selection
 
 ///Types of glasses that can be selected at character selection with the Nearsighted quirk
-GLOBAL_LIST_INIT(nearsighted_glasses, list("Regular","Thin","Circle","Hipster"))
+GLOBAL_LIST_INIT(nearsighted_glasses, list("Regular","Thin","Circle","Hipster", "Modern"))

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -297,6 +297,8 @@
 			glasses = /obj/item/clothing/glasses/regular/circle
 		if ("Hipster")
 			glasses = /obj/item/clothing/glasses/regular/hipster
+		if ("Modern")
+			glasses = /obj/item/clothing/glasses/betterunshit
 		else
 			glasses = /obj/item/clothing/glasses/regular
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title, its in the lil selection box

## How This Contributes To The Skyrat Roleplay Experience

It's a set of glasses.  It saves time and backpack space.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
expansion: you can now select modern glasses in the dropdown box
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
