### PR TITLE
You can no longer shove people off of tables from range

### DIFF
--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -44,8 +44,6 @@
 	SIGNAL_HANDLER
 	var/list/climbers = LAZYACCESS(current_climbers, climbed_thing)
 	for(var/i in climbers)
-		if(!in_range(i, user)) //SKYRAT CHANGE: fixes borgs shoving people off tables
-			continue
 		var/mob/living/structure_climber = i
 		if(structure_climber == user)
 			return

--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -44,7 +44,7 @@
 	SIGNAL_HANDLER
 	var/list/climbers = LAZYACCESS(current_climbers, climbed_thing)
 	for(var/i in climbers)
-		if(!in_range(i, user))
+		if(!in_range(i, user)) //SKYRAT CHANGE: fixes borgs shoving people off tables
 			continue
 		var/mob/living/structure_climber = i
 		if(structure_climber == user)

--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -44,6 +44,8 @@
 	SIGNAL_HANDLER
 	var/list/climbers = LAZYACCESS(current_climbers, climbed_thing)
 	for(var/i in climbers)
+		if(!in_range(i, user))
+			continue
 		var/mob/living/structure_climber = i
 		if(structure_climber == user)
 			return

--- a/modular_skyrat/master_files/code/game/objects/structures/tables_racks.dm
+++ b/modular_skyrat/master_files/code/game/objects/structures/tables_racks.dm
@@ -1,3 +1,5 @@
 //Lets cyborgs move dragged objects onto tables
 /obj/structure/table/attack_robot(mob/user, list/modifiers)
+	if(!in_range(src, user))
+		return
 	return attack_hand(user, modifiers)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You're able to shove people off tables as a borg from any range, this fixes that.
Note that according to the reporter, this is only a skyrat, not /tg/ issue.

## How This Contributes To The Skyrat Roleplay Experience

Bugs are bad.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Borgs can no longer shove people off tables at range.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
