### PR TITLE
[Modular] Makes anthromorphs/mutants able to wear tech robes

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/non_anthro_clothes.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/non_anthro_clothes.dm
@@ -446,3 +446,9 @@
 
 /obj/item/clothing/under/rank/prisoner/skirt
 	mutant_variants = NONE
+
+/obj/item/clothing/suit/hooded/techpriest
+	mutant_variants = NONE
+
+/obj/item/clothing/head/hooded/techpriest
+	mutant_variants = NONE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does as title says, adds none to mutant appearances

## How This Contributes To The Skyrat Roleplay Experience

begone [Missing Sprite Texture]

## Changelog

:cl:
fix: techpriest robes can now be visible on anthromorphs/mutants
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
