### PR TITLE
removes 2 reach from reagent spears for more ash walker nerfs

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/modules/reagent_forging/forge_weapons.dm
+++ b/modular_skyrat/modules/reagent_forging/code/modules/reagent_forging/forge_weapons.dm
@@ -55,7 +55,6 @@
 	attack_verb_simple = list("attack", "poke", "jab", "tear", "lacerate", "gore")
 	wound_bonus = -15
 	bare_wound_bonus = 15
-	reach = 2
 	sharpness = SHARP_POINTY
 
 /obj/item/forging/reagent_weapon/spear/ComponentInitialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

removes the 2 reach from reagent spears, its likely they got 2 reach for much the same reason bone spears did 

## How This Contributes To The Skyrat Roleplay Experience

two range and any weapon gives it a super sizeable step up, less one that can inject poisons. much the same reason bone spears got nerfed ash walkers shouldn't be powerful

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: makes the regnant spear only 1 reach
🆑 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
