### PR TITLE
Makes it clear that alt-titles aren't a reason to avoid doing your job.

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -263,7 +263,7 @@ SUBSYSTEM_DEF(job)
 			JobDebug("GRJ skipping Central Command role, Player: [player], Job: [job]")
 			continue
 		//SKYRAT EDIT END
-		
+
 		// This check handles its own output to JobDebug.
 		if(check_job_eligibility(player, job, "GRJ", add_job_to_log = TRUE) != JOB_AVAILABLE)
 			continue
@@ -519,7 +519,8 @@ SUBSYSTEM_DEF(job)
 	// SKYRAT EDIT ADDITION BEGIN - ALTERNATIVE_JOB_TITLES
 	// The alt job title, if user picked one, or the default
 	var/chosen_title = player_client?.prefs.alt_job_titles[job.title] || job.title
-	// SKYRAT EDIT ADDITION END - ALTERNATIVE_JOB_TITLES
+	var/default_title = job.title
+	// SKYRAT EDIT ADDITION END - job.title
 
 	equipping.job = job.title
 
@@ -550,7 +551,11 @@ SUBSYSTEM_DEF(job)
 			to_chat(player_client, "<span class='infoplain'><b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b></span>")
 		if(CONFIG_GET(number/minimal_access_threshold))
 			to_chat(player_client, span_notice("<B>As this station was initially staffed with a [CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B>"))
-
+		//SKYRAT EDIT START - ALTERNATIVE_JOB_TITLES
+		if(chosen_title != default_title)
+			to_chat(player_client, "<span class='warning'>Remember that alternate titles are, for the most part, for flavor and roleplay. \
+					<b>Do not use your alt title as an excuse to forego your duties as a [job.title].</b></span>")
+		//SKYRAT EDIT END
 		var/related_policy = get_policy(job.title)
 		if(related_policy)
 			to_chat(player_client, related_policy)


### PR DESCRIPTION
## About The Pull Request

![JobText](https://user-images.githubusercontent.com/46720418/144532777-7da95933-e280-451f-a104-619d75648529.png)

This PR adds the stuff in the scary red text.

## How This Contributes To The Skyrat Roleplay Experience

This is something we had on old-base but whoever added job titles never ported it over here.
Should fix the issues that https://github.com/Skyrat-SS13/Skyrat-tg/pull/9775 had, without needing to remove anything.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Nanotrasen reminds all workers that they are fully responsibility for the full duties of their job, regardless of specialization.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
