### PR TITLE
Removes direct character references from Blueshift

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_upper.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_upper.dmm
@@ -34716,10 +34716,6 @@
 	pixel_y = 10
 	},
 /obj/machinery/light_switch/directional/south,
-/obj/item/paper/fluff{
-	info = "Thank you Riley for being an invaluable asset in the testing process of this vessel, your patience was unmatched and Nanotrasen would like to wholeheartedly thank you for your service, as a reward we put some extra love in this cabin which you will most likely occupy, with kind regards~ Nanotrasen Shipyard Management.";
-	name = "Note to Riley Fukui"
-	},
 /obj/item/reagent_containers/food/drinks/flask,
 /obj/structure/table/wood/fancy/royalblue,
 /turf/open/floor/carpet/royalblue,
@@ -38477,10 +38473,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
 	pixel_x = 6;
 	pixel_y = 19
-	},
-/obj/item/paper/fluff{
-	info = "Nanotrasen's ship construction crew would like to formally thank you for your service in overseeing the project, along with engineering foreman Oliver Bolt and regulatory advisor Meeko, we hope you may find many unforgettable memories amongst the stars on this beautifull spacevessel, with kind regards~ Axel.";
-	name = "Note to Damian Blue"
 	},
 /obj/item/stack/spacecash/c500,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{


### PR DESCRIPTION
## About The Pull Request

Removes two pieces of paper with direct references to the character names of two people.

## How This Contributes To The Skyrat Roleplay Experience

This stuff is just gonna age real fast. If you want to make references in the game, make it more subtle than this.

## Changelog
:cl:
del: Removed two direct character references from Blueshift
/:cl: