### PR TITLE
Pollution changes

### DIFF
--- a/code/__DEFINES/~skyrat_defines/pollution.dm
+++ b/code/__DEFINES/~skyrat_defines/pollution.dm
@@ -34,4 +34,6 @@
 #define THICKNESS_ALPHA_COEFFICIENT 0.0025
 
 //Cap for active emitters that can be running for a very long time
-#define POLLUTION_ACTIVE_EMITTER_CAP 300
+#define POLLUTION_ACTIVE_EMITTER_CAP 200
+//For things that you dont want to cause too much pollution
+#define POLLUTION_PASSIVE_EMITTER_CAP 70

--- a/code/__DEFINES/~skyrat_defines/pollution.dm
+++ b/code/__DEFINES/~skyrat_defines/pollution.dm
@@ -16,6 +16,8 @@
 #define SCENT_DESC_SMELL       "smell"
 #define SCENT_DESC_FRAGRANCE   "fragrance"
 
+#define POLLUTION_DISSIPATION_PLANETARY_MULTIPLIER 4
+
 ///Minimum amount of smell power to be able to sniff a pollutant
 #define POLLUTANT_SMELL_THRESHOLD 3.5
 

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -313,7 +313,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			extinguish()
 			return
 
-	location.PolluteTurf(pollution_type, 10) //SKYRAT EDIT ADDITION
+	location.PolluteTurf(pollution_type, 5, POLLUTION_PASSIVE_EMITTER_CAP) //SKYRAT EDIT ADDITION
 
 	smoketime -= delta_time * (1 SECONDS)
 	if(smoketime <= 0)
@@ -1082,7 +1082,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	//SKYRAT EDIT ADDITION
 	//open flame removed because vapes are a closed system, they won't light anything on fire
 	var/turf/my_turf = get_turf(src)
-	my_turf.PolluteTurf(/datum/pollutant/smoke/vape, 10)
+	my_turf.PolluteTurf(/datum/pollutant/smoke/vape, 5, POLLUTION_PASSIVE_EMITTER_CAP)
 	//SKYRAT EDIT END
 
 	if(obj_flags & EMAGGED)

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -146,8 +146,9 @@
 		extinguish()
 		return
 	//SKYRAT EDIT ADDITION
-	var/turf/my_turf = get_turf(src)
-	my_turf.PolluteListTurf(list(/datum/pollutant/smoke = 20, /datum/pollutant/carbon_air_pollution = 5), POLLUTION_ACTIVE_EMITTER_CAP)
+	var/turf/open/my_turf = get_turf(src)
+	if(istype(my_turf) && !my_turf.planetary_atmos) //Pollute, but only when we're not on planetary atmos
+		my_turf.PolluteListTurf(list(/datum/pollutant/smoke = 15, /datum/pollutant/carbon_air_pollution = 5), POLLUTION_ACTIVE_EMITTER_CAP)
 	//SKYRAT EDIT END
 	bonfire_burn(delta_time)
 

--- a/modular_skyrat/modules/pollution/code/pollution.dm
+++ b/modular_skyrat/modules/pollution/code/pollution.dm
@@ -82,7 +82,7 @@
 		qdel(src)
 		return
 	if(planetary_multiplier && my_turf.planetary_atmos) //Dissipate faster on planetary atmos
-		amount_to_scrub *= 2
+		amount_to_scrub *= 4
 	for(var/type in pollutants)
 		pollutants[type] -= amount_to_scrub * pollutants[type] / total_amount
 	total_amount -= amount_to_scrub

--- a/modular_skyrat/modules/pollution/code/pollution.dm
+++ b/modular_skyrat/modules/pollution/code/pollution.dm
@@ -82,7 +82,7 @@
 		qdel(src)
 		return
 	if(planetary_multiplier && my_turf.planetary_atmos) //Dissipate faster on planetary atmos
-		amount_to_scrub *= 4
+		amount_to_scrub *= POLLUTION_DISSIPATION_PLANETARY_MULTIPLIER
 	for(var/type in pollutants)
 		pollutants[type] -= amount_to_scrub * pollutants[type] / total_amount
 	total_amount -= amount_to_scrub


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Active emission cap is now 200
Bonfires no longer pollute planetary turfs
Cigs and vapes pollute half as much and have a 70 emission cap
Pollution dissipates 4 times as fast on planetary turfs (from 2 time as fast)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
dunno was asked to do this

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Pollution has been changed to be less intrusive with the smoke.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
