### PR TITLE
[modular][ready]makes the victorian vests show up in the loadout

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -183,22 +183,6 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	item_path = /obj/item/clothing/under/utility/com
 	restricted_roles = list("Captain", "Head of Personnel", "Blueshield", "Head of Security", "Research Director", "Quartermaster", "Chief Medical Officer", "Chief Engineer")
 
-/datum/loadout_item/under/jumpsuit/vic_vest
-	name = "victorian vest"
-	item_path = /obj/item/clothing/under/costume/vic_vest
-
-/datum/loadout_item/under/jumpsuit/vic_vest
-	name = "red victorian vest"
-	item_path = /obj/item/clothing/under/costume/vic_vest/red
-
-/datum/loadout_item/under/jumpsuit/vic_vest
-	name = "blue victorian vest"
-	item_path = /obj/item/clothing/under/costume/vic_vest/blue
-
-/datum/loadout_item/under/jumpsuit/vic_vest
-	name = "red alt victorian vest"
-	item_path = /obj/item/clothing/under/costume/vic_vest/red_alt
-
 /////////////////////////////////////////////////////////////MISC UNDERSUITS
 /datum/loadout_item/under/miscellaneous
 
@@ -809,7 +793,23 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	name = "French Marshall's Uniform"
 	item_path = /obj/item/clothing/under/trek/q
 
-/datum/loadout_item/under/formal/jeanshorts
+/datum/loadout_item/under/formal/vic_vest
+	name = "Victorian Vest"
+	item_path = /obj/item/clothing/under/costume/vic_vest
+
+/datum/loadout_item/under/formal/vic_vest/red
+	name = "Red Victorian Shirt with Vest"
+	item_path = /obj/item/clothing/under/costume/vic_vest/red
+
+/datum/loadout_item/under/formal/vic_vest/blue
+	name = "Blue Victorian Vest"
+	item_path = /obj/item/clothing/under/costume/vic_vest/blue
+
+/datum/loadout_item/under/formal/vic_vest/red/shirt
+	name = "Red Victorian Vest"
+	item_path = /obj/item/clothing/under/costume/vic_vest/red_alt
+
+/datum/loadout_item/under/formal/jeanshorts //why are these formal??? who the fuck wears jorts formally??????
 	name = "Jean Shorts"
 	item_path = /obj/item/clothing/under/pants/jeanshort
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

title, they were all under one datum, now they arent

## How This Contributes To The Skyrat Roleplay Experience

shit should work in the loadout
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: the victorian suits are in the loadout now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
