### PR TITLE
 [modular][ready] woah old and new job titles, cool

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -73,7 +73,7 @@
 	alt_titles = list("Detective", "Forensic Technician", "Private Investigator", "Forensic Scientist")
 
 /datum/job/doctor
-	alt_titles = list("Medical Doctor", "Surgeon", "Nurse", "General Practitioner", "Medical Resident", "Physician") //originally "Podiatrist" was here, but well...no fun allowed
+	alt_titles = list("Medical Doctor", "Surgeon", "Nurse", "General Practitioner", "Medical Resident", "Physician") //in memorium to "Podiatrist" , killed in it's cradle
 
 /datum/job/engineering_guard //see science guard
 

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -13,7 +13,7 @@
 	alt_titles = list("AI", "Station Intelligence", "Automated Overseer")
 
 /datum/job/assistant
-	alt_titles = list("Assistant", "Civilian", "Tourist", "Businessman", "Trader", "Entertainer", "Off-Duty Staff")
+	alt_titles = list("Assistant", "Civilian", "Tourist", "Businessman", "Trader", "Entertainer", "Freelancer", "Off-Duty Staff")
 
 /datum/job/atmospheric_technician
 	alt_titles = list("Atmospheric Technician", "Life Support Technician", "Emergency Fire Technician")
@@ -22,17 +22,16 @@
 	alt_titles = list("Salon Manager", "Salon Technician", "Stylist", "Colorist")
 
 /datum/job/bartender
-	alt_titles = list("Bartender", "Mixologist")
+	alt_titles = list("Bartender", "Mixologist", "Barkeeper")
 
 /datum/job/blueshield
 	alt_titles = list("Blueshield", "Command Bodyguard", "Executive Protection Agent")
-
 
 /datum/job/botanist
 	alt_titles = list("Botanist", "Hydroponicist", "Gardener", "Botanical Researcher", "Herbalist")
 
 /datum/job/bouncer
-
+	alt_titles = list("Bouncer", "Doorman", "Door Supervisor")
 
 /datum/job/brigoff
 	alt_titles = list("Corrections Officer", "Brig Officer", "Prison Guard")
@@ -44,16 +43,16 @@
 	alt_titles = list("Cargo Technician", "Deck Worker", "Mailman")
 
 /datum/job/chaplain
-	alt_titles = list("Chaplain", "Priest", "Preacher")
+	alt_titles = list("Chaplain", "Priest", "Preacher", "Imam", "Rabbi", "Monk")
 
 /datum/job/chemist
 	alt_titles = list("Chemist", "Pharmacist", "Pharmacologist")
 
 /datum/job/chief_engineer
-	alt_titles = list("Chief Engineer", "Engineering Foreman")
+	alt_titles = list("Chief Engineer", "Engineering Foreman", "Head of Engineering")
 
 /datum/job/chief_medical_officer
-	alt_titles = list("Chief Medical Officer", "Medical Director")
+	alt_titles = list("Chief Medical Officer", "Medical Director", "Head of Medical")
 
 /datum/job/clown
 	alt_titles = list("Clown", "Jester")
@@ -65,7 +64,7 @@
 	alt_titles = list("Curator", "Librarian", "Journalist", "Archivist")
 
 /datum/job/customs_agent
-
+	alt_titles = list("Customs Agent", "Customs Officer", "Cargo Watchman", "Cargo Officer")
 
 /datum/job/cyborg
 	alt_titles = list("Cyborg", "Robot", "Android")
@@ -74,10 +73,10 @@
 	alt_titles = list("Detective", "Forensic Technician", "Private Investigator", "Forensic Scientist")
 
 /datum/job/doctor
-	alt_titles = list("Medical Doctor", "Surgeon", "Nurse")
+	alt_titles = list("Medical Doctor", "Surgeon", "Nurse", "General Practitioner", "Medical Resident", "Physician", "Podiatrist")
 
 /datum/job/engineering_guard
-
+	alt_titles = list("Engineering Guard", "Construction Guard", "Engineering Watchman")
 
 /datum/job/expeditionary_trooper
 
