### PR TITLE
[FUCK] Map configs will no longer systematically fail to load due to an incorrect typepath being provided

### DIFF
--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -16,7 +16,7 @@
 	// Config actually from the JSON - should default to Meta
 	var/map_name = "Meta Station"
 	var/map_path = "map_files/MetaStation"
-	var/map_file = "MetaStation.dmm"
+	var/map_file = "MetaStation_skyrat.dmm" // SKYRAT EDIT - Making our Skyrat MetaStation the default MetaStation.
 
 	var/traits = null
 	var/space_ruin_levels = 7
@@ -34,8 +34,11 @@
 	/// Dictionary of job sub-typepath to template changes dictionary
 	var/job_changes = list()
 
-/proc/load_map_config(filename = "next_map.json", default_to_box, delete_after, error_if_missing = TRUE)
-	filename = "_maps/[filename].json"
+/proc/load_map_config(filename = "next_map", default_to_box, delete_after, error_if_missing = TRUE)
+	if(filename == "next_map")
+		filename = "data/[filename].json"
+	else
+		filename = "_maps/[filename].json"
 	var/datum/map_config/config = new
 	if (default_to_box)
 		return config

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -35,7 +35,7 @@
 	var/job_changes = list()
 
 /proc/load_map_config(filename = "next_map", default_to_box, delete_after, error_if_missing = TRUE)
-	if(filename == "next_map")
+	if(filename == "next_map") // Since they don't share the same path, you gotta handle them differently...
 		filename = "data/[filename].json"
 	else
 		filename = "_maps/[filename].json"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So, clearly, the person that did that refactor to fix some security issues didn't know how maps are loaded.
As such, at the end of every round, the next map would get written to `data/next_map.json`, and the next round, the game would try and load `_maps/next_map.json.json`. I got a feeling they didn't test their PR too much.

This makes it so that if no parameter is specified for `filename`, aka, `filename` is `next_map`, then it handles that differently than the rest. That way, the game will be able to load the correct map after a restart.

And, yes, I tested it, and it works.

This PR is also up upstream, but I included in this one a small change to make it so, upon failing to load a proper map config, it'll load Skyrat's MetaStation, rather than the mess that is our upstream MetaStation.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
There's only so many times people will enjoy playing on the same map every single round. Especially when it breaks the Interlink's shuttle reliably.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: GoldenAlpharex
fix: Maps will now correctly be loaded at the start of a round. Hurray!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
