### PR TITLE
No safeties on mining guns

### DIFF
--- a/modular_skyrat/modules/gunsafety/code/gun_safety.dm
+++ b/modular_skyrat/modules/gunsafety/code/gun_safety.dm
@@ -6,8 +6,11 @@
 
 /obj/item/gun/energy
 	has_gun_safety = TRUE
+	
+/obj/item/gun/energy/plasmacutter
+	has_gun_safety = FALSE
 
-/obj/item/gun/energy/kinetic_accelerator/minebot
+/obj/item/gun/energy/kinetic_accelerator
 	has_gun_safety = FALSE
 
 /obj/item/gun/ballistic/rifle/enchanted


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the safeties from the plasma cutters and PKA

## How This Contributes To The Skyrat Roleplay Experience

Juggling the safeties with combat intents on mining tools is so fucking annoying and makes using them a huge pain in the ass. Finding I can't shoot my PKA in a critical moment because I turned the combat mode off (for accuracy) only to find I have to toggle the safety (AGAIN) is the fucking worst

Safeties on mining equipment doesn't contribute to RP at all, removing them is pure QOL for miners.

## Changelog

:cl:
fix: removed safeties on the PKA and plasma cutter because they aren't helpful
/:cl:
