### PR TITLE
[MODULAR] Chapel Morgue fix on Icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
@@ -2694,7 +2694,7 @@
 /area/security/prison)
 "im" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 2
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
@@ -17027,7 +17027,7 @@
 /area/mine/living_quarters)
 "ZT" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 2
+	dir = 1
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured_half{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed the rotation of the morgues in IceBox chapel. They are currently rotated in a way that makes it impossible to put bodies in them, as they open up into a wall.

(This doesn't conflict with https://github.com/Skyrat-SS13/Skyrat-tg/pull/10104)

## How This Contributes To The Skyrat Roleplay Experience

Allows the chaplains morgue to _actually_ be functional 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Rotates the Chapels Morgue on Icebox to make it functional again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
