### PR TITLE
Fixes interdynefob map

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
@@ -1200,7 +1200,7 @@
 "em" = (
 /obj/machinery/door/airlock/security/old{
 	hackProof = 1;
-	id_tag = Armory;
+	id_tag = "Armory";
 	name = "Armory";
 	req_access_txt = "151"
 	},
@@ -7145,7 +7145,7 @@
 /obj/structure/cable,
 /obj/machinery/button/door/directional/west{
 	desc = "To keep your valuable gear away from prying eyes.";
-	id = Armory;
+	id = "Armory";
 	name = "Armory Door bolt";
 	normaldoorcontrol = 1;
 	req_access_txt = "151";
@@ -10276,7 +10276,7 @@
 	},
 /obj/item/bikehorn,
 /obj/item/paper/crumpled{
-	desc = A letter from Donk co. it has a clown stamp on it, garish.;
+	desc = "A letter from Donk co. it has a clown stamp on it, garish.";
 	info = "Hey there Deep Space 2 crew, sorry about your stolen book, hope this horn helps! HONK! -Love Donk Co.";
 	name = "A Note from Donk co."
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The interdynefob.dmm map somehow has had invalid lines that were missing required quotes since September. I guess the runtime dmm loader can read it, but Dreammaker cannot.
* Fixed the entries.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

You can now edit DS-2 again.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
fix: Fixed a few corrupted tiles in DS-2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
