### PR TITLE
[MODULAR] Improves Hypospray vial swapping

### DIFF
--- a/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
+++ b/modular_skyrat/modules/hyposprays/code/hyposprays_II.dm
@@ -116,10 +116,12 @@
 
 /obj/item/hypospray/mkii/proc/insert_vial(obj/item/new_vial, mob/living/user, obj/item/current_vial)
 	var/obj/item/reagent_containers/glass/vial/container = new_vial
+	var/old_loc //The location of and old vial.
 	if(!is_type_in_list(container, allowed_containers))
 		to_chat(user, span_notice("[src] doesn't accept this type of vial."))
 		return FALSE
 	if(current_vial)
+		old_loc = container.loc
 		var/obj/item/reagent_containers/glass/vial/old_container = current_vial
 		old_container.forceMove(drop_location())
 	if(!user.transferItemToLoc(container, src))
@@ -129,7 +131,10 @@
 	playsound(loc, 'sound/weapons/autoguninsert.ogg', 35, 1)
 	update_appearance()
 	if(current_vial)
-		user.put_in_hands(current_vial)
+		if(old_loc == user)
+			user.put_in_hands(current_vial)
+		else
+			current_vial.forceMove(old_loc)
 
 /obj/item/hypospray/mkii/attackby(obj/item/used_item, mob/living/user)
 	if((istype(used_item, /obj/item/reagent_containers/glass/vial) && vial != null))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Improves the swapping of hypovials in the inventory, having the location of the hypovial end up in the location of the old one rather than the user's hands.

Here is a video of the change in action

https://user-images.githubusercontent.com/68373373/142710173-d0f3f92b-ae24-4631-a70b-d1bf2fccaed8.mp4

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
This makes a Skyrat specific item more easily usable and less clunky to use.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: when swapping to a vial in the inventory, the old vial now goes to the place where the inserted vial used to be instead of inside the user's hands
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
