### PR TITLE
Replaces Captain and NT Rep sidearms with default energy guns

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -17,7 +17,7 @@
 	new /obj/item/radio/headset/heads/captain/alt(src)
 	new /obj/item/radio/headset/heads/captain(src)
 	new /obj/item/storage/belt/sabre(src)
-	new /obj/item/storage/box/gunset/pdh_captain(src) //SKYRAT EDIT CHANGE - SEC_HAUL
+	new /obj/item/gun/energy/e_gun(src)
 	new /obj/item/door_remote/captain(src)
 	new /obj/item/storage/photo_album/captain(src)
 

--- a/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_representative.dm
+++ b/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_representative.dm
@@ -141,25 +141,12 @@
 	new /obj/item/pet_carrier(src)
 	new /obj/item/clothing/shoes/sneakers/brown(src)
 	new /obj/item/clothing/suit/armor/vest(src)
-	// SKYRAT EDIT REMOVAL BEGIN - MOVED TO COMMAND CLOTHING VENDOR // I know this is modular and I don't have to do this, but just let me live man.
-	/*
-	// new /obj/item/clothing/suit/armor/vest/nanotrasen_representative(src)
-	// new /obj/item/clothing/under/rank/nanotrasen_representative(src)
-	// new /obj/item/clothing/under/rank/nanotrasen_representative/skirt(src)
-	// new /obj/item/clothing/head/nanotrasen_representative(src)
-	// new /obj/item/clothing/head/nanotrasen_representative/beret(src)
-	// new /obj/item/clothing/head/beret/centcom_formal/ntrep(src)
-	*/
-	// SKYRAT EDIT REMOVAL END
 	new /obj/item/cartridge/captain(src)
 	new /obj/item/radio/headset/heads/nanotrasen_representative/alt(src)
 	new /obj/item/radio/headset/heads/nanotrasen_representative(src)
 	new /obj/item/clothing/glasses/sunglasses/gar/giga(src)
 	new /obj/item/clothing/gloves/combat(src)
-	new /obj/item/storage/box/gunset/nanotrasen_representative(src)
 	new /obj/item/storage/photo_album/personal(src)
 	new /obj/item/bedsheet/centcom(src)
-	// new /obj/item/clothing/suit/toggle/armor/vest/centcom_formal/ntrep(src) // SKYRAT EDIT REMOVAL - COMMAND CLOTHING VENDOR
 	new /obj/item/clothing/suit/hooded/wintercoat/centcom/ntrep(src)
-	// new /obj/item/clothing/head/centhat(src) // SKYRAT EDIT REMOVAL - COMMAND CLOTHING VENDOR
-	// new /obj/item/clothing/head/centcom_cap(src) // SKYRAT EDIT REMOVAL - COMMAND CLOTHING VENDOR
+	new /obj/item/gun/energy/e_gun(src)


### PR DESCRIPTION
## About The Pull Request

Title, removes the gunsets from their lockers and replaces them with e-guns. This will likely be changed to microfusion guns in the future.

![image](https://user-images.githubusercontent.com/8881105/144259506-aa36561b-e34d-44e4-87d8-92af46ec737b.png)

_M45A5 technically waiting on approval._

## How This Contributes To The Skyrat Roleplay Experience

These guns are waaaay more firepower than these roles need to defend themselves considering they _also_ have the Blueshield - and I'd rather remove the guns than the Blueshield.

This gives antagonists an actual chance to go for high-value targets rather than being cock-blocked by both a dedicated bodyguard and a very powerful sidearm _on top_ of that, ideally meaning they'll need to go for less firepower themselves if they want to go for it and promoting more RP focused interactions rather than gunfights.

It also fits better into our shift back into lasers and away from ballistics.

## Changelog
:cl:
balance: Captain and NT Rep gunsets have been removed in favour of energy guns.
/:cl: