### PR TITLE
Microfusion bugfixes

### DIFF
--- a/modular_skyrat/modules/microfusion/code/microfusion_designs.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_designs.dm
@@ -216,3 +216,13 @@
 	build_path = /obj/item/microfusion_gun_attachment/xray
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/microfusion_gun_attachment_rgb
+	name = "Phase Emitter Spectrograph"
+	desc = "An attachment hooked up to the phase emitter, allowing the user to adjust the color of the beam outputted. This has seen widespread use by various factions capable of getting their hands on microfusion weapons, whether as a calling card or simply for entertainment."
+	id = "microfusion_gun_attachment_rgb"
+	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 1000, /datum/material/silver = 500, /datum/material/bronze = 500)
+	build_path = /obj/item/microfusion_gun_attachment/rgb
+	category = list("Weapons")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE

--- a/modular_skyrat/modules/microfusion/code/microfusion_gun_attachments.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_gun_attachments.dm
@@ -28,6 +28,7 @@
 	microfusion_gun.heat_per_shot += heat_addition
 	microfusion_gun.update_appearance()
 	microfusion_gun.extra_power_usage += power_usage
+	microfusion_gun.chambered?.refresh_shot()
 	return
 
 /obj/item/microfusion_gun_attachment/proc/process_attachment(obj/item/gun/microfusion/microfusion_gun)
@@ -42,6 +43,7 @@
 	microfusion_gun.heat_per_shot -= heat_addition
 	microfusion_gun.update_appearance()
 	microfusion_gun.extra_power_usage -= power_usage
+	microfusion_gun.chambered?.refresh_shot()
 	return
 
 /*
@@ -275,14 +277,14 @@ Converts shots to STAMNINA damage.
 /obj/item/microfusion_gun_attachment/undercharger/proc/toggle(obj/item/gun/microfusion/microfusion_gun, mob/user)
 	if(toggle)
 		toggle = FALSE
-		microfusion_gun.heat_dissipation_bonus -= cooling_rate_increase
-		microfusion_gun.recoil -= recoil_to_remove
-		microfusion_gun.spread -= spread_to_remove
-	else
-		toggle = TRUE
 		microfusion_gun.heat_dissipation_bonus += cooling_rate_increase
 		microfusion_gun.recoil += recoil_to_remove
 		microfusion_gun.spread += spread_to_remove
+	else
+		toggle = TRUE
+		microfusion_gun.heat_dissipation_bonus -= cooling_rate_increase
+		microfusion_gun.recoil -= recoil_to_remove
+		microfusion_gun.spread -= spread_to_remove
 
 	if(user)
 		to_chat(user, span_notice("You toggle [src] [toggle ? "ON" : "OFF"]."))

--- a/modular_skyrat/modules/microfusion/code/microfusion_techweb.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_techweb.dm
@@ -24,6 +24,8 @@
 		"microfusion_cell_attachment_rechargeable",
 		"enhanced_microfusion_phase_emitter",
 		"microfusion_gun_attachment_black_camo",
+		"microfusion_gun_attachment_heatsink",
+		"microfusion_gun_attachment_rgb",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3500)
 

--- a/modular_skyrat/modules/microfusion/code/phase_emitter.dm
+++ b/modular_skyrat/modules/microfusion/code/phase_emitter.dm
@@ -173,7 +173,7 @@ Basically the heart of the gun, can be upgraded.
 /obj/item/microfusion_phase_emitter/enhanced
 	name = "enhanced microfusion phase emitter"
 	desc = "A second-generation phase emitter, this one is made of more robust materials which allow for a higher capacity for heat, a faster dissipation and cooling of it, and more capacity for thermal throttling."
-	max_heat = 3000
+	max_heat = 2500
 	throttle_percentage = 85
 	heat_dissipation_per_tick = 40
 	cooling_system_rate = 40
@@ -183,7 +183,7 @@ Basically the heart of the gun, can be upgraded.
 /obj/item/microfusion_phase_emitter/advanced
 	name = "advanced microfusion phase emitter"
 	desc = "A third-generation phase emitter, boasting a high capacity for heat, greater dissipation and cooling, and is built using higher-grade materials for more durability."
-	max_heat = 4000
+	max_heat = 3000
 	throttle_percentage = 90
 	heat_dissipation_per_tick = 50
 	cooling_system_rate = 50
@@ -193,7 +193,7 @@ Basically the heart of the gun, can be upgraded.
 /obj/item/microfusion_phase_emitter/bluespace
 	name = "bluespace microfusion phase emitter"
 	desc = "A fourth-generation phase emitter, utilizing a bluespace medium to store and manage heat, allowing for much cooler temperatures than realspace would allow. This is made of nothing but the latest materials, leading to the highest durability of any phase emitter on the market."
-	max_heat = 5000
+	max_heat = 3500
 	throttle_percentage = 95
 	heat_dissipation_per_tick = 60
 	cooling_system_rate = 60

--- a/modular_skyrat/modules/microfusion/code/projectiles.dm
+++ b/modular_skyrat/modules/microfusion/code/projectiles.dm
@@ -10,6 +10,9 @@
 	fire_sound = 'modular_skyrat/modules/microfusion/sound/laser_1.ogg'
 	fire_sound_volume = 100
 
+/obj/item/ammo_casing/proc/refresh_shot()
+	loaded_projectile = new projectile_type(src, src)
+
 /obj/projectile/beam/laser/microfusion
 	name = "microfusion laser"
 	icon = 'modular_skyrat/modules/microfusion/icons/projectiles.dmi'


### PR DESCRIPTION

## Changelog

:cl: Cobalt, Microfusion gun update
fix: The RGB/Heatsink are now in the tech tree.
fix: Removing an attachment should now update the bullet before firing.
fix: The undercharger now actually functions as intended, removing recoil when on, and adding it when off.
balance: Phase emitters increase by 500 C per level instead of 1000 C.
/:cl:

