### PR TITLE
Re-adds the recently removed two tile range from bone spears

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -181,6 +181,7 @@
 	desc = "A haphazardly-constructed yet still deadly weapon. The pinnacle of modern technology."
 	force = 12
 	throwforce = 22
+	reach = 2 // SKYRAT EDIT
 	armour_penetration = 15 //Enhanced armor piercing
 
 /obj/item/spear/bonespear/ComponentInitialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds back the extra tile of range that bone spears used to have

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
The PR that removed the two tile range claimed that having an extra tile of range for the ashwalker's main melee weapon was overpowered against miners and against HRP, as well as comments saying that this should add variety.

On that first point, arguing that a lizard with a two tile range spear is overpowered against someone with a ranged weapon that has infinite ammunition and works wonders in low pressure, as well as whatever gear they can get and instant healing medicine, is if not biased at the very least uninformed. 

In the rare event that miners and ashwalkers come to blows the miners would have the upper hand at any time the ashwalker isn't using a bow, spear or not, and I don't see how giving the lizards a tool to hunt down mobs that doesn't entail them risking their life for every goliath is less HRP than a bunch of spacemen using science magic to destroy the fauna quicker than any ashwalker will ever be able to.

As for the argument that says removing the two tile range will force the ashwalkers to use their other weapons and add variety to their arsenal, I've to say removing the two tile range will make most ashwalkers not use the spear at all. If they want to attack something at range, they will use a bow. If they want to kill something in melee, they will get an axe. The spear will be removed alltogether from its nice 2 tile range hunting niche and ashwalker weapon variety will go down by one for basically no reason at all.

tl:dr removing two tile range on spears doesn't impact balance meaningfully outside of heavily nerfing starting or unexperienced ashwalkers for zero gains towards the overall roleplay or fun experience
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Gives bone spears their 2 tile range back
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
