### PR TITLE
Advanced shuttle edges now have transparency

### DIFF
--- a/modular_skyrat/modules/advanced_shuttles/code/turfs.dm
+++ b/modular_skyrat/modules/advanced_shuttles/code/turfs.dm
@@ -15,10 +15,26 @@
 	smoothing_groups = null
 	canSmoothWith = null
 
-/*
-/turf/closed/wall/mineral/titanium/shuttle_wall/Initialize(mapload)
-UNDERLAYS ARE BROKEN, PLEASE SOMEONE HELP FOR I CANNOT FIX THEM
-*/
+/turf/closed/wall/mineral/titanium/shuttle_wall/AfterChange(flags, oldType)
+	. = ..()
+	// Manually add space underlay, in a way similar to turf_z_transparency,
+	// but we actually show the old content of the same z-level, as desired for shuttles
+
+	var/turf/underturf_path
+
+	// Grab previous turf icon
+	if(!ispath(oldType, /turf/closed/wall/mineral/titanium/shuttle_wall))
+		underturf_path = oldType
+	else
+		// Else use whatever SSmapping tells us, like transparent open tiles do
+		underturf_path = SSmapping.level_trait(z, ZTRAIT_BASETURF) || /turf/open/space
+
+	var/mutable_appearance/underlay_appearance = mutable_appearance(
+		initial(underturf_path.icon),
+		initial(underturf_path.icon_state),
+		layer = TURF_LAYER - 0.02, plane = initial(underturf_path.plane))
+	underlay_appearance.appearance_flags = RESET_ALPHA | RESET_COLOR
+	underlays += underlay_appearance
 
 /turf/closed/wall/mineral/titanium/shuttle_wall/window
 	opacity = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For some reason the issue was never reported, but previously, the advanced_shuttle edge tiles had a black background as they had no code to add space parallax / whatever tile is supposed to appear underneath.

This PR adds whatever tiles would be there before the shuttle moved as an underlay, solving that graphical issue. As a fallback if a shuttle shifts around or something, it renders the z-levels base tile.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

The shuttles look better.

### Click to view video:
[![Video](https://i.imgur.com/MgLBzUt.png)](https://i.imgur.com/MgLBzUt.mp4)

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
fix: Advanced shuttle tiles now show the underlying environment on the transparent parts instead of a black void.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
