### PR TITLE
Fixes space tiles in blueshift maint

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_lower.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_lower.dmm
@@ -5025,8 +5025,7 @@
 	},
 /obj/structure/railing,
 /turf/open/floor/iron/stairs{
-	dir = 8;
-	initial_gas_mix = "TEMP=2.7"
+	dir = 8
 	},
 /area/cargo/miningdock)
 "csU" = (
@@ -7018,6 +7017,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"dVw" = (
+/obj/machinery/button/door{
+	id = "Sbay1";
+	name = "Shuttle Bay 1";
+	pixel_y = -24
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/fore)
 "dVR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -7045,6 +7052,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light/directional/north,
+/obj/machinery/button/door{
+	id = "Sbay1";
+	name = "Shuttle Bay 1";
+	pixel_y = 24
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/fore)
 "dXR" = (
@@ -11540,6 +11552,10 @@
 	},
 /turf/open/floor/iron/bluespace,
 /area/engineering/atmos)
+"hMV" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hNk" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
@@ -16116,6 +16132,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"lsh" = (
+/obj/machinery/button/door{
+	id = "Sbay2";
+	name = "Shuttle Bay 2";
+	pixel_y = -24
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/fore)
 "lsq" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -21653,6 +21677,25 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"pMC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/button/door{
+	id = "Sbay2";
+	name = "Shuttle Bay 2";
+	pixel_y = 24
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/fore)
 "pNm" = (
 /obj/structure/table/glass,
 /obj/item/folder/blue,
@@ -28631,6 +28674,11 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"vHV" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "vIf" = (
 /obj/structure/chair/plastic{
 	dir = 1
@@ -28938,6 +28986,11 @@
 	},
 /turf/open/floor/wood,
 /area/security/prison/workout)
+"vRO" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "vRR" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -31908,6 +31961,10 @@
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"xZs" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "xZB" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/bot,
@@ -55033,12 +55090,12 @@ ylQ
 ylQ
 ylQ
 ayE
-xKm
-xKm
-xKm
-xKm
-xKm
-xKm
+xPb
+aqR
+aqR
+aqR
+aqR
+aqR
 flW
 aqR
 aqR
@@ -55290,12 +55347,12 @@ ylQ
 ylQ
 ylQ
 ayE
-xKm
-xKm
-xKm
-xKm
-xKm
-xKm
+ipg
+aqR
+aqR
+aqR
+aqR
+aqR
 arP
 aqR
 aqR
@@ -55547,12 +55604,12 @@ ylQ
 ylQ
 ylQ
 ayE
-xKm
-xKm
-xKm
-xKm
-xKm
-xKm
+sjb
+aqR
+aqR
+aqR
+aqR
+xZs
 arP
 aqR
 pgW
@@ -55804,12 +55861,12 @@ ylQ
 ylQ
 ylQ
 ayE
-xKm
-xKm
-xKm
-xKm
-xKm
-xKm
+aqR
+aqR
+aqR
+aqR
+aqR
+hMV
 arP
 aqR
 aqR
@@ -56061,12 +56118,12 @@ ylQ
 ylQ
 ylQ
 ayE
-xKm
-xKm
-xKm
-xKm
-xKm
-xKm
+aqR
+aqR
+aqR
+aqR
+aqR
+vZa
 xto
 aqR
 aqR
@@ -56318,11 +56375,11 @@ ylQ
 ylQ
 ylQ
 ayE
+vRO
+vHV
+qqn
 aqR
-aqR
-aqR
-aqR
-aqR
+vML
 arP
 arP
 arP
@@ -58891,7 +58948,7 @@ vMU
 vMU
 vMU
 afB
-xOl
+dVw
 arP
 dXF
 qDr
@@ -59662,9 +59719,9 @@ skK
 skK
 skK
 afG
-xOl
+lsh
 arP
-apT
+pMC
 qDr
 xPg
 xPg


### PR DESCRIPTION
## About The Pull Request
Fixed some tiles that were exposed to space in the hangar near security on the bottom deck. No idea how they got there.
Also added some extra junk in the room and buttons for the shutters in that hangar.
Before:
![image](https://cdn.discordapp.com/attachments/887144169754222612/919438063963361331/unknown.png)
After:
![image](https://user-images.githubusercontent.com/6972764/145705332-bb936e64-221f-42d6-88bf-f566a6ffd09f.png)
Also fixed up some stairs leading to the mining shuttle having the wrong temperature set, causing an active turf at roundstart.

## How This Contributes To The Skyrat Roleplay Experience

No longer will a fair chunk of the bottom deck be exposed to space.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed some space tiles in maint on blueshift
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
