### PR TITLE
Makes a fireplace's fire last a lot longer

### DIFF
--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -1,6 +1,6 @@
 #define LOG_BURN_TIMER 5000 //SKYRAT EDIT original: #define LOG_BURN_TIMER 150
 #define PAPER_BURN_TIMER 5
-#define MAXIMUM_BURN_TIMER 60000 //SKYRAT EDIT original: #define MAXIMUM_BURN_TIMER 3000
+#define MAXIMUM_BURN_TIMER 100000 //SKYRAT EDIT original: #define MAXIMUM_BURN_TIMER 3000
 
 /obj/structure/fireplace
 	name = "fireplace"
@@ -75,15 +75,15 @@
 		return
 
 	switch(burn_time_remaining())
-		if(0 to 10000) //SKYRAT EDIT original: if(0 to 500)
+		if(0 to 19999) //SKYRAT EDIT original: if(0 to 500)
 			. += "fireplace_fire0"
-		if(10000 to 20000) //SKYRAT EDIT original: if(500 to 1000)
+		if(20000 to 39999) //SKYRAT EDIT original: if(500 to 1000)
 			. += "fireplace_fire1"
-		if(20000 to 30000) //SKYRAT EDIT original: if(1000 to 1500)
+		if(40000 to 59999) //SKYRAT EDIT original: if(1000 to 1500)
 			. += "fireplace_fire2"
-		if(30000 to 40000) //SKYRAT EDIT original: if(1500 to 2000)
+		if(60000 to 79999) //SKYRAT EDIT original: if(1500 to 2000)
 			. += "fireplace_fire3"
-		if(40000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: if(2000 to MAXIMUM_BURN_TIMER)
+		if(800000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: if(2000 to MAXIMUM_BURN_TIMER)
 			. += "fireplace_fire4"
 	. += "fireplace_glow"
 
@@ -93,15 +93,15 @@
 		return
 
 	switch(burn_time_remaining())
-		if(0 to 10000) //SKYRAT EDIT original: if(0 to 500)
+		if(0 to 19999) //SKYRAT EDIT original: if(0 to 500)
 			set_light(1)
-		if(10000 to 20000) //SKYRAT EDIT original: if(500 to 1000)
+		if(20000 to 39999) //SKYRAT EDIT original: if(500 to 1000)
 			set_light(2)
-		if(20000 to 30000) //SKYRAT EDIT original: if(1000 to 1500)
+		if(40000 to 59999) //SKYRAT EDIT original: if(1000 to 1500)
 			set_light(3)
-		if(30000 to 40000) //SKYRAT EDIT original: if(1500 to 2000)
+		if(60000 to 79999) //SKYRAT EDIT original: if(1500 to 2000)
 			set_light(4)
-		if(40000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: if(2000 to MAXIMUM_BURN_TIMER)
+		if(800000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: if(2000 to MAXIMUM_BURN_TIMER)
 			set_light(6)
 
 /obj/structure/fireplace/process(delta_time)

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -1,6 +1,6 @@
-#define LOG_BURN_TIMER 900 //SKYRAT EDIT original: #define LOG_BURN_TIMER 150
+#define LOG_BURN_TIMER 5000 //SKYRAT EDIT original: #define LOG_BURN_TIMER 150
 #define PAPER_BURN_TIMER 5
-#define MAXIMUM_BURN_TIMER 18000 //SKYRAT EDIT original: #define MAXIMUM_BURN_TIMER 3000
+#define MAXIMUM_BURN_TIMER 60000 //SKYRAT EDIT original: #define MAXIMUM_BURN_TIMER 3000
 
 /obj/structure/fireplace
 	name = "fireplace"
@@ -75,15 +75,15 @@
 		return
 
 	switch(burn_time_remaining())
-		if(0 to 1800) //SKYRAT EDIT original: if(0 to 500)
+		if(0 to 10000) //SKYRAT EDIT original: if(0 to 500)
 			. += "fireplace_fire0"
-		if(1800 to 4800) //SKYRAT EDIT original: if(500 to 1000)
+		if(10000 to 20000) //SKYRAT EDIT original: if(500 to 1000)
 			. += "fireplace_fire1"
-		if(4800 to 8400) //SKYRAT EDIT original: if(1000 to 1500)
+		if(20000 to 30000) //SKYRAT EDIT original: if(1000 to 1500)
 			. += "fireplace_fire2"
-		if(8400 to 12000) //SKYRAT EDIT original: if(1500 to 2000)
+		if(30000 to 40000) //SKYRAT EDIT original: if(1500 to 2000)
 			. += "fireplace_fire3"
-		if(12000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: if(2000 to MAXIMUM_BURN_TIMER)
+		if(40000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: if(2000 to MAXIMUM_BURN_TIMER)
 			. += "fireplace_fire4"
 	. += "fireplace_glow"
 
@@ -93,15 +93,15 @@
 		return
 
 	switch(burn_time_remaining())
-		if(0 to 1800) //SKYRAT EDIT original: if(0 to 500)
+		if(0 to 10000) //SKYRAT EDIT original: if(0 to 500)
 			set_light(1)
-		if(1800 to 4800) //SKYRAT EDIT original: if(500 to 1000)
+		if(10000 to 20000) //SKYRAT EDIT original: if(500 to 1000)
 			set_light(2)
-		if(4800 to 8400) //SKYRAT EDIT original: if(1000 to 1500)
+		if(20000 to 30000) //SKYRAT EDIT original: if(1000 to 1500)
 			set_light(3)
-		if(8400 to 12000) //SKYRAT EDIT original: if(1500 to 2000)
+		if(30000 to 40000) //SKYRAT EDIT original: if(1500 to 2000)
 			set_light(4)
-		if(12000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: if(2000 to MAXIMUM_BURN_TIMER)
+		if(40000 to MAXIMUM_BURN_TIMER) //SKYRAT EDIT original: if(2000 to MAXIMUM_BURN_TIMER)
 			set_light(6)
 
 /obj/structure/fireplace/process(delta_time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
No, I didn't test it, yes, it's arbitrary number, yes, it's big numbers, yes, I might make them bigger.
**EDIT:** Yeah I made them bigger.

This should mean that it takes over half an hour to go from the first stage to the next. Hopefully we can actually enjoy roleplaying instead of just wondering about the fire going out.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
If a campfire doesn't run out of fuel, why should a fireplace run out of fuel? It's shit to have to interrupt your roleplay to go get more wood because you ran out *again*.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: GoldenAlpharex
qol: Fireplaces can sustain a fire for significantly longer periods of time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