@@ -89,13 +88,13 @@
 	alt_titles = list("Head of Personnel", "Executive Officer", "Employment Officer", "Crew Supervisor")
 
 /datum/job/head_of_security
-	alt_titles = list("Head of Security", "Security Commander")
+	alt_titles = list("Head of Security", "Security Commander", "Chief Constable", "Chief of Security", "Sheriff")
 
 /datum/job/janitor
 	alt_titles = list("Janitor", "Custodian", "Custodial Technicial", "Sanitation Technician", "Maid")
 
 /datum/job/lawyer
-	alt_titles = list("Lawyer", "Internal Affairs Agent", "Human Resources Agent")
+	alt_titles = list("Lawyer", "Internal Affairs Agent", "Human Resources Agent", "Defence Attorney", "Public Defender", "Barrister", "Prosecutor")
 
 /datum/job/mime
 	alt_titles = list("Mime", "Pantomimist")
@@ -104,7 +103,7 @@
 	alt_titles = list("Nanotrasen Representative", "Nanotrasen Diplomat", "Central Command Representative")
 
 /datum/job/orderly
-
+	alt_titles = list("Orderly", "Medical Attendant", "Ward Officer")
 
 /datum/job/paramedic
 	alt_titles = list("Paramedic", "Emergency Medical Technician", "Search and Rescue Technician")
@@ -116,7 +115,7 @@
 	alt_titles = list("Psychologist", "Psychiatrist", "Therapist", "Counsellor")
 
 /datum/job/quartermaster
-	alt_titles = list("Quartermaster", "Deck Chief", "Cargo Foreman")
+	alt_titles = list("Quartermaster", "Deck Chief", "Cargo Foreman", "Head of Cargo", "Chief Transport Officer")
 
 /datum/job/research_director
 	alt_titles = list("Research Director", "Silicon Administrator", "Lead Researcher", "Biorobotics Director", "Research Supervisor", "Chief Science Officer")
@@ -125,7 +124,7 @@
 	alt_titles = list("Roboticist", "Biomechanical Engineer", "Mechatronic Engineer")
 
 /datum/job/science_guard
