### PR TITLE
[NON-MODULAR] Re-adds the glowy TK head we removed because being able to have TK with absolutely zero trade-off is terrible in practice

### DIFF
--- a/code/datums/mutations/telekinesis.dm
+++ b/code/datums/mutations/telekinesis.dm
@@ -8,10 +8,10 @@
 	limb_req = BODY_ZONE_HEAD
 	instability = 30
 
-/*/datum/mutation/human/telekinesis/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
+/datum/mutation/human/telekinesis/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
 	..()
 	if(!(type in visual_indicators))
-		visual_indicators[type] = list(mutable_appearance('icons/effects/genetics.dmi', "telekinesishead", -MUTATIONS_LAYER)) */ // Skyrat edit -  Removes terminal glowy-head syndrome.
+		visual_indicators[type] = list(mutable_appearance('icons/effects/genetics.dmi', "telekinesishead", -MUTATIONS_LAYER))
 
 /datum/mutation/human/telekinesis/on_acquiring(mob/living/carbon/human/H)
 	. = ..()
@@ -24,10 +24,10 @@
 	if(.)
 		return
 	UnregisterSignal(H, COMSIG_MOB_ATTACK_RANGED)
-/* SKYRAT EDIT REMOVAL
+
 /datum/mutation/human/telekinesis/get_visual_indicator()
 	return visual_indicators[type][1]
-*/
+
 ///Triggers on COMSIG_MOB_ATTACK_RANGED. Usually handles stuff like picking up items at range.
 /datum/mutation/human/telekinesis/proc/on_ranged_attack(mob/source, atom/target)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request

Glowy head is back for TK because there's about a billion ways to be an asshole with telekinesis and if I can't tell who in a crowd of people just decided to make my chemical factory produce explosions, I don't know who to stick my orderlies on.

## How This Contributes To The Skyrat Roleplay Experience

Telekinesis with absolutely no way to know who has it for sure other than playing a guessing game and hoping you get the right person is bad, actually. It's Telekinesis. Strong as hell. Shouldn't have the like, downside removed.

The tradeoff for having TK is that you've got a bright glowy head aura so people know it's your fault when some telekinesis sparkles appear on the chemistry factory and it explodes 5 seconds later.

## Changelog

:cl:
add: Re-adds the glowy TK head we removed because being able to have TK with absolutely zero trade-off is terrible in practice.
/:cl:
