### PR TITLE
Fixing the Felinid/Tajaran's ability to land on their feet

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -47,12 +47,14 @@
 	GLOB.human_list -= src
 	return ..()
 
+/* SKYRAT REMOVAL START - MOVED TO MODULAR - modular_skyrat\master_files\code\modules\mob\living\carbon\human.dm
 /mob/living/carbon/human/ZImpactDamage(turf/T, levels)
 	if(!HAS_TRAIT(src, TRAIT_FREERUNNING) || levels > 1) // falling off one level
 		return ..()
 	visible_message(span_danger("[src] makes a hard landing on [T] but remains unharmed from the fall."), \
 					span_userdanger("You brace for the fall. You make a hard landing on [T] but remain unharmed."))
 	Knockdown(levels * 40)
+*/ // SKYRAT REMOVAL END
 
 /mob/living/carbon/human/prepare_data_huds()
 	//Update med hud images...

--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human.dm
@@ -9,7 +9,7 @@
 		Stun(0.5 SECONDS) // You can't move and you can't use items
 		//Nailed it!
 		visible_message(span_notice("[src] lands elegantly on [p_their()] feet!"),
-			span_warning("You fall [levels] level[levels > 1 ? "s" : ""] into [T], perfecting the landing!"))
+			span_warning("You fall [levels > 1 ? "[levels] levels" : "one level"] into [T], perfecting the landing!"))
 		return
 	
 	if(!HAS_TRAIT(src, TRAIT_FREERUNNING) || levels > 1) // falling off one level

--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human.dm
@@ -1,13 +1,19 @@
 /mob/living/carbon/human/ZImpactDamage(turf/T, levels)
-	//Non cat-people smash into the ground
-	if(!isfelinid(src) && !istajaran(src))
+	// Cat-people always land on their feet
+	if(isfelinid(src) || istajaran(src))
+		//Check to make sure legs are working
+		var/obj/item/bodypart/left_leg = get_bodypart(BODY_ZONE_L_LEG)
+		var/obj/item/bodypart/right_leg = get_bodypart(BODY_ZONE_R_LEG)
+		if(!left_leg || !right_leg || left_leg.bodypart_disabled || right_leg.bodypart_disabled)
+			return ..()
+		Paralyze(0.5 SECONDS)
+		//Nailed it!
+		visible_message(span_notice("[src] lands elegantly on [p_their()] feet!"),
+			span_warning("You fall [levels] level[levels > 1 ? "s" : ""] into [T], perfecting the landing!"))
+		return
+	
+	if(!HAS_TRAIT(src, TRAIT_FREERUNNING) || levels > 1) // falling off one level
 		return ..()
-	//Check to make sure legs are working
-	var/obj/item/bodypart/left_leg = get_bodypart(BODY_ZONE_L_LEG)
-	var/obj/item/bodypart/right_leg = get_bodypart(BODY_ZONE_R_LEG)
-	if(!left_leg || !right_leg || left_leg.bodypart_disabled || right_leg.bodypart_disabled)
-		return ..()
-	Paralyze(0.5 SECONDS)
-	//Nailed it!
-	visible_message(span_notice("[src] lands elegantly on [p_their()] feet!"),
-		span_warning("You fall [levels] level[levels > 1 ? "s" : ""] into [T], perfecting the landing!"))
+	visible_message(span_danger("[src] makes a hard landing on [T] but remains unharmed from the fall."), \
+			span_userdanger("You brace for the fall. You make a hard landing on [T] but remain unharmed."))
+	Knockdown(levels * 40)

--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human.dm
@@ -6,7 +6,7 @@
 		var/obj/item/bodypart/right_leg = get_bodypart(BODY_ZONE_R_LEG)
 		if(!left_leg || !right_leg || left_leg.bodypart_disabled || right_leg.bodypart_disabled)
 			return ..()
-		Paralyze(0.5 SECONDS)
+		Immobilize(0.5 SECONDS)
 		//Nailed it!
 		visible_message(span_notice("[src] lands elegantly on [p_their()] feet!"),
 			span_warning("You fall [levels] level[levels > 1 ? "s" : ""] into [T], perfecting the landing!"))

--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human.dm
@@ -6,7 +6,7 @@
 		var/obj/item/bodypart/right_leg = get_bodypart(BODY_ZONE_R_LEG)
 		if(!left_leg || !right_leg || left_leg.bodypart_disabled || right_leg.bodypart_disabled)
 			return ..()
-		Immobilize(0.5 SECONDS)
+		Stun(0.5 SECONDS) // You can't move and you can't use items
 		//Nailed it!
 		visible_message(span_notice("[src] lands elegantly on [p_their()] feet!"),
 			span_warning("You fall [levels] level[levels > 1 ? "s" : ""] into [T], perfecting the landing!"))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4116,6 +4116,7 @@
 #include "modular_skyrat\master_files\code\modules\mob\dead\new_player\preferences_setup.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\emote_popup.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\living_defines.dm"
+#include "modular_skyrat\master_files\code\modules\mob\living\carbon\human.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\carbon\human_helpers.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\human\species.dm"
 #include "modular_skyrat\master_files\code\modules\mob\living\simple_animal\simple_animal.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The file wasn't even ticked. I also fixed the code so they'd fall on their feet rather than still laying down flat on the floor, because that's not what landing on your feet is like.

I wanted to add this to the TRAIT_FELINE but honestly that's waaaay too much for a free quirk. So, not gonna happen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
That's how it was meant to be :)
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: GoldenAlpharex
fix: Cat-people that were meant to land on their feet, will now land on their feet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
