### PR TITLE
[MODULAR] Allows the L6-Saw to close its dust cover

### DIFF
--- a/modular_skyrat/master_files/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/modular_skyrat/master_files/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -215,7 +215,6 @@
 
 
 /obj/item/gun/ballistic/automatic/l6_saw/AltClick(mob/user)
-	. = ..()
 	if(!user.canUseTopic(src))
 		return
 	cover_open = !cover_open


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You couldn't close the dust cover on the l6 without removing the magazine (both required alt+click), now you cannot remove the magazine with alt+click (you can still remove it any of the other ways)

## How This Contributes To The Skyrat Roleplay Experience
Being able to reload your gun is good, bugs bad.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can now close the L6-Saw LMG's dust cover without removing the magazine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
