### PR TITLE
[MODULAR] Rebinds Hypospray Controls

### DIFF
--- a/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
@@ -141,7 +141,7 @@
 		vial.attack_self(user)
 		return TRUE
 
-/obj/item/hypospray/mkii/CtrlClick(mob/user)
+/obj/item/hypospray/mkii/attack_self_secondary(mob/user)
 	. = ..()
 	if(vial)
 		vial.attack_self_secondary(user)

--- a/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
@@ -162,9 +162,6 @@
 	obj_flags |= EMAGGED
 	return TRUE
 
-/obj/item/hypospray/mkii/attack_hand(mob/user)
-	. = ..() //Don't bother changing this or removing it from containers will break.
-
 /obj/item/hypospray/mkii/attack(obj/item/hypo, mob/user, params)
 	mode = HYPO_INJECT
 	return
@@ -231,15 +228,17 @@
 /obj/item/hypospray/mkii/afterattack_secondary(atom/target, mob/living/user, proximity)
 	return SECONDARY_ATTACK_CALL_NORMAL
 
-/obj/item/hypospray/mkii/attack_self_secondary(mob/living/user)
-	if(user)
+/obj/item/hypospray/mkii/attack_hand(mob/living/user)
+	if(user && loc == user && user.is_holding(src))
 		if(user.incapacitated())
 			return
 		else if(!vial)
-			to_chat(user, "This Hypo needs to be loaded first!")
+			. = ..()
 			return
 		else
 			unload_hypo(vial,user)
+	else
+		. = ..()
 
 /obj/item/hypospray/mkii/examine(mob/user)
 	. = ..()

--- a/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
@@ -136,7 +136,7 @@
 		insert_vial(used_item, user)
 		return TRUE
 
-/obj/item/hypospray/mkii/AltClick(mob/user)
+/obj/item/hypospray/mkii/attack_self(mob/user)
 	. = ..()
 	if(vial)
 		vial.attack_self(user)
@@ -218,7 +218,7 @@
 	to_chat(user, span_notice("You [fp_verb] [vial.amount_per_transfer_from_this] units of the solution. The hypospray's cartridge now contains [vial.reagents.total_volume] units."))
 	update_appearance()
 
-/obj/item/hypospray/mkii/attack_self(mob/living/user)
+/obj/item/hypospray/mkii/attack_self_secondary(mob/living/user)
 	if(user)
 		if(user.incapacitated())
 			return

--- a/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
@@ -91,7 +91,6 @@
 		. += "[vial] has [vial.reagents.total_volume]u remaining."
 	else
 		. += "It has no vial loaded in."
-	. += "[src] is set to [mode ? "Inject" : "Spray"] contents on application."
 
 /obj/item/hypospray/mkii/proc/unload_hypo(obj/item/hypo, mob/user)
 	if((istype(hypo, /obj/item/reagent_containers/glass/vial)))
@@ -167,7 +166,12 @@
 	. = ..() //Don't bother changing this or removing it from containers will break.
 
 /obj/item/hypospray/mkii/attack(obj/item/hypo, mob/user, params)
+	mode = HYPO_INJECT
 	return
+
+/obj/item/hypospray/mkii/attack_secondary(obj/item/hypo, mob/user, params)
+	mode = HYPO_SPRAY
+	return SECONDARY_ATTACK_CONTINUE_CHAIN
 
 /obj/item/hypospray/mkii/afterattack(atom/target, mob/living/user, proximity)
 	if(istype(target, /obj/item/reagent_containers/glass/vial))
@@ -223,6 +227,9 @@
 	playsound(loc, long_sound ? 'modular_skyrat/modules/hyposprays/sound/hypospray_long.ogg' : pick('modular_skyrat/modules/hyposprays/sound/hypospray.ogg','modular_skyrat/modules/hyposprays/sound/hypospray2.ogg'), 50, 1, -1)
 	to_chat(user, span_notice("You [fp_verb] [vial.amount_per_transfer_from_this] units of the solution. The hypospray's cartridge now contains [vial.reagents.total_volume] units."))
 	update_appearance()
+
+/obj/item/hypospray/mkii/afterattack_secondary(atom/target, mob/living/user, proximity)
+	return SECONDARY_ATTACK_CALL_NORMAL
 
 /obj/item/hypospray/mkii/attack_self_secondary(mob/living/user)
 	if(user)

--- a/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
@@ -142,6 +142,12 @@
 		vial.attack_self(user)
 		return TRUE
 
+/obj/item/hypospray/mkii/AltClick(mob/user)
+	. = ..()
+	if(vial)
+		vial.attack_self_secondary(user)
+		return TRUE
+
 /obj/item/hypospray/mkii/emag_act(mob/user)
 	. = ..()
 	if(obj_flags & EMAGGED)

--- a/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
@@ -242,7 +242,7 @@
 
 /obj/item/hypospray/mkii/examine(mob/user)
 	. = ..()
-	. += span_notice("<b>Left Click</b> on patients to inject, <b>Right Click</b> to spray.")
+	. += span_notice("<b>Left-Click</b> on patients to inject, <b>Right-Click</b> to spray.")
 
 #undef HYPO_SPRAY
 #undef HYPO_INJECT

--- a/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
@@ -141,7 +141,7 @@
 		vial.attack_self(user)
 		return TRUE
 
-/obj/item/hypospray/mkii/AltClick(mob/user)
+/obj/item/hypospray/mkii/CtrlClick(mob/user)
 	. = ..()
 	if(vial)
 		vial.attack_self_secondary(user)
@@ -241,21 +241,9 @@
 		else
 			unload_hypo(vial,user)
 
-/obj/item/hypospray/mkii/CtrlClick(mob/living/user)
-	. = ..()
-	if(user.canUseTopic(src, FALSE) && user.get_active_held_item(src))
-		switch(mode)
-			if(HYPO_SPRAY)
-				mode = HYPO_INJECT
-				to_chat(user, "[src] is now set to inject contents on application.")
-			if(HYPO_INJECT)
-				mode = HYPO_SPRAY
-				to_chat(user, "[src] is now set to spray contents on application.")
-		return TRUE
-
 /obj/item/hypospray/mkii/examine(mob/user)
 	. = ..()
-	. += span_notice("<b>Ctrl-Click</b> it to toggle its mode from spraying to injecting and vice versa.")
+	. += span_notice("<b>Left Click</b> on patients to inject, <b>Right Click</b> to spray.")
 
 #undef HYPO_SPRAY
 #undef HYPO_INJECT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Remaps the Hypospray controls to be more responsive and use the Right mouse button.

- Injecting is done by left clicking a patient, spraying is done by right clicking.
  - Because of this change, the button to swap between spraying and injecting has been removed
- You can now left click on a Hypospray or use it in hand to change the transfer amount
  - Alternatively you can now Right click to decrease the transfer amount. 
- Ejecting a vial is now mapped to using an empty hand on a Hypospray loaded with a vial, similar to ballsitic guns work.

Here is a video of the changes in action:

https://user-images.githubusercontent.com/68373373/142527012-b3157f30-1905-4315-a5aa-45b244e9aaa8.mp4

https://user-images.githubusercontent.com/68373373/142581784-5ddf0690-dadd-455c-b42e-657c023c7e46.mp4
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
This should make the Hypospray feel more responsive to use, making it a better tool for doctors.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: the controls on the Hypospray have been rebinded to take advantage of the right mouse button, please check  :https://github.com/Skyrat-SS13/Skyrat-tg/pull/9558 for details
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
