### PR TITLE
[MODULAR] Mildly buffs teshari (heavily)

### DIFF
--- a/modular_skyrat/modules/teshari/modules/mob/living/carbon/human/species_types/teshari.dm
+++ b/modular_skyrat/modules/teshari/modules/mob/living/carbon/human/species_types/teshari.dm
@@ -1,9 +1,9 @@
 #define TESHARI_TEMP_OFFSET -30 // K, added to comfort/damage limit etc
-#define TESHARI_BURNMOD 1.5 // They take more damage from practically everything
-#define TESHARI_BRUTEMOD 1.5
-#define TESHARI_HEATMOD 1.5
+#define TESHARI_BURNMOD 1.25 // They take more damage from practically everything
+#define TESHARI_BRUTEMOD 1.2
+#define TESHARI_HEATMOD 1.3
 #define TESHARI_COLDMOD 0.67 // Except cold.
-#define TESHARI_PUNCH_LOW 1 // Lower bound punch damage
+#define TESHARI_PUNCH_LOW 2 // Lower bound punch damage
 #define TESHARI_PUNCH_HIGH 6
 
 /datum/species/teshari


### PR DESCRIPTION
## About The Pull Request

Lower's the bonus damage from teshari, as 50% is a bit to steep, even for me, for comparison, they get no where near as many bonus' from being small (2, vs the like 20 synths have) for almost the same incoming damage bonus.

## How This Contributes To The Skyrat Roleplay Experience

Less teshari getting two tapped by 30 damage guns, vs someone who just ate six shots from the same gun

## Changelog


:cl:
balance: rebalances teshari incomming damage to 20-25% vs the previous of 50%, and gives them a single point more of punch damage so they quit magically rolling 0, don't ask, I also don't know why.
/:cl:

