### PR TITLE
[FUCK] Fixes ghost role spawners on maps

### DIFF
--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/IceRuins/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/IceRuins/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -585,7 +585,7 @@
 /area/ruin/syndicate_lava_base/dormitories)
 "ex" = (
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -698,7 +698,7 @@
 /area/ruin/syndicate_lava_base/cargo)
 "gn" = (
 /obj/machinery/light/directional/west,
-/obj/effect/mob_spawn/human/lavaland_syndicate/shaftminer/ice{
+/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/shaftminer/ice{
 	dir = 4
 	},
 /turf/open/floor/iron/smooth_edge{
@@ -790,7 +790,7 @@
 "gZ" = (
 /obj/machinery/griddle,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -835,7 +835,6 @@
 	onstation = 0
 	},
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/cafeteria,
@@ -1222,7 +1221,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/white,
@@ -1337,13 +1336,13 @@
 "nx" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm/directional/west{
-	dir = 4;
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/plating/grass,
 /area/ruin/syndicate_lava_base/bar)
 "ny" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate/deckofficer{
+/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/deckofficer{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1758,7 +1757,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west{
-	dir = 4;
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -1898,7 +1897,7 @@
 	},
 /obj/machinery/camera/xray{
 	c_tag = "Xenobio East";
-	dir = 8;
+	dir = 4;
 	network = list("fsci")
 	},
 /turf/open/floor/engine,
@@ -2311,7 +2310,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -2439,7 +2438,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -2472,7 +2471,7 @@
 /area/ruin/syndicate_lava_base/medbay)
 "Cc" = (
 /obj/machinery/light/directional/south,
-/obj/effect/mob_spawn/human/lavaland_syndicate/ice{
+/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/ice{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -2548,7 +2547,7 @@
 /area/ruin/syndicate_lava_base/engineering)
 "CN" = (
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -2718,7 +2717,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east{
-	dir = 8;
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_corner{
@@ -3181,7 +3180,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/east{
-	dir = 8;
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -3339,7 +3338,6 @@
 /obj/structure/table/glass,
 /obj/item/stock_parts/cell/bluespace,
 /obj/machinery/airalarm/directional/west{
-	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -3553,7 +3551,7 @@
 	},
 /obj/machinery/camera/xray{
 	c_tag = "Xenobio West";
-	dir = 4;
+	dir = 8;
 	network = list("fsci")
 	},
 /turf/open/floor/engine,
@@ -3661,7 +3659,7 @@
 /area/ruin/syndicate_lava_base/cargo)
 "Qq" = (
 /obj/machinery/light/directional/east,
-/obj/effect/mob_spawn/human/lavaland_syndicate/ice{
+/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/ice{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -3754,7 +3752,7 @@
 /area/ruin/syndicate_lava_base/testlab)
 "RN" = (
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -3913,7 +3911,6 @@
 /area/ruin/syndicate_lava_base/engineering)
 "TI" = (
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -4019,7 +4016,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/suit_storage_unit/syndicate,
 /obj/machinery/airalarm/directional/east{
-	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -4112,7 +4108,7 @@
 "VW" = (
 /obj/machinery/suit_storage_unit/mining,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -4311,7 +4307,7 @@
 /area/ruin/syndicate_lava_base/cargo)
 "Yl" = (
 /obj/machinery/light/directional/north,
-/obj/effect/mob_spawn/human/lavaland_syndicate/ice,
+/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/ice,
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/dormitories)
 "Yo" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -23,7 +23,7 @@
 /turf/closed/mineral/random/volcanic,
 /area/lavaland/surface/outdoors)
 "as" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate/deckofficer{
+/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/deckofficer{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -527,7 +527,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -540,7 +540,6 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /obj/machinery/vending/dorms{
@@ -554,7 +553,7 @@
 /area/ruin/syndicate_lava_base/cargo)
 "gd" = (
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -1034,7 +1033,6 @@
 /area/ruin/syndicate_lava_base/medbay)
 "ml" = (
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -1345,7 +1343,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west{
-	dir = 4;
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -1353,7 +1351,7 @@
 "pR" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm/directional/west{
-	dir = 4;
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/plating/grass,
@@ -1379,7 +1377,7 @@
 "qb" = (
 /obj/machinery/suit_storage_unit/mining,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -1393,7 +1391,7 @@
 /area/ruin/syndicate_lava_base/testlab)
 "qj" = (
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -2002,7 +2000,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/white,
@@ -2229,7 +2227,7 @@
 "AU" = (
 /obj/machinery/griddle,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -2289,7 +2287,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -2360,7 +2358,7 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/testlab)
 "Co" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate/shaftminer{
+/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/shaftminer{
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
@@ -2663,7 +2661,7 @@
 /obj/structure/table/glass,
 /obj/item/stock_parts/cell/bluespace,
 /obj/machinery/airalarm/directional/west{
-	dir = 4;
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -3085,7 +3083,7 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "Lb" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate{
+/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate{
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
@@ -3240,7 +3238,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/suit_storage_unit/syndicate,
 /obj/machinery/airalarm/directional/east{
-	dir = 8;
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -3435,7 +3433,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/east{
-	dir = 8;
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -3528,7 +3526,6 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east{
-	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_corner{
@@ -3684,7 +3681,7 @@
 /area/ruin/syndicate_lava_base/bar)
 "Sh" = (
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -3795,7 +3792,7 @@
 	},
 /obj/machinery/camera/xray{
 	c_tag = "Xenobio West";
-	dir = 4;
+	dir = 8;
 	network = list("fsci")
 	},
 /turf/open/floor/engine,
@@ -4143,7 +4140,7 @@
 	},
 /obj/machinery/camera/xray{
 	c_tag = "Xenobio East";
-	dir = 8;
+	dir = 4;
 	network = list("fsci")
 	},
 /turf/open/floor/engine,
@@ -4205,7 +4202,7 @@
 /turf/open/floor/stone,
 /area/ruin/syndicate_lava_base/bar)
 "Yb" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate,
+/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate,
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/dormitories)
@@ -4289,7 +4286,7 @@
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/bar)
 "YV" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate{
+/obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate{
 	dir = 8
 	},
 /obj/machinery/light/directional/east,

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/blackmarket.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/blackmarket.dmm
@@ -35,7 +35,9 @@
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "dm" = (
 /obj/structure/table,
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/south{
+	dir = 1
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
@@ -654,7 +656,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "Ph" = (
-/obj/effect/mob_spawn/human/blackmarket{
+/obj/effect/mob_spawn/ghost_role/human/blackmarket{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -804,7 +806,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/skyrat/blackmarket)
 "YR" = (
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/firealarm/directional/west{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/cargodiselost.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/cargodiselost.dmm
@@ -2131,7 +2131,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "MB" = (
-/obj/effect/mob_spawn/human/lostcargoqm{
+/obj/effect/mob_spawn/ghost_role/human/lostcargoqm{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -2513,7 +2513,7 @@
 /turf/open/floor/iron/brown/side,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Rt" = (
-/obj/effect/mob_spawn/human/lostminer{
+/obj/effect/mob_spawn/ghost_role/human/lostminer{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -2569,7 +2569,7 @@
 	},
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "SF" = (
-/obj/effect/mob_spawn/human/lostminer{
+/obj/effect/mob_spawn/ghost_role/human/lostminer{
 	dir = 1
 	},
 /obj/machinery/light,
@@ -2595,7 +2595,7 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "SY" = (
-/obj/effect/mob_spawn/human/lostcargo{
+/obj/effect/mob_spawn/ghost_role/human/lostcargo{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -2613,7 +2613,7 @@
 	},
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Te" = (
-/obj/effect/mob_spawn/human/lostcargo{
+/obj/effect/mob_spawn/ghost_role/human/lostcargo{
 	dir = 1
 	},
 /obj/machinery/light,
@@ -2972,7 +2972,7 @@
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Xm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/mob_spawn/human/miner/rig,
+/obj/effect/mob_spawn/corpse/human/miner/rig,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Xn" = (

--- a/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
+++ b/modular_skyrat/modules/mapping/_maps/RandomRuins/SpaceRuins/interdynefob.dmm
@@ -57,7 +57,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "ag" = (
 /obj/item/storage/belt/security/full,
-/obj/item/radio/headset/headset_sec/alt/interdyne,
+/obj/item/radio/headset/interdyne,
 /obj/item/clothing/under/utility/sec/old/syndicate,
 /obj/structure/closet/secure_closet{
 	icon_state = "sec";
@@ -628,7 +628,7 @@
 "cn" = (
 /obj/structure/chair/sofa,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/wood,
@@ -736,7 +736,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
 "cG" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/mob_spawn/human/ds2/syndicate{
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate{
 	uses = 4
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -759,7 +759,7 @@
 	req_access_txt = "151"
 	},
 /obj/item/storage/belt/security/full,
-/obj/item/radio/headset/headset_sec/alt/interdyne,
+/obj/item/radio/headset/interdyne,
 /obj/item/clothing/under/utility/sec/old/syndicate,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
@@ -1099,7 +1099,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/plating,
@@ -1119,7 +1118,6 @@
 "eb" = (
 /obj/structure/table/glass,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /obj/item/healthanalyzer,
@@ -1436,7 +1434,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/side{
@@ -1647,7 +1645,7 @@
 "fU" = (
 /obj/structure/closet/firecloset/full,
 /obj/machinery/airalarm/directional/west{
-	dir = 4;
+	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -2313,7 +2311,6 @@
 "ib" = (
 /obj/machinery/deepfryer,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/kitchen{
@@ -2412,7 +2409,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "iv" = (
-/obj/effect/mob_spawn/human/ds2/syndicate/service{
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/service{
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
@@ -2454,7 +2451,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/carpet/donk,
@@ -2643,7 +2639,6 @@
 "jj" = (
 /obj/machinery/stasissleeper,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_large,
@@ -3457,7 +3452,7 @@
 "mg" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -3472,7 +3467,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
 "mj" = (
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/textured_large,
@@ -4069,7 +4064,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west{
-	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/wood,
@@ -4609,7 +4603,6 @@
 	dir = 10
 	},
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/plating,
@@ -4662,7 +4655,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/research)
 "qk" = (
 /obj/machinery/light/directional/north,
-/obj/effect/mob_spawn/human/ds2/syndicate/admiral,
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/admiral,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
 "ql" = (
@@ -4718,7 +4711,6 @@
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_large,
@@ -5018,7 +5010,7 @@
 "rt" = (
 /obj/effect/spawner/liquids_spawner,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/pool,
@@ -5477,7 +5469,6 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "ta" = (
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/smooth_edge{
@@ -5752,7 +5743,6 @@
 "tY" = (
 /obj/structure/filingcabinet,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/wood,
@@ -5833,7 +5823,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/library)
 "ut" = (
-/obj/effect/mob_spawn/human/ds2/prisoner{
+/obj/effect/mob_spawn/ghost_role/human/ds2/prisoner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -6071,7 +6061,6 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/mining_equipment)
 "uY" = (
 /obj/machinery/airalarm/directional/east{
-	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_large,
@@ -6083,7 +6072,7 @@
 	req_access_txt = "150"
 	},
 /obj/item/storage/belt/security/full,
-/obj/item/radio/headset/headset_sec/alt/interdyne,
+/obj/item/radio/headset/interdyne,
 /obj/item/clothing/under/utility/sec/old/syndicate,
 /obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced/survival_pod{
@@ -6107,7 +6096,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "ve" = (
 /obj/machinery/light/directional/north,
-/obj/effect/mob_spawn/human/ds2/syndicate/masteratarms,
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/masteratarms,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/smooth_edge{
@@ -6408,7 +6397,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "wd" = (
-/obj/effect/mob_spawn/human/ds2/prisoner{
+/obj/effect/mob_spawn/ghost_role/human/ds2/prisoner{
 	dir = 8
 	},
 /obj/structure/cable,
@@ -6592,7 +6581,7 @@
 /turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "wB" = (
-/obj/effect/mob_spawn/human/ds2/syndicate{
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate{
 	dir = 1;
 	uses = 4
 	},
@@ -6677,7 +6666,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/freezer,
@@ -7299,7 +7288,7 @@
 /obj/item/knife/combat/survival,
 /obj/item/storage/bag/ore,
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_large,
@@ -7898,7 +7887,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "Be" = (
 /obj/machinery/light/directional/south,
-/obj/effect/mob_spawn/human/ds2/syndicate/brigoff{
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/brigoff{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -8316,7 +8305,6 @@
 /obj/structure/dresser,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/wood/large,
@@ -8816,7 +8804,6 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/west{
-	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/large,
@@ -9017,7 +9004,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -9291,7 +9278,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/hangar)
 "FQ" = (
-/obj/machinery/cryopod,
+/obj/machinery/cryopod{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms)
 "FR" = (
@@ -9371,7 +9360,6 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east{
-	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/wood,
@@ -9862,7 +9850,7 @@
 /obj/structure/sink{
 	pixel_y = 20
 	},
-/obj/effect/mob_spawn/human/ds2/syndicate/service,
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/service,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/hydroponics)
 "HZ" = (
@@ -9930,7 +9918,6 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "Ig" = (
 /obj/machinery/airalarm/directional/west{
-	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/smooth_corner{
@@ -10190,7 +10177,6 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "IV" = (
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/red/side{
@@ -10206,7 +10192,7 @@
 	},
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "IX" = (
-/obj/effect/mob_spawn/human/ds2/syndicate/stationmed,
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/stationmed,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/skyrat/interdynefob/medbay)
 "IY" = (
@@ -10942,7 +10928,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/skyrat/interdynefob/halls)
 "Lq" = (
-/obj/effect/mob_spawn/human/ds2/syndicate/enginetech{
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/enginetech{
 	dir = 8;
 	uses = 2
 	},
@@ -11145,7 +11131,6 @@
 "LX" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
@@ -11316,7 +11301,6 @@
 /obj/structure/closet/secure_closet/brig/genpop,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/smooth_large,
@@ -12004,7 +11988,6 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/northwest)
 "OP" = (
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/side{
@@ -12072,7 +12055,6 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "Pb" = (
 /obj/machinery/airalarm/directional/east{
-	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/carpet/red,
@@ -12110,7 +12092,7 @@
 "Pj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/east{
-	dir = 8;
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/textured_large,
@@ -12482,7 +12464,7 @@
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/cl)
 "Qp" = (
-/obj/effect/mob_spawn/human/ds2/syndicate/researcher{
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/researcher{
 	dir = 8;
 	uses = 2
 	},
@@ -12983,7 +12965,7 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/airalarm/directional/east{
-	dir = 8;
+	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -13002,7 +12984,7 @@
 "RV" = (
 /obj/machinery/chem_master,
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -13030,7 +13012,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/obj/effect/mob_spawn/human/ds2/syndicate{
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate{
 	dir = 1;
 	uses = 4
 	},
@@ -13226,7 +13208,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south{
-	dir = 1;
+	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark,
@@ -13251,7 +13233,7 @@
 /turf/open/floor/iron/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/dorms/fitness)
 "SN" = (
-/obj/effect/mob_spawn/human/ds2/syndicate/brigoff{
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/brigoff{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -13419,7 +13401,6 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "Tv" = (
 /obj/machinery/airalarm/directional/west{
-	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/wood,
@@ -13555,7 +13536,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/skyrat/interdynefob/security)
 "TN" = (
-/obj/effect/mob_spawn/human/ds2/syndicate{
+/obj/effect/mob_spawn/ghost_role/human/ds2/syndicate{
 	uses = 4
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -13918,7 +13899,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/chapel)
 "Vo" = (
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
+	dir = 1;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/textured_edge{
@@ -14340,7 +14321,6 @@
 	name = "blue line"
 	},
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/blue/side{
@@ -14611,7 +14591,7 @@
 	req_access_txt = "151"
 	},
 /obj/item/storage/belt/security/full,
-/obj/item/radio/headset/headset_sec/alt/interdyne,
+/obj/item/radio/headset/interdyne,
 /obj/item/clothing/suit/armor/vest/warden/syndicate,
 /obj/item/clothing/under/utility/sec/old/syndicate,
 /obj/structure/cable,
@@ -15246,7 +15226,6 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/north{
-	dir = 2;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/blue/side{
@@ -15255,7 +15234,6 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
 "ZI" = (
 /obj/machinery/airalarm/directional/east{
-	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron/dark/smooth_edge{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

No one properly updated the maps to use the spawners. This fixes that among fixing the directionals on air alarms and cameras on Interdyne/DS-2

![image](https://user-images.githubusercontent.com/81479835/147192102-17e0cfab-0f5f-436d-8fb8-7af9c45d4615.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Hmm today I will play my favorite roles.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Syndicate operatives have been taken off unpaid break and are back to work on Bioweapon research. Along with other workers returning to work.
fix: DS-2 and Interdyne's air alarms no longer float off walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
