### PR TITLE
[MODULAR] Ghouls are no longer exclusively agender

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
@@ -5,7 +5,7 @@
 	say_mod = "rasps"
 	sexes = FALSE
 	default_color = "#c4af7c"
-	species_traits = list(NOEYESPRITES, DYNCOLORS, AGENDER, HAS_FLESH, HAS_BONE, HAIR, FACEHAIR)
+	species_traits = list(NOEYESPRITES, DYNCOLORS,HAS_FLESH, HAS_BONE, HAIR, FACEHAIR)
 	can_have_genitals = FALSE //WHY WOULD YOU WANT TO FUCK ONE OF THESE THINGS?
 	mutant_bodyparts = list("ghoulcolor" = "Tan Necrotic")
 	default_mutant_bodyparts = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes "Agender" trait from ghouls, allowing them to select gendered pronouns in character creation if they wish. 
This edits one line in "ghoul.dm" to remove the species trait.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Being able to select your character's gender is a feature of almost every other humanoid species available, so not allowing it for ghouls feels like an arbitrary restriction, even if it is a niche species. While arguments can be made in favor of keeping them agender for biological reasons, you're already capable of selecting your character's gender separately from their body type and genitals, not to mention that totally synthetic beings (IPCs, synthetic anthromorphs) can select a gender as well. This simply allows more freedom with how people make characters with this species, but doesn't prevent them from having an agender ghoul due to the "other" option being available in the gender selection.

In summary: It's a literal one-line change that gives players more customization for their character.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Ghouls can now select their gender/pronouns in character creation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
