### PR TITLE
Skyrat Friendly Transmission for Virology

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -244,14 +244,15 @@
 		else
 			visibility_flags &= ~HIDDEN_SCANNER
 
-		if(properties["transmittable"]>=11)
+		/*if(properties["transmittable"]>=11)
 			SetSpread(DISEASE_SPREAD_AIRBORNE)
 		else if(properties["transmittable"]>=7)
 			SetSpread(DISEASE_SPREAD_CONTACT_SKIN)
 		else if(properties["transmittable"]>=3)
 			SetSpread(DISEASE_SPREAD_CONTACT_FLUIDS)
 		else
-			SetSpread(DISEASE_SPREAD_BLOOD)
+			SetSpread(DISEASE_SPREAD_BLOOD)*/
+		SetSpread(DISEASE_SPREAD_BLOOD)
 
 		permeability_mod = max(CEILING(0.4 * properties["transmittable"], 1), 1)
 		cure_chance = clamp(7.5 - (0.5 * properties["resistance"]), 5, 10) // can be between 5 and 10

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -252,7 +252,7 @@
 			SetSpread(DISEASE_SPREAD_CONTACT_FLUIDS)
 		else
 			SetSpread(DISEASE_SPREAD_BLOOD)*/
-		SetSpread(DISEASE_SPREAD_BLOOD)
+		SetSpread(DISEASE_SPREAD_BLOOD) //Skyrat Changes, just makes tranmiss default to low spread
 
 		permeability_mod = max(CEILING(0.4 * properties["transmittable"], 1), 1)
 		cure_chance = clamp(7.5 - (0.5 * properties["resistance"]), 5, 10) // can be between 5 and 10


### PR DESCRIPTION
## About The Pull Request

So transmission on viruses has been a big bwoinkable point for virology for as long as I've been on this server. Be it antag or benevolent, you're not allowed to make a transmissible virus, or you may just find yourself on the better end of a job ban. So why does transmissibility exist then, if it's just universally bad? Everyone agrees that we don't want rounds where you stand in a medbay full of people coughing, hacking, doubling over while we wait 15 minutes for chemistry to stop their ERP sesh and get us a cure, but the statistic is engrained in the entire mod of virology so we can't just easily snip it out.

Here's my proposal then. Diseases can ONLY spread by blood (injection, consuming, etc. It's just a lot harder to get) and by sneezing and coughing, which are still pretty bad, but are symptoms you can neuter as a virologist. Transmissibility is a stat that actually has a lot of cool buildcraft when it comes to making viruses, but it normally gets overlooked because we're never allowed to create a virus with a transmissibility above 2. This way, we can create viruses that have high transmissibility stat, but don't make them any more contagious. We can finally push for thresholds on plasma fixation, radioactive resonance, and starlight condensation to have a bit more variety on what good viruses we can use.

TLDR; Makes the transmission stat only used for thresholding viruses, and will no longer make viruses more contagious.

## How This Contributes To The Skyrat Roleplay Experience

Makes virology a more forgiving role for new players who are interested in giving it a try (No accidental mass infections) and gives veteran virologists more room to play around with the buildcraft of making good viruses.

## Changelog

:cl:
qol: made Transmissibility Skyrat friendly
code: Commented out line 247-254 in code/datums/diseases/advance/advance.dm and added SetSpread(DISEASE_SPREAD_BLOOD) right after.
/:cl: