### PR TITLE
Fixes microfusion charging runtime

### DIFF
--- a/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
@@ -84,6 +84,9 @@
 		recharge_newshot() //and try to charge a new shot
 		update_appearance()
 
+/obj/item/gun/microfusion/get_cell()
+	return cell
+
 /obj/item/gun/microfusion/Initialize(mapload)
 	. = ..()
 	if(cell_type)


### PR DESCRIPTION
## About The Pull Request

`Runtime in recharger.dm, line 45: Cannot execute null.percent().`
```
if(charging)
	var/obj/item/stock_parts/cell/C = charging.get_cell()
	. += span_notice("- \The [charging]'s cell is at <b>[C.percent()]%</b>.")
```

## Changelog
:cl:
fix: A charging microfusion gun will no longer runtime on examine
/:cl: