### PR TITLE
[NON-MODULAR]Fixes corrupt photo records

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -983,7 +983,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 		return humanoid_icon_cache[icon_id]
 // SKYRAT EDIT BEGIN - Icon Rendering Corruption Fix
 	var/mob/living/mob_to_copy = get_mob_by_key(dummy_key)
-	var/mob/living/carbon/human/dummy/body = generate_dummy_lookalike(mob_to_copy, mob_to_copy)
+	var/mob/living/carbon/human/dummy/body = generate_dummy_lookalike(mob_to_copy, mob_to_copy) //original = generate_or_wait_for_human_dummy(dummy_key)
 // SKYRAT EDIT END- Icon Rendering Corruption Fix
 	if(prefs)
 		prefs.apply_prefs_to(body, TRUE)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -981,10 +981,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	var/static/list/humanoid_icon_cache = list()
 	if(icon_id && humanoid_icon_cache[icon_id])
 		return humanoid_icon_cache[icon_id]
-// SKYRAT EDIT BEGIN - Icon Rendering Corruption Fix
-	var/mob/living/mob_to_copy = get_mob_by_key(dummy_key)
-	var/mob/living/carbon/human/dummy/body = generate_dummy_lookalike(mob_to_copy, mob_to_copy) //original = generate_or_wait_for_human_dummy(dummy_key)
-// SKYRAT EDIT END- Icon Rendering Corruption Fix
+	var/mob/living/carbon/human/dummy/body = generate_dummy_lookalike() //SKYRAT EDIT: original = generate_or_wait_for_human_dummy(dummy_key)
 	if(prefs)
 		prefs.apply_prefs_to(body, TRUE)
 

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -982,7 +982,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	if(icon_id && humanoid_icon_cache[icon_id])
 		return humanoid_icon_cache[icon_id]
 
-	var/mob/living/carbon/human/dummy/body = generate_or_wait_for_human_dummy(dummy_key)
+	var/mob/living/carbon/human/dummy/body = generate_dummy_lookalike(REF(dummy_key), dummy_key)  // SKYRAT EDIT - FIXES CORRUPT PHOTO RECORDS
 
 	if(prefs)
 		prefs.apply_prefs_to(body, TRUE)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -981,9 +981,10 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	var/static/list/humanoid_icon_cache = list()
 	if(icon_id && humanoid_icon_cache[icon_id])
 		return humanoid_icon_cache[icon_id]
-
-	var/mob/living/carbon/human/dummy/body = generate_dummy_lookalike(REF(dummy_key), dummy_key)  // SKYRAT EDIT - FIXES CORRUPT PHOTO RECORDS
-
+// SKYRAT EDIT BEGIN - Icon Rendering Corruption Fix
+	var/mob/living/togenerate = get_mob_by_key(dummy_key)
+	var/mob/living/carbon/human/dummy/body = generate_dummy_lookalike(togenerate, togenerate)
+// SKYRAT EDIT END- Icon Rendering Corruption Fix
 	if(prefs)
 		prefs.apply_prefs_to(body, TRUE)
 

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -982,8 +982,8 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	if(icon_id && humanoid_icon_cache[icon_id])
 		return humanoid_icon_cache[icon_id]
 // SKYRAT EDIT BEGIN - Icon Rendering Corruption Fix
-	var/mob/living/togenerate = get_mob_by_key(dummy_key)
-	var/mob/living/carbon/human/dummy/body = generate_dummy_lookalike(togenerate, togenerate)
+	var/mob/living/mob_to_copy = get_mob_by_key(dummy_key)
+	var/mob/living/carbon/human/dummy/body = generate_dummy_lookalike(mob_to_copy, mob_to_copy)
 // SKYRAT EDIT END- Icon Rendering Corruption Fix
 	if(prefs)
 		prefs.apply_prefs_to(body, TRUE)

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -127,7 +127,7 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 	if(!istype(target))
 		return generate_or_wait_for_human_dummy(slotkey)
 
-	var/mob/living/carbon/human/dummy/copycat = generate_dummy_lookalike(REF(slotkey), slotkey)  // SKYRAT EDIT - FIXES CORRUPT PHOTO RECORDS
+	var/mob/living/carbon/human/dummy/copycat = generate_or_wait_for_human_dummy(slotkey)
 
 	if(iscarbon(target))
 		var/mob/living/carbon/carbon_target = target

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -127,7 +127,7 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 	if(!istype(target))
 		return generate_or_wait_for_human_dummy(slotkey)
 
-	var/mob/living/carbon/human/dummy/copycat = generate_or_wait_for_human_dummy(slotkey)
+	var/mob/living/carbon/human/dummy/copycat = generate_dummy_lookalike(REF(slotkey), slotkey)  // SKYRAT EDIT - FIXES CORRUPT PHOTO RECORDS
 
 	if(iscarbon(target))
 		var/mob/living/carbon/carbon_target = target


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes the broken photo records. Testmerge first! Only tested with two ckeys!

This corrects the proc to that generates icons to use the correct proc, as as well as get the ckey's loaded mob. The original proc this used is a deprecated way to generate icons since the tgui prefs and inspection were in. 

## How This Contributes To The Skyrat Roleplay Experience

We actually get accurate photo records of characters again! And wanted posters, etc, function correctly as they all use the generated photo.

![dreamseeker_qOczyqcOrL](https://user-images.githubusercontent.com/77420409/147724136-d12683e3-f612-429b-b840-eb9e9b9ac6e2.png)


![dreamseeker_9noSm8ovfe](https://user-images.githubusercontent.com/77420409/147724141-bc6705d2-0c5f-4f08-a616-f25d487f74b0.png)



## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: stops the crew records automatically generated photos from having a corrupted appearance.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
