### PR TITLE
[modular] better whitespace for the examine menu

### DIFF
--- a/tgui/packages/tgui/interfaces/ExaminePanel.js
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.js
@@ -39,32 +39,23 @@ export const ExaminePanel = (props, context) => {
           <Stack.Item grow>
             <Stack fill vertical>
               <Stack.Item grow>
-                <Section scrollable fill title={character_name + "'s Flavor Text:"}>
-                  {flavor_text.split("\n").map((val, i) => (
-                    <Stack.Item key={i} grow fill>
-                      {val || val !== "" ? val : <br />}
-                    </Stack.Item>
-                  ))}
+                <Section scrollable fill title={character_name + "'s Flavor Text:"}
+                  preserveWhitespace>
+                  {flavor_text}
                 </Section>
               </Stack.Item>
               <Stack.Item grow>
                 <Stack fill>
                   <Stack.Item grow basis={0}>
-                    <Section scrollable fill title="OOC Notes">
-                      {ooc_notes.split("\n").map((val, i) => (
-                        <Stack.Item key={i} grow fill>
-                          {val || val !== "" ? val : <br />}
-                        </Stack.Item>
-                      ))}
+                    <Section scrollable fill title="OOC Notes"
+                      preserveWhitespace>
+                      {ooc_notes}
                     </Section>
                   </Stack.Item>
                   <Stack.Item grow basis={0}>
-                    <Section scrollable fill title={(custom_species ? "Species: " + custom_species : "No Custom Species!")}>
-                      {(custom_species ? custom_species_lore.split("\n").map((val, i) => (
-                        <Stack.Item key={i} grow fill>
-                          {val || val !== "" ? val : <br />}
-                        </Stack.Item>
-                      )) : "Just a normal space dweller.")}
+                    <Section scrollable fill title={(custom_species ? "Species: " + custom_species : "No Custom Species!")}
+                      preserveWhitespace>
+                      {(custom_species ? custom_species_lore : "Just a normal space dweller.")}
                     </Section>
                   </Stack.Item>
                 </Stack>


### PR DESCRIPTION
## About The Pull Request

title

## How This Contributes To The Skyrat Roleplay Experience

I didn't know how tgui worked when I made the original whitespace change so uh, it doesn't, but, it does add code improvements (and you can now use tabs in the examine panel)

## Changelog

:cl:
code: whitespace is now properly handled in the examine menu
/:cl: