### PR TITLE
[Modular] Fixes the missing security autolathe on Icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -295,8 +295,8 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "acf" = (
-/obj/structure/frame/machine,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,
+/obj/machinery/autolathe,
 /turf/open/floor/iron,
 /area/security/office)
 "aci" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simply replaces the unfinished machine frame in the brig of Icebox with an autolathe using settings identical to those of other stations. It being left in this state is almost certainly an oversight by mappers, which this PR fixes. As an edit to the modular map file, should not cause any modularization conflicts.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Prevents security from having to hunt down an autolathe board for no particular reason whatsoever on a single map.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Replaces the machine frame in Icebox's brig with the intended autolathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
