### PR TITLE
[MODULAR][FIX] Fixes message on use of conversion kits displaying a first person message to everyone. 

### DIFF
--- a/modular_skyrat/modules/customization/game/objects/items/conversion_kits.dm
+++ b/modular_skyrat/modules/customization/game/objects/items/conversion_kits.dm
@@ -1,5 +1,5 @@
 /obj/item/device/custom_kit
-    name = "modification kit" 
+    name = "modification kit"
     desc = "A box of parts for modifying a certain object."
     icon = 'modular_skyrat/master_files/icons/donator/obj/kits.dmi'
     icon_state = "partskit"
@@ -16,7 +16,7 @@
     else if(target_obj.type == from_obj) //Checks whether the item is eligible to be converted
         var/obj/item/converted_item = new to_obj(get_turf(src))
         user.put_in_hands(converted_item)
-        user.visible_message("You modify [target_obj] into [converted_item].")
+        user.visible_message(span_notice("[user] modifies [target_obj] into [converted_item]."), span_notice("You modify [target_obj] into [converted_item]."))
         qdel(target_obj)
         qdel(src)
     else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the text that shows up when using conversion kits so that it doesn't use the user message for everyone in range of the conversion kit.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Inconsistent text is bad for RP
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Using a conversion kit will no longer display a first person message to people besides the user.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
