### PR TITLE
[HALLOWEEN ONLY TESTMERGE] Adds the british people as a playable race

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/british
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/british
@@ -1,0 +1,31 @@
+/datum/species/unathi/british
+	name = "The people of England" // unathi because im psure they're lizards at heart
+	id = SPECIES_TEA
+	default_color = "#4B4B4B"
+	species_traits = list(MUTCOLORS,
+		EYECOLOR,
+		LIPS,
+		HAS_FLESH,
+		HAS_BONE,
+		HAIR,
+		FACEHAIR
+	)
+	inherent_traits = list(
+		TRAIT_ADVANCEDTOOLUSER,
+		TRAIT_CAN_STRIP
+	)
+	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID
+	mutant_bodyparts = list()
+	default_mutant_bodyparts = list(
+		"tail" = "None",
+		"snout" = "None",
+		"ears" = "None",
+		"legs" = "Normal Legs",
+		"wings" = "None",
+		"taur" = "None",
+		"horns" = "None"
+	)
+	liked_food = GROSS | FRIED
+	payday_modifier = 0.75
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
+	limbs_id = SPECIES_HUMAN

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/british.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/british.dm
@@ -12,7 +12,9 @@
 	)
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
-		TRAIT_CAN_STRIP
+		TRAIT_CAN_STRIP,
+		TRAIT_UNINTELLIGIBLE_SPEECH,
+		TRAIT_NOGUNS
 	)
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	mutant_bodyparts = list()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/british.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/british.dm
@@ -1,5 +1,5 @@
 /datum/species/unathi/british
-	name = "The people of England" // unathi because im psure they're lizards at heart
+	name = "The 'people' of England" // unathi because im psure they're lizards at heart
 	id = SPECIES_TEA
 	default_color = "#4B4B4B"
 	species_traits = list(MUTCOLORS,

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/british.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/british.dm
@@ -1,6 +1,7 @@
 /datum/species/unathi/british
 	name = "The 'people' of England" // unathi because im psure they're lizards at heart
 	id = SPECIES_TEA
+	say_mod = "says britishly"
 	default_color = "#4B4B4B"
 	species_traits = list(MUTCOLORS,
 		EYECOLOR,

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/british.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/british.dm
@@ -25,7 +25,7 @@
 		"taur" = "None",
 		"horns" = "None"
 	)
-	liked_food = GROSS | FRIED
+	liked_food = GROSS | FRIED | Tea | Beef Wellington
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_id = SPECIES_HUMAN

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/british.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/british.dm
@@ -25,7 +25,7 @@
 		"taur" = "None",
 		"horns" = "None"
 	)
-	liked_food = GROSS | FRIED | Tea | Beef Wellington
+	liked_food = GROSS | FRIED | TEA | BEEF WELLINGTON
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_id = SPECIES_HUMAN


### PR DESCRIPTION


## About The Pull Request

adds a mythical race that lost to the (gigachad) space americans in the war of who has the better flag circa 2472

## How This Contributes To The Skyrat Roleplay Experience
here's the lore the Wikpedia, the free encyclopedia: The British people, or Britons, are the citizens of the United Kingdom of Great Britain and Northern Ireland, the British Overseas Territories, and the Crown dependencies. British nationality law governs modern British citizenship and nationality, which can be acquired, for instance, by descent from British nationals. When used in a historical context, "British" or "Britons" can refer to the Ancient Britons, the indigenous inhabitants of Great Britain and Brittany, whose surviving members are the modern Welsh people, Cornish people, and Bretons.[35] It also refers to citizens of the former British Empire, who settled in the country prior to 1973, and hold neither UK citizenship nor nationality.[37]

## Changelog


:cl:
add: Added the british people
/:cl:


