### PR TITLE
[MODULAR] Adds a Supply playtime requirement to the Quartermaster job

### DIFF
--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -8,6 +8,8 @@
 	//supervisors = "the head of personnel" //ORIGINAL
 	supervisors = "the captain" //SKYRAT EDIT CHANGE
 	selection_color = "#d7b088"
+	exp_requirements = 180 //SKYRAT EDIT CHANGE
+	exp_required_type = EXP_TYPE_CREW //SKYRAT EDIT CHANGE
 	exp_required_type_department = EXP_TYPE_SUPPLY
 	exp_granted_type = EXP_TYPE_CREW
 


### PR DESCRIPTION
## About The Pull Request

Quartermaster is the only command role that does not have any time restriction chained to it. This changes it to have the same time restriction as all Heads of Departments.

## How This Contributes To The Skyrat Roleplay Experience

The issue with Quartermaster being the only command job without a playtime restriction is that it allows players to play a command job without having any experience in said department. While it is my personal experience, There has been multiple rounds where I ended up being more competent than my Quartermaster, and I don't even have 40hrs of experience yet. This PR will hopefully make those who wish to play command do so in good faith over playing Quartermaster.

## Changelog

:cl:
balance: Quartermaster now requires 40hr of Supply playtime, like every other Department Head requiring 40h of their department's.
/:cl: