### PR TITLE
Re-corrects two plushie names

### DIFF
--- a/modular_skyrat/modules/customization/game/objects/items/plushes.dm
+++ b/modular_skyrat/modules/customization/game/objects/items/plushes.dm
@@ -21,7 +21,7 @@
 	squeak_override = list('modular_skyrat/modules/customization/game/objects/items/sound/deerplush.ogg' = 1)
 
 /obj/item/toy/plush/fermis
-	name = "med-cat plushie"
+	name = "medcat plushie"
 	desc = "An affectionate stuffed toy that resembles a certain medcat, comes complete with battery operated wagging tail!! You get the impression she's cheering you on to find happiness and be kind to people."
 	icon = 'modular_skyrat/master_files/icons/obj/plushes.dmi'
 	icon_state = "plushie_fermis"
@@ -32,7 +32,7 @@
 	gender = FEMALE
 
 /obj/item/toy/plush/fermis/chen
-	name = "securi-cat plushie"
+	name = "securicat plushie"
 	desc = "The official stuffed companion to the medcat plushie!! It resembles a certain securicat. You get the impression she's encouraging you to be brave and protect those you care for."
 	icon_state = "plushie_chen"
 	inhand_icon_state = "plushie_chen"


### PR DESCRIPTION
## About The Pull Request
Small grammar revert of #9631 for two plushies

## How This Contributes To The Skyrat Roleplay Experience

The names for these are intentional: see the descriptions. 
(also because I said they are)

## Changelog
no