### PR TITLE
Fixes empty 12ga bulldog drum in uplinks

### DIFF
--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -274,6 +274,7 @@
 			Ammunition not included."
 	cost = 1
 	item = /obj/item/ammo_box/magazine/m12g/empty
+	purchasable_from = ALL
 
 //SUITS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I forgot to add the line of code that lets empty 12ga bulldog drums appear in uplinks for traitors, this fixes that.

## How This Contributes To The Skyrat Roleplay Experience

Bugs are bad, especially when my own code introduced them in the first place

## Changelog

No GBP here

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
