### PR TITLE
Fixes spelling and improves the fishing master skillchip's name

### DIFF
--- a/modular_skyrat/modules/fishing/code/fishing.dm
+++ b/modular_skyrat/modules/fishing/code/fishing.dm
@@ -90,7 +90,7 @@ GLOBAL_LIST_INIT(fishing_weights, list(
 		if(96 to 100)
 			spawning_reward = /obj/item/skillchip/fishing_master
 	new spawning_reward(spawning_turf)
-	atom_parent.visible_message(span_notice("Something flys out of [atom_parent]!"))
+	atom_parent.visible_message(span_notice("Something flies out of [atom_parent]!"))
 
 /turf/open/water/Initialize(mapload)
 	. = ..()
@@ -101,7 +101,7 @@ GLOBAL_LIST_INIT(fishing_weights, list(
 	AddComponent(/datum/component/fishing, set_loot = GLOB.fishing_weights, allow_fishes = FALSE)
 
 /obj/item/skillchip/fishing_master
-	name = "Fishing Master skillchip"
+	name = "M4ST3R B41T skillchip"
 	desc = "A master of fishing, capable of wrangling the whole ocean if we must."
 	auto_traits = list(TRAIT_FISHING_MASTER)
 	skill_name = "Fishing Master"


### PR DESCRIPTION
## About The Pull Request
Fixing a typo, and adding a neat subtle Terraria reference to the fishing master skillchip.

## How This Contributes To The Skyrat Roleplay Experience
Grammar mistakes bad, and a more fitting name for the skillchip is a good thing :D

## Changelog

:cl: GoldenAlpharex
spellcheck: Fixes a spelling mistake in the feedback for fishing something.
spellcheck: Renamed to fishing master skillchip to something cooler and more in line with the skillchip naming theme.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
