### PR TITLE
[NON-MODULAR] Nerfs the medibot by increasing the time it takes per tend wounds.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -534,7 +534,7 @@
 			C.visible_message(span_danger("[src] is trying to tend the wounds of [patient]!"), \
 				span_userdanger("[src] is trying to tend your wounds!"))
 
-			if(do_mob(src, patient, 20)) //Slightly faster than default tend wounds, but does less HPS
+			if(do_mob(src, patient, 10 SECONDS)) //SKYRAT EDIT: Increased time as tradeoff for automated healing. ORIGINAL: if(do_mob(src, patient, 20))
 				if((get_dist(src, patient) <= 1) && (bot_mode_flags & BOT_MODE_ON) && assess_patient(patient))
 					var/healies = heal_amount
 					var/obj/item/storage/firstaid/FA = firstaid


### PR DESCRIPTION
## About The Pull Request

Medibots now require that you sit still for five* times as long in order to get the benefits of their healing - which, unupgraded, isn't very much per cycle. 

## How This Contributes To The Skyrat Roleplay Experience

The Luddites had a point. Automated and in many cases entirely sufficient healing from medibots has led to their being stacked up as a quick-and-easy replacement for quite a bit of interaction with medical or the pursuit of otherwise finite resources (chems, med supplies, healing plants, etc.) While it is okay for them to be resourceless, this shouldn't make them a dominant strategy for treating basic, non-wound damage - especially unupgraded. This PR seeks to incentivize more interaction with medical, cargo, or botany (at least their resources) as alternatives to the time you'll spend getting healing from medibots alone.

## Changelog

:cl:
balance: Medibot healing time increased by a factor of five.
/:cl:
