### PR TITLE
[MODULAR] Uh oh, horrorform stat touching, oh noo oh noooo

### DIFF
--- a/modular_skyrat/modules/horrorform/code/true_changeling.dm
+++ b/modular_skyrat/modules/horrorform/code/true_changeling.dm
@@ -1,4 +1,4 @@
-#define TRUE_CHANGELING_REFORM_THRESHOLD 2 MINUTES
+#define TRUE_CHANGELING_REFORM_THRESHOLD 40 SECONDS // 40s so they cant jump in and out of it to reset the health
 #define TRUE_CHANGELING_PASSIVE_HEAL 3 //Amount of brute damage restored per tick
 
 //Changelings in their true form.

--- a/modular_skyrat/modules/horrorform/code/true_changeling.dm
+++ b/modular_skyrat/modules/horrorform/code/true_changeling.dm
@@ -20,7 +20,7 @@
 	status_flags = CANPUSH
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	maxHealth = 500 //3 3/4ths crewman worth of health, vaguely.
+	maxHealth = 500 //3 and 3/4ths crewmen worth of health, vaguely.
 	health = 200 
 	healable = FALSE
 	see_in_dark = 8
@@ -56,7 +56,6 @@
 	devour = new /datum/action/innate/devour
 	turn_to_human.Grant(src)
 	devour.Grant(src)
-	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
 /mob/living/simple_animal/hostile/true_changeling/Life()
 	. = ..()

--- a/modular_skyrat/modules/horrorform/code/true_changeling.dm
+++ b/modular_skyrat/modules/horrorform/code/true_changeling.dm
@@ -1,4 +1,4 @@
-#define TRUE_CHANGELING_REFORM_THRESHOLD 5 MINUTES
+#define TRUE_CHANGELING_REFORM_THRESHOLD 2 MINUTES
 #define TRUE_CHANGELING_PASSIVE_HEAL 3 //Amount of brute damage restored per tick
 
 //Changelings in their true form.

--- a/modular_skyrat/modules/horrorform/code/true_changeling.dm
+++ b/modular_skyrat/modules/horrorform/code/true_changeling.dm
@@ -20,14 +20,14 @@
 	status_flags = CANPUSH
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	maxHealth = 750 //Very durable
-	health = 500
+	maxHealth = 500 //3 3/4ths crewman worth of health, vaguely.
+	health = 200 
 	healable = FALSE
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	environment_smash = TRUE
-	melee_damage_lower = 40
-	melee_damage_upper = 40
+	melee_damage_lower = 30
+	melee_damage_upper = 30 // equal to an esword, coupled with their faster attacks this is more then enough.
 	wander = FALSE
 	attack_verb_continuous = "rips into"
 	attack_verb_simple = "rip into"

--- a/modular_skyrat/modules/horrorform/code/true_changeling.dm
+++ b/modular_skyrat/modules/horrorform/code/true_changeling.dm
@@ -27,7 +27,7 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	environment_smash = TRUE
 	melee_damage_lower = 30
-	melee_damage_upper = 30 // equal to an esword, coupled with their faster attacks this is more then enough.
+	melee_damage_upper = 30 // equal to an esword, coupled with their faster attacks this is more than enough.
 	wander = FALSE
 	attack_verb_continuous = "rips into"
 	attack_verb_simple = "rip into"


### PR DESCRIPTION
## About The Pull Request

Opening this for general feedback, but it's gone untouched for a while, and isn't upstream at all regarding antags, but with secs generally lethality, and access to g u n lowered, these are a bit overdue for a tone-back.

## How This Contributes To The Skyrat Roleplay Experience

this shit has 750 total health, and instantly starts at 500, that's like 5 entire magazines of a pitbull with 0 misses, as well as having ten damage above an esword, with like, double the attack-speed, which during highpop is like being thanos with four of the stones.

## Changelog



:cl:
balance: rebalanced (nerfed hard) horrorform health, and melee damage, and removes it's ventcrawling, but letting people swap in and out of it more often, making it better for ambushes
/:cl:

