### PR TITLE
[NON-MODULAR] You can no longer expand non-32x32 cyborg sprites.

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -558,7 +558,7 @@
 			to_chat(usr, span_warning("This unit already has an expand module installed!"))
 			return FALSE
 		// SKYRAT EDIT BEGIN
-		if(R_TRAIT_WIDE in borg.model.model_features)
+		if(R_TRAIT_WIDE in R.model.model_features)
 			to_chat(usr, span_warning("This unit's chassis cannot be enlarged any further."))
 			return FALSE
 		// SKYRAT EDIT END

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -557,6 +557,11 @@
 		if(R.hasExpanded)
 			to_chat(usr, span_warning("This unit already has an expand module installed!"))
 			return FALSE
+		// SKYRAT EDIT BEGIN
+		if(R_TRAIT_WIDE in borg.model.model_features)
+			to_chat(usr, span_warning("This unit's chassis cannot be enlarged any further."))
+			return FALSE
+		// SKYRAT EDIT END
 
 		R.notransform = TRUE
 		var/prev_lockcharge = R.lockcharge


### PR DESCRIPTION
## About The Pull Request

You can no longer expand non-32x32 cyborg sprites.

## How This Contributes To The Skyrat Roleplay Experience

If your sprite is already larger than a normal cyborg, it doesn't need to be even larger.

## Changelog

:cl:
balance: You can no longer expand non-32x32 cyborg sprites.
/:cl:
