### PR TITLE
Positronic Console now speaks to Science Comms

### DIFF
--- a/modular_skyrat/modules/positronic_alert_console/code/positronic_alert_console.dm
+++ b/modular_skyrat/modules/positronic_alert_console/code/positronic_alert_console.dm
@@ -6,9 +6,9 @@
 	var/inuse = FALSE
 
 	/// The encryption key typepath that will be used by the console.
-	/var/radio_key = /obj/item/encryptionkey/headset_sci
+	var/radio_key = /obj/item/encryptionkey/headset_sci
 	/// The radio used to send messages over the science channel.
-	/var/obj/item/radio/radio
+	var/obj/item/radio/radio
 
 /obj/machinery/posialert/Initialize(mapload)
 	. = ..()

--- a/modular_skyrat/modules/positronic_alert_console/code/positronic_alert_console.dm
+++ b/modular_skyrat/modules/positronic_alert_console/code/positronic_alert_console.dm
@@ -18,6 +18,7 @@
 /obj/machinery/posialert/Destroy()
 	QDEL_NULL(radio)
 	. = ..()
+
 /obj/machinery/posialert/attack_ghost(mob/user)
 	. = ..()
 	if(inuse)

--- a/modular_skyrat/modules/positronic_alert_console/code/positronic_alert_console.dm
+++ b/modular_skyrat/modules/positronic_alert_console/code/positronic_alert_console.dm
@@ -5,8 +5,10 @@
 	icon_state = "posialert"
 	var/inuse = FALSE
 
-/var/radio_key = /obj/item/encryptionkey/headset_sci
-/var/obj/item/radio/radio
+	/// The encryption key typepath that will be used by the console.
+	/var/radio_key = /obj/item/encryptionkey/headset_sci
+	/// The radio used to send messages over the science channel.
+	/var/obj/item/radio/radio
 
 /obj/machinery/posialert/Initialize(mapload)
 	. = ..()

--- a/modular_skyrat/modules/positronic_alert_console/code/positronic_alert_console.dm
+++ b/modular_skyrat/modules/positronic_alert_console/code/positronic_alert_console.dm
@@ -26,7 +26,7 @@
 	inuse = TRUE
 	flick("posialertflash",src)
 	say("There are positronic personalities available.")
-	radio.talk_into(src,"There are positronic personalities available.", RADIO_CHANNEL_SCIENCE)
+	radio.talk_into(src, "There are positronic personalities available.", RADIO_CHANNEL_SCIENCE)
 	playsound(loc, 'sound/machines/ping.ogg', 50)
 	addtimer(CALLBACK(src, /obj/machinery/posialert.proc/liftcooldown), 30 SECONDS)
 

--- a/modular_skyrat/modules/positronic_alert_console/code/positronic_alert_console.dm
+++ b/modular_skyrat/modules/positronic_alert_console/code/positronic_alert_console.dm
@@ -5,6 +5,19 @@
 	icon_state = "posialert"
 	var/inuse = FALSE
 
+/var/radio_key = /obj/item/encryptionkey/headset_sci
+/var/obj/item/radio/radio
+
+/obj/machinery/posialert/Initialize(mapload)
+	. = ..()
+	radio = new(src)
+	radio.keyslot = new radio_key
+	radio.listening = FALSE
+	radio.recalculateChannels()
+
+/obj/machinery/posialert/Destroy()
+	QDEL_NULL(radio)
+	. = ..()
 /obj/machinery/posialert/attack_ghost(mob/user)
 	. = ..()
 	if(inuse)
@@ -12,6 +25,7 @@
 	inuse = TRUE
 	flick("posialertflash",src)
 	say("There are positronic personalities available.")
+	radio.talk_into(src,"There are positronic personalities available.", RADIO_CHANNEL_SCIENCE)
 	playsound(loc, 'sound/machines/ping.ogg', 50)
 	addtimer(CALLBACK(src, /obj/machinery/posialert.proc/liftcooldown), 30 SECONDS)
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Positronic console now speaks into science radio.
![image](https://user-images.githubusercontent.com/71794877/145077561-f7613342-0692-4e76-acc4-828ff31dc8b6.png)

## How This Contributes To The Skyrat Roleplay Experience
Allows the positronic console to be heard on radio allowing for it to be heard in the event it is obstructed or just out of view.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Positronic console now speaks into science radio.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
