### PR TITLE
Update event_overrides.dm

### DIFF
--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -12,7 +12,7 @@
  * To accomodate for much longer rounds.
  */
 /datum/controller/subsystem/events
-	frequency_lower = 5 MINUTES
+	frequency_lower = 8 MINUTES
 	frequency_upper = 15 MINUTES
 
 /**


### PR DESCRIPTION
Minimum event timer now 8 minutes instead of 5