### PR TITLE
adds the space assassin kit at 35 tc

### DIFF
--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -5,12 +5,12 @@
 //Place any new uplink items in this file, and explain what they do
 
 //BUNDLES
-/* /datum/uplink_item/bundles_tc/spaceassassin
+/datum/uplink_item/bundles_tc/spaceassassin
 	name = "Space Assassin Bundle"
 	desc = "A unique kit commonly used by military infiltrators and the like to get the drop on unsuspecting crew, perfect for the aspiring covert assassin and stealthy manipulator."
 	item = /obj/item/storage/box/syndie_kit/spaceassassin
-	cost = 30 //40 tc would have been better
-*/ //To be balanced
+	cost = 35 //literally all of your TC
+//One day when coderbus was coding, valid got salad 
 //DANGEROUS
 /datum/uplink_item/dangerous/aps_traitor
 	name = "Stechkin APS Machine Pistol"


### PR DESCRIPTION
sussy baka

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
The Space Assassin kit from the original More Trairor Items PR, rebalanced in its cost and finally brought to light once more. This kit features only a combat knife, syndicate softsuit, and a book that teaches the user how to ventcrawl.

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
More traitor versatility encouraging substandard playstyles without simply giving them ten new ways to beat someone to death or shoot them

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Space Assassin bundle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
