### PR TITLE
[MODULAR] Re-adds bleeding/burn wounds to slimes, like they had on oldbase.

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -1,5 +1,11 @@
 /datum/species/jelly
-	species_traits = list(MUTCOLORS,EYECOLOR,NOBLOOD,HAIR,FACEHAIR)
+	species_traits = list(MUTCOLORS,
+		EYECOLOR,
+		NOBLOOD,
+		HAIR,
+		FACEHAIR,
+		HAS_FLESH
+	)
 	default_mutant_bodyparts = list("tail" = "None", "snout" = "None", "ears" = "None", "taur" = "None", "wings" = "None", "legs" = "Normal Legs", "horns" = "None",  "spines" = "None", "frills" = "None")
 	mutant_bodyparts = list()
 	hair_color = "mutcolor"


### PR DESCRIPTION

## About The Pull Request
Let's slimes take bleeding wounds again, meaning they are no longer 100% immune to the wounds system.

## How This Contributes To The Skyrat Roleplay Experience

Jelly-things should probably start bleeding after getting stabbed twelve times.

## Changelog


:cl:
fix: Slimes can get bleeding wounds again.
/:cl:

