### PR TITLE
Soft-Revert of "[MIRROR] The bureaucratic mistake station trait can now truly chose any job. [MDB IGNORE]"

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -106,6 +106,10 @@
 
 /datum/station_trait/overflow_job_bureaucracy/New()
 	. = ..()
+	/* SKYRAT EDIT START - Nice try
+	var/datum/job/picked_job = pick(SSjob.joinable_occupations)
+	chosen_job = picked_job.type
+	*/ // ORIGINAL END
 	var/list/jobs_to_use = list(
 		/datum/job/clown,
 		/datum/job/bartender,
@@ -117,6 +121,7 @@
 		/datum/job/prisoner,
 		)
 	chosen_job = pick(jobs_to_use)
+	// SKYRAT EDIT END
 	RegisterSignal(SSjob, COMSIG_SUBSYSTEM_POST_INITIALIZE, .proc/set_overflow_job_override)
 
 /datum/station_trait/overflow_job_bureaucracy/get_report()

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -106,8 +106,17 @@
 
 /datum/station_trait/overflow_job_bureaucracy/New()
 	. = ..()
-	var/datum/job/picked_job = pick(SSjob.joinable_occupations)
-	chosen_job = picked_job.type
+	var/list/jobs_to_use = list(
+		/datum/job/clown,
+		/datum/job/bartender,
+		/datum/job/cook,
+		/datum/job/botanist,
+		/datum/job/cargo_technician,
+		/datum/job/mime,
+		/datum/job/janitor,
+		/datum/job/prisoner,
+		)
+	chosen_job = pick(jobs_to_use)
 	RegisterSignal(SSjob, COMSIG_SUBSYSTEM_POST_INITIALIZE, .proc/set_overflow_job_override)
 
 /datum/station_trait/overflow_job_bureaucracy/get_report()


### PR DESCRIPTION
Reverts Skyrat-SS13/Skyrat-tg#9622

# LOL, Nice try Goof

:cl: GoldenAlpharex
del: Nanotrasen denies any and all allegations of slacking off when hiring their HR Interns. Coincidentally, after several interns suddenly went missing, the severity of bureaucratic mistakes was severely reduced for brand-new stations.
/:cl: