### PR TITLE
[NON-MODULAR] Brings the void cloak heretic armor up to par with guard armor.

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -175,7 +175,7 @@
 	flags_cover = NONE
 	desc = "Black like tar, doesn't reflect any light. Runic symbols line the outside, with each flash you loose comprehension of what you are seeing."
 	item_flags = EXAMINE_SKIP
-	armor = list(MELEE = 30, BULLET = 30, LASER = 30,ENERGY = 30, BOMB = 15, BIO = 0, FIRE = 0, ACID = 0)
+	armor = list(MELEE = 35, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 50, ACID = 50, WOUND = 10)
 
 /obj/item/clothing/suit/hooded/cultrobes/void
 	name = "void cloak"
@@ -186,7 +186,7 @@
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/void
 	flags_inv = NONE
 	// slightly worse than normal cult robes
-	armor = list(MELEE = 30, BULLET = 30, LASER = 30,ENERGY = 30, BOMB = 15, BIO = 0, FIRE = 0, ACID = 0)
+	armor = list(MELEE = 35, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 50, ACID = 50, WOUND = 10)
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/void_cloak
 	alternative_mode = TRUE
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -175,6 +175,7 @@
 	flags_cover = NONE
 	desc = "Black like tar, doesn't reflect any light. Runic symbols line the outside, with each flash you loose comprehension of what you are seeing."
 	item_flags = EXAMINE_SKIP
+	//Skyrat edit, Original: armor = list(MELEE = 30, BULLET = 30, LASER = 30,ENERGY = 30, BOMB = 15, BIO = 0, FIRE = 0, ACID = 0)
 	armor = list(MELEE = 35, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 50, ACID = 50, WOUND = 10)
 
 /obj/item/clothing/suit/hooded/cultrobes/void
@@ -186,6 +187,7 @@
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/void
 	flags_inv = NONE
 	// slightly worse than normal cult robes
+	//Skyrat edit, Original: armor = list(MELEE = 30, BULLET = 30, LASER = 30,ENERGY = 30, BOMB = 15, BIO = 0, FIRE = 0, ACID = 0)
 	armor = list(MELEE = 35, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 50, ACID = 50, WOUND = 10)
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/void_cloak
 	alternative_mode = TRUE


### PR DESCRIPTION
## About The Pull Request

So I asked in the discord if anyone would mind me buffing the resistances slightly for the void cloak and no one really seemed to be irked by it, so I thought I'd make it a pr. This brings the void cloak (black cloak) armor up to par with generic guard armor that sec or dpt. guards get. The eldritch robes are still much better in terms of resistance numbers, so this does not overwrite the robe's purpose, but considering the void cloak is an over-suit armor, it needs a little something to maybe get chosen more often. It has the auxiliary uses of being able to turn invisible while on your person, and store a few items, so it would still be better then normal guard armor, but it takes investment of valuable heretic points to even be able to make it.

## How This Contributes To The Skyrat Roleplay Experience

Makes the void cloak a slightly more favorable choice of a item for heretic to maybe pursue. They probably won't still but hey, I like the edgy swag and I'm gonna make it a little better god damn it. Also feel free to debate I dunno if I'm even allowed to make a balance change like this lol.

## Changelog

:cl:
code: Adjusts defense levels for void cloak.
/:cl:
