### PR TITLE
Removes the Alt-titles from Medical Doctor and Scientist due to causing intense confusion among players about what you're expected/allowed to do as a Job.

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/jobs/jobs/medical_doctor.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/jobs/jobs/medical_doctor.ts
@@ -6,7 +6,6 @@ const MedicalDoctor: Job = {
   description: "Save lives, run around the station looking for victims, \
     scan everyone in sight",
   department: Medical,
-  alt_titles: ["Medical Doctor", "Surgeon", "Nurse"],
 };
 
 export default MedicalDoctor;

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/jobs/jobs/scientist.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/jobs/jobs/scientist.ts
@@ -5,17 +5,6 @@ const Scientist: Job = {
   name: "Scientist",
   description: "Do experiments, perform research, feed the slimes, make bombs.",
   department: Science,
-  alt_titles: [
-    "Scientist",
-    "Circuitry Designer",
-    "Xenobiologist",
-    "Cytologist",
-    "Nanomachine Programmer",
-    "Plasma Researcher",
-    "Anomalist",
-    "Lab Technician",
-    "Theoretical Physicist",
-  ],
 };
 
 export default Scientist;


### PR DESCRIPTION
## About The Pull Request

Removes the Alt-titles from Medical Doctor and Scientist.

## How This Contributes To The Skyrat Roleplay Experience

Folks just are not seeing the bit when they spawn about how the title on the ID card is purely a flavor thing, and we're running into situations where none of the Scientists will hit R&D buttons because they're all Xenobiologists and Circuitry Designers, and none of the doctors will do surgery because they're all Nurses, either because they're afraid of getting banned for it because they don't know it doesn't actually matter, or because they want an excuse to not do their job.

This is not good for these jobs, unfortunately.

## Changelog

:cl:
del: Removes the Alt-titles from Medical Doctor and Scientist due to causing intense confusion among players about what you're expected/allowed to do as a Job.
/:cl:
