### PR TITLE
Fixes the Automated Announcement System feeling shy and not announcing anything

### DIFF
--- a/modular_skyrat/modules/radiosound/code/headset.dm
+++ b/modular_skyrat/modules/radiosound/code/headset.dm
@@ -8,8 +8,6 @@
 	radiosound = 'modular_skyrat/modules/radiosound/sound/radio/security.ogg'
 
 /obj/item/radio/headset/talk_into(mob/living/M, message, channel, list/spans, datum/language/language, list/message_mods, direct = TRUE)
-	if(!listening)
-		return ITALICS | REDUCE_RANGE
-	if(radiosound)
+	if(radiosound && listening)
 		playsound(M, radiosound, rand(20, 30), 0, 0, SOUND_FALLOFF_EXPONENT)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
The Automated Announcement System will now once again announce people's arrivals and departures as they happen.

## How This Contributes To The Skyrat Roleplay Experience
Silly bug, it's something that massively helps getting people together as you can more easily know when someone you know is on, even if you don't know their CKEY or their Discord.

## Changelog

:cl: GoldenAlpharex
fix: The Automated Announcement System went through therapy and is no longer feeling so socially anxious it forgets how to use a radio to announce anything over Common.
/:cl: