### PR TITLE
[NON-MODULAR] Allows (some) Heads of Staff to be blind.

### DIFF
--- a/code/__DEFINES/~skyrat_defines/jobs.dm
+++ b/code/__DEFINES/~skyrat_defines/jobs.dm
@@ -6,4 +6,4 @@
 
 #define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE
 #define HEAD_RESTRICTED_QUIRKS "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE
-#define TECH_RESTRICTED_QUIRKS "Chunky Fingers" = TRUE
+#define TECH_RESTRICTED_QUIRKS "Chunky Fingers" = TRUE, "Blind" = TRUE

--- a/code/__DEFINES/~skyrat_defines/jobs.dm
+++ b/code/__DEFINES/~skyrat_defines/jobs.dm
@@ -5,5 +5,5 @@
 #define JOB_UNAVAILABLE_LANGUAGE JOB_UNAVAILABLE_SPECIES + 1
 
 #define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE
-#define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE
+#define HEAD_RESTRICTED_QUIRKS "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE
 #define TECH_RESTRICTED_QUIRKS "Chunky Fingers" = TRUE

--- a/code/__DEFINES/~skyrat_defines/jobs.dm
+++ b/code/__DEFINES/~skyrat_defines/jobs.dm
@@ -5,5 +5,5 @@
 #define JOB_UNAVAILABLE_LANGUAGE JOB_UNAVAILABLE_SPECIES + 1
 
 #define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE
-#define HEAD_RESTRICTED_QUIRKS "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE
-#define TECH_RESTRICTED_QUIRKS "Chunky Fingers" = TRUE, "Blind" = TRUE
+#define HEAD_RESTRICTED_QUIRKS "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE // SKYRAT EDIT
+#define TECH_RESTRICTED_QUIRKS "Chunky Fingers" = TRUE, "Blind" = TRUE // SKYRAT EDIT

--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -81,10 +81,10 @@
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS, HEAD_RESTRICTED_QUIRKS)
 
 /datum/job/chief_medical_officer
-	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
+	banned_quirks = list(HEAD_RESTRICTED_QUIRKS, "Blind" = TRUE)
 
 /datum/job/chief_engineer
-	banned_quirks = list(HEAD_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)
+	banned_quirks = list(HEAD_RESTRICTED_QUIRKS, TECH_RESTRICTED_QUIRKS "Paraplegic" = TRUE)
 
 /datum/job/research_director
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)

--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -84,7 +84,7 @@
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS, "Blind" = TRUE)
 
 /datum/job/chief_engineer
-	banned_quirks = list(HEAD_RESTRICTED_QUIRKS, TECH_RESTRICTED_QUIRKS "Paraplegic" = TRUE)
+	banned_quirks = list(HEAD_RESTRICTED_QUIRKS, TECH_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)
 
 /datum/job/research_director
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)

--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -81,10 +81,10 @@
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS, HEAD_RESTRICTED_QUIRKS)
 
 /datum/job/chief_medical_officer
-	banned_quirks = list(HEAD_RESTRICTED_QUIRKS, "Blind" = TRUE)
+	banned_quirks = list(HEAD_RESTRICTED_QUIRKS, "Blind" = TRUE) // SKYRAT EDIT
 
 /datum/job/chief_engineer
-	banned_quirks = list(HEAD_RESTRICTED_QUIRKS, TECH_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)
+	banned_quirks = list(HEAD_RESTRICTED_QUIRKS, TECH_RESTRICTED_QUIRKS, "Paraplegic" = TRUE) // SKYRAT EDIT
 
 /datum/job/research_director
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes "Blind" from HEAD_RESTRICTED_QUIRKS. Does not remove it from SEC_RESTRICTED_QUIRKS, as to ensure that jobs which require full field of view aren't overlooked. 

Restricts CE and CMO from being able to be blind.

While being blind, you can still access and control computers, tablets, and other interactables. This will not remove the Head of Personnel, for example's, ability to use their ID console and other job-critical abilities.

## How This Contributes To The Skyrat Roleplay Experience

Allowing for blind characters in more roleplay-situated positions could open up new scenarios to take place.

## Changelog

:cl:

qol: NanoTrasen has opened hiring positions for non-combat-critical positions for blinded personnel.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
