### PR TITLE
[MODULAR] Added Alt Jester related outfits

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_shoes.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_shoes.dm
@@ -164,6 +164,12 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 	name = "Dominant heels"
 	item_path = /obj/item/clothing/shoes/dominaheels
 
+// Job Restricted
+/datum/loadout_item/shoes/jester
+	name = "Jester shoes"
+	item_path = /obj/item/clothing/shoes/clown_shoes/jester
+	restricted_roles = list(JOB_CLOWN)
+
 //Families Gear
 /datum/loadout_item/shoes/deckers
 	name = "Deckers Shoes"

--- a/modular_skyrat/modules/modular_vending/code/autodrobe.dm
+++ b/modular_skyrat/modules/modular_vending/code/autodrobe.dm
@@ -42,6 +42,8 @@
 		/obj/item/clothing/under/suit/helltaker = 5,
 		/obj/item/clothing/under/suit/helltaker/skirt = 5,
 		/obj/item/clothing/suit/toggle/lawyer/white = 5,
+		/obj/item/clothing/head/jester/alt = 1,
+		/obj/item/clothing/under/rank/civilian/clown/jester/alt = 1,
 		)
 
 	skyrat_contraband = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR does two things:
1. It adds the alternative Jester outfit + hat to the Autodrobe
2. It adds the Jester clown shoes to the loadout, job restricted for clown

## How This Contributes To The Skyrat Roleplay Experience

Would give clown a better variation of outfits and please the clowncil (not my words)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Alternative Jester outfit and hat to Autodrobe
add: Jester shoes to the Loadout, job restricted for clown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
