### PR TITLE
Small Microfusion Hotfix

### DIFF
--- a/modular_skyrat/modules/microfusion/code/microfusion_designs.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_designs.dm
@@ -172,7 +172,7 @@
 	desc = "A heatsink attachment for your microfusion weapon. Massively increases cooling potential."
 	id = "microfusion_gun_attachment_heatsink"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	materials = list(/datum/material/iron = 1000, /datum/material/glass = 1000, /datum/material/silver = 500, /datum/material/bronze = 500)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 1000, /datum/material/silver = 500, /datum/material/gold = 500)
 	build_path = /obj/item/microfusion_gun_attachment/heatsink
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE
@@ -222,7 +222,7 @@
 	desc = "An attachment hooked up to the phase emitter, allowing the user to adjust the color of the beam outputted. This has seen widespread use by various factions capable of getting their hands on microfusion weapons, whether as a calling card or simply for entertainment."
 	id = "microfusion_gun_attachment_rgb"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
-	materials = list(/datum/material/iron = 1000, /datum/material/glass = 1000, /datum/material/silver = 500, /datum/material/bronze = 500)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 1000, /datum/material/silver = 500, /datum/material/gold = 500)
 	build_path = /obj/item/microfusion_gun_attachment/rgb
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE


### PR DESCRIPTION
## About The Pull Request
Bronze can't actually be inserted in the silo, making these unprintable.

## How This Contributes To The Skyrat Roleplay Experience
I want to fire black laser beams out of a supercooled MCR-01 named Unlimited Sin, or something like that.

## Changelog
:cl:
fix: The heatsink and RGB attachments are now actually printable.
/:cl:
