### PR TITLE
[MODULAR] Let's the crusader belt hold the claymore, and it's subtypes

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
@@ -80,6 +80,7 @@
 		/obj/item/storage/belt/storage_pouch,
 		/obj/item/forging/reagent_weapon/sword,
 		/obj/item/melee/sabre,
+		/obj/item/claymore,
 		/obj/item/melee/cleric_mace,
 		/obj/item/knife,
 		/obj/item/melee/baton,


### PR DESCRIPTION
## About The Pull Request
Lets the 'crusader' belt, the craftable one, hold the curator/faire crates claymores, because it should probably be able to hold the knight sword.

## How This Contributes To The Skyrat Roleplay Experience

sword go in belt who's entire purpose is to hold swords, probably an oversight.

## Changelog


:cl:
add: the crusader belt can now hold like, half the swords present on station, namely the ones that already fit on the belt-slot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
