### PR TITLE
positronic changes

### DIFF
--- a/modular_skyrat/modules/positronic_alert_console/code/positronic_alert_console.dm
+++ b/modular_skyrat/modules/positronic_alert_console/code/positronic_alert_console.dm
@@ -3,12 +3,23 @@
 	desc = "A console that will ping when a positronic personality is available for download."
 	icon = 'modular_skyrat/modules/positronic_alert_console/icons/terminals.dmi'
 	icon_state = "posialert"
-	var/inuse = FALSE
-
+	// to create a cooldown so if roboticists are tired of ghosts
+	COOLDOWN_DECLARE(robotics_cooldown)
+	/// the reason that the console is muted (player decided)
+	var/mute_reason
+	// to create a cooldown so ghosts cannot spam it
+	COOLDOWN_DECLARE(ghost_cooldown)
 	/// The encryption key typepath that will be used by the console.
 	var/radio_key = /obj/item/encryptionkey/headset_sci
 	/// The radio used to send messages over the science channel.
 	var/obj/item/radio/radio
+
+/obj/machinery/posialert/examine(mob/user)
+	. = ..()
+	if(!COOLDOWN_FINISHED(src, robotics_cooldown))
+		. += span_notice("Remaining time on mute is [COOLDOWN_TIMELEFT(src, robotics_cooldown) * 0.1] seconds.")
+		. += span_notice("Mute reason: [mute_reason]")
+	. += span_notice("Press the screen to mute or unmute the console.")
 
 /obj/machinery/posialert/Initialize(mapload)
 	. = ..()
@@ -21,16 +32,31 @@
 	QDEL_NULL(radio)
 	. = ..()
 
+/obj/machinery/posialert/attack_hand(mob/living/user, list/modifiers)
+	. = ..()
+	if(!COOLDOWN_FINISHED(src, robotics_cooldown))
+		COOLDOWN_RESET(src, robotics_cooldown)
+		to_chat(user, span_notice("You have removed the mute on [src]."))
+		return
+	mute_reason = null
+	mute_reason = stripped_input(user, "What would the reason for the mute be? (max characters is 20)", "Mute Reason", "", 20)
+	if(!mute_reason)
+		to_chat(user, span_warning("[src] requires a reason to mute!"))
+		return
+	COOLDOWN_START(src, robotics_cooldown, 5 MINUTES)
+	to_chat(user, span_notice("You have muted [src] for five minutes."))
+
 /obj/machinery/posialert/attack_ghost(mob/user)
 	. = ..()
-	if(inuse)
+	if(!COOLDOWN_FINISHED(src, robotics_cooldown))
+		to_chat(user, span_warning("[src] has been muted! Remaining time on mute is [COOLDOWN_TIMELEFT(src, robotics_cooldown) * 0.1] seconds."))
+		to_chat(user, span_warning("[src]'s mute reason: [mute_reason]"))
 		return
-	inuse = TRUE
+	if(!COOLDOWN_FINISHED(src, ghost_cooldown))
+		to_chat(user, span_warning("[src] is currently still on cooldown! Remaining time on cooldown is [COOLDOWN_TIMELEFT(src, ghost_cooldown) * 0.1] seconds."))
+		return
+	COOLDOWN_START(src, ghost_cooldown, 30 SECONDS)
 	flick("posialertflash",src)
 	say("There are positronic personalities available.")
 	radio.talk_into(src, "There are positronic personalities available.", RADIO_CHANNEL_SCIENCE)
 	playsound(loc, 'sound/machines/ping.ogg', 50)
-	addtimer(CALLBACK(src, /obj/machinery/posialert.proc/liftcooldown), 30 SECONDS)
-
-/obj/machinery/posialert/proc/liftcooldown()
-	inuse = FALSE

--- a/modular_skyrat/modules/positronic_alert_console/readme.md
+++ b/modular_skyrat/modules/positronic_alert_console/readme.md
@@ -1,0 +1,28 @@
+# Title: POSITRONIC ALERT CONSOLE
+
+MODULE ID: POSI_ALERT:
+
+## Description
+
+Adds a machine to be added to Skyrat maps. The Automated Postronic alert can be clicked on by ghosts to notify nearby mobs of ghost presence for posibrains.
+
+## TG Proc/File Changes
+
+- N/A
+
+## Defines
+
+- N/A
+
+## Master file additions
+
+- N/A
+
+## Included files that are not contained in this module
+
+- N/A
+
+## Credits
+
+Original Code - jjpark-kb (Jake Park)
+Ported from OldRat - Funce (Foxtrot)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
changes the addtimer and stuff on the positronic to the cooldown system
allows people to mute the positronic console so long as they supply a reason (for 5 minutes)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
more functionality to the posi alert consoles... and to stop annoying ghosts for valid (or not) reasons.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: changed some addtimer to cooldown in the posi alert console
add: posi alert consoles can now be muted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
