### PR TITLE
final cme nerf

### DIFF
--- a/code/game/objects/items/devices/anomaly_neutralizer.dm
+++ b/code/game/objects/items/devices/anomaly_neutralizer.dm
@@ -23,11 +23,11 @@
 	//SKYRAT EDIT ADDITON START - CME
 	if(istype(target, /obj/effect/cme))
 		var/obj/effect/cme/C = target
+		if(C.neutralized)
+			return
 		to_chat(user, "<span class='danger'>The circuitry of [src] fries from the strain of neutralizing [C] causing you to absorb the shock!</span>")
 		do_sparks(5, FALSE, src)
 		electrocute_mob(user, get_area(src), src, 1, TRUE)
-		user.adjust_fire_stacks(5)
-		user.IgniteMob()
 		C.anomalyNeutralize()
 		qdel(src)
 	//SKYRAT EDIT END

--- a/modular_skyrat/modules/cme/code/_cme_defines.dm
+++ b/modular_skyrat/modules/cme/code/_cme_defines.dm
@@ -23,35 +23,35 @@ GLOBAL_LIST_INIT(cme_loot_list, list(
 #define CME_MINIMAL_LIGHT_RANGE_UPPER 10 //The highest range for the emp pulse light range.
 #define CME_MINIMAL_HEAVY_RANGE_LOWER 5 //The lowest range for the emp pulse heavy range.
 #define CME_MINIMAL_HEAVY_RANGE_UPPER 7 //The highest range for the emp pulse heavy range.
-#define CME_MINIMAL_FREQUENCY_LOWER 25 * 0.5 //The lower time range for cme bubbles to appear.
-#define CME_MINIMAL_FREQUENCY_UPPER 30 * 0.5 //The higher time range for cme bubbles to appear.
+#define CME_MINIMAL_FREQUENCY_LOWER 30 * 0.5 //The lower time range for cme bubbles to appear.
+#define CME_MINIMAL_FREQUENCY_UPPER 35 * 0.5 //The higher time range for cme bubbles to appear.
 #define CME_MINIMAL_BUBBLE_BURST_TIME 45 SECONDS //The time taken for a cme bubble to pop.
 #define CME_MINIMAL_START_LOWER 120 * 0.5 //The lowest amount of time for the event to start from the announcement. - Prep time
 #define CME_MINIMAL_START_UPPER 180 * 0.5 //The highest amount of time for the event to start from the announcement. - Prep time
-#define CME_MINIMAL_END 240 * 0.5 //The amount of time starting from THE MINIMAL START TIME for the event to end. - How long it actually lasts.
+#define CME_MINIMAL_END 60 * 0.5 //The amount of time starting from THE MINIMAL START TIME for the event to end. - How long it actually lasts.
 
 #define CME_MODERATE_LIGHT_RANGE_LOWER 10
 #define CME_MODERATE_LIGHT_RANGE_UPPER 15
 #define CME_MODERATE_HEAVY_RANGE_LOWER 7
 #define CME_MODERATE_HEAVY_RANGE_UPPER 10
-#define CME_MODERATE_FREQUENCY_LOWER 20 * 0.5
-#define CME_MODERATE_FREQUENCY_UPPER 25 * 0.5
+#define CME_MODERATE_FREQUENCY_LOWER 25 * 0.5
+#define CME_MODERATE_FREQUENCY_UPPER 30 * 0.5
 #define CME_MODERATE_BUBBLE_BURST_TIME 35 SECONDS
 #define CME_MODERATE_START_LOWER 120 * 0.5
 #define CME_MODERATE_START_UPPER 180 * 0.5
-#define CME_MODERATE_END 240 * 0.5
+#define CME_MODERATE_END 90 * 0.5
 
 
 #define CME_EXTREME_LIGHT_RANGE_LOWER 15
 #define CME_EXTREME_LIGHT_RANGE_UPPER 20
 #define CME_EXTREME_HEAVY_RANGE_LOWER 10
 #define CME_EXTREME_HEAVY_RANGE_UPPER 13
-#define CME_EXTREME_FREQUENCY_LOWER 15 * 0.5
-#define CME_EXTREME_FREQUENCY_UPPER 20 * 0.5
+#define CME_EXTREME_FREQUENCY_LOWER 20 * 0.5
+#define CME_EXTREME_FREQUENCY_UPPER 25 * 0.5
 #define CME_EXTREME_BUBBLE_BURST_TIME 25 SECONDS
 #define CME_EXTREME_START_LOWER 60 * 0.5
 #define CME_EXTREME_START_UPPER 120 * 0.5
-#define CME_EXTREME_END 300 * 0.5
+#define CME_EXTREME_END 120 * 0.5
 
 #define CME_ARMAGEDDON_LIGHT_RANGE_LOWER 25
 #define CME_ARMAGEDDON_LIGHT_RANGE_UPPER 30
@@ -62,4 +62,4 @@ GLOBAL_LIST_INIT(cme_loot_list, list(
 #define CME_ARMAGEDDON_BUBBLE_BURST_TIME 10 SECONDS
 #define CME_ARMAGEDDON_START_LOWER 60 * 0.5
 #define CME_ARMAGEDDON_START_UPPER 70 * 0.5
-#define CME_ARMAGEDDON_END 600 * 0.5
+#define CME_ARMAGEDDON_END 300 * 0.5

--- a/modular_skyrat/modules/cme/code/cme.dm
+++ b/modular_skyrat/modules/cme/code/cme.dm
@@ -15,10 +15,10 @@ Armageddon is truly going to fuck the station, use it sparingly.
 /datum/round_event_control/cme
 	name = "Coronal Mass Ejection: Random"
 	typepath = /datum/round_event/cme
-	weight = 5
-	min_players = 30
+	weight = 4
+	min_players = 60
 	max_occurrences = 1
-	earliest_start = 25 MINUTES
+	earliest_start = 30 MINUTES
 
 /datum/round_event/cme
 	startWhen = 6


### PR DESCRIPTION
## About The Pull Request

final nerf of the cme which I forgot to do
neutralising no longer ignites you
min freq lower 25 > 30
min freq upper 30 > 35
min end 4 mins > 1 min

moderate freq lower 25 > 30
moderate freq upper 30 > 35
moderate end 4 min > 1 min 30

extreme freq lower 15 > 20
extreme freq upper 20 > 25
extreme end 5 mins > 2 mins

min players 30 > 60
weight 5 > 4

these are so unbelievably easy to deal with now that if you complain about them, saying get good to you is entirely valid.

## Changelog

:cl:
add: CME has been nerfed
/:cl:

