### PR TITLE
Fixes #9151 and cleans up some jank with barbervend.dm

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -557,7 +557,8 @@
 		/obj/machinery/vending/tool = "YouTool",
 		/obj/machinery/vending/custom = "Custom Vendor",
 		/obj/machinery/vending/dorms = "LustWish",	//SKYRAT EDIT CHANGE - ERP UPDATE - ORIGINAL: /obj/machinery/vending/dorms = "KinkVend"
-		/obj/machinery/vending/access/command = "Command Outfitting Station") //SKYRAT EDIT ADDITION
+		/obj/machinery/vending/access/command = "Command Outfitting Station", //SKYRAT EDIT ADDITION
+		/obj/machinery/vending/barbervend = "Fab-O-Vend") //SKYRAT EDIT ADDITION
 
 /obj/item/circuitboard/machine/vendor/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)

--- a/modular_skyrat/modules/salon/code/barbervend.dm
+++ b/modular_skyrat/modules/salon/code/barbervend.dm
@@ -5,6 +5,7 @@
 	icon_state = "barbervend"
 	product_slogans = "Spread the colour, like butter, onto toast... Onto their hair.; Sometimes, I dream about dyes...; Paint 'em up and call me Mr. Painter.; Look brother, I'm a vendomat, I solve practical problems."
 	product_ads = "Cut 'em all!; To sheds!; Hair be gone!; Prettify!; Beautify!"
+	vend_reply = "Come again!; Buy another!; Dont you love your new look?"
 	req_access = list(ACCESS_BARBER)
 	refill_canister = /obj/item/vending_refill/barbervend
 	products = list(
@@ -24,7 +25,11 @@
 		/obj/item/razor = 1,
 		/obj/item/storage/box/perfume = 1,
 	)
+	refill_canister = /obj/item/vending_refill/barbervend
+	default_price = PAYCHECK_ASSISTANT
+	extra_price = PAYCHECK_HARD
+	payment_department = ACCOUNT_SRV
 
 /obj/item/vending_refill/barbervend
-	name = "barber vend resupply"
-
+	machine_name = "barber vend resupply"
+	icon_state = "refill_snack" //generic item refill because there isnt one sprited yet.


### PR DESCRIPTION
## About The Pull Request
Closes #9151 and adds some buy reply lines to the Barber vendor.

## How This Contributes To The Skyrat Roleplay Experience
N/A, bugfix.

## Changelog

:cl: Gonenoculer5
fix: Fixes the Fab-O-Vend's custom vendor setting on the vendor board.
fix: Fixes the Fab-O-Vend's lack of buy reply strings and tells it where to pay out its dues to.
fix: Fixes the Fab-O-Vend's vendor resupply, or lack thereof due to improper naming.
/:cl:
