### PR TITLE
[MODULAR] Medigun Toxin Healing now scales with non-medicine chemicals in bloodstream

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/medcells.dm
@@ -89,7 +89,12 @@
 /obj/projectile/energy/medical/proc/healTox(mob/living/target, amount_healed)
 	if(!IsLivingHuman(target))
 		return FALSE
-	target.adjustToxLoss(-amount_healed)
+	var/healing_multiplier = 1.5
+	var/non_meds = checkReagents(target)
+	healing_multiplier = healing_multiplier - (non_meds / 4)
+	if(healing_multiplier < 0.25)
+		healing_multiplier = 0.25
+	target.adjustToxLoss(-(amount_healed * healing_multiplier))
 
 //T1 Healing Projectiles//
 //The Basic Brute Heal Projectile//

--- a/modular_skyrat/modules/modular_weapons/code/medcells.dm
+++ b/modular_skyrat/modules/modular_weapons/code/medcells.dm
@@ -45,6 +45,13 @@
 		return FALSE
 	else
 		return TRUE
+//Checks for non-medicine reagents in the bloodstream
+/obj/projectile/energy/medical/proc/checkReagents(mob/living/target)
+	var/non_medicine_chems = 0 //Keeps track of how many chemicals in the bloodstream aren't medicine.
+	for(var/reagent in target.reagents.reagent_list)
+		if(!istype(reagent, /datum/reagent/medicine))
+			non_medicine_chems += 1
+	return non_medicine_chems
 //Heals Brute without safety
 /obj/projectile/energy/medical/proc/healBrute(mob/living/target, amount_healed, max_clone, base_disgust)
 	if(!IsLivingHuman(target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR makes it so that the amount of toxin healing you get out of the Medigun is affected by how many non-medicine chemicals are inside of your patients bloodstream. With no chemicals, the healing has a 1.5 multiplier, but with each non-medicine chemical this is decreased by 0.25 before eventually reaching a minimum of 0.25 healing per shot. 
## How This Contributes To The Skyrat Roleplay Experience
Having the Toxin healing be based on the non-medicine chemicals in the bloodstream rewards doctors for thinking and dealing with the cause of the toxin damage and punishes doctors that mindlessly blast patients with the toxin mode. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: the toxin mode on the medigun now heals more or less according to how many non-medicine chemicals are inside of the patient's bloodstream.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
