### PR TITLE
Disables tesla and PA cargo packs

### DIFF
--- a/modular_skyrat/modules/singularity_engine/code/supply/packs.dm
+++ b/modular_skyrat/modules/singularity_engine/code/supply/packs.dm
@@ -1,3 +1,4 @@
+/*
 /datum/supply_pack/engine/particle_accelerator
 	name = "Particle Accelerator Crate"
 	desc = "A supermassive black hole or hyper-powered teslaball are the perfect way to spice up any party! This \"My First Apocalypse\" kit contains everything you need to build your own Particle Accelerator! Ages 10 and up."
@@ -10,17 +11,18 @@
 					/obj/structure/particle_accelerator/power_box,
 					/obj/structure/particle_accelerator/end_cap)
 	crate_name = "particle accelerator crate"
-/*
+
 /datum/supply_pack/engine/sing_gen
 	name = "Singularity Generator Crate"
 	desc = "The key to unlocking the power of Lord Singuloth. Particle Accelerator not included."
 	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/machinery/the_singularitygen)
 	crate_name = "singularity generator crate"
-*/
+
 /datum/supply_pack/engine/tesla_gen
 	name = "Tesla Generator Crate"
 	desc = "The key to unlocking the power of the Tesla energy ball. Particle Accelerator not included."
 	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/machinery/the_singularitygen/tesla)
 	crate_name = "tesla generator crate"
+*/


### PR DESCRIPTION
## About The Pull Request

Title

## How This Contributes To The Skyrat Roleplay Experience

Tesla is entirely useless, being bugged to not generate power. It currently does nothing but generate lag and end rounds.
I'd rather remove it outright, but this will tide things over until a consensus is reached on either removing or fixing them.

## Changelog

:cl:
del: The tesla and particle accelerator crates have been removed from the cargo menu. Budget cuts, or something.
/:cl: