### PR TITLE
Adds ambition approval/discarding to ticket counter

### DIFF
--- a/modular_skyrat/modules/ambitions/code/ambition.dm
+++ b/modular_skyrat/modules/ambitions/code/ambition.dm
@@ -293,6 +293,7 @@
 					log_action("DISCARDED: Review discarded without approval")
 					to_chat(my_mind.current, span_warning("<b>Your ambitions review request was discarded by [key_name(usr, FALSE, FALSE)].</b>"))
 					message_admins(span_adminhelp("[ADMIN_TPMONTY(my_mind.current)]'s ambitions review request was DISCARDED by [key_name(usr, FALSE, TRUE)]. (<a href='?src=[REF(src)];admin_pref=show_ambitions'>VIEW</a>)"))
+					ticket_counter_add_handled(usr.key, 1)
 			if("approve")
 				cancel_auto_approve()
 				admin_approval = TRUE
@@ -302,6 +303,7 @@
 				log_action("APPROVED", FALSE)
 				to_chat(my_mind.current, span_nicegreen("<b>Your ambitions were approved by [key_name(usr, FALSE, FALSE)].</b>"))
 				message_admins(span_nicegreen("[ADMIN_TPMONTY(my_mind.current)]'s ambitions were approved by [key_name(usr, FALSE, TRUE)]. (<a href='?src=[REF(src)];admin_pref=show_ambitions'>VIEW</a>)"))
+				ticket_counter_add_handled(usr.key, 1)
 				submit()
 			if("logs")
 				var/datum/browser/popup = new(usr, "Ambition logging", "Ambition logs", 500, 200)

--- a/modular_skyrat/modules/ticket_counter/code/counter.dm
+++ b/modular_skyrat/modules/ticket_counter/code/counter.dm
@@ -10,8 +10,8 @@ GLOBAL_LIST_INIT(ticket_counter, list())
 /datum/admin_help_tickets/stat_entry()
 	var/list/L = ..()
 	L[++L.len] = list(null, null, null, null)
-	L[++L.len] = list("Ticket statistics", null, null, null)
-	L[++L.len] = list("Admin:", "Tickets handled:", null, null)
+	L[++L.len] = list("Activity statistics", null, null, null)
+	L[++L.len] = list("Admin:", "Tickets/Ambitions handled:", null, null)
 
 	for(var/ckey in GLOB.ticket_counter)
 		//assumption, that there's no keys with empty values


### PR DESCRIPTION
## About The Pull Request

When ambitions are approved or discarded, it'll increase that admin's ticket counter by one.
Renames "Ticket statistics" to "Activity statistics", and "Tickets handled" to "Tickets/Ambitions handled"

## How This Contributes To The Skyrat Roleplay Experience

I want it

## Changelog
:cl:
admin: Ambitions now count towards tickets handled
/:cl: