### PR TITLE
Multiple APC warning fix

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -89,10 +89,6 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/interlink)
-"adY" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
-/area/centcom/ncvtitan)
 "aer" = (
 /obj/structure/chair/sofa/corner,
 /turf/open/indestructible/hotelwood,
@@ -359,7 +355,6 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
 "ahk" = (
@@ -1277,7 +1272,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
 "aoi" = (
@@ -5125,7 +5119,6 @@
 /area/centcom/interlink)
 "aTj" = (
 /obj/machinery/light/directional/west,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
 "aTk" = (
@@ -6018,13 +6011,6 @@
 	},
 /turf/open/floor/carpet,
 /area/centcom/interlink)
-"bgO" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/carpet/royalblue,
-/area/centcom/ncvtitan)
 "bhw" = (
 /obj/structure/artilleryplaceholder{
 	icon_state = "10"
@@ -6038,7 +6024,6 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Docking Control"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
 "biw" = (
@@ -6380,11 +6365,6 @@
 /obj/machinery/recharger,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/ncvtitan)
-"cHE" = (
-/obj/machinery/light/directional/south,
-/obj/structure/cable,
-/turf/open/floor/carpet/neon/simple/cyan/nodots,
-/area/centcom/ncvtitan)
 "cJb" = (
 /obj/machinery/autolathe/hacked,
 /obj/effect/turf_decal/delivery,
@@ -6413,10 +6393,6 @@
 /area/centcom/ncvtitan)
 "cMJ" = (
 /turf/closed/wall/mineral/titanium,
-/area/centcom/ncvtitan)
-"cNs" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
 /area/centcom/ncvtitan)
 "cNZ" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -6453,7 +6429,6 @@
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
 "cSW" = (
@@ -6926,12 +6901,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
-"eKy" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/iron/dark,
-/area/centcom/ncvtitan)
 "eLC" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -7123,14 +7092,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/interlink)
-"fBr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
-/area/centcom/ncvtitan)
 "fGe" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
@@ -7326,13 +7287,6 @@
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/floor/plating/asteroid,
 /area/centcom/interlink)
-"gpK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
-/area/centcom/ncvtitan)
 "gul" = (
 /obj/structure/lattice,
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -7539,7 +7493,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/flashlight/seclite,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/ncvtitan)
 "hgc" = (
@@ -7552,10 +7505,6 @@
 	},
 /turf/open/indestructible/hoteltile,
 /area/centcom/interlink)
