### PR TITLE
[MODULAR] Adds Trash Piles back to TG Maps 2: Stealth Revert Edition

### DIFF
--- a/modular_skyrat/master_files/code/game/effects/spawners/random/structure.dm
+++ b/modular_skyrat/master_files/code/game/effects/spawners/random/structure.dm
@@ -1,0 +1,14 @@
+/obj/effect/spawner/random/structure/crate
+	name = "crate spawner"
+	icon_state = "crate"
+	loot = list(
+		/obj/effect/spawner/random/structure/crate_loot = 495,
+		/obj/structure/trash_pile = 250,
+		/obj/structure/closet/crate/trashcart/filled = 75,
+		/obj/effect/spawner/random/trash/moisture_trap = 50,
+		/obj/effect/spawner/random/trash/hobo_squat = 30,
+		/obj/structure/closet/mini_fridge = 35,
+		/obj/effect/spawner/random/trash/mess = 30,
+		/obj/item/kirbyplants/fern = 20,
+		/obj/structure/closet/crate/decorations = 15,
+	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4045,6 +4045,7 @@
 #include "modular_skyrat\master_files\code\datums\traits\good.dm"
 #include "modular_skyrat\master_files\code\datums\traits\negative.dm"
 #include "modular_skyrat\master_files\code\datums\traits\neutral.dm"
+#include "modular_skyrat\master_files\code\game\effects\spawners\random\structure.dm"
 #include "modular_skyrat\master_files\code\game\machinery\doors\firedoor.dm"
 #include "modular_skyrat\master_files\code\game\objects\ghost_role_spawners.dm"
 #include "modular_skyrat\master_files\code\game\objects\items.dm"


### PR DESCRIPTION
## About The Pull Request

#6154 was stealth removed by #8344
This PR undoes that

## How This Contributes To The Skyrat Roleplay Experience

See #6154

## Changelog
:cl: YakumoChen
fix: Trash Piles can spawn in place of Maint Crates once again.
/:cl: