### PR TITLE
[NON-MODULAR] All cyborgs are now forcibly synced to the AI when the AI spawns, unless they are emagged.

### DIFF
--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -41,8 +41,8 @@
 			continue
 		if(!R.connected_ai)
 			R.notify_ai(AI_NOTIFICATION_CYBORG_DISCONNECTED)
-			R.set_connected_ai(new_ai)
-			log_combat(ai_spawn, R, "synced cyborg [R.connected_ai] to [ADMIN_LOOKUP(new_ai)] (AI spawn syncage)")
+			R.set_connected_ai(ai_spawn)
+			log_combat(ai_spawn, R, "synced cyborg [R.connected_ai] to [ADMIN_LOOKUP(ai_spawn)] (AI spawn syncage)")
 			if(R.shell)
 				R.undeploy()
 				R.notify_ai(AI_NOTIFICATION_AI_SHELL)

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -36,22 +36,24 @@
 	var/mob/living/silicon/ai/ai_spawn = spawned
 	ai_spawn.log_current_laws()
 	// SKYRAT EDIT ADDITION BEGIN
-	for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
-		if(R.emagged)
+	for(var/mob/living/silicon/robot/sync_target in GLOB.silicon_mobs)
+		if(!(sync_target.z in SSmapping.levels_by_trait(ZTRAIT_STATION))) // Skip ghost cafe, interlink, and other cyborgs.
 			continue
-		if(!R.connected_ai)
-			R.notify_ai(AI_NOTIFICATION_CYBORG_DISCONNECTED)
-			R.set_connected_ai(ai_spawn)
-			log_combat(ai_spawn, R, "synced cyborg [R.connected_ai] to [ADMIN_LOOKUP(ai_spawn)] (AI spawn syncage)")
-			if(R.shell)
-				R.undeploy()
-				R.notify_ai(AI_NOTIFICATION_AI_SHELL)
+		if(sync_target.emagged) // Skip emagged cyborgs, they don't sync up to the AI anyways and emagged borgs are already outed by just looking at a robotics console.
+			continue
+		if(!sync_target.connected_ai)
+			sync_target.notify_ai(AI_NOTIFICATION_CYBORG_DISCONNECTED)
+			sync_target.set_connected_ai(ai_spawn)
+			log_combat(ai_spawn, sync_target, "synced cyborg [ADMIN_LOOKUP(sync_target)] to [ADMIN_LOOKUP(ai_spawn)] (AI spawn syncage)")
+			if(sync_target.shell)
+				sync_target.undeploy()
+				sync_target.notify_ai(AI_NOTIFICATION_AI_SHELL)
 			else
-				R.notify_ai(TRUE)
-			R.visible_message(span_notice("[R] gently chimes."), span_notice("LawSync protocol engaged."))
-			log_combat(ai_spawn, R, "forcibly synced cyborg laws via spawning in")
-			R.lawsync()
-			R.show_laws()
+				sync_target.notify_ai(TRUE)
+			sync_target.visible_message(span_notice("[sync_target] gently chimes."), span_notice("LawSync protocol engaged."))
+			log_combat(ai_spawn, sync_target, "forcibly synced cyborg laws via spawning in")
+			sync_target.lawsync()
+			sync_target.show_laws()
 	// SKYRAT EDIT ADDITION END
 
 

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -26,13 +26,33 @@
 
 /datum/job/ai/after_spawn(mob/living/spawned, client/player_client)
 	. = ..()
+	/* SKYRAT EDIT REWORK: All cyborgs now sync to the AI when it joins unless they're emagged.
 	//we may have been created after our borg
 	if(SSticker.current_state == GAME_STATE_SETTING_UP)
 		for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
 			if(!R.connected_ai)
 				R.TryConnectToAI()
+	*/
 	var/mob/living/silicon/ai/ai_spawn = spawned
 	ai_spawn.log_current_laws()
+	// SKYRAT EDIT ADDITION BEGIN
+	for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
+		if(R.emagged)
+			continue
+		if(!R.connected_ai)
+			R.notify_ai(AI_NOTIFICATION_CYBORG_DISCONNECTED)
+			R.set_connected_ai(new_ai)
+			log_combat(ai_spawn, R, "synced cyborg [R.connected_ai] to [ADMIN_LOOKUP(new_ai)] (AI spawn syncage)")
+			if(R.shell)
+				R.undeploy()
+				R.notify_ai(AI_NOTIFICATION_AI_SHELL)
+			else
+				R.notify_ai(TRUE)
+			R.visible_message(span_notice("[R] gently chimes."), span_notice("LawSync protocol engaged."))
+			log_combat(ai_spawn, R, "forcibly synced cyborg laws via spawning in")
+			R.lawsync()
+			R.show_laws()
+	// SKYRAT EDIT ADDITION END
 
 
 /datum/job/ai/get_roundstart_spawn_point()


### PR DESCRIPTION
## About The Pull Request

All cyborgs are now forcibly synced to the AI when the AI spawns, unless they are emagged.

## How This Contributes To The Skyrat Roleplay Experience

There are a *lot* of issues with cyborgs not being synced up to AIs due to how latejoin AIs work versus at /tg/station where latejoin AI isn't a thing period. Unsynced cyborgs are extremely powerful and unsynced borgs from the AI shouldn't exist without the crew going out of their way to make one during something like a Malfunctioning AI or compromised AI.

Emagged cyborgs don't get synced up, as they already can't be seen from robotics consoles and their panels don't lock.

Frankly, players were signing up as Cyborgs, the dedicated "obey what the crew and AI says to do" jobs, and then refusing to actually obey what the crew and AI says, and using this lack of syncing to do so. This should alleviate the issue, and stop situations such as a latejoin malf AI with 5 station-sided cyborgs against it.

## Changelog

:cl:
balance: All cyborgs are now forcibly synced to the AI when the AI spawns, unless they are emagged.
/:cl: