### PR TITLE
Fixes stripper poles and other ERP equipment being constructable in boxes

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/milking_machine.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/milking_machine.dm
@@ -1035,6 +1035,8 @@
 // Processor of the process of assembling a kit into a machine
 /obj/item/milking_machine/constructionkit/attackby(obj/item/I, mob/living/carbon/user, params)
 	var/M = /obj/structure/chair/milking_machine
+	if((item_flags & IN_INVENTORY) || (item_flags & IN_STORAGE))
+		return
 	if(I.tool_behaviour == TOOL_WRENCH)
 		if(user.get_held_items_for_side(LEFT_HANDS) == src || user.get_held_items_for_side(RIGHT_HANDS) == src)
 			return

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
@@ -17,7 +17,7 @@
 /obj/item/bdsm_bed_kit/attackby(obj/item/P, mob/user, params) //constructing a bed here.
 	add_fingerprint(user)
 	if(istype(P, /obj/item/wrench))
-		if (!(item_flags & IN_INVENTORY))
+		if (!(item_flags & IN_INVENTORY) && !(item_flags & IN_STORAGE))
 			to_chat(user, span_notice("You fasten the frame to the floor and begin to inflate the latex pillows..."))
 			if(P.use_tool(src, user, 8 SECONDS, volume=50))
 				to_chat(user, span_notice("You assemble the bdsm bed."))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
@@ -271,7 +271,7 @@
 /obj/item/x_stand_kit/attackby(obj/item/P, mob/user, params) //constructing a bed here.
 	add_fingerprint(user)
 	if(istype(P, /obj/item/wrench))
-		if (!(item_flags & IN_INVENTORY))
+		if (!(item_flags & IN_INVENTORY) && !(item_flags & IN_STORAGE))
 			to_chat(user, span_notice("You begin fastening the frame to the floor."))
 			if(P.use_tool(src, user, 8 SECONDS, volume=50))
 				to_chat(user, span_notice("You assemble the x-stand."))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
@@ -159,7 +159,7 @@
 /obj/item/polepack/attackby(obj/item/P, mob/user, params) //erecting a pole here.
 	add_fingerprint(user)
 	if(istype(P, /obj/item/wrench))
-		if (!(item_flags & IN_INVENTORY))
+		if (!(item_flags & IN_INVENTORY) && !(item_flags & IN_STORAGE))
 			to_chat(user, span_notice("You begin fastening the frame to the floor and ceiling..."))
 			if(P.use_tool(src, user, 8 SECONDS, volume=50))
 				to_chat(user, span_notice("You assemble the stripper pole."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR stops stripper poles being constructed in boxes, which allows people to get stuck in said box

Edit: also fixes milking machine and BDSM furniture

## How This Contributes To The Skyrat Roleplay Experience

![image](https://user-images.githubusercontent.com/41448081/144366928-a0dc61d8-29b4-4089-bc44-b97db0849e15.png)
This is not good.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Stripper poles and all other ERP equipment can no longer be built in boxes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
