### PR TITLE
Makes the "Do your job regardless of alt title" warning extra loud and obnoxious

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -554,7 +554,7 @@ SUBSYSTEM_DEF(job)
 		//SKYRAT EDIT START - ALTERNATIVE_JOB_TITLES
 		if(chosen_title != default_title)
 			to_chat(player_client, span_infoplain(span_warning("Remember that alternate titles are purely for flavor and roleplay.")))
-			to_chat(player_client, span_infoplain("<span class='flashingfuckingwarning'>Do not use your alt title as an excuse to forego your duties as a [job.title].</span>"))
+			to_chat(player_client, span_infoplain("<span class='doyourjobidiot'>Do not use your alt title as an excuse to forego your duties as a [job.title].</span>"))
 		//SKYRAT EDIT END
 		var/related_policy = get_policy(job.title)
 		if(related_policy)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -554,7 +554,7 @@ SUBSYSTEM_DEF(job)
 		//SKYRAT EDIT START - ALTERNATIVE_JOB_TITLES
 		if(chosen_title != default_title)
 			to_chat(player_client, span_infoplain(span_warning("Remember that alternate titles are purely for flavor and roleplay.")))
-			to_chat(player_client, span_infoplain("<span class='doyourjobidiot'>Do not use your alt title as an excuse to forego your duties as a [job.title].</span>"))
+			to_chat(player_client, span_infoplain("<span class='doyourjobidiot'>Do not use your \"[chosen_title]\" alt title as an excuse to forego your duties as a [job.title].</span>"))
 		//SKYRAT EDIT END
 		var/related_policy = get_policy(job.title)
 		if(related_policy)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -553,8 +553,8 @@ SUBSYSTEM_DEF(job)
 			to_chat(player_client, span_notice("<B>As this station was initially staffed with a [CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B>"))
 		//SKYRAT EDIT START - ALTERNATIVE_JOB_TITLES
 		if(chosen_title != default_title)
-			to_chat(player_client, "<span class='warning'>Remember that alternate titles are, for the most part, for flavor and roleplay. \
-					<b>Do not use your alt title as an excuse to forego your duties as a [job.title].</b></span>")
+			to_chat(player_client, span_infoplain(span_warning("Remember that alternate titles are purely for flavor and roleplay.")))
+			to_chat(player_client, span_infoplain("<span class='flashingfuckingwarning'>Do not use your alt title as an excuse to forego your duties as a [job.title].</span>"))
 		//SKYRAT EDIT END
 		var/related_policy = get_policy(job.title)
 		if(related_policy)

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -166,6 +166,31 @@ h1.alert, h2.alert		{color: #000000;}
 		60% 	{color: #ffb31a;}
 		100% 	{color: #ff33cc;}
 }
+
+.doyourjobidiot {
+  color: #c51e1e;
+  text-shadow: 0 0 4px #e22525;
+  font-size: 125%;
+  font-weight: bold;
+  animation: flashingfuckingwarning 250ms infinite;
+}
+
+@keyframes flashingfuckingwarning {
+  0% {
+    color: #c51e1e;
+    text-shadow: 0 0 4px #c51e1e;
+  }
+
+  50% {
+    color: #e22525;
+    text-shadow: 0 0 8px #e22525;
+  }
+
+  100% {
+    color: #c51e1e;
+    text-shadow: 0 0 4px #c51e1e;
+  }
+}
 // SKYRAT ADDITION END
 
 .phobia			{color: #dd0000;	font-weight: bold;	animation: phobia 750ms infinite;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -813,6 +813,30 @@ em {
   }
 }
 
+.doyourjobidiot {
+  color: #c51e1e;
+  text-shadow: 0 0 4px #e22525;
+  font-size: 125%;
+  font-weight: bold;
+  animation: flashingfuckingwarning 250ms infinite;
+}
+
+@keyframes flashingfuckingwarning {
+  0% {
+    color: #c51e1e;
+    text-shadow: 0 0 4px #c51e1e;
+  }
+
+  50% {
+    color: #e22525;
+    text-shadow: 0 0 8px #e22525;
+  }
+
+  100% {
+    color: #c51e1e;
+    text-shadow: 0 0 4px #c51e1e;
+  }
+}
 // SKYRAT ADDITION END
 
 .phobia {


### PR DESCRIPTION
## About The Pull Request

![aaaaa](https://user-images.githubusercontent.com/82850673/145576832-5f7badb1-eb25-4c46-9f9a-cf2813d23b24.gif)
Response to https://github.com/Skyrat-SS13/Skyrat-tg/pull/9973
If you ignore this warning now, you are legally blind.

## How This Contributes To The Skyrat Roleplay Experience

Removing features because some people slightly annoyed goofball with admittedly shitty behavior would suck.

## Changelog

:cl: Bob Joga
qol: NanoTrasen now loudly screams the duties of each job position, regardless of specialization, for those who are legally blind.
/:cl: