### PR TITLE
[NON-MODULAR] Bandana hats for 'mutants'

### DIFF
--- a/code/modules/clothing/masks/bandana.dm
+++ b/code/modules/clothing/masks/bandana.dm
@@ -13,10 +13,12 @@
 
 /obj/item/clothing/mask/bandana/attack_self(mob/user)
 	adjustmask(user)
+	//SKYRAT EDIT START: BANDANA HATS FOR MUTANTS
 	if(slot_flags & ITEM_SLOT_HEAD)
 		mutant_variants = NONE
 	if(slot_flags & ITEM_SLOT_MASK)
 		mutant_variants = initial(mutant_variants)
+	//SKYRAT EDIT END
 
 /obj/item/clothing/mask/bandana/AltClick(mob/user)
 	. = ..()

--- a/code/modules/clothing/masks/bandana.dm
+++ b/code/modules/clothing/masks/bandana.dm
@@ -13,6 +13,10 @@
 
 /obj/item/clothing/mask/bandana/attack_self(mob/user)
 	adjustmask(user)
+	if(slot_flags & ITEM_SLOT_HEAD)
+		mutant_variants = NONE
+	if(slot_flags & ITEM_SLOT_MASK)
+		mutant_variants = initial(mutant_variants)
 
 /obj/item/clothing/mask/bandana/AltClick(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Was a little harder then I thought it would be, but there you go! Allows bandanas that have been turned into hat-mode to work on anthros, while also retaining their ability to work as masks for anthro faces. The mutant_variants has to be set to none for when it is in hat mode, but default when it's a mask.

## How This Contributes To The Skyrat Roleplay Experience

Allows all the bandana colors to be worn as hats again! What's not to like?

## Changelog

:cl:
code: Adds two if statements to swap between mutant_variant = none and default. I would do an else but I dunno what other variables might hit it on accident. If it works, it works.
/:cl: