### PR TITLE
[MODULAR] Disables singularity crates from cargo

### DIFF
--- a/modular_skyrat/modules/singularity_engine/code/supply/packs.dm
+++ b/modular_skyrat/modules/singularity_engine/code/supply/packs.dm
@@ -10,14 +10,14 @@
 					/obj/structure/particle_accelerator/power_box,
 					/obj/structure/particle_accelerator/end_cap)
 	crate_name = "particle accelerator crate"
-
+/*
 /datum/supply_pack/engine/sing_gen
 	name = "Singularity Generator Crate"
 	desc = "The key to unlocking the power of Lord Singuloth. Particle Accelerator not included."
 	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/machinery/the_singularitygen)
 	crate_name = "singularity generator crate"
-
+*/
 /datum/supply_pack/engine/tesla_gen
 	name = "Tesla Generator Crate"
 	desc = "The key to unlocking the power of the Tesla energy ball. Particle Accelerator not included."


### PR DESCRIPTION
## About The Pull Request
Disables the crate being ordered as it still likes to consume it's shielding for fun. It also doesn't work anymore, so there's no reason for people to build it anymore.

## How This Contributes To The Skyrat Roleplay Experience

Less 'Let's try this new engine, OH NO IT ATE THE SHIELDS IMMEDIATELY'

## Changelog

:cl:
del: Removed the Singularity crate from cargo, to prevent it getting wiley in the engineering wing. It couldn't even be used as a power source anymore anyway.
/:cl:
