### PR TITLE
[NON-MODULAR] Players in the interlink can no longer be selected as antagonist objective targets

### DIFF
--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -126,8 +126,10 @@
 			continue
 		if(!(player.mind.assigned_role.job_flags & JOB_CREW_MEMBER))
 			continue
-		if(SSticker.IsRoundInProgress() && istype(get_area(player), /area/centcom/interlink)) //SKYRAT EDIT: Players in the interlink can't be obsession targets
+		// SKYRAT EDIT ADDITION START - Players in the interlink can't be obsession targets
+		if(SSticker.IsRoundInProgress() && istype(get_area(player), /area/centcom/interlink))
 			continue
+		// SKYRAT EDIT END
 		viable_minds += player.mind
 	for(var/datum/mind/possible_target as anything in viable_minds)
 		if(possible_target != owner && ishuman(possible_target.current))

--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -126,7 +126,8 @@
 			continue
 		if(!(player.mind.assigned_role.job_flags & JOB_CREW_MEMBER))
 			continue
-		if(istype(get_area(player), /area/centcom/interlink))
+		if(istype(get_area(player), /area/centcom/interlink)) //SKYRAT EDIT: Players in the interlink can't be obsession targets
+			continue
 		viable_minds += player.mind
 	for(var/datum/mind/possible_target as anything in viable_minds)
 		if(possible_target != owner && ishuman(possible_target.current))

--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -126,7 +126,7 @@
 			continue
 		if(!(player.mind.assigned_role.job_flags & JOB_CREW_MEMBER))
 			continue
-		if(istype(get_area(player), /area/centcom/interlink)) //SKYRAT EDIT: Players in the interlink can't be obsession targets
+		if(SSticker.IsRoundInProgress() && istype(get_area(player), /area/centcom/interlink)) //SKYRAT EDIT: Players in the interlink can't be obsession targets
 			continue
 		viable_minds += player.mind
 	for(var/datum/mind/possible_target as anything in viable_minds)

--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -88,7 +88,7 @@
 /datum/brain_trauma/special/obsessed/proc/on_failed_social_interaction()
 	if(QDELETED(owner) || owner.stat >= UNCONSCIOUS)
 		return
-	switch(rand(1, 100)) 
+	switch(rand(1, 100))
 		if(1 to 40)
 			INVOKE_ASYNC(owner, /mob.proc/emote, pick("blink", "blink_r"))
 			owner.blur_eyes(10)
@@ -126,6 +126,7 @@
 			continue
 		if(!(player.mind.assigned_role.job_flags & JOB_CREW_MEMBER))
 			continue
+		if(istype(get_area(player), /area/centcom/interlink))
 		viable_minds += player.mind
 	for(var/datum/mind/possible_target as anything in viable_minds)
 		if(possible_target != owner && ishuman(possible_target.current))

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -136,8 +136,10 @@ GLOBAL_LIST_EMPTY(objectives) //SKYRAT EDIT ADDITION
 			continue
 		if(possible_target in blacklist)
 			continue
-		if(SSticker.IsRoundInProgress() && istype(target_area, /area/centcom/interlink)) //SKYRAT EDIT: people in the interlink can't be objective targets
+		// SKYRAT EDIT ADDITION START - Players in the interlink can't be obsession targets
+		if(SSticker.IsRoundInProgress() && istype(target_area, /area/centcom/interlink))
 			continue
+		// SKYRAT EDIT END
 		possible_targets += possible_target
 	if(try_target_late_joiners)
 		var/list/all_possible_targets = possible_targets.Copy()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -136,7 +136,7 @@ GLOBAL_LIST_EMPTY(objectives) //SKYRAT EDIT ADDITION
 			continue
 		if(possible_target in blacklist)
 			continue
-		if(istype(target_area, /area/centcom/interlink)) //SKYRAT EDIT: people in the interlink can't be objective targets
+		if(SSticker.IsRoundInProgress() && istype(target_area, /area/centcom/interlink)) //SKYRAT EDIT: people in the interlink can't be objective targets
 			continue
 		possible_targets += possible_target
 	if(try_target_late_joiners)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -136,6 +136,8 @@ GLOBAL_LIST_EMPTY(objectives) //SKYRAT EDIT ADDITION
 			continue
 		if(possible_target in blacklist)
 			continue
+		if(istype(target_area, /area/centcom/interlink)) //SKYRAT EDIT: people in the interlink can't be objective targets
+			continue
 		possible_targets += possible_target
 	if(try_target_late_joiners)
 		var/list/all_possible_targets = possible_targets.Copy()

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -339,8 +339,10 @@
 	if(target_candidates.len == 0)
 		message_admins("Cult Sacrifice: Could not find unconvertible target, checking for convertible target.")
 		for(var/mob/living/carbon/human/player in GLOB.player_list)
-			if(SSticker.IsRoundInProgress() && istype(get_area(player), /area/centcom/interlink)) //SKYRAT EDIT: people in the interlink can't be cult sacrifice targets
-				continue
+		// SKYRAT EDIT ADDITION START - Players in the interlink can't be obsession targets
+		if(SSticker.IsRoundInProgress() && istype(get_area(player), /area/centcom/interlink))
+			continue
+		// SKYRAT EDIT END
 			if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && player.stat != DEAD)
 				target_candidates += player.mind
 	list_clear_nulls(target_candidates)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -340,8 +340,8 @@
 		message_admins("Cult Sacrifice: Could not find unconvertible target, checking for convertible target.")
 		for(var/mob/living/carbon/human/player in GLOB.player_list)
 		// SKYRAT EDIT ADDITION START - Players in the interlink can't be obsession targets
-		if(SSticker.IsRoundInProgress() && istype(get_area(player), /area/centcom/interlink))
-			continue
+			if(SSticker.IsRoundInProgress() && istype(get_area(player), /area/centcom/interlink))
+				continue
 		// SKYRAT EDIT END
 			if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && player.stat != DEAD)
 				target_candidates += player.mind

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -332,17 +332,19 @@
 	var/datum/team/cult/cult = team
 	var/list/target_candidates = list()
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
-		if(SSticker.IsRoundInProgress() && istype(get_area(player), /area/centcom/interlink)) //SKYRAT EDIT: people in the interlink can't be cult sacrifice targets
+		// SKYRAT EDIT ADDITION START - Players in the interlink can't be obsession targets
+		if(SSticker.IsRoundInProgress() && istype(get_area(player), /area/centcom/interlink))
 			continue
+		// SKYRAT EDIT END
 		if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && !is_convertable_to_cult(player) && player.stat != DEAD)
 			target_candidates += player.mind
 	if(target_candidates.len == 0)
 		message_admins("Cult Sacrifice: Could not find unconvertible target, checking for convertible target.")
 		for(var/mob/living/carbon/human/player in GLOB.player_list)
-		// SKYRAT EDIT ADDITION START - Players in the interlink can't be obsession targets
+			// SKYRAT EDIT ADDITION START - Players in the interlink can't be obsession targets
 			if(SSticker.IsRoundInProgress() && istype(get_area(player), /area/centcom/interlink))
 				continue
-		// SKYRAT EDIT END
+			// SKYRAT EDIT END
 			if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && player.stat != DEAD)
 				target_candidates += player.mind
 	list_clear_nulls(target_candidates)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -332,14 +332,14 @@
 	var/datum/team/cult/cult = team
 	var/list/target_candidates = list()
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
-		if(istype(get_area(player), /area/centcom/interlink)) //SKYRAT EDIT: people in the interlink can't be cult sacrifice targets
+		if(SSticker.IsRoundInProgress() && istype(get_area(player), /area/centcom/interlink)) //SKYRAT EDIT: people in the interlink can't be cult sacrifice targets
 			continue
 		if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && !is_convertable_to_cult(player) && player.stat != DEAD)
 			target_candidates += player.mind
 	if(target_candidates.len == 0)
 		message_admins("Cult Sacrifice: Could not find unconvertible target, checking for convertible target.")
 		for(var/mob/living/carbon/human/player in GLOB.player_list)
-			if(istype(get_area(player), /area/centcom/interlink)) //SKYRAT EDIT: people in the interlink can't be cult sacrifice targets
+			if(SSticker.IsRoundInProgress() && istype(get_area(player), /area/centcom/interlink)) //SKYRAT EDIT: people in the interlink can't be cult sacrifice targets
 				continue
 			if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && player.stat != DEAD)
 				target_candidates += player.mind

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -332,11 +332,15 @@
 	var/datum/team/cult/cult = team
 	var/list/target_candidates = list()
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
+		if(istype(get_area(player), /area/centcom/interlink)) //SKYRAT EDIT: people in the interlink can't be cult sacrifice targets
+			continue
 		if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && !is_convertable_to_cult(player) && player.stat != DEAD)
 			target_candidates += player.mind
 	if(target_candidates.len == 0)
 		message_admins("Cult Sacrifice: Could not find unconvertible target, checking for convertible target.")
 		for(var/mob/living/carbon/human/player in GLOB.player_list)
+			if(istype(get_area(player), /area/centcom/interlink)) //SKYRAT EDIT: people in the interlink can't be cult sacrifice targets
+				continue
 			if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && player.stat != DEAD)
 				target_candidates += player.mind
 	list_clear_nulls(target_candidates)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -278,12 +278,12 @@ But i keeped it as unobtainable breain trauma, so admins can add it through VV *
 	var/list/special_pool = list() //The special list, for quirk-based
 	var/chosen_victim  //The obsession target
 
-	for(var/mob/Player in GLOB.player_list)//prevents crewmembers falling in love with nuke ops they never met, and other annoying hijinks
-		if(SSticker.IsRoundInProgress() && istype(get_area(Player), /area/centcom/interlink))
+	for(var/mob/player in GLOB.player_list) //prevents crewmembers falling in love with nuke ops they never met, and other annoying hijinks
+		if(SSticker.IsRoundInProgress() && istype(get_area(player), /area/centcom/interlink))
 			continue
-		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) && !isbrain(Player) && Player.client && Player != owner && SSjob.GetJob(Player.mind.assigned_role))
-			if(Player.client.prefs?.read_preference(/datum/preference/toggle/erp/noncon))
-				viable_minds += Player.mind
+		if(player.mind && player.stat != DEAD && !isnewplayer(player) && !isbrain(player) && player.client && player != owner && SSjob.GetJob(player.mind.assigned_role))
+			if(player?.client?.prefs?.read_preference(/datum/preference/toggle/erp/noncon))
+				viable_minds += player.mind
 	for(var/datum/mind/possible_target in viable_minds)
 		if(possible_target != owner && ishuman(possible_target.current))
 			possible_targets += possible_target.current

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -279,6 +279,8 @@ But i keeped it as unobtainable breain trauma, so admins can add it through VV *
 	var/chosen_victim  //The obsession target
 
 	for(var/mob/Player in GLOB.player_list)//prevents crewmembers falling in love with nuke ops they never met, and other annoying hijinks
+		if(SSticker.IsRoundInProgress() && istype(get_area(Player), /area/centcom/interlink))
+			continue
 		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) && !isbrain(Player) && Player.client && Player != owner && SSjob.GetJob(Player.mind.assigned_role))
 			if(Player.client.prefs?.read_preference(/datum/preference/toggle/erp/noncon))
 				viable_minds += Player.mind


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR blocks people who are currently in the Interlink for being selected as objective targets. 
Some antags this affects are:
Cult sacrifice objective
Heretic sacrifice target
Obsession target

## How This Contributes To The Skyrat Roleplay Experience

As an antagonist, it can suck to get an objective that requires you to be around/kill a person currently in the Interlink, since it's a safe zone.
For example, if you're a heretic and choose someone in the Interlink (keeping in mind that you can't tell where they are when you select a target), you're now dependent on either getting a new Living Heart (which is its own ordeal), or hoping that said target comes back to the station at some point.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Antagonist objectives can no longer target players currently in the Interlink.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
