### PR TITLE
[MODULAR] Removes Roller Bed from sec-medic Heirlooms (TLDR it doesn't work)

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/security_medic/security_medic.dm
+++ b/modular_skyrat/modules/sec_haul/code/security_medic/security_medic.dm
@@ -30,7 +30,7 @@
 		/datum/job_department/medical,
 	)
 
-	family_heirlooms = list(/obj/item/clothing/neck/stethoscope, /obj/item/roller, /obj/item/book/manual/wiki/security_space_law)
+	family_heirlooms = list(/obj/item/clothing/neck/stethoscope, /obj/item/book/manual/wiki/security_space_law)
 
 	//This is the paramedic goodie list. Secmedics are paramedics more or less so they can use these instead of raiding medbay.
 	mail_goodies = list(


### PR DESCRIPTION
## About The Pull Request

Removes the roller bed as a possible heirloom for sec-medic. The rollerbed is a object that switches between multiple states, and there's no code in that currently allows it to retain its 'heirloom' state, so if it is used, it will lose that property, and the owner of said heirloom will lose their heirloom, get the negative moodlet and never be able to recover. Better to just remove it, or replace it with something else instead of trying to code in something for this niche case of an heirloom.

## How This Contributes To The Skyrat Roleplay Experience

Removes the chance to be permanently depressed because of a bug with your heirloom as sec-med. Prooobably for the best.

## Changelog

:cl:
code: deletes the rollerbed out of the sec-meds heirloom list
/:cl:
