### PR TITLE
[NON-MODULAR] Makes showers clickable with mobs on them by adjusting their layer.

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -14,6 +14,7 @@
 	name = "shower"
 	desc = "The HS-452. Installed in the 2550s by the Nanotrasen Hygiene Division, now with 2560 lead compliance! Passively replenishes itself with water when not in use."
 	icon = 'icons/obj/watercloset.dmi'
+	layer = WALL_OBJ_LAYER // SKYRAT EDIT - SHOWERS BECOME CLICKABLE
 	icon_state = "shower"
 	density = FALSE
 	use_power = NO_POWER_USE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR raises the showers layer to that above mobs, so that it can be interacted with easier. It also makes visual sense. 
## Before
![dreamseeker_JCspm4IjxF](https://user-images.githubusercontent.com/77420409/147537642-3c9e60c9-5f51-4096-bb15-d4e563b2765a.png)
## After
![dreamseeker_wD0puc0syG](https://user-images.githubusercontent.com/77420409/147537673-c2529a32-e703-4fcf-a4d9-7d0ef7875211.png)


## How This Contributes To The Skyrat Roleplay Experience

It's great to be able to interact with a shower when someone is on the tile as one.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: Showers now go over TOP mobs

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
