### PR TITLE
[TM ONLY] Temporarily disables the Gulag Teleporter console as whether is it a Rules Violation to use is currently pending a Player Council appeal, so that more players do not step on the bear trap that is the Gulag and get secbanned for it.

### DIFF
--- a/code/game/machinery/computer/prisoner/gulag_teleporter.dm
+++ b/code/game/machinery/computer/prisoner/gulag_teleporter.dm
@@ -20,6 +20,8 @@
 	scan_machinery()
 
 /obj/machinery/computer/prisoner/gulag_teleporter_computer/ui_interact(mob/user, datum/tgui/ui)
+	to_chat(user, span_warning("The Gulag Teleporter is currently disabled server-side pending approval via rules!<br>It is not advised to utilize the Gulag system manually at this time, at risk of a potential ban occuring due to a lack of written policy on the Gulag.")) // Skyrat EDIT ADDITION
+	return // SKYRAT EDIT ADDITION
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "GulagTeleporterConsole", name)


### PR DESCRIPTION
Until the next Security Policy update, which is in an unknown amount of time, I do not want players stepping on this bear trap