### PR TITLE
Small Interdyne/DS-2 fixes

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/IceRuins/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/IceRuins/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -78,7 +78,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	dir = 8
+	},
 /turf/open/floor/iron/kitchen,
 /area/ruin/syndicate_lava_base/bar)
 "aB" = (
@@ -173,7 +175,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/west{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
 "bq" = (
@@ -202,6 +206,7 @@
 	dir = 4;
 	id = "interdynecargoout"
 	},
+/obj/structure/plasticflaps,
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/cargo)
 "bz" = (
@@ -580,6 +585,7 @@
 /area/ruin/syndicate_lava_base/dormitories)
 "ex" = (
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -784,6 +790,7 @@
 "gZ" = (
 /obj/machinery/griddle,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -828,6 +835,7 @@
 	onstation = 0
 	},
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/cafeteria,
@@ -913,7 +921,9 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/south{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
 "iQ" = (
@@ -1212,6 +1222,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/white,
@@ -1326,6 +1337,7 @@
 "nx" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm/directional/west{
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/plating/grass,
@@ -1343,7 +1355,9 @@
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers/bluespace,
 /obj/item/storage/box/beakers/bluespace,
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/west{
+	dir = 4
+	},
 /obj/machinery/reagentgrinder,
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
@@ -1422,7 +1436,9 @@
 /area/ruin/syndicate_lava_base/testlab)
 "oz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/north{
+	dir = 2
+	},
 /turf/open/floor/iron/smooth_edge,
 /area/ruin/syndicate_lava_base/medbay)
 "oA" = (
@@ -1700,6 +1716,7 @@
 	dir = 8;
 	id = "interdynecargoin"
 	},
+/obj/structure/plasticflaps,
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/cargo)
 "sg" = (
@@ -1741,6 +1758,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west{
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -2073,7 +2091,9 @@
 "wF" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/west{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "wG" = (
@@ -2291,6 +2311,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -2418,6 +2439,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -2526,6 +2548,7 @@
 /area/ruin/syndicate_lava_base/engineering)
 "CN" = (
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -2679,7 +2702,9 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
 "ES" = (
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/testlab)
 "EU" = (
@@ -2693,6 +2718,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east{
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_corner{
@@ -2843,7 +2869,9 @@
 /area/ruin/syndicate_lava_base/bar)
 "Gb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/north{
+	dir = 2
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/dormitories)
 "Gh" = (
@@ -2899,7 +2927,9 @@
 	},
 /area/ruin/syndicate_lava_base/cargo)
 "GA" = (
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/south{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "GB" = (
@@ -2922,7 +2952,9 @@
 /obj/machinery/computer/crew/syndie{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/west{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "Hb" = (
@@ -2993,7 +3025,9 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/south{
+	dir = 1
+	},
 /obj/machinery/quantumpad{
 	map_pad_id = "interdyne";
 	map_pad_link_id = "ds2";
@@ -3067,7 +3101,9 @@
 /turf/open/floor/iron/kitchen,
 /area/ruin/syndicate_lava_base/bar)
 "IS" = (
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/south{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
 "Jd" = (
@@ -3108,8 +3144,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/defibrillator_mount/directional/east,
 /obj/machinery/iv_drip,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 28
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "JP" = (
@@ -3143,6 +3181,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/east{
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -3262,7 +3301,9 @@
 /area/ruin/syndicate_lava_base/bar)
 "LD" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	dir = 8
+	},
 /turf/open/floor/plating/grass,
 /area/ruin/syndicate_lava_base/bar)
 "LF" = (
@@ -3298,6 +3339,7 @@
 /obj/structure/table/glass,
 /obj/item/stock_parts/cell/bluespace,
 /obj/machinery/airalarm/directional/west{
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -3460,7 +3502,9 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
 "Ol" = (
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/north{
+	dir = 2
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
 "Ov" = (
@@ -3710,6 +3754,7 @@
 /area/ruin/syndicate_lava_base/testlab)
 "RN" = (
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -3777,7 +3822,9 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "Tc" = (
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
 "Td" = (
@@ -3866,6 +3913,7 @@
 /area/ruin/syndicate_lava_base/engineering)
 "TI" = (
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -3971,6 +4019,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/suit_storage_unit/syndicate,
 /obj/machinery/airalarm/directional/east{
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -4063,6 +4112,7 @@
 "VW" = (
 /obj/machinery/suit_storage_unit/mining,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -4208,7 +4258,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/syndicate_lava_base/dormitories)
 "XO" = (
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "XR" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -200,7 +200,9 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/south{
+	dir = 1
+	},
 /obj/machinery/quantumpad{
 	map_pad_id = "interdyne";
 	map_pad_link_id = "ds2";
@@ -525,6 +527,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -537,6 +540,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /obj/machinery/vending/dorms{
@@ -550,6 +554,7 @@
 /area/ruin/syndicate_lava_base/cargo)
 "gd" = (
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -691,7 +696,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/west{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
 "hN" = (
@@ -856,7 +863,9 @@
 /turf/open/floor/catwalk_floor/plated,
 /area/ruin/syndicate_lava_base/medbay)
 "jN" = (
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/south{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "jP" = (
@@ -905,7 +914,9 @@
 "kw" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/west{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "ky" = (
@@ -1023,6 +1034,7 @@
 /area/ruin/syndicate_lava_base/medbay)
 "ml" = (
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -1174,7 +1186,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	dir = 8
+	},
 /turf/open/floor/iron/kitchen,
 /area/ruin/syndicate_lava_base/bar)
 "oe" = (
@@ -1331,6 +1345,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west{
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -1338,6 +1353,7 @@
 "pR" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm/directional/west{
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/plating/grass,
@@ -1346,8 +1362,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/defibrillator_mount/directional/east,
 /obj/machinery/iv_drip,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 28
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "qa" = (
@@ -1361,6 +1379,7 @@
 "qb" = (
 /obj/machinery/suit_storage_unit/mining,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -1374,6 +1393,7 @@
 /area/ruin/syndicate_lava_base/testlab)
 "qj" = (
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -1584,7 +1604,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/testlab)
 "tH" = (
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
 "tI" = (
@@ -1638,7 +1660,9 @@
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/cargo)
 "uE" = (
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/testlab)
 "uK" = (
@@ -1922,7 +1946,9 @@
 /area/ruin/syndicate_lava_base/cargo)
 "yb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/north{
+	dir = 2
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/dormitories)
 "yd" = (
@@ -1976,6 +2002,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/white,
@@ -2153,7 +2180,9 @@
 /area/ruin/syndicate_lava_base/medbay)
 "Au" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	dir = 8
+	},
 /turf/open/floor/plating/grass,
 /area/ruin/syndicate_lava_base/bar)
 "Aw" = (
@@ -2200,6 +2229,7 @@
 "AU" = (
 /obj/machinery/griddle,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -2259,6 +2289,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -2388,7 +2419,9 @@
 /area/ruin/syndicate_lava_base/cargo)
 "CZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/north{
+	dir = 2
+	},
 /turf/open/floor/iron/smooth_edge,
 /area/ruin/syndicate_lava_base/medbay)
 "Dk" = (
@@ -2446,7 +2479,9 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/south{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
 "DZ" = (
@@ -2628,6 +2663,7 @@
 /obj/structure/table/glass,
 /obj/item/stock_parts/cell/bluespace,
 /obj/machinery/airalarm/directional/west{
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -3082,7 +3118,9 @@
 /obj/machinery/computer/crew/syndie{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/west{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "Ln" = (
@@ -3202,6 +3240,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/suit_storage_unit/syndicate,
 /obj/machinery/airalarm/directional/east{
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -3396,6 +3435,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/east{
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -3488,6 +3528,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east{
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_corner{
@@ -3643,6 +3684,7 @@
 /area/ruin/syndicate_lava_base/bar)
 "Sh" = (
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -3711,7 +3753,9 @@
 	},
 /area/ruin/syndicate_lava_base/cargo)
 "Tb" = (
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/south{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
 "Tg" = (
@@ -3728,7 +3772,9 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "To" = (
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/north{
+	dir = 2
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
 "Tq" = (
@@ -3892,7 +3938,9 @@
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
 "VI" = (
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "VL" = (
@@ -4104,7 +4152,9 @@
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers/bluespace,
 /obj/item/storage/box/beakers/bluespace,
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/west{
+	dir = 4
+	},
 /obj/machinery/reagentgrinder,
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
@@ -617,6 +617,7 @@
 "cn" = (
 /obj/structure/chair/sofa,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/wood,
@@ -1076,6 +1077,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/plating,
@@ -1095,6 +1097,7 @@
 "eb" = (
 /obj/structure/table/glass,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /obj/item/healthanalyzer,
@@ -1411,6 +1414,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/side{
@@ -1621,6 +1625,7 @@
 "fU" = (
 /obj/structure/closet/firecloset/full,
 /obj/machinery/airalarm/directional/west{
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -2286,6 +2291,7 @@
 "ib" = (
 /obj/machinery/deepfryer,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/kitchen{
@@ -2437,6 +2443,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/carpet/donk,
@@ -2625,6 +2632,7 @@
 "jj" = (
 /obj/machinery/stasissleeper,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_large,
@@ -2668,8 +2676,10 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
 "js" = (
 /obj/structure/table/reinforced,
-/obj/machinery/defibrillator_mount/directional/west,
 /obj/item/storage/firstaid/regular,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = -28
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "jt" = (
@@ -3005,7 +3015,9 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/north{
+	dir = 2
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "kF" = (
@@ -3413,6 +3425,7 @@
 "mg" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -3427,6 +3440,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
 "mj" = (
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/textured_large,
@@ -4023,6 +4037,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west{
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/wood,
@@ -4562,6 +4577,7 @@
 	dir = 10
 	},
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/plating,
@@ -4670,6 +4686,7 @@
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_large,
@@ -4969,6 +4986,7 @@
 "rt" = (
 /obj/effect/spawner/liquids_spawner,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/pool,
@@ -5248,7 +5266,9 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "so" = (
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/south{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "sp" = (
@@ -5444,6 +5464,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "ta" = (
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/smooth_edge{
@@ -5718,6 +5739,7 @@
 "tY" = (
 /obj/structure/filingcabinet,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/wood,
@@ -6036,6 +6058,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/mining_equipment)
 "uY" = (
 /obj/machinery/airalarm/directional/east{
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_large,
@@ -6356,7 +6379,9 @@
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge)
 "wf" = (
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/south{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -6608,6 +6633,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/freezer,
@@ -7119,7 +7145,9 @@
 /obj/machinery/chem_dispenser/drinks{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/south{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "yH" = (
@@ -7227,6 +7255,7 @@
 /obj/item/knife/combat/survival,
 /obj/item/storage/bag/ore,
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_large,
@@ -8243,6 +8272,7 @@
 /obj/structure/dresser,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/wood/large,
@@ -8742,6 +8772,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/west{
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/large,
@@ -8942,6 +8973,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -9295,6 +9327,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east{
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/wood,
@@ -9853,6 +9886,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "Ig" = (
 /obj/machinery/airalarm/directional/west{
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/smooth_corner{
@@ -10112,6 +10146,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "IV" = (
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/red/side{
@@ -10986,7 +11021,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "LI" = (
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/north{
+	dir = 2
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -11097,6 +11134,7 @@
 "LX" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -11267,6 +11305,7 @@
 /obj/structure/closet/secure_closet/genpop,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_large,
@@ -11954,6 +11993,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/northwest)
 "OP" = (
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/side{
@@ -12021,6 +12061,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "Pb" = (
 /obj/machinery/airalarm/directional/east{
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/carpet/red,
@@ -12058,6 +12099,7 @@
 "Pj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/east{
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/textured_large,
@@ -12947,6 +12989,7 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/airalarm/directional/east{
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -12965,6 +13008,7 @@
 "RV" = (
 /obj/machinery/chem_master,
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -12977,7 +13021,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "RX" = (
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/north{
+	dir = 2
+	},
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -13186,6 +13232,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south{
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -13378,6 +13425,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "Tv" = (
 /obj/machinery/airalarm/directional/west{
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/wood,
@@ -13890,6 +13938,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/chapel)
 "Vo" = (
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/textured_edge{
@@ -14027,7 +14076,9 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "VM" = (
 /obj/structure/bookcase/random/fiction,
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/north{
+	dir = 2
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "VN" = (
@@ -14309,6 +14360,7 @@
 	name = "blue line"
 	},
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/blue/side{
@@ -14395,7 +14447,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "Xb" = (
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/north{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
 	},
@@ -15197,6 +15251,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/north{
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/blue/side{
@@ -15205,6 +15260,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
 "ZI" = (
 /obj/machinery/airalarm/directional/east{
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/smooth_edge{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the directions of the air alarms/fire alarms as they're rotated to be floating off the wall now, for some reason. See image:
![image](https://user-images.githubusercontent.com/81479835/141279166-26a42869-8971-43d7-b0c7-06f8676ade45.png)

Readds defibs into the defib mounts since that was also changed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Fix

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Interdyne and DS-2 air alarms/fire alarms are properly oriented, defibrilators are returned to their mounts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
