### PR TITLE
[NON-MODULAR] stops medhuds from seeing DNRs as revivable

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -193,7 +193,9 @@ Medical HUD! Basic mode needs suit sensors on.
 	if(HAS_TRAIT(src, TRAIT_XENO_HOST))
 		holder.icon_state = "hudxeno"
 	else if(stat == DEAD || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))
-		if((key || get_ghost(FALSE, TRUE)) && (can_defib() & DEFIB_REVIVABLE_STATES))
+		//if((key || get_ghost(FALSE, TRUE)) && (can_defib() & DEFIB_REVIVABLE_STATES))
+		//SKYRAT EDIT CHANGE
+		if(!HAS_TRAIT(src, TRAIT_DNR) && (key || get_ghost(FALSE, TRUE)) && (can_defib() & DEFIB_REVIVABLE_STATES))
 			holder.icon_state = "huddefib"
 		else
 			holder.icon_state = "huddead"

--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human_helpers.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human_helpers.dm
@@ -4,7 +4,7 @@
 	var/t_his = p_their(TRUE)
 	var/t_is = p_are()
 	//This checks to see if the body is revivable
-	if(key || !getorgan(/obj/item/organ/brain) || ghost?.can_reenter_corpse)
+	if(!HAS_TRAIT(src, TRAIT_DNR) && (key || !getorgan(/obj/item/organ/brain) || ghost?.can_reenter_corpse))
 		return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life...")
 	else
 		return span_deadsay("[t_He] [t_is] limp and unresponsive. [t_his] consciousness has degraded beyond revival.")


### PR DESCRIPTION
## About The Pull Request

title

## How This Contributes To The Skyrat Roleplay Experience

because medical shouldn't be trying to revive DNR people

## Changelog

:cl:
fix: stops medhuds from seeing DNRs as revivable
/:cl: