### PR TITLE
Brief Blueshift balance pass

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -734,8 +734,9 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "aic" = (
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/bot,
+/obj/structure/table/reinforced,
+/obj/machinery/dish_drive/bullet,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aid" = (
@@ -6478,16 +6479,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/stock_parts/matter_bin/bluespace,
-/obj/item/stock_parts/matter_bin/bluespace,
-/obj/item/stock_parts/scanning_module/triphasic,
-/obj/item/stock_parts/scanning_module/triphasic,
-/obj/item/stock_parts/manipulator/femto,
-/obj/item/stock_parts/manipulator/femto,
-/obj/item/stock_parts/capacitor/quadratic,
-/obj/item/stock_parts/capacitor/quadratic,
-/obj/item/stock_parts/micro_laser/quadultra,
-/obj/item/stock_parts/micro_laser/quadultra,
+/obj/effect/spawner/random/entertainment/money,
+/obj/effect/spawner/random/entertainment/money,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "bOs" = (
@@ -23060,6 +23053,7 @@
 	name = "engineering camera"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/cell_charger,
 /turf/open/floor/iron/dark,
 /area/commons/storage/primary)
 "iyH" = (
@@ -31530,9 +31524,8 @@
 /turf/open/floor/carpet,
 /area/service/cafeteria)
 "lWN" = (
-/obj/machinery/autolathe,
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes,
+/obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "lWP" = (
@@ -36198,9 +36191,9 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/cell_charger_multi,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
+/obj/machinery/cell_charger,
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
 "nOG" = (
@@ -36939,20 +36932,15 @@
 "oeW" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
-/obj/machinery/cell_charger_multi{
-	pixel_x = -16
-	},
 /obj/item/radio{
-	pixel_x = 6;
+	pixel_x = -5;
 	pixel_y = 7
 	},
 /obj/item/radio{
 	pixel_x = 10;
 	pixel_y = 3
 	},
-/obj/item/radio{
-	pixel_x = 6
-	},
+/obj/item/radio,
 /turf/open/floor/iron/dark,
 /area/commons/storage/primary)
 "oeX" = (
@@ -48404,7 +48392,8 @@
 /area/maintenance/port/aft)
 "sKE" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/vending/engivend,
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/material_cheap,
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
 "sKF" = (
@@ -50001,9 +49990,9 @@
 /area/hallway/primary/port)
 "ttz" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/autolathe,
 /obj/machinery/newscaster/directional/south,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/vending/tool,
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
 "ttL" = (
@@ -53410,8 +53399,8 @@
 /area/maintenance/department/engine)
 "uJn" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/vending/tool,
 /obj/machinery/light/directional/south,
+/obj/machinery/vending/engivend,
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
 "uJM" = (
@@ -61338,12 +61327,12 @@
 "xFS" = (
 /obj/effect/turf_decal/stripes,
 /obj/structure/table/reinforced,
-/obj/machinery/cell_charger_multi,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/newscaster/directional/north,
+/obj/machinery/cell_charger,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "xFU" = (

--- a/_maps/map_files/Blueshift/BlueShift_upper.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_upper.dmm
@@ -5644,7 +5644,6 @@
 /area/science/explab)
 "boc" = (
 /obj/structure/table/wood,
-/obj/item/skillchip/job/psychology,
 /turf/open/floor/wood,
 /area/medical/psychology)
 "boj" = (
@@ -19324,8 +19323,8 @@
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "ggW" = (
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/delivery,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/science/explab)
 "ghg" = (
@@ -21444,7 +21443,7 @@
 /area/medical/medbay/central)
 "gYt" = (
 /obj/effect/turf_decal/bot_red,
-/obj/machinery/autolathe,
+/obj/structure/frame/machine,
 /turf/open/floor/mineral/plastitanium,
 /area/science/robotics/lab)
 "gYD" = (
@@ -28802,7 +28801,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "jOy" = (
-/obj/machinery/autolathe,
+/obj/structure/frame/machine,
 /turf/open/floor/iron,
 /area/medical/storage)
 "jOP" = (
@@ -32473,12 +32472,12 @@
 /area/science/explab)
 "lfs" = (
 /obj/structure/table/reinforced,
-/obj/machinery/cell_charger_multi,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/structure/cable,
+/obj/machinery/cell_charger,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},


### PR DESCRIPTION
Removes roundstart autolathes and multi-cell chargers

Replaces multi-chargers with regular ones, and autolathes with like, plants, or machine frames, or whatever.

Also removes spare psych skillchip. They spawn with one anyway, there's only ever one, and it's not key like the RD's.

Cargo keeps their autolathe, naturally.

## Changelog
:cl:
del: Blueshift now only has one autolathe shift-start, located in cargo.
del: Shift-start multi-cell chargers are now only single-cell chargers on Blueshift.
del: The psychologist no longer has a spare skillchip on Blueshift.
/:cl: