### PR TITLE
Disables medical cyborg pinpointer and remote crew monitor access

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -924,6 +924,7 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/*
 /datum/design/borg_upgrade_pinpointer
 	name = "Cyborg Upgrade (Crew pinpointer)"
 	id = "borg_upgrade_pinpointer"
@@ -932,6 +933,7 @@
 	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
+*/
 
 /datum/design/borg_upgrade_broomer
 	name = "Cyborg Upgrade (Experimental Push Broom)"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -899,7 +899,7 @@
 		"borg_upgrade_defibrillator",
 		"borg_upgrade_expandedsynthesiser",
 		"borg_upgrade_piercinghypospray",
-		"borg_upgrade_pinpointer",
+		//"borg_upgrade_pinpointer", // SKYRAT EDIT REMOVAL
 		"borg_upgrade_surgicalprocessor",
 
 		//SKYRAT EDIT START - RESEARCH DESIGNS


### PR DESCRIPTION
## About The Pull Request

Disables the pinpointer upgrade from being printed. This also disables the remote crew monitor access.

## How This Contributes To The Skyrat Roleplay Experience

After a discussion yesterday about medical cyborgs being MDs, paramedics, and better at both at once, this was brought up as a potential way to resolve some of that. As it stands, they can locate a dead or dying crewmember extremely easily (better than a regular paramedic) through their environmental (fire, pressure, etc) resistances, their lack of slowdown, and their all-access. They can then do field surgery to revive the crew member on the spot. This takes a job away from TWO people (MD & paramedic) in favour of the work of ONE person (borg).

This'll stop medical cyborgs from being straight-up better paramedics, as they won't be able to find crew easily by themselves - though they could easily still team up with a paramedic (or anyone with a crew pinpointer/monitor) to take advantage of their innate AA and environmental resistances.

They can, if they really need to do paramedic work but cannot find a paramedic/willing crewmember to take with them, drag a modular tablet or such around with lifeline installed, or install it onto themselves. 

## Changelog
:cl:
balance: Medical cyborgs no longer get a pinpointer upgrade, nor the remote crew monitor access that comes with it.
/:cl: