### PR TITLE
Fixes emp_act on gun/ballistic

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -8,8 +8,7 @@
 		jammed = TRUE
 		playsound(src, 'sound/effects/stall.ogg', 60, TRUE)
 		if(magazine)
-			magazine.forceMove(src.loc)
-			playsound(src, load_empty_sound, load_sound_volume, load_sound_vary)
+			eject_magazine()
 
 /obj/item/gun/ballistic/automatic/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/6957

## Changelog

:cl:
fix: Ballistic guns that are vulnerable to EMPs will no longer have a phantom mag when EMP'd
/:cl: