### PR TITLE
[MODULAR] Hardlight Bullets can now pierce windows and grilles.

### DIFF
--- a/modular_skyrat/modules/goofsec/projectiles/projectiles.dm
+++ b/modular_skyrat/modules/goofsec/projectiles/projectiles.dm
@@ -12,7 +12,7 @@
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/projectiles.dmi'
 	icon_state = "bullet"
 	name = "hardlight bullet"
-	pass_flags = PASSTABLE // All of the below is to not break kayfabe about it not being a bullet.
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE  // All of the below is to not break kayfabe about it not being a bullet.
 	hitsound ='sound/weapons/pierce.ogg'
 	hitsound_wall = "ricochet"
 	light_system = NO_LIGHT_SUPPORT


### PR DESCRIPTION
:cl:
balance: Hardlight Bullets can now pierce windows and grilles.
/:cl:

This was something I did to avoid breaking kayfabe about them being bullets aesthetically, but it's proven to be far too bad in practice for Security due to SS13 map design!

You see, maps with actual designers behind them(Metastation, Kilostation, Deltastation, etc.) compared to Box which just has been fair game for everyone and anyone for 15 years, have assumptions they make about how people fight in them.

One of those assumptions is that security can fire through windows. That assumption is broken on Skyrat as of this time.

Currently, Security can throw down with folks in hallways and shit just fine, but the second they hit maintenance tunnels and departments, they get immediately stonewalled if the guy they're shooting runs behind a door. because bullets do not penetrate glass and grilles like lasers did. They have to shoot the glass or the door down to get in, meaning the guy can immediately fuck right off into maintenance and be 5 miles away by the time the window is blasted down or the door's been opened, completely killing all pressure they had on the target.

So, the armory gun bullets now pass windows and grilles.