### PR TITLE
Removes Medical Doctor alt-titles and most of the Scientist alt-titles because even after adding the angry red text saying you still have to do your job, people are still getting wishy washy about doing their job.

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -74,7 +74,6 @@
 	alt_titles = list("Detective", "Forensic Technician", "Private Investigator", "Forensic Scientist")
 
 /datum/job/doctor
-	alt_titles = list("Medical Doctor", "Surgeon", "Nurse")
 
 /datum/job/engineering_guard
 
@@ -128,17 +127,7 @@
 
 
 /datum/job/scientist
-	alt_titles = list(
-    "Scientist",
-    "Circuitry Designer",
-    "Xenobiologist",
-    "Cytologist",
-    "Nanomachine Programmer",
-    "Plasma Researcher",
-    "Anomalist",
-    "Lab Technician",
-    "Theoretical Physicist",
-	)
+	alt_titles = list("Scientist", "Lab Technician", "Theoretical Physicist")
 
 /datum/job/security_medic
 	alt_titles = list("Security Medic", "Field Medic", "Security Corpsman", "Brig Physician")


### PR DESCRIPTION
## About The Pull Request
Removes Medical Doctor alt-titles and most of the Scientist alt-titles because even after adding the angry red text saying you still have to do your job, people are still getting wishy washy about doing their job.

## How This Contributes To The Skyrat Roleplay Experience

Really sucks when a medical doctor refuses to medical doctor you because their ID says nurse, and it really sucks when nobody in R&D but the science guard will hit the buttons because everyone says their ID cards are individual jobs.

## Changelog

:cl:
del: Removes Medical Doctor alt-titles and most of the Scientist alt-titles because even after adding the angry red text saying you still have to do your job, people are still getting wishy washy about doing their job.
/:cl:
