### PR TITLE
[MODULAR] Blackmarket Uplink added to maint loot

### DIFF
--- a/modular_skyrat/master_files/code/_globalvars/maint_loot_uncommon.dm
+++ b/modular_skyrat/master_files/code/_globalvars/maint_loot_uncommon.dm
@@ -133,7 +133,8 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/storage/box/fireworks = 5,
 		/obj/item/storage/box/handcuffs = 5,
 		/obj/item/toy/cards/deck/syndicate = 5,
-		/obj/item/wormhole_jaunter = 5
+		/obj/item/wormhole_jaunter = 5,
+		/obj/item/blackmarket_uplink = 100,
 	) = 200,
 	list( //Ammo
 		/obj/item/ammo_casing/shotgun/beanbag = 50,
@@ -158,7 +159,7 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/ammo_casing/c45 = 10,
 		/obj/item/ammo_casing/c9mm = 10,
 		/obj/item/ammo_casing/caseless/foam_dart = 100,
-		/obj/item/ammo_casing/caseless/foam_dart/riot = 100 ,
+		/obj/item/ammo_casing/caseless/foam_dart/riot = 100,
 	) = 50,
 	list( // Good memes.
 		/obj/item/aicard/aitater = 10,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/tgstation/tgstation/pull/62575 but modular because we have different trash lists

## How This Contributes To The Skyrat Roleplay Experience

I like the system. It would be good for self-antagging (legal) or mini-antags, and it probably needs more variety on skyrat like actual tot equipment, but I'm not sure where to balance that yet. Ideas would be appreciated.  Going around cargo and the several jobs designed to make getting contraband harder is a good prospect. 

## Changelog

:cl:
qol: Blackmarket uplink is now maint loot. Try the rocket boots! (It's a terrible idea!)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
