### PR TITLE
[Modular] Xeno-resin *turf emote gets its own quirk

### DIFF
--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -22,6 +22,7 @@
 #define TRAIT_FLORAL_ASPECT "floral_aspect"
 #define TRAIT_ASH_ASPECT "ash_aspect"
 #define TRAIT_SPARKLE_ASPECT "sparkle_aspect"
+#define TRAIT_XENO_ASPECT "xeno_aspect"
 
 // Trait sources
 #define GHOSTROLE_TRAIT "ghostrole" // SKYRAT EDIT ADDITION -- Ghost Cafe Traits

--- a/modular_skyrat/master_files/code/datums/traits/good.dm
+++ b/modular_skyrat/master_files/code/datums/traits/good.dm
@@ -67,6 +67,16 @@
 	value = 0
 	mob_trait = TRAIT_SPARKLE_ASPECT
 	gain_text = span_notice("You're covered in sparkling dust!")
-	lose_text = span_danger("Somehow, you've completely cleaned yourself of glitter..")
+	lose_text = span_danger("Somehow, you've completely cleaned yourself of glitter...")
 	medical_record_text = "Patient seems to be looking fabulous."
 	icon = "hand-sparkles"
+
+/datum/quirk/xeno_aspect
+	name = "Resin aspect (Emotes)"
+	desc = "(Xeno innate) Xeno-hibridity is a result of science left rampant in space. (Say *turf to cast)"
+	value = 0
+	mob_trait = TRAIT_XENO_ASPECT
+	gain_text = span_notice("You feel your resin-gland churn.")
+	lose_text = span_danger("You no longer feel a resin-gland within your body...")
+	medical_record_text = "Patient in posession of a resin-production gland."
+	icon = "xeno"

--- a/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
+++ b/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
@@ -33,7 +33,7 @@ var/current_turf
 		if(isroundstartslime(user) || isslimeperson(user) || isjellyperson(user))
 			user.allowed_turfs += "slime"
 
-		if(isxenohybrid(user))
+		if(isxenohybrid(user) || HAS_TRAIT(user, TRAIT_XENO_ASPECT))
 			user.allowed_turfs += "xenoresin"
 
 		if(isinsect(user) || HAS_TRAIT(user, TRAIT_WEBBING_ASPECT))


### PR DESCRIPTION
## About The Pull Request

Hi, I'm back. 👋😊
Another one of the race-exclusive *turf emotes gets a quirk to add it onto other species.

## How This Contributes To The Skyrat Roleplay Experience

It was requested, and I understand since the amazing new character editor allows more freedom.

## Changelog

:cl:
add: Xeno-resin quirk
/:cl:
