### PR TITLE
Re-enables the goodie packs for the Detective's alternative ammunition, and the Survival Knife.

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -3,8 +3,7 @@
 	access = NONE
 	group = "Goodies"
 	goody = TRUE
-//SKYRAT EDIT REMOVAL BEGIN
-/*
+
 /datum/supply_pack/goody/dumdum38
 	name = ".38 DumDum Speedloader"
 	desc = "Contains one speedloader of .38 DumDum ammunition, good for embedding in soft targets."
@@ -38,7 +37,8 @@
 	desc = "Contains one sharpened survival knive. Guaranteed to fit snugly inside any Nanotrasen-standard boot."
 	cost = PAYCHECK_HARD * 1.75
 	contains = list(/obj/item/knife/combat/survival)
-
+//SKYRAT EDIT REMOVAL BEGIN
+/*
 /datum/supply_pack/goody/ballistic_single
 	name = "Combat Shotgun Single-Pack"
 	desc = "For when the enemy absolutely needs to be replaced with lead. Contains one Aussec-designed Combat Shotgun, and one Shotgun Bandolier."

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -24,14 +24,16 @@
 	cost = PAYCHECK_MEDIUM * 1.5
 	access_view = ACCESS_BRIG
 	contains = list(/obj/item/ammo_box/c38/match/bouncy)
-
+//SKYRAT EDIT REMOVAL BEGIN
+/*
 /datum/supply_pack/goody/stingbang
 	name = "Stingbang Single-Pack"
 	desc = "Contains one \"stingbang\" grenade, perfect for playing meanhearted pranks."
 	cost = PAYCHECK_HARD * 2.5
 	access_view = ACCESS_BRIG
 	contains = list(/obj/item/grenade/stingbang)
-
+*/
+//SKYRAT EDIT REMOVAL END
 /datum/supply_pack/goody/Survivalknives_single
 	name = "Survival Knife Single-Pack"
 	desc = "Contains one sharpened survival knive. Guaranteed to fit snugly inside any Nanotrasen-standard boot."


### PR DESCRIPTION
## About The Pull Request

Re-enables the goodie packs for Stingbangs, the Detective's alternative ammunition, and the Survival Knife.

## How This Contributes To The Skyrat Roleplay Experience

The Detective is supposed to be fucking around with alternative rounds for his gun. It's his entire thing, his revolver has a large variety of ammunition types and he's the go-to for "i wanna fire a bullet against specific targets under specific circumstances.", along with being Security's dedicated anti-EMP guy since he's packing pure ballistics and can just go "lmao" at your emp grenade and fill you full of holes.

~~Stingbangs are a less than lethal crowd control item.~~

The survival knife is no longer a Security item and is technically a Service item now.

The pull request that removed all of these items didn't mention it in the description or PR title, instead simply saying ``removes some guns and there ammo from cargo goodie``. This of course is referring to the WT-550, which is what the PR was about, but due to poor documentation the PR just kinda disabled a bunch of unrelated stuff.

## Changelog

:cl:
balance: Re-enables the goodie packs for Stingbangs, the Detective's alternative ammunition, and the Survival Knife.
/:cl:

