### PR TITLE
[NON-MODULAR] Re-adds per-character PDA settings

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -141,6 +141,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 	. = ..()
 	if(!equipped)
 		if(user.client)
+			//SKYRAT EDIT ADDITION BEGIN - CUSTOMIZATION
+			ttone = trim(user.client.prefs.read_preference(/datum/preference/text/pda_ringer), 20)
+			//SKYRAT EDIT ADDITION END
 			background_color = user.client.prefs.read_preference(/datum/preference/color/pda_color)
 			switch(user.client.prefs.read_preference(/datum/preference/choiced/pda_style))
 				if(MONO)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -141,8 +141,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 	. = ..()
 	if(!equipped)
 		if(user.client)
-			//SKYRAT EDIT ADDITION BEGIN - CUSTOMIZATION
-			ttone = trim(user.client.prefs.read_preference(/datum/preference/text/pda_ringer), 20)
+			//SKYRAT EDIT ADDITION BEGIN - Per-character PDA settings
+			ttone = sanitize(trim(user.client.prefs.read_preference(/datum/preference/text/pda_ringer), 20))
 			//SKYRAT EDIT ADDITION END
 			background_color = user.client.prefs.read_preference(/datum/preference/color/pda_color)
 			switch(user.client.prefs.read_preference(/datum/preference/choiced/pda_style))

--- a/code/modules/client/preferences/pda.dm
+++ b/code/modules/client/preferences/pda.dm
@@ -1,14 +1,8 @@
 /// The color of a PDA
 /datum/preference/color/pda_color
-	//SKYRAT EDIT CHANGE BEGIN
-	//category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
-	//SKYRAT EDIT CHANGE END
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL // SKYRAT EDIT - Per-character PDA settings - ORIGINAL: category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "pda_color"
-	//SKYRAT EDIT CHANGE BEGIN
-	//savefile_identifier = PREFERENCE_PLAYER
-	savefile_identifier = PREFERENCE_CHARACTER
-	//SKYRAT EDIT CHANGE END
+	savefile_identifier = PREFERENCE_CHARACTER // SKYRAT EDIT - Per-character PDA settings - ORIGINAL: savefile_identifier = PREFERENCE_PLAYER
 
 /datum/preference/color/pda_color/create_default_value()
 	return COLOR_OLIVE
@@ -20,25 +14,19 @@
 
 /// The visual style of a PDA
 /datum/preference/choiced/pda_style
-	//SKYRAT EDIT CHANGE BEGIN
-	//category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
-	//SKYRAT EDIT CHANGE END
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL // SKYRAT EDIT - Per-character PDA settings - ORIGINAL: category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "pda_style"
-	//SKYRAT EDIT CHANGE BEGIN
-	//savefile_identifier = PREFERENCE_PLAYER
-	savefile_identifier = PREFERENCE_CHARACTER
-	//SKYRAT EDIT CHANGE END
+	savefile_identifier = PREFERENCE_CHARACTER // SKYRAT EDIT - Per-character PDA settings - ORIGINAL: savefile_identifier = PREFERENCE_PLAYER
 
 /datum/preference/choiced/pda_style/init_possible_values()
 	return GLOB.pda_styles
 
-// SKYRAT EDIT ADDITION BEGIN -- CUSTOMIZATION
+// SKYRAT EDIT ADDITION BEGIN -- Per-character PDA settings
 /datum/preference/choiced/pda_style/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE
 // SKYRAT EDIT END
 
-// SKYRAT EDIT ADDITION BEGIN -- CUSTOMIZATION
+// SKYRAT EDIT ADDITION BEGIN -- Per-character PDA settings
 /// The thing your PDA says
 /datum/preference/text/pda_ringer
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL

--- a/code/modules/client/preferences/pda.dm
+++ b/code/modules/client/preferences/pda.dm
@@ -1,17 +1,53 @@
 /// The color of a PDA
 /datum/preference/color/pda_color
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	//SKYRAT EDIT CHANGE BEGIN
+	//category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	//SKYRAT EDIT CHANGE END
 	savefile_key = "pda_color"
-	savefile_identifier = PREFERENCE_PLAYER
+	//SKYRAT EDIT CHANGE BEGIN
+	//savefile_identifier = PREFERENCE_PLAYER
+	savefile_identifier = PREFERENCE_CHARACTER
+	//SKYRAT EDIT CHANGE END
 
 /datum/preference/color/pda_color/create_default_value()
 	return COLOR_OLIVE
 
+// SKYRAT EDIT ADDITION BEGIN -- CUSTOMIZATION
+/datum/preference/color/pda_color/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE
+// SKYRAT EDIT END
+
 /// The visual style of a PDA
 /datum/preference/choiced/pda_style
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	//SKYRAT EDIT CHANGE BEGIN
+	//category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	//SKYRAT EDIT CHANGE END
 	savefile_key = "pda_style"
-	savefile_identifier = PREFERENCE_PLAYER
+	//SKYRAT EDIT CHANGE BEGIN
+	//savefile_identifier = PREFERENCE_PLAYER
+	savefile_identifier = PREFERENCE_CHARACTER
+	//SKYRAT EDIT CHANGE END
 
 /datum/preference/choiced/pda_style/init_possible_values()
 	return GLOB.pda_styles
+
+// SKYRAT EDIT ADDITION BEGIN -- CUSTOMIZATION
+/datum/preference/choiced/pda_style/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE
+// SKYRAT EDIT END
+
+// SKYRAT EDIT ADDITION BEGIN -- CUSTOMIZATION
+/// The thing your PDA says
+/datum/preference/text/pda_ringer
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_key = "pda_ringer"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/text/pda_ringer/create_default_value()
+	return "beep"
+
+/datum/preference/text/pda_ringer/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE
+// SKYRAT EDIT END

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
@@ -70,7 +70,7 @@ export const exploitable_info: Feature<string> = {
 
 export const pda_ringer: Feature<string> = {
   name: "PDA Ringer Message",
-  description: "Want your PDA to say something other than \"beep\"? Maybe make it scream about BLOOD or EXPLOSIONS or DEPTHS? Accepts the first 20 characters.",
+  description: "Want your PDA to say something other than \"beep\"? Accepts the first 20 characters.",
   component: FeatureShortTextInput,
 };
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
@@ -68,6 +68,12 @@ export const exploitable_info: Feature<string> = {
   component: FeatureTextInput,
 };
 
+export const pda_ringer: Feature<string> = {
+  name: "PDA Ringer Message",
+  description: "Want your PDA to say something other than \"beep\"? Maybe make it scream about BLOOD or EXPLOSIONS or DEPTHS? Accepts the first 20 characters.",
+  component: FeatureShortTextInput,
+};
+
 export const background_info: Feature<string> = {
   name: "Records - Background",
   description: "nobody uses this lmao",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Basically ports https://github.com/Skyrat-SS13/Skyrat-tg/pull/6612 to the new system!

Moves PDA settings (PDA color and font) from general preferences to character preferences.

Adds a PDA setting to set a round-start PDA ringer message, so you can have your PDA say something like depths instead of beep without having to set it every time by hand.

Adds a non-modular line in PDA.dm that sets the message on spawn.

NOTE: This'll very likely wipe any PDA settings that're set, so make sure you write down the color and font beforehand!

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Makes PDAs more personal with less effort!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

## Changelog
:cl:
add: PDA customization is now set and saved per character.
add: PDA ring messages can now be set in character preferences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
