### PR TITLE
Perfume cap can now be toggled by using them inhand

### DIFF
--- a/modular_skyrat/modules/pollution/code/perfumes.dm
+++ b/modular_skyrat/modules/pollution/code/perfumes.dm
@@ -35,10 +35,17 @@
 		. += span_notice("Alt-click [src] to [ cap ? "take the cap off" : "put the cap on"].")
 
 /obj/item/perfume/AltClick(mob/user)
-	if(has_cap && user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, TRUE))
-		cap = !cap
-		to_chat(user, span_notice("The cap on [src] is now [cap ? "on" : "off"]."))
-		update_appearance()
+    toggle_cap(user)
+
+/obj/item/perfume/attack_self(mob/user, modifiers)
+    toggle_cap(user)
+
+/// Proc to handle removing the cap of the perfume bottle.
+/obj/item/perfume/proc/toggle_cap(mob/user)
+    if(has_cap && user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, TRUE))
+            cap = !cap
+            to_chat(user, span_notice("The cap on [src] is now [cap ? "on" : "off"]."))
+            update_appearance()
 
 /obj/item/perfume/afterattack(atom/attacked, mob/user, proximity)
 	. = ..()

--- a/modular_skyrat/modules/pollution/code/perfumes.dm
+++ b/modular_skyrat/modules/pollution/code/perfumes.dm
@@ -35,14 +35,14 @@
 		. += span_notice("Alt-click [src] to [ cap ? "take the cap off" : "put the cap on"].")
 
 /obj/item/perfume/AltClick(mob/user)
-    toggle_cap(user)
+	toggle_cap(user)
 
 /obj/item/perfume/attack_self(mob/user, modifiers)
-    toggle_cap(user)
+	toggle_cap(user)
 
 /// Proc to handle removing the cap of the perfume bottle.
 /obj/item/perfume/proc/toggle_cap(mob/user)
-    if(has_cap && user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, TRUE))
+	if(has_cap && user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, TRUE))
 		cap = !cap
 		to_chat(user, span_notice("The cap on [src] is now [cap ? "on" : "off"]."))
 		update_appearance()

--- a/modular_skyrat/modules/pollution/code/perfumes.dm
+++ b/modular_skyrat/modules/pollution/code/perfumes.dm
@@ -43,9 +43,9 @@
 /// Proc to handle removing the cap of the perfume bottle.
 /obj/item/perfume/proc/toggle_cap(mob/user)
     if(has_cap && user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, TRUE))
-            cap = !cap
-            to_chat(user, span_notice("The cap on [src] is now [cap ? "on" : "off"]."))
-            update_appearance()
+		cap = !cap
+		to_chat(user, span_notice("The cap on [src] is now [cap ? "on" : "off"]."))
+		update_appearance()
 
 /obj/item/perfume/afterattack(atom/attacked, mob/user, proximity)
 	. = ..()


### PR DESCRIPTION
See title.

:cl: Useroth
qol: Perfume bottles can now have their cap toggled by using them in-hand, rather than just relying on alt-click.
/:cl: