### PR TITLE
Add say modifier to Feline Traits quirk

### DIFF
--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -5,10 +5,6 @@
 			return "loosely signs"
 		else
 			return "slurs"
-	//SKYRAT EDIT ADDITION BEGIN - TRAIT_FELINE
-	if(HAS_TRAIT(src, TRAIT_FELINE))
-		return "meows"
-	//SKYRAT EDIT ADDITION END
 	else
 		. = ..()
 

--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -5,6 +5,10 @@
 			return "loosely signs"
 		else
 			return "slurs"
+	//SKYRAT EDIT ADDITION BEGIN - TRAIT_FELINE
+	if(HAS_TRAIT(src, TRAIT_FELINE))
+		return "meows"
+	//SKYRAT EDIT ADDITION END
 	else
 		. = ..()
 

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -539,3 +539,21 @@
 	speaker.verb_whisper = initial(verb_whisper)
 	speaker.verb_sing = initial(verb_sing)
 	speaker.verb_yell = initial(verb_yell)
+
+/obj/item/organ/tongue/cat
+	name = "feline tongue"
+	desc = "Like sandpaper, but in cat form."
+	say_mod = "meows"
+	icon_state = "tonguenormal"
+	modifies_speech = TRUE
+
+/obj/item/organ/tongue/cat/Insert(mob/living/carbon/signer)
+	. = ..()
+
+/obj/item/organ/tongue/cat/Remove(mob/living/carbon/speaker, special = 0)
+	..()
+	speaker.verb_ask = initial(verb_ask)
+	speaker.verb_exclaim = initial(verb_exclaim)
+	speaker.verb_whisper = initial(verb_whisper)
+	speaker.verb_sing = initial(verb_sing)
+	speaker.verb_yell = initial(verb_yell)

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -110,7 +110,7 @@
 				addtimer(CALLBACK(user, /mob/proc/emote, "laugh"), 5 SECONDS)
 				addtimer(CALLBACK(user, /mob/proc/emote, "laugh"), 10 SECONDS)
 
-/datum/quirk/feline_aspect
+/datum/quirk/item_quirk/feline_aspect
 	name = "Feline Traits"
 	desc = "You happen to act like a feline, for whatever reason."
 	gain_text = span_notice("Nya could go for some catnip right about now...")
@@ -119,6 +119,15 @@
 	value = 0
 	mob_trait = TRAIT_FELINE
 	icon = "cat"
+
+/datum/quirk/item_quirk/feline_aspect/add_unique()
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	var/obj/item/organ/tongue/old_tongue = human_holder.getorganslot(ORGAN_SLOT_TONGUE)
+	old_tongue.Remove(human_holder)
+	qdel(old_tongue)
+
+	var/obj/item/organ/tongue/cat/new_tongue = new(get_turf(human_holder))
+	new_tongue.Insert(human_holder)
 
 /datum/quirk/item_quirk/canine
 	name = "Canidae Traits"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -1,6 +1,7 @@
 /datum/species/tajaran
 	name = "Tajaran"
 	id = SPECIES_TAJARAN
+	say_mod = "meows"
 	default_color = "#4B4B4B"
 	species_traits = list(
 		MUTCOLORS,
@@ -25,7 +26,6 @@
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
-	say_mod = "meows"
 	liked_food = GROSS | MEAT | FRIED
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -25,6 +25,7 @@
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
+	say_mod = "meows"
 	liked_food = GROSS | MEAT | FRIED
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds respective say modification for Tajaran species and Feline Traits quirk, similar to the canine modification added by the Canidae Traits quirk.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Characters will "meow" instead of "say" when they have the trait, similar to how Canidae Traits gives "woofs" and "arfs."
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:lessthanthree
fix: Tajaran and Feline Traits quirk now applies feline voice modifier.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
