### PR TITLE
Fixes oversight in mateba cost

### DIFF
--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -29,7 +29,7 @@
 	name = "Unica Six Revolver"
 	desc = "A retro high-powered autorevolver typically used by officers of the New Russia military. Uses .357 ammo."
 	item = /obj/item/gun/ballistic/revolver/mateba
-	cost = 11
+	cost = 13
 	surplus = 50
 
 /datum/uplink_item/dangerous/holocarp


### PR DESCRIPTION
## About The Pull Request

Makes mateba 13 TC instead of 11

## How This Contributes To The Skyrat Roleplay Experience

It's literally a reskinned .357 with no mechanical changes. This is an oversight.

## Changelog
:cl:
fix: The mateba has had an uplink price increase to match the .357, as they're mechanically identical
/:cl: