### PR TITLE
[SEMI-MODULAR] Removes the Cyborg Shrinker from the techweb.

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -842,10 +842,6 @@
 		"borg_upgrade_selfrepair",
 		"borg_upgrade_thrusters",
 		"borg_upgrade_trashofholding",
-
-		//SKYRAT EDIT START - RESEARCH DESIGNS
-		"borg_upgrade_shrink",
-		//SKYRAT EDIT END - RESEARCH DESIGNS
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 


### PR DESCRIPTION
## About The Pull Request
Removes the Cyborg Shrinker from the techweb.

## How This Contributes To The Skyrat Roleplay Experience

If you want to be a small robot, play a synthetic crewmember that isn't a cyborg. Letting cyborgs have a free hitbox reduction with absolutely zero downside is ridiculous, and it makes sprites look godawful.

![Screenshot_21](https://user-images.githubusercontent.com/4081722/147326815-810061e2-3c77-424d-a5b8-53677a306d25.png)


## Changelog

:cl:
del: Removes the Cyborg Shrinker from the techweb.
/:cl: