### PR TITLE
Makes the auto-dementor pref start at FALSE

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/auto_dementor.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/auto_dementor.dm
@@ -2,4 +2,5 @@
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "auto_dementor_pref"
 	savefile_identifier = PREFERENCE_PLAYER
+	default_value = FALSE // We want people to not automatically dementor by default, otherwise they just don't know about the fact they're mentors.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It should have been that way from the start, that's how it was when I created the pref, sadly that didn't really carry over properly. I'll have a thonk over resetting that prefs for the admins and mentors right now, just so it works properly for everyone, once again.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
More mentors to answer your questions = more sharing of knowledge without the need for cluttering ahelps = happier staff = better experience on the server.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: GoldenAlpharex
fix: The Auto-Dementor pref will now start unchecked, so people know that they are actually mentors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
