### PR TITLE
PDAs now visible_message and balloon alert when you send a message. No more silently calling backup to avoid getting shot by antags for calling backup like a coward!

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -811,6 +811,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	if(prob(1))
 		message += "\nSent from my PDA"
+	// SKYRAT EDIT BEGIN - PDA messages show a visible message, to comply with CI policy on calling for backup.
+	user.visible_message(span_notice("[user] presses some buttons on [user.p_their()] [src]."), span_notice("You press some buttons on your [src]."))
+	// SKYRAT EDIT END
 	// Send the signal
 	var/list/string_targets = list()
 	for (var/obj/item/pda/P in targets)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -813,6 +813,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		message += "\nSent from my PDA"
 	// SKYRAT EDIT BEGIN - PDA messages show a visible message, to comply with CI policy on calling for backup.
 	user.visible_message(span_notice("[user] presses some buttons on [user.p_their()] [src]."), span_notice("You press some buttons on your [src]."))
+	user.balloon_alert_to_viewers("sent a PDA message")
 	// SKYRAT EDIT END
 	// Send the signal
 	var/list/string_targets = list()


### PR DESCRIPTION
## About The Pull Request
PDAs now visible_message and balloon alert to all viewers when you send a message.

## How This Contributes To The Skyrat Roleplay Experience

CI policy allows for antagonists to immediately engage upon hearing any indication that you called for backup.

Clever players were shutting the ringer off on their PDAs and just PDAing security or coworkers whenever they ran into antags for backup so that the antagonist wouldn't know and wouldn't be able to act on them calling backup.

As a reminder to players engaging in mechanics, the second someone calls for backup, or does something that could be potentially calling for backup(ie. talks on the radio and makes a sound, PDAs someone and you see the message that they pressed buttons on their PDA, screams into a walkie talkie or radio on the wall), _**you can immediately attack them. You don't need to press the CI button and wait ~~3~~ 7 seconds holy shit, they engaged mechanics by calling backup and you can immediately start kicking their ass**_

## Changelog
:cl:
qol: PDAs now visible_message and balloon alert to all viewers when you send a message. No more silently calling backup to avoid getting shot by antags for calling backup like a coward!
/:cl:
