### PR TITLE
[MODULAR] Moves the departmental guards baton to their backpack on spawn.

### DIFF
--- a/modular_skyrat/modules/goofsec/jobs/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/jobs/department_guards.dm
@@ -109,7 +109,6 @@
 	suit = /obj/item/clothing/suit/armor/vest/blueshirt/skyrat/orderly
 	l_pocket = /obj/item/restraints/handcuffs
 	r_pocket = /obj/item/assembly/flash/handheld
-	suit_store = /obj/item/melee/baton/security/loaded
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded = 1,
 		)

--- a/modular_skyrat/modules/goofsec/jobs/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/jobs/department_guards.dm
@@ -110,6 +110,9 @@
 	l_pocket = /obj/item/restraints/handcuffs
 	r_pocket = /obj/item/assembly/flash/handheld
 	suit_store = /obj/item/melee/baton/security/loaded
+	backpack_contents = list(
+		/obj/item/melee/baton/security/loaded = 1,
+		)
 
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med
@@ -174,7 +177,9 @@
 	suit = /obj/item/clothing/suit/armor/vest/blueshirt/skyrat
 	l_pocket = /obj/item/restraints/handcuffs
 	r_pocket = /obj/item/assembly/flash/handheld
-	suit_store = /obj/item/melee/baton/security/loaded
+	backpack_contents = list(
+		/obj/item/melee/baton/security/loaded = 1,
+		)
 
 	backpack = /obj/item/storage/backpack/science
 	satchel = /obj/item/storage/backpack/satchel/science
@@ -241,7 +246,9 @@
 	suit = /obj/item/clothing/suit/armor/vest/blueshirt/skyrat/guard
 	l_pocket = /obj/item/restraints/handcuffs
 	r_pocket = /obj/item/assembly/flash/handheld
-	suit_store = /obj/item/melee/baton/security/loaded
+	backpack_contents = list(
+		/obj/item/melee/baton/security/loaded = 1,
+		)
 	glasses = /obj/item/clothing/glasses/sunglasses
 
 	backpack = /obj/item/storage/backpack
@@ -307,7 +314,9 @@
 	suit = /obj/item/clothing/suit/armor/vest/blueshirt/skyrat/customs_agent
 	l_pocket = /obj/item/restraints/handcuffs
 	r_pocket = /obj/item/assembly/flash/handheld
-	suit_store = /obj/item/melee/baton/security/loaded
+	backpack_contents = list(
+		/obj/item/melee/baton/security/loaded = 1,
+		)
 
 	backpack = /obj/item/storage/backpack
 	satchel = /obj/item/storage/backpack/satchel
@@ -372,7 +381,9 @@
 	suit = /obj/item/clothing/suit/armor/vest/blueshirt/skyrat/engineering_guard
 	l_pocket = /obj/item/restraints/handcuffs
 	r_pocket = /obj/item/assembly/flash/handheld
-	suit_store = /obj/item/melee/baton/security/loaded
+	backpack_contents = list(
+		/obj/item/melee/baton/security/loaded = 1,
+		)
 
 	backpack = /obj/item/storage/backpack/industrial
 	satchel = /obj/item/storage/backpack/satchel/eng


### PR DESCRIPTION


## About The Pull Request

Moves the departmental guard's spawn-baton to his backpack, which fixes having a suit loadout item deleting it. (assuming you don't use move-to-case, as this breaks GAGS colorable stuff)

## How This Contributes To The Skyrat Roleplay Experience

not RP related, but batong is important for the guard-job

## Changelog


:cl:
fix: fixes the guard baton being deleted because you brought your wintercoat to work.
/:cl:

