### PR TITLE
[NON-MODULAR] Adds shock + punishments for not using anaesthetic

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -626,7 +626,7 @@
  */
 
 /obj/structure/table/optable//SKYRAT EDIT - ICON OVERRIDEN BY AESTHETICS - SEE MODULE
-	name = "stasis operating table" // SKYRAT EDIT name = "operating table"
+	name = "operating table"
 	desc = "Used for advanced medical procedures. Now comes with built in stasis technology, patented by Cinco: A Family Company!" // SKYRAT EDIT desc = "Used for advanced medical procedures."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "optable"
@@ -687,26 +687,6 @@
 		return TRUE
 	return FALSE
 
-///SKYRAT EDIT: Operating Tables now provide Stasis
-/obj/structure/table/optable/proc/chill_out(mob/living/target)
-	var/freq = rand(24750, 26550)
-	playsound(src, 'sound/effects/spray.ogg', 5, TRUE, 2, frequency = freq)
-	target.apply_status_effect(STATUS_EFFECT_STASIS, STASIS_MACHINE_EFFECT)
-	ADD_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
-	target.extinguish_mob()
-
-/obj/structure/table/optable/proc/thaw_them(mob/living/target)
-	target.remove_status_effect(STATUS_EFFECT_STASIS, STASIS_MACHINE_EFFECT)
-	REMOVE_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
-
-/obj/structure/table/optable/post_buckle_mob(mob/living/L)
-	set_patient(L)
-	chill_out(L)
-
-/obj/structure/table/optable/post_unbuckle_mob(mob/living/L)
-	set_patient(null)
-	thaw_them(L)
-///SKYRAT EDIT END
 /*
  * Racks
  */

--- a/modular_skyrat/master_files/code/datums/diseases/shock.dm
+++ b/modular_skyrat/master_files/code/datums/diseases/shock.dm
@@ -1,0 +1,42 @@
+/datum/disease/shock
+	form = "Condition"
+	name = "Shock"
+	max_stages = 3
+	cure_text = "Trauma"
+	cures = list(/datum/reagent/medicine/epinephrine)
+	cure_chance = 15
+	agent = "Insufficient Blood Flow"
+	viable_mobtypes = list(/mob/living/carbon/human)
+	permeability_mod = 1
+	desc = "If left untreated the subject will suffer from fast heart rate, and ultimately cardiac arrest."
+	severity = DISEASE_SEVERITY_MEDIUM
+	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
+	visibility_flags = HIDDEN_PANDEMIC
+	bypasses_immunity = TRUE
+
+/datum/disease/shock/stage_act(delta_time, times_fired)
+	. = ..()
+	if(!.)
+		return
+
+	switch(stage)
+		if(1) //just warning signs
+			if(DT_PROB(2.5, delta_time))
+				to_chat(affected_mob, span_warning(pick("You feel anxious.", "Your heart feels faster.")))
+				affected_mob.add_confusion(rand(2,3))
+		if(2) //actual symptoms
+			if(DT_PROB(3, delta_time))
+				affected_mob.visible_message(span_warning("[affected_mob] starts to look pale."))
+			if(DT_PROB(2.5, delta_time))
+				to_chat(affected_mob, span_warning(pick("You have trouble breathing!", "You feel like you are going to pass out at any moment!")))
+				affected_mob.jitteriness += (rand(6,8))
+			if(DT_PROB(1, delta_time))
+				to_chat(affected_mob, span_warning(pick("You feel panicky!", "You feel like you're about to have a heart attack!")))
+				affected_mob.add_confusion(rand(6,8))
+			if(DT_PROB(0.5, delta_time))
+				affected_mob.vomit(stun = FALSE)
+		if(3) //the big one: the heart attack
+			if(DT_PROB(5, delta_time) && !affected_mob.undergoing_cardiac_arrest() && affected_mob.can_heartattack())
+				affected_mob.set_heartattack(TRUE)
+				if(affected_mob.stat == CONSCIOUS)
+					affected_mob.visible_message(span_userdanger("[affected_mob] clutches at [affected_mob.p_their()] chest as if [affected_mob.p_their()] heart stopped!"))

--- a/modular_skyrat/master_files/code/datums/diseases/shock.dm
+++ b/modular_skyrat/master_files/code/datums/diseases/shock.dm
@@ -23,16 +23,16 @@
 		if(1) //just warning signs
 			if(DT_PROB(2.5, delta_time))
 				to_chat(affected_mob, span_warning(pick("You feel anxious.", "Your heart feels faster.")))
-				affected_mob.add_confusion(rand(2,3))
+				affected_mob.add_confusion(rand(2, 3))
 		if(2) //actual symptoms
 			if(DT_PROB(3, delta_time))
 				affected_mob.visible_message(span_warning("[affected_mob] starts to look pale."))
 			if(DT_PROB(2.5, delta_time))
 				to_chat(affected_mob, span_warning(pick("You have trouble breathing!", "You feel like you are going to pass out at any moment!")))
-				affected_mob.jitteriness += (rand(6,8))
+				affected_mob.jitteriness += (rand(6, 8))
 			if(DT_PROB(1, delta_time))
 				to_chat(affected_mob, span_warning(pick("You feel panicky!", "You feel like you're about to have a heart attack!")))
-				affected_mob.add_confusion(rand(6,8))
+				affected_mob.add_confusion(rand(6, 8))
 			if(DT_PROB(0.5, delta_time))
 				affected_mob.vomit(stun = FALSE)
 		if(3) //the big one: the heart attack

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4120,6 +4120,7 @@
 #include "modular_skyrat\master_files\code\datums\emotes.dm"
 #include "modular_skyrat\master_files\code\datums\ert.dm"
 #include "modular_skyrat\master_files\code\datums\components\fullauto.dm"
+#include "modular_skyrat\master_files\code\datums\diseases\shock.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\jobs.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\solgov.dm"
 #include "modular_skyrat\master_files\code\datums\id_trim\syndicate.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Essentially a smaller version of my previous medical PR, but with less of the controversial bits.

- Adds in shock, a condition which can quickly deteriorate into a heart attack if not treated.
- Not putting patients under anesthetic causes a risk of shock, and increases surgery failure rate. (Alcohol can work as a ghetto anesthetic)
- Reverts operating tables to no longer put patients into stasis. (Necessary so shock actually works as intended)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Shock will now serve as another way to motivate doctors to actually numb their patients before doing surgery. It also creates roleplay through realistic consequences of non-anaesthetized surgery.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added shock
balance: Not putting patients under anesthetic causes risk of shock and higher surgery failure rates
balance: Operating tables no longer put players under stasis
code: Surgery step failure rates now use the implements list (like it used to do)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
