### PR TITLE
[Modular] Body size 0.8 is pickable again

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/cursed_shit.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/cursed_shit.dm
@@ -395,7 +395,7 @@
 	savefile_key = "body_size"
 	minimum = BODY_SIZE_MIN
 	maximum = BODY_SIZE_MAX
-	step = 0.01
+	step = 0.0000001
 
 /datum/preference/numeric/body_size/is_accessible(datum/preferences/preferences)
 	var/passed_initial_check = ..(preferences)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

'Fixes' a rounding error(?) that made sanitize_float round 0.8 down to 0.79999995, and therefore think 0.8 is less than 0.8 when step was set to 0.01.

Literally just set step in /datum/preference/numeric/body_size from 0.01 to 0.0000001. Seems to work just fine.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Short characters can be that teensy bit shorter like they should be.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Body size now accepts 0.8 as it should.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
