### PR TITLE
Removes more player references

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/cargodiselost.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/cargodiselost.dmm
@@ -702,9 +702,7 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "oQ" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate{
-	name = "Delivery - Flint and Nettles"
-	},
+/obj/structure/closet/crate,
 /obj/effect/spawner/random/decoration/paint,
 /obj/effect/spawner/random/decoration/paint,
 /obj/effect/spawner/random/decoration/paint,
@@ -782,9 +780,7 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "pH" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate{
-	name = "Delivery - NSS Citadel"
-	},
+/obj/structure/closet/crate,
 /obj/effect/spawner/random/engineering/vending_restock,
 /obj/effect/spawner/random/engineering/vending_restock,
 /obj/effect/spawner/random/engineering/vending_restock,
@@ -874,9 +870,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/closet/crate{
-	name = "Delivery - Lea Heatherholm"
-	},
+/obj/structure/closet/crate,
 /obj/item/clothing/sextoy/dildo,
 /obj/item/clothing/glasses/hypno,
 /obj/item/reagent_containers/glass/bottle/hexacrocin,
@@ -1069,17 +1063,6 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/brown,
-/area/ruin/space/has_grav/deepstorage/lostcargo)
-"tZ" = (
-/obj/structure/closet/crate/secure{
-	name = "If you cryo, stash yer stuff here"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/green/side{
-	dir = 8
-	},
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "ug" = (
 /obj/structure/safe,
@@ -1837,9 +1820,7 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Ib" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/medical{
-	name = "Delivery - Hartmann von Berlichingen"
-	},
+/obj/structure/closet/crate/medical,
 /obj/effect/spawner/random/medical/firstaid,
 /obj/effect/spawner/random/medical/firstaid,
 /obj/effect/spawner/random/medical/firstaid_rare,
@@ -1880,7 +1861,7 @@
 	},
 /obj/item/knife/combat,
 /obj/item/reagent_containers/hypospray/medipen/stimpack,
-/obj/item/clothing/glasses/hud/security/sunglasses/gars/supergars,
+/obj/item/clothing/glasses/hud/security/sunglasses/gars/giga,
 /obj/item/clothing/under/enclave/real,
 /turf/open/floor/iron/brown/side,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
@@ -1917,9 +1898,7 @@
 /obj/effect/turf_decal/arrows/red{
 	dir = 1
 	},
-/obj/structure/closet/crate/freezer{
-	name = "Delivery - Grima Rainwater"
-	},
+/obj/structure/closet/crate/freezer,
 /obj/item/food/meat/slab,
 /obj/item/food/meat/slab,
 /obj/item/food/meat/slab,
@@ -2233,9 +2212,7 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Nu" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate{
-	name = "Delivery - Xyverious"
-	},
+/obj/structure/closet/crate,
 /obj/effect/spawner/random/decoration/carpet,
 /obj/effect/spawner/random/decoration/carpet,
 /obj/machinery/light,
@@ -2846,9 +2823,7 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Vl" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate{
-	name = "Delivery - NSS Terry"
-	},
+/obj/structure/closet/crate,
 /obj/effect/spawner/random/engineering/material,
 /obj/effect/spawner/random/engineering/material,
 /obj/effect/spawner/random/engineering/material,
@@ -3343,7 +3318,7 @@ yv
 PG
 Bb
 kB
-tZ
+Ta
 ys
 Bb
 oo


### PR DESCRIPTION
## About The Pull Request

Removes crate names on cargo freighter ruin

## How This Contributes To The Skyrat Roleplay Experience

This is weird and will just get stale and their meanings lost to time. If I was witty, I'd come up with funny new ones that don't talk about specific people, but I'm not, so I haven't. The contents weren't even a reference anyway, for the most part.

## Changelog
:cl:
del: References to players removed from cargo freighter space ruin
/:cl: