### PR TITLE
[MODULAR-ISH] Removes paychecks from the game. Do bounties.

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -41,7 +41,6 @@ SUBSYSTEM_DEF(economy)
 	var/bounty_modifier = 1
 	///The modifier multiplied to the value of cargo pack prices.
 	var/pack_price_modifier = 1
-	var/fire_counter_for_paycheck = 0 //SKYRAT EDIT ADDITION
 
 	/// Total value of exported materials.
 	var/export_total = 0
@@ -70,7 +69,6 @@ SUBSYSTEM_DEF(economy)
 	dep_cards = SSeconomy.dep_cards
 
 /datum/controller/subsystem/economy/fire(resumed = 0)
-	fire_counter_for_paycheck++ //SKYRAT EDIT ADDITION
 	var/temporary_total = 0
 	var/delta_time = wait / (5 MINUTES)
 	departmental_payouts()
@@ -78,17 +76,9 @@ SUBSYSTEM_DEF(economy)
 	station_target_buffer += STATION_TARGET_BUFFER
 	for(var/account in bank_accounts_by_id)
 		var/datum/bank_account/bank_account = bank_accounts_by_id[account]
-		//SKYRAT EDIT ADDITION BEGIN
-		if(fire_counter_for_paycheck >= PAYCHECK_CYCLE_WAIT)
-			bank_account.payday(PAYCHECK_CYCLE_AMOUNT)
-		//SKYRAT EDIT ADDITION END
 		if(bank_account?.account_job && !ispath(bank_account.account_job))
 			temporary_total += (bank_account.account_job.paycheck * STARTING_PAYCHECKS)
 		station_total += bank_account.account_balance
-	//SKYRAT EDIT ADDITION BEGIN
-	if(fire_counter_for_paycheck >= PAYCHECK_CYCLE_WAIT) //30 minutes per each paycheck
-		fire_counter_for_paycheck = 0
-	//SKYRAT EDIT ADDITION END
 	station_target = max(round(temporary_total / max(bank_accounts_by_id.len * 2, 1)) + station_target_buffer, 1)
 	if(!HAS_TRAIT(SSeconomy, TRAIT_MARKET_CRASHING))
 		price_update()


### PR DESCRIPTION
## About The Pull Request

Removes paychecks from the game. Do bounties.

## How This Contributes To The Skyrat Roleplay Experience

Paychecks don't work well because most departmental budgets get emptied after one or two paychecks, especially for civilians because of the sheer volume of Assistants(125 a check doesn't seem like much, but it adds up with like 40 assistants, nickle and diming is real), and because the design of the economy upstream revolves around active income vs passive income. I'd be interested in instead upping the value of bounty payouts in replacement for the paychecks given the longer rounds, but seeing as Manuel holds up just fine economy-wise with 2 hour or longer rounds, I'm not convinced we need paychecks at that round length.

## Changelog

:cl:
del: Removes paychecks from the game. Do bounties.
/:cl:
