### PR TITLE
[MODULAR] Makes adv-eguns once more crafted with eguns.

### DIFF
--- a/modular_skyrat/modules/crafting/crafting_skyrat.dm
+++ b/modular_skyrat/modules/crafting/crafting_skyrat.dm
@@ -1,17 +1,3 @@
-/datum/crafting_recipe/advancedegun
-	name = "Advanced Energy Gun"
-	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
-	result = /obj/item/gun/energy/e_gun/nuclear
-	reqs = list(/obj/item/gun/energy/laser = 1,
-				/obj/item/stack/cable_coil = 5,
-				/obj/item/weaponcrafting/gunkit/nuclear = 1)
-	time = 200
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-
-/datum/crafting_recipe/advancedegun/New()
-	..()
-	blacklist += subtypesof(/obj/item/gun/energy/laser)
 
 /datum/crafting_recipe/tempgun
 	name = "Temperature Gun"


### PR DESCRIPTION


## About The Pull Request
Deletes old modular code from when E-guns were removed, since they are now back.

## How This Contributes To The Skyrat Roleplay Experience

Makes the advanced egun, once more, be crafted with energy guns and not laser guns.

## Changelog



:cl:
del: Deletes modular adv-egun crafting recipe, making it once more crafted with energy guns, and not laser guns.
/:cl:

