### PR TITLE
Fixes the m23 and m2 shotguns being unable to be loaded with the ammo they start with

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -703,6 +703,7 @@
 
 /obj/item/ammo_box/magazine/internal/shot/m23
 	name = "m23 shotgun internal magazine"
+	caliber = CALIBER_14GAUGE
 	ammo_type = /obj/item/ammo_casing/s14gauge
 	max_ammo = 6
 
@@ -729,6 +730,7 @@
 
 /obj/item/ammo_box/magazine/internal/shot/as2
 	name = "shotgun internal magazine"
+	caliber = CALIBER_14GAUGE
 	ammo_type = /obj/item/ammo_casing/s14gauge
 	max_ammo = 4
 


### PR DESCRIPTION
## About The Pull Request

fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/7752

## Changelog

:cl:
fix: m23 and m2 shotguns can now be loaded with 14 gauge ammo as intended
/:cl: