### PR TITLE
[NONMODULAR] Adjusts the damage-threshold knockout from regen-coma

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -334,7 +334,7 @@
 			return power * 0.9
 		if(SOFT_CRIT)
 			return power * 0.5
-	if(M.getBruteLoss() + M.getFireLoss() >= 70 && !active_coma)
+	// if(M.getBruteLoss() + M.getFireLoss() >= 70 && !active_coma) SKYRAT EDIT - Removes sudden damage KO, because 70 is alot less health here as compared to TG.
 		to_chat(M, span_warning("You feel yourself slip into a regenerative coma..."))
 		active_coma = TRUE
 		addtimer(CALLBACK(src, .proc/coma, M), 60)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -334,7 +334,7 @@
 			return power * 0.9
 		if(SOFT_CRIT)
 			return power * 0.5
-	// if(M.getBruteLoss() + M.getFireLoss() >= 70 && !active_coma) SKYRAT EDIT - Removes sudden damage KO, because 70 is alot less health here as compared to TG.
+	if(M.getBruteLoss() + M.getFireLoss() >= 170 && !active_coma) //SKYRAT EDIT: ORIGINAL: 70 - Removes sudden damage KO, by making it happen in already-crit, because 70 is alot less health here as compared to TG.
 		to_chat(M, span_warning("You feel yourself slip into a regenerative coma..."))
 		active_coma = TRUE
 		addtimer(CALLBACK(src, .proc/coma, M), 60)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -334,7 +334,7 @@
 			return power * 0.9
 		if(SOFT_CRIT)
 			return power * 0.5
-	if(M.getBruteLoss() + M.getFireLoss() >= 170 && !active_coma) //SKYRAT EDIT: ORIGINAL: 70 - Removes sudden damage KO, by making it happen in already-crit, because 70 is alot less health here as compared to TG.
+	if(M.getBruteLoss() + M.getFireLoss() >= 103 && !active_coma) //SKYRAT EDIT: ORIGINAL: 70 - Adjusts this to remain 37.5% of total health(plus crit health). Because 70 is alot less health here then it is on tg.
 		to_chat(M, span_warning("You feel yourself slip into a regenerative coma..."))
 		active_coma = TRUE
 		addtimer(CALLBACK(src, .proc/coma, M), 60)


### PR DESCRIPTION
## About The Pull Request

One of the most obtuse and hard to use symptoms has(had) a check which causes you to instantly fall into the regen coma (hard sleeping) at 70 flat damage, meaning it will stun lock you a whole 60 damage away from crit, namely because it was never updated for our much-increased health pool.

## How This Contributes To The Skyrat Roleplay Experience

Perhaps, a crumb more versatility and use being available in Virology, instead of nocturnal and starlight on every virus.

## Changelog



:cl:
qol: Makes regen coma not instantly hard-sleep you a whole 60 damage early, thus letting virologists actually use the symptom without it KO'ing people at half-health.
/:cl:


