### PR TITLE
Fixes fat-fingering 911 by moving where the 911 buttons are(911 still requires an ID swipe as always)

### DIFF
--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -439,27 +439,6 @@ const PageMain = (props, context) => {
             content="Make Priority Announcement"
             onClick={() => act("makePriorityAnnouncement")}
           />}
-          {
-            // SKYRAT EDIT BEGIN
-          }
-          {!!canMakeAnnouncement && <Button
-            icon="bullhorn"
-            content="Call Sol Federation 911: Police Response"
-            onClick={() => act("callThePolice")}
-          />}
-          {!!canMakeAnnouncement && <Button
-            icon="bullhorn"
-            content="Call Sol Federation 911: Firefighter Response"
-            onClick={() => act("callTheFireDep")}
-          />}
-          {!!canMakeAnnouncement && <Button
-            icon="bullhorn"
-            content="Call Sol Federation 911: Medical Response"
-            onClick={() => act("callTheParameds")}
-          />}
-          {
-            // SKYRAT EDIT END
-          }
           {!!canToggleEmergencyAccess && <Button.Confirm
             icon="id-card-o"
             content={`${emergencyAccess ? "Disable" : "Enable"} Emergency Maintenance Access`}
@@ -509,7 +488,28 @@ const PageMain = (props, context) => {
             content="Restore Backup Routing Data"
             onClick={() => act("restoreBackupRoutingData")}
           />}
-        </Flex>
+          {
+            // SKYRAT EDIT BEGIN
+          }
+          {!!canMakeAnnouncement && <Button
+            icon="bullhorn"
+            content="Call Sol Federation 911: Police Response"
+            onClick={() => act("callThePolice")}
+          />}
+          {!!canMakeAnnouncement && <Button
+            icon="bullhorn"
+            content="Call Sol Federation 911: Firefighter Response"
+            onClick={() => act("callTheFireDep")}
+          />}
+          {!!canMakeAnnouncement && <Button
+            icon="bullhorn"
+            content="Call Sol Federation 911: Medical Response"
+            onClick={() => act("callTheParameds")}
+          />}
+          {
+            // SKYRAT EDIT END
+          }
+          </Flex>
       </Section>
 
       {!!canMessageAssociates && messagingAssociates && <MessageModal


### PR DESCRIPTION
so basically, to make it hard to fatfinger dial 911, you have to swipe your card, right
the problem is the location on the screen where the confirm button for raising the alert level
is the exact same location one of the 911 buttons are now when the confirm button is hit
so galaxy brain captains keep double clicking
because the alert level requires a swipe as well

it is now moved down to the bottom of the UI to reduce fat-fingering

:cl:
fix: Reduces the chance you've fatfingered 911.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
