### PR TITLE
[MODULAR] The breaching hammer is now exclusively for breaching doors.

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_hammer.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_hammer.dm
@@ -8,8 +8,8 @@
 	lefthand_file = 'modular_skyrat/modules/sec_haul/icons/peacekeeper/baton/peacekeeper_baton_lefthand.dmi'
 	righthand_file = 'modular_skyrat/modules/sec_haul/icons/peacekeeper/baton/peacekeeper_baton_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT
-	force = 10
-	throwforce = 7
+	force = 15
+	throwforce = 10
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb_continuous = list("whacks","breaches","bulldozes","flings","thwachs")
 	attack_verb_simple = list("breach","hammer","whack","slap","thwach","fling")

--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_hammer.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_hammer.dm
@@ -8,12 +8,8 @@
 	lefthand_file = 'modular_skyrat/modules/sec_haul/icons/peacekeeper/baton/peacekeeper_baton_lefthand.dmi'
 	righthand_file = 'modular_skyrat/modules/sec_haul/icons/peacekeeper/baton/peacekeeper_baton_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT
-	force = 15
-	throwforce = 20
-	throw_range = 1
-	wound_bonus = 30
-	bare_wound_bonus = 40
-	block_chance = 25
+	force = 10
+	throwforce = 7
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb_continuous = list("whacks","breaches","bulldozes","flings","thwachs")
 	attack_verb_simple = list("breach","hammer","whack","slap","thwach","fling")
@@ -30,11 +26,6 @@
 	/// the amount that the force is multiplied by , that is then applied as damage to the door.
 	var/breaching_multipler = 2.5
 
-/obj/item/melee/hammer/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(attack_type == PROJECTILE_ATTACK)
-		final_block_chance = 5 // Less likely to parry a fucking bullet
-	return ..()
-
 /obj/item/melee/hammer/afterattack(atom/target, mob/user, proximity)
 	. = ..()
 	if(!proximity)
@@ -49,11 +40,6 @@
 		breacher = user
 		SEND_SIGNAL(target, COMSIG_BREACHING, user)
 		breaching_target = target
-	if(iscarbon(target))
-		user.changeNext_move(2 SECONDS)
-		var/mob/living/carbon/H = target
-		H.apply_damage_type(40, STAMINA)
-		H.throw_at(get_step_away(H, user), 1, 1, user, TRUE, gentle = TRUE)
 
 /// Removes any form of tracking from the user and the item , make sure to call it on he proper item
 /obj/item/melee/hammer/proc/remove_track(mob/living/carbon/human/user)


### PR DESCRIPTION
## About The Pull Request

The breaching hammer throwforce values have been reduced from 20 throwforce to 10 throwforce.
The breaching hammer no longer gives you a 25% chance to block.
The breaching hammer no longer has wound bonuses.
The breaching hammer no longer functions as a baseball bat plus stun baton combo.

## How This Contributes To The Skyrat Roleplay Experience

After speaking with staff members handling security policy, they expressed interest in moving the breaching hammer to exclusively be a breaching tool for emergencies using the two-person method, and not being a combat tool.

If you need to get through a door faster as Security and can't find a buddy to use the hammer with, consider the following methods:
1. ;AI DOOR
2. Hack the door open
3. Go around the door somehow
4. Ask someone with access to open the door
5. Go to the HoP and get the proper access for that door, or a job change
6. Teleport around the door using teleporters
7. Use one of the myriad of ways people get around doors in SS13

## Changelog
:cl:
balance: The breaching hammer throwforce values have been reduced from 20 throwforce to 10 throwforce.
balance: The breaching hammer no longer gives you a 25% chance to block.
balance: The breaching hammer no longer has wound bonuses.
balance: The breaching hammer no longer functions as a baseball bat plus stun baton combo.
/:cl: