### PR TITLE
Fixing cryopods and bringing back item storage

### DIFF
--- a/tgui/packages/tgui/interfaces/CryopodConsole.js
+++ b/tgui/packages/tgui/interfaces/CryopodConsole.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { LabeledList, NoticeBox, Section, Stack } from '../components';
+import { Button, LabeledList, NoticeBox, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 export const CryopodConsole = (props, context) => {
@@ -20,6 +20,9 @@ export const CryopodConsole = (props, context) => {
           </Stack.Item>
           <Stack.Item grow>
             <CrewList />
+          </Stack.Item>
+          <Stack.Item grow>
+            <ItemList />
           </Stack.Item>
         </Stack>
       </Window.Content>
@@ -46,6 +49,35 @@ const CrewList = (props, context) => {
       </Section>
     ) || (
       <NoticeBox>No stored crew!</NoticeBox>
+    )
+  );
+};
+
+const ItemList = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { item_ref_list, item_ref_name, item_retrieval_allowed } = data;
+  if (!item_retrieval_allowed) {
+    return (
+      <NoticeBox>You are not authorized for item management.</NoticeBox>
+    );
+  }
+  return (
+    item_ref_list.length && (
+      <Section fill scrollable>
+        <LabeledList>
+          {item_ref_list.map((item) => (
+            <LabeledList.Item key={item} label={item_ref_name[item]}>
+              <Button
+                icon="exclamation-circle"
+                content="Retrieve"
+                color="bad"
+                onClick={() => act('item_get', { item_get: item })} />
+            </LabeledList.Item>
+          ))}
+        </LabeledList>
+      </Section>
+    ) || (
+      <NoticeBox>No stored items!</NoticeBox>
     )
   );
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cryopods are now restored to their previous functionalities of storing items, no more looting Cryo for epic loot.

Most of this code isn't mine, mind you, I simply improved some code made by Zephyr in the past.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Makes the cryopods much better. Plus, that also means that people that cryo no longer appear in the PDA messenger list, which is an absolute win in my books.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: GoldenAlpharex
fix: Cryopods will now store items properly again.
fix: You will no longer be able to message people that are cryo'd, as was intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