-
+	alt_titles = list("Science Guard", "Science Officer", "Science Watchman")
 
 /datum/job/scientist
 	alt_titles = list(
@@ -146,16 +145,16 @@
 	alt_titles = list("Security Officer", "Security Operative", "Peacekeeper")
 
 /datum/job/security_sergeant
-	alt_titles = list("Security Sergeant", "Security Squad Leader", "Security Task Force Leader", "Security Fireteam Leader")
+	alt_titles = list("Security Sergeant", "Security Squad Leader", "Security Task Force Leader", "Security Fireteam Leader", "Security Enforcer") //why are these all so edgy, you're a mall cop
 
 /datum/job/shaft_miner
 	alt_titles = list("Shaft Miner", "Excavator")
 
 /datum/job/station_engineer
-	alt_titles = list("Station Engineer", "Emergency Damage Control Technician", "Electrician", "Engine Technician", "EVA Technician")
+	alt_titles = list("Station Engineer", "Emergency Damage Control Technician", "Electrician", "Engine Technician", "EVA Technician", "Engineer")
 
 /datum/job/virologist
 	alt_titles = list("Virologist", "Pathologist")
 
 /datum/job/warden
-	alt_titles = list("Warden", "Brig Sergeant", "Dispatch Officer")
+	alt_titles = list("Warden", "Brig Sergeant", "Dispatch Officer", "Brig Governor", "Jailer")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -31,7 +31,7 @@
 	alt_titles = list("Botanist", "Hydroponicist", "Gardener", "Botanical Researcher", "Herbalist")
 
 /datum/job/bouncer
-	alt_titles = list("Bouncer", "Doorman", "Door Supervisor")
+	alt_titles = list("Bouncer", "Service Guard") //was originally Doorman, Door Supervisor here, goof request
 
 /datum/job/brigoff
 	alt_titles = list("Corrections Officer", "Brig Officer", "Prison Guard")
@@ -64,7 +64,7 @@
 	alt_titles = list("Curator", "Librarian", "Journalist", "Archivist")
 
 /datum/job/customs_agent
-	alt_titles = list("Customs Agent", "Customs Officer", "Cargo Watchman", "Cargo Officer")
+	alt_titles = list("Customs Agent", "Customs Guard", "Cargo Guard") //originally had cargo watchman, goof request to remove it
 
 /datum/job/cyborg
 	alt_titles = list("Cyborg", "Robot", "Android")
@@ -75,8 +75,8 @@
 /datum/job/doctor
 	alt_titles = list("Medical Doctor", "Surgeon", "Nurse", "General Practitioner", "Medical Resident", "Physician", "Podiatrist")
 
-/datum/job/engineering_guard
-	alt_titles = list("Engineering Guard", "Construction Guard", "Engineering Watchman")
+/datum/job/engineering_guard //see science guard
+
 
 /datum/job/expeditionary_trooper
 
@@ -103,7 +103,7 @@
 	alt_titles = list("Nanotrasen Representative", "Nanotrasen Diplomat", "Central Command Representative")
 
 /datum/job/orderly
-	alt_titles = list("Orderly", "Medical Attendant", "Ward Officer")
+	alt_titles = list("Orderly", "Medical Guard") //ward assistant is a real term, but confusion etc etc, originally was medical attendant as well, but goof request
 
 /datum/job/paramedic
 	alt_titles = list("Paramedic", "Emergency Medical Technician", "Search and Rescue Technician")
@@ -123,8 +123,8 @@
 /datum/job/roboticist
 	alt_titles = list("Roboticist", "Biomechanical Engineer", "Mechatronic Engineer")
 
-/datum/job/science_guard
-	alt_titles = list("Science Guard", "Science Officer", "Science Watchman")
+/datum/job/science_guard //none for them, goof request :(
+
 
 /datum/job/scientist
 	alt_titles = list(
@@ -157,4 +157,4 @@
 	alt_titles = list("Virologist", "Pathologist")
 
 /datum/job/warden
-	alt_titles = list("Warden", "Brig Sergeant", "Dispatch Officer", "Brig Governor", "Jailer")
+	alt_titles = list("Warden", "Brig Sergeant", "Dispatch Officer", "Brig Governor", "Jailer", "Gaoler")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -127,7 +127,7 @@
 
 
 /datum/job/scientist
-	alt_titles = list("Scientist", "Circuitry Designer","Xenobiologist", "Cytologist", "Plasma Researcher", "Anomalist", "Lab Technician", "Theoretical Physicist")
+	alt_titles = list("Scientist", "Circuitry Designer","Xenobiologist", "Cytologist", "Plasma Researcher", "Anomalist", "Lab Technician", "Theoretical Physicist", "Ordnance Technician")
 
 /datum/job/security_medic
 	alt_titles = list("Security Medic", "Field Medic", "Security Corpsman", "Brig Physician")
@@ -142,7 +142,7 @@
 	alt_titles = list("Shaft Miner", "Excavator", "Spelunker", "Drill Technician", "Prospector")
 
 /datum/job/station_engineer
-	alt_titles = list("Station Engineer", "Emergency Damage Control Technician", "Electrician", "Engine Technician", "EVA Technician", "Engineer")
+	alt_titles = list("Station Engineer", "Emergency Damage Control Technician", "Electrician", "Engine Technician", "EVA Technician", "Engineer", "Mechanic")
 
 /datum/job/virologist
 	alt_titles = list("Virologist", "Pathologist")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -115,7 +115,7 @@
 	alt_titles = list("Psychologist", "Psychiatrist", "Therapist", "Counsellor")
 
 /datum/job/quartermaster
-	alt_titles = list("Quartermaster", "Deck Chief", "Cargo Foreman", "Head of Cargo", "Chief Transport Officer")
+	alt_titles = list("Quartermaster", "Deck Chief", "Cargo Foreman", "Head of Cargo", "Chief Requisition Officer")
 
 /datum/job/research_director
 	alt_titles = list("Research Director", "Silicon Administrator", "Lead Researcher", "Biorobotics Director", "Research Supervisor", "Chief Science Officer")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -73,7 +73,7 @@
 	alt_titles = list("Detective", "Forensic Technician", "Private Investigator", "Forensic Scientist")
 
 /datum/job/doctor
-	alt_titles = list("Medical Doctor", "Surgeon", "Nurse", "General Practitioner", "Medical Resident", "Physician") //in memorium to "Podiatrist" , killed in it's cradle
+	alt_titles = list("Medical Doctor", "Surgeon", "Nurse", "General Practitioner", "Medical Resident", "Physician")
 
 /datum/job/engineering_guard //see orderly
 

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -73,7 +73,7 @@
 	alt_titles = list("Detective", "Forensic Technician", "Private Investigator", "Forensic Scientist")
 
 /datum/job/doctor
-	alt_titles = list("Medical Doctor", "Surgeon", "Nurse", "General Practitioner", "Medical Resident", "Physician", "Podiatrist")
+	alt_titles = list("Medical Doctor", "Surgeon", "Nurse", "General Practitioner", "Medical Resident", "Physician") //originally "Podiatrist" was here, but well...no fun allowed
 
 /datum/job/engineering_guard //see science guard
 

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -75,7 +75,7 @@
 /datum/job/doctor
 	alt_titles = list("Medical Doctor", "Surgeon", "Nurse", "General Practitioner", "Medical Resident", "Physician") //in memorium to "Podiatrist" , killed in it's cradle
 
-/datum/job/engineering_guard //see science guard
+/datum/job/engineering_guard //see orderly
 
 
 /datum/job/expeditionary_trooper

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -127,7 +127,17 @@
 
 
 /datum/job/scientist
-	alt_titles = list("Scientist", "Circuitry Designer","Xenobiologist", "Cytologist", "Plasma Researcher", "Anomalist", "Lab Technician", "Theoretical Physicist", "Ordnance Technician")
+	alt_titles = list(
+		"Scientist",
+		"Circuitry Designer",
+		"Xenobiologist",
+		"Cytologist",
+		"Plasma Researcher",
+		"Anomalist",
+		"Lab Technician",
+		"Theoretical Physicist",
+		"Ordnance Technician"
+	)
 
 /datum/job/security_medic
 	alt_titles = list("Security Medic", "Field Medic", "Security Corpsman", "Brig Physician")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -79,7 +79,7 @@
 
 
 /datum/job/expeditionary_trooper
-
+	alt_titles = list("Expeditionary Trooper", "Vanguard Operative", "Vanguard Pointman", "Expeditionary Field Medic", "Vanguard Marksman", "Expeditionary Combat Technician") //i know vanguard is dead, i'm adding this because i want, in some small way, for my friend, cheshify's hard work and effort to be remembered, even in a tiny way
 
 /datum/job/geneticist
 	alt_titles = list("Geneticist", "Mutation Researcher")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -31,7 +31,7 @@
 	alt_titles = list("Botanist", "Hydroponicist", "Gardener", "Botanical Researcher", "Herbalist")
 
 /datum/job/bouncer
-	alt_titles = list("Bouncer", "Service Guard") //was originally Doorman, Door Supervisor here, goof request
+	alt_titles = list("Bouncer", "Service Guard")
 
 /datum/job/brigoff
 	alt_titles = list("Corrections Officer", "Brig Officer", "Prison Guard")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -127,16 +127,7 @@
 
 
 /datum/job/scientist
-	alt_titles = list(
-    "Scientist",
-    "Circuitry Designer",
-    "Xenobiologist",
-    "Cytologist",
-    "Plasma Researcher",
-    "Anomalist",
-    "Lab Technician",
-    "Theoretical Physicist",
-	)
+	alt_titles = list("Scientist", "Circuitry Designer","Xenobiologist", "Cytologist", "Plasma Researcher", "Anomalist", "Lab Technician", "Theoretical Physicist")
 
 /datum/job/security_medic
 	alt_titles = list("Security Medic", "Field Medic", "Security Corpsman", "Brig Physician")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -158,4 +158,4 @@
 	alt_titles = list("Virologist", "Pathologist")
 
 /datum/job/warden
-	alt_titles = list("Warden", "Brig Sergeant", "Dispatch Officer", "Brig Governor", "Jailer", "Brig Gaoler")
+	alt_titles = list("Warden", "Brig Sergeant", "Dispatch Officer", "Brig Governor", "Jailer")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -103,7 +103,7 @@
 	alt_titles = list("Nanotrasen Representative", "Nanotrasen Diplomat", "Central Command Representative")
 
 /datum/job/orderly
-	alt_titles = list("Orderly", "Medical Guard") //goof requested that alt dept guards titles be kept to [department] guard
+	alt_titles = list("Orderly", "Medical Guard") // departmental guards alt-titles should be kept to [department] guard to avoid confusion
 
 /datum/job/paramedic
 	alt_titles = list("Paramedic", "Emergency Medical Technician", "Search and Rescue Technician")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -103,7 +103,7 @@
 	alt_titles = list("Nanotrasen Representative", "Nanotrasen Diplomat", "Central Command Representative")
 
 /datum/job/orderly
-	alt_titles = list("Orderly", "Medical Guard") //ward assistant is a real term, but confusion etc etc, originally was medical attendant as well, but goof request
+	alt_titles = list("Orderly", "Medical Guard") //goof requested that alt dept guards titles be kept to [department] guard
 
 /datum/job/paramedic
 	alt_titles = list("Paramedic", "Emergency Medical Technician", "Search and Rescue Technician")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -13,7 +13,7 @@
 	alt_titles = list("AI", "Station Intelligence", "Automated Overseer")
 
 /datum/job/assistant
-	alt_titles = list("Assistant", "Civilian", "Tourist", "Businessman", "Trader", "Entertainer", "Freelancer", "Off-Duty Staff")
+	alt_titles = list("Assistant", "Civilian", "Tourist", "Businessman", "Businesswoman", "Trader", "Entertainer", "Freelancer", "Off-Duty Staff")
 
 /datum/job/atmospheric_technician
 	alt_titles = list("Atmospheric Technician", "Life Support Technician", "Emergency Fire Technician")
@@ -43,7 +43,7 @@
 	alt_titles = list("Cargo Technician", "Deck Worker", "Mailman")
 
 /datum/job/chaplain
-	alt_titles = list("Chaplain", "Priest", "Preacher", "Imam", "Rabbi", "Monk")
+	alt_titles = list("Chaplain", "Priest", "Preacher", "Reverend", "Oracle", "Pontifex", "Magister", "High Priest", "Imam", "Rabbi", "Monk") //i would add OT III but honestly, thats way too specific
 
 /datum/job/chemist
 	alt_titles = list("Chemist", "Pharmacist", "Pharmacologist")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -109,7 +109,7 @@
 	alt_titles = list("Paramedic", "Emergency Medical Technician", "Search and Rescue Technician")
 
 /datum/job/prisoner
-	alt_titles = list("Prisoner", "Minimum Security Prisoner", "Maximum Security Prisoner", "SuperMax Security Prisoner", "Protective Custody Prisoner")
+	alt_titles = list("Prisoner", "Minimum Security Prisoner", "Maximum Security Prisoner", "SuperMax Security Prisoner", "Protective Custody Prisoner", "Convict", "Felon", "Inmate")
 
 /datum/job/psychologist
 	alt_titles = list("Psychologist", "Psychiatrist", "Therapist", "Counsellor")
@@ -148,7 +148,7 @@
 	alt_titles = list("Security Sergeant", "Security Squad Leader", "Security Task Force Leader", "Security Fireteam Leader", "Security Enforcer") //why are these all so edgy, you're a mall cop
 
 /datum/job/shaft_miner
-	alt_titles = list("Shaft Miner", "Excavator")
+	alt_titles = list("Shaft Miner", "Excavator", "Spelunker", "Drill Technician", "Prospector")
 
 /datum/job/station_engineer
 	alt_titles = list("Station Engineer", "Emergency Damage Control Technician", "Electrician", "Engine Technician", "EVA Technician", "Engineer")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -64,7 +64,7 @@
 	alt_titles = list("Curator", "Librarian", "Journalist", "Archivist")
 
 /datum/job/customs_agent
-	alt_titles = list("Customs Agent", "Customs Guard", "Cargo Guard") //originally had cargo watchman, goof request to remove it
+	alt_titles = list("Customs Agent", "Customs Guard", "Cargo Guard")
 
 /datum/job/cyborg
 	alt_titles = list("Cyborg", "Robot", "Android")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -142,7 +142,7 @@
 	alt_titles = list("Shaft Miner", "Excavator", "Spelunker", "Drill Technician", "Prospector")
 
 /datum/job/station_engineer
-	alt_titles = list("Station Engineer", "Emergency Damage Control Technician", "Electrician", "Engine Technician", "EVA Technician", "Engineer", "Mechanic")
+	alt_titles = list("Station Engineer", "Emergency Damage Control Technician", "Electrician", "Engine Technician", "EVA Technician", "Mechanic")
 
 /datum/job/virologist
 	alt_titles = list("Virologist", "Pathologist")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -148,4 +148,4 @@
 	alt_titles = list("Virologist", "Pathologist")
 
 /datum/job/warden
-	alt_titles = list("Warden", "Brig Sergeant", "Dispatch Officer", "Brig Governor", "Jailer", "Gaoler")
+	alt_titles = list("Warden", "Brig Sergeant", "Dispatch Officer", "Brig Governor", "Jailer", "Brig Gaoler")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -13,7 +13,7 @@
 	alt_titles = list("AI", "Station Intelligence", "Automated Overseer")
 
 /datum/job/assistant
-	alt_titles = list("Assistant", "Civilian", "Tourist", "Businessman", "Businesswoman", "Trader", "Entertainer", "Freelancer", "Off-Duty Staff")
+	alt_titles = list("Assistant", "Civilian", "Tourist", "Businessman", "Businesswoman", "Trader", "Entertainer", "Freelancer", "Artist", "Off-Duty Staff")
 
 /datum/job/atmospheric_technician
 	alt_titles = list("Atmospheric Technician", "Life Support Technician", "Emergency Fire Technician")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -136,7 +136,8 @@
 		"Anomalist",
 		"Lab Technician",
 		"Theoretical Physicist",
-		"Ordnance Technician"
+		"Ordnance Technician",
+		"Xenoarchaeologist",
 	)
 
 /datum/job/security_medic

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -79,7 +79,7 @@
 
 
 /datum/job/expeditionary_trooper
-	alt_titles = list("Expeditionary Trooper", "Vanguard Operative", "Vanguard Pointman", "Expeditionary Field Medic", "Vanguard Marksman", "Expeditionary Combat Technician") //i know vanguard is dead, i'm adding this because i want, in some small way, for my friend, cheshify's hard work and effort to be remembered, even in a tiny way
+	alt_titles = list("Expeditionary Trooper", "Vanguard Operative", "Vanguard Pointman", "Expeditionary Field Medic", "Vanguard Marksman", "Expeditionary Combat Technician")
 
 /datum/job/geneticist
 	alt_titles = list("Geneticist", "Mutation Researcher")

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -123,7 +123,7 @@
 /datum/job/roboticist
 	alt_titles = list("Roboticist", "Biomechanical Engineer", "Mechatronic Engineer")
 
-/datum/job/science_guard //none for them, goof request :(
+/datum/job/science_guard // See ordlerly
 
 
 /datum/job/scientist


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

i added new job titles

## How This Contributes To The Skyrat Roleplay Experience

i know vanguard is dead, i'm adding them because i want, in some small way, for my friend, cheshify's hard work and effort to be remembered, even in a tiny way
I am not allowed to put that in the code, so its here


a lot of these were old ones that goof forgot, sheriff is one I love
a lot of the sec stuff is me fighting against the ever existent y*nk and their incorrect terms
lawyer got some titles to better segregate what kinda lawyer they are
priests were given more terms for other religions outside of Christianity 
its more flavour

also the departmental guards got alt titles, also taken from real world stuff related to their jobs
edit: they did, goof requested them removed, I'm sorry

quite a few heads got "chief officer" and "head of" titles for parity because brain like patterns :)
medical got more titles for stuff, with medical resident being "please help me I am new"

## Changelog
:cl:
expansion: New and old job titles, far too many to list, please see pr #10187 for the full list.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