-"hhq" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/centcom/ncvtitan)
 "hhW" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -7610,7 +7559,6 @@
 	name = "Office";
 	req_access_txt = "101"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
 "hAT" = (
@@ -7701,7 +7649,6 @@
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
 "hQn" = (
@@ -7811,14 +7758,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
-"ilU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
-/area/centcom/ncvtitan)
 "ime" = (
 /obj/machinery/washing_machine{
 	pixel_x = 2
@@ -7844,7 +7783,6 @@
 /area/centcom/ncvtitan)
 "irD" = (
 /obj/machinery/shuttle_manipulator,
-/obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/centcom/ncvtitan)
 "itP" = (
@@ -7868,13 +7806,6 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
 /area/centcom/interlink)
-"ivg" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/centcom/ncvtitan)
 "iwb" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/smooth_large,
@@ -8232,10 +8163,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
-"kdy" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/neon/simple/cyan,
-/area/centcom/ncvtitan)
 "kfp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -8308,7 +8235,6 @@
 	name = "Administrative Office";
 	req_access_txt = "109"
 	},
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/centcom/ncvtitan)
 "klo" = (
@@ -8365,14 +8291,12 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Diner"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
 "koA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
 "kqG" = (
@@ -8542,11 +8466,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/iron,
 /area/centcom/interlink)
-"kVR" = (
-/obj/machinery/light/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
-/area/centcom/ncvtitan)
 "kWH" = (
 /turf/open/floor/iron/grimy,
 /area/centcom/interlink)
@@ -8608,14 +8527,12 @@
 /turf/open/floor/carpet/neon/simple/cyan/nodots,
 /area/centcom/ncvtitan)
 "lfm" = (
-/obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/centcom/ncvtitan)
 "lfY" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
 "lgV" = (
@@ -8647,7 +8564,6 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
 "ljZ" = (
@@ -8730,11 +8646,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
-"ltP" = (
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/centcom/ncvtitan)
 "luy" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 4
@@ -8796,7 +8707,6 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/glass,
 /area/centcom/ncvtitan)
 "lUk" = (
@@ -8819,19 +8729,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
-"lUQ" = (
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/centcom/ncvtitan)
-"maM" = (
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/centcom/ncvtitan)
 "mcJ" = (
 /obj/machinery/light/directional/north,
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -8860,10 +8757,6 @@
 "mmy" = (
 /turf/open/floor/plating/grass/planet,
 /area/centcom/interlink)
-"mni" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/royalblue,
-/area/centcom/ncvtitan)
 "mnr" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 8
@@ -9092,7 +8985,6 @@
 "mVg" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/floor,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
 "mZc" = (
@@ -9212,11 +9104,6 @@
 	},
 /obj/structure/table/glass,
 /turf/open/floor/iron/textured,
-/area/centcom/ncvtitan)
-"nra" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/carpet/royalblue,
 /area/centcom/ncvtitan)
 "ntq" = (
 /obj/effect/turf_decal/sand/plating,
@@ -9391,7 +9278,6 @@
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
 "oaj" = (
@@ -9463,10 +9349,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
-"opW" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/neon/simple/cyan/nodots,
-/area/centcom/ncvtitan)
 "oqC" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -9556,7 +9438,6 @@
 /obj/item/clipboard,
 /obj/item/folder/red,
 /obj/item/pen/red,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/ncvtitan)
 "oFj" = (
@@ -9585,7 +9466,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
 "oHE" = (
@@ -9598,7 +9478,6 @@
 /turf/open/floor/plating/airless,
 /area/centcom/ncvtitan)
 "oIA" = (
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/centcom/ncvtitan)
 "oMJ" = (
@@ -9837,10 +9716,6 @@
 /obj/item/storage/box/donkpockets/donkpocketgondola,
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
-"pOy" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/executive,
-/area/centcom/ncvtitan)
 "pOQ" = (
 /obj/structure/artilleryplaceholder{
 	icon_state = "11"
@@ -9881,7 +9756,6 @@
 	},
 /obj/effect/turf_decal/caution,
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
 "pTB" = (
@@ -10102,11 +9976,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
-"qvu" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/carpet/neon/simple/cyan,
-/area/centcom/ncvtitan)
 "qwZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/asteroid,
@@ -10325,10 +10194,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
-"rpJ" = (
-/obj/structure/cable,
-/turf/open/floor/glass,
-/area/centcom/ncvtitan)
 "rqO" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -10750,23 +10615,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/smooth,
 /area/centcom/ncvtitan)
-"sHy" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
-/area/centcom/ncvtitan)
 "sHK" = (
 /obj/structure/artilleryplaceholder{
 	icon_state = "19"
 	},
 /turf/open/floor/plating/airless,
-/area/centcom/ncvtitan)
-"sIJ" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
 /area/centcom/ncvtitan)
 "sKu" = (
 /obj/structure/chair/comfy/brown,
@@ -10910,13 +10763,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
-"tmK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/centcom/ncvtitan)
 "toK" = (
 /obj/docking_port/stationary{
 	dheight = 3;
@@ -11001,11 +10847,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
-"tyz" = (
-/obj/machinery/light/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/centcom/ncvtitan)
 "tza" = (
 /obj/structure/artilleryplaceholder{
 	icon_state = "23"
@@ -11047,7 +10888,6 @@
 	},
 /obj/effect/turf_decal/caution,
 /obj/machinery/light/directional/south,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
 "tGP" = (
@@ -11253,7 +11093,6 @@
 "uyf" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
 "uyr" = (
@@ -11488,14 +11327,6 @@
 "vAp" = (
 /turf/open/floor/iron/dark/green/side,
 /area/centcom/interlink)
-"vBO" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/caution{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
-/area/centcom/ncvtitan)
 "vEi" = (
 /obj/structure/sign/logo{
 	icon_state = "nanotrasen_sign2"
@@ -11730,7 +11561,6 @@
 	name = "Administrative Office";
 	req_access_txt = "109"
 	},
-/obj/structure/cable,
 /turf/open/floor/carpet/executive,
 /area/centcom/ncvtitan)
 "wkt" = (
@@ -11826,7 +11656,6 @@
 	name = "Medbay";
 	req_access_txt = "101"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
 "wyP" = (
@@ -11871,7 +11700,6 @@
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
 "wHX" = (
@@ -11918,8 +11746,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron/textured,
 /area/centcom/ncvtitan)
 "wUm" = (
@@ -11941,7 +11767,6 @@
 /area/centcom/interlink)
 "wZw" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/centcom/ncvtitan)
 "wZN" = (
@@ -12004,16 +11829,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
-"xiV" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/carpet/neon/simple/cyan/nodots,
-/area/centcom/ncvtitan)
-"xqr" = (
-/obj/structure/sign/nanotrasen,
-/obj/structure/cable,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/centcom/ncvtitan)
 "xqI" = (
 /obj/machinery/vending/dorms,
 /turf/open/indestructible/hotelwood,
@@ -12095,13 +11910,6 @@
 	},
 /turf/open/floor/iron/dark/red,
 /area/centcom/ncvtitan)
-"xHJ" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/centcom/ncvtitan)
 "xIC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -12130,7 +11938,6 @@
 	dir = 8
 	},
 /obj/machinery/light/floor,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
 "xNb" = (
@@ -12217,7 +12024,6 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/ncvtitan)
 "xUX" = (
@@ -12227,7 +12033,6 @@
 /obj/structure/sign/poster/official/obey{
 	pixel_y = -32
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/ncvtitan)
 "xVT" = (
@@ -12270,7 +12075,6 @@
 /obj/item/encryptionkey/headset_cargo,
 /obj/item/encryptionkey/headset_cargo,
 /obj/item/encryptionkey/headset_cargo,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron/dark,
 /area/centcom/ncvtitan)
@@ -14989,7 +14793,7 @@ aaa
 aaa
 aaa
 rKz
-hhq
+rMb
 dyB
 rKz
 cMJ
@@ -15246,8 +15050,8 @@ aaa
 aaa
 aaa
 rKz
-hhq
-hhq
+dyB
+dyB
 dyB
 rKz
 nci
@@ -15504,8 +15308,8 @@ aaa
 aaa
 rKz
 rKz
-hhq
-hhq
+dyB
+dyB
 rKz
 wzR
 uYn
@@ -15762,7 +15566,7 @@ aaa
 aaa
 rKz
 rKz
-hhq
+dyB
 rKz
 wzR
 uYn
@@ -16019,7 +15823,7 @@ aaa
 aaa
 aaa
 rKz
-hhq
+dyB
 rKz
 uuq
 uuq
@@ -16276,7 +16080,7 @@ aaa
 aaa
 aaa
 rKz
-hhq
+dyB
 rKz
 gby
 gby
@@ -16533,7 +16337,7 @@ aaa
 aaa
 aaa
 rKz
-hhq
+dyB
 rKz
 rKz
 rKz
@@ -16790,7 +16594,7 @@ aaa
 aaa
 aaa
 rKz
-hhq
+dyB
 rKz
 cKo
 acc
@@ -17047,7 +16851,7 @@ aaa
 aaa
 aaa
 tcU
-hhq
+dyB
 tcU
 mcJ
 kzy
@@ -17304,7 +17108,7 @@ aaa
 aaa
 aaa
 rKz
-hhq
+dyB
 rKz
 rNe
 kzy
@@ -17561,7 +17365,7 @@ aaa
 aaa
 aaa
 rKz
-hhq
+dyB
 rKz
 rKz
 rKz
@@ -17818,7 +17622,7 @@ aaa
 aaa
 aaa
 rKz
-hhq
+dyB
 rKz
 twB
 mqG
@@ -18075,7 +17879,7 @@ aaa
 aaa
 aaa
 tcU
-hhq
+dyB
 tcU
 wes
 vYL
@@ -18332,7 +18136,7 @@ aaa
 aaa
 aaa
 rKz
-hhq
+dyB
 rKz
 tOf
 vYL
@@ -18353,10 +18157,10 @@ uQr
 uQr
 uQr
 uQr
-gpK
-adY
-cNs
-cNs
+wdf
+okl
+lQJ
+lQJ
 lQJ
 lQJ
 lQJ
@@ -18589,7 +18393,7 @@ aaa
 aaa
 aaa
 rKz
-hhq
+dyB
 rKz
 rKz
 rKz
@@ -18610,10 +18414,10 @@ uQr
 uQr
 uQr
 uQr
-ilU
+qLG
 rKz
 bGX
-tmK
+bGX
 bGX
 bGX
 tcU
@@ -18846,7 +18650,7 @@ aaa
 aaa
 aaa
 rKz
-hhq
+dyB
 rKz
 nOT
 mtw
@@ -18867,10 +18671,10 @@ uQr
 uQr
 uQr
 uQr
-gpK
+wdf
 rKz
 ndr
-hhq
+dyB
 dyB
 dyB
 xHl
@@ -19103,7 +18907,7 @@ aaa
 aaa
 aaa
 tcU
-hhq
+dyB
 tcU
 esz
 mtw
@@ -19124,10 +18928,10 @@ uQr
 uQr
 uQr
 uQr
-gpK
+wdf
 rKz
 pUv
-hhq
+dyB
 dyB
 dyB
 ufa
@@ -19360,7 +19164,7 @@ aaa
 aaa
 aaa
 rKz
-hhq
+dyB
 rKz
 mHc
 mtw
@@ -19381,10 +19185,10 @@ uQr
 uQr
 uQr
 uQr
-gpK
+wdf
 rKz
 aBz
-hhq
+dyB
 dyB
 dyB
 xHl
@@ -19617,7 +19421,7 @@ aaa
 aaa
 aaa
 rKz
-hhq
+dyB
 rKz
 rKz
 rKz
@@ -19640,8 +19444,8 @@ uQr
 uQr
 tGb
 rKz
-eKy
-hhq
+jgW
+dyB
 dyB
 dyB
 tcU
@@ -19874,7 +19678,7 @@ aaa
 aaa
 rKz
 rKz
-hhq
+dyB
 rKz
 dqv
 dqv
@@ -19895,7 +19699,7 @@ uQr
 uQr
 uQr
 uQr
-gpK
+wdf
 rKz
 dKt
 dyB
@@ -20131,7 +19935,7 @@ aaa
 rKz
 rKz
 dyB
-hhq
+dyB
 rKz
 rxe
 xsd
@@ -20387,8 +20191,8 @@ fZr
 fZr
 rKz
 dyB
-hhq
-hhq
+dyB
+dyB
 rKz
 tQa
 tQa
@@ -20409,7 +20213,7 @@ uQr
 uQr
 uQr
 uQr
-fBr
+tiQ
 rKz
 mZH
 dyB
@@ -20651,10 +20455,10 @@ rKz
 rKz
 rKz
 rKz
-xiV
-cHE
-adY
-sHy
+leI
+aSw
+okl
+iwb
 uQr
 uQr
 uQr
@@ -20666,7 +20470,7 @@ uQr
 uQr
 uQr
 uQr
-gpK
+wdf
 rKz
 cRx
 dyB
@@ -20901,17 +20705,17 @@ aaa
 aaa
 rKz
 leI
-opW
-opW
-opW
-opW
-opW
-opW
-opW
-opW
+leI
+leI
+leI
+leI
+leI
+leI
+leI
+leI
 leI
 rKz
-vBO
+rkj
 uQr
 uQr
 uQr
@@ -21168,7 +20972,7 @@ leI
 leI
 leI
 rKz
-sHy
+iwb
 flZ
 uQr
 uQr
@@ -21180,7 +20984,7 @@ uQr
 uQr
 uQr
 flZ
-gpK
+wdf
 rKz
 rKz
 rKz
@@ -21939,7 +21743,7 @@ lsx
 lsx
 tcU
 sdG
-sHy
+iwb
 uQr
 uQr
 uQr
@@ -22196,7 +22000,7 @@ dyB
 dyB
 tcU
 wdf
-sHy
+iwb
 uQr
 uQr
 uQr
@@ -22453,7 +22257,7 @@ dyB
 tJs
 tcU
 wdf
-sHy
+iwb
 uQr
 uQr
 uQr
@@ -22710,7 +22514,7 @@ dyB
 tJs
 tcU
 wdf
-sHy
+iwb
 uQr
 uQr
 uQr
@@ -22961,13 +22765,13 @@ leI
 leI
 rKz
 xYq
-hhq
-hhq
-hhq
-hhq
+dyB
+dyB
+dyB
+dyB
 bik
-gpK
-sHy
+wdf
+iwb
 uQr
 uQr
 uQr
@@ -23224,7 +23028,7 @@ dyB
 dyB
 tcU
 wdf
-sHy
+iwb
 uQr
 uQr
 uQr
@@ -23481,7 +23285,7 @@ okl
 gvJ
 nXH
 wdf
-sHy
+iwb
 uQr
 uQr
 uQr
@@ -23995,7 +23799,7 @@ jRA
 okl
 kxE
 wdf
-adY
+okl
 iKc
 iKc
 beE
@@ -24252,9 +24056,9 @@ hbU
 okl
 nHC
 wdf
-adY
-adY
-adY
+okl
+okl
+okl
 okl
 okl
 okl
@@ -24512,8 +24316,8 @@ xYw
 epR
 emv
 uyf
-kVR
-adY
+kXT
+okl
 okl
 kXT
 okl
@@ -24770,7 +24574,7 @@ rKz
 rKz
 rKz
 rKz
-adY
+okl
 fIc
 odB
 okl
@@ -25284,7 +25088,7 @@ mdL
 mdL
 uOZ
 rKz
-xHJ
+plk
 qZp
 pdj
 qZp
@@ -25530,7 +25334,7 @@ rKz
 oQJ
 rKz
 rKz
-qvu
+fuD
 ihi
 mdL
 rtY
@@ -25787,16 +25591,16 @@ dyB
 dyB
 dyB
 beC
-kdy
-opW
-opW
-opW
-opW
-opW
-opW
-opW
-opW
-kdy
+fuD
+leI
+leI
+leI
+leI
+leI
+leI
+leI
+leI
+fuD
 kou
 cSo
 gaa
@@ -26822,11 +26626,11 @@ bHP
 bHP
 bHP
 rKz
-rMb
-hhq
+dyB
+dyB
 riK
 rKz
-xHJ
+plk
 gaa
 ujD
 mLn
@@ -27080,14 +26884,14 @@ hgc
 mlM
 rKz
 exd
-hhq
-hhq
+dyB
+dyB
 hAB
-lUQ
+cSo
 hOx
 lTe
 nYV
-maM
+nVo
 wyw
 anV
 qZp
@@ -27342,7 +27146,7 @@ dyB
 rKz
 plk
 qZp
-rpJ
+pdj
 qZp
 nPg
 rKz
@@ -27599,7 +27403,7 @@ dyB
 rKz
 plk
 qZp
-rpJ
+pdj
 qZp
 nPg
 rKz
@@ -27844,9 +27648,9 @@ aaa
 xWU
 gul
 cMJ
-nra
-bgO
-mni
+vYL
+sRI
+vYL
 rKz
 bvl
 fij
@@ -27856,7 +27660,7 @@ uZM
 rKz
 dyB
 aHw
-xqr
+odB
 dyB
 aHw
 rKz
@@ -28103,7 +27907,7 @@ cMJ
 cMJ
 xuL
 vYL
-mni
+vYL
 rKz
 dZs
 yao
@@ -28360,7 +28164,7 @@ cMJ
 rKz
 vYL
 aAN
-mni
+vYL
 rKz
 emC
 cds
@@ -28370,7 +28174,7 @@ hTw
 dyB
 dyB
 dyB
-hhq
+dyB
 dyB
 dyB
 dyB
@@ -29131,7 +28935,7 @@ aaa
 tcU
 khG
 cxY
-ivg
+cxY
 cxY
 khG
 rKz
@@ -29388,11 +29192,11 @@ aaa
 tcU
 vWU
 vWU
-pOy
-pOy
-pOy
+vWU
+vWU
+vWU
 wko
-hhq
+dyB
 ukC
 ldb
 dyB
@@ -29649,7 +29453,7 @@ vWU
 qec
 vWU
 rKz
-ltP
+hQR
 dyB
 dyB
 dyB
@@ -29906,13 +29710,13 @@ hsb
 eWC
 rUK
 rKz
-hhq
-hhq
-tyz
-hhq
+dyB
+dyB
+cBt
+dyB
 nlM
 oee
-sIJ
+oee
 oee
 dLR
 dyB
@@ -30166,10 +29970,10 @@ rKz
 gcO
 kst
 rKz
-rMb
-hhq
-hhq
-hhq
+dyB
+dyB
+dyB
+dyB
 dyB
 dyB
 dyB


### PR DESCRIPTION
## About The Pull Request

NCV Titan had multiple APCs in the same area, which gave a warning.
I could've split it into areas and kept each APC but it's unused so I don't think it's exactly necessary.

## Changelog

:cl:
fix: Due to budget cuts, the NCV Titan no longer has seven APCs in the same area.
/:cl: