### PR TITLE
Fixes hot and cold augmented lung messages

### DIFF
--- a/modular_skyrat/modules/organs/code/lungs.dm
+++ b/modular_skyrat/modules/organs/code/lungs.dm
@@ -3,7 +3,7 @@
 	icon = 'modular_skyrat/modules/organs/icons/lungs.dmi'
 	desc = "A set of lungs adapted to low temperatures, though they are more susceptible to high temperatures"
 	icon_state = "lungs_cold"
-	cold_message = "There is a slightly painful, though bearable, cold sensation with every breath you take"
+	cold_message = "a slightly painful, though bearable, cold sensation"
 	cold_level_1_threshold = 208
 	cold_level_2_threshold = 200
 	cold_level_3_threshold = 170
@@ -12,7 +12,7 @@
 	cold_level_3_damage = COLD_GAS_DAMAGE_LEVEL_2
 	cold_damage_type = BURN
 
-	hot_message = "You can't stand the searing heat with every breath you take!"
+	hot_message = "the searing heat with every breath you take"
 	heat_level_1_threshold = 318
 	heat_level_2_threshold = 348
 	heat_level_3_threshold = 1000
@@ -27,7 +27,7 @@
 	icon = 'modular_skyrat/modules/organs/icons/lungs.dmi'
 	desc = "A set of lungs adapted to high temperatures, though they are more susceptible to low temperatures"
 	icon_state = "lungs_heat"
-	cold_message = "You can't stand the freezing cold with every breath you take!"
+	cold_message = "the freezing cold with every breath you take"
 	cold_level_1_threshold = 248
 	cold_level_2_threshold = 220
 	cold_level_3_threshold = 170
@@ -36,7 +36,7 @@
 	cold_level_3_damage = COLD_GAS_DAMAGE_LEVEL_3
 	cold_damage_type = BURN
 
-	hot_message = "There is a slightly painful, though bearable, warmth with every breath you take"
+	hot_message = "a slightly painful, though bearable, warmth"
 	heat_level_1_threshold = 373
 	heat_level_2_threshold = 473
 	heat_level_3_threshold = 523
@@ -53,7 +53,7 @@
 	safe_plasma_max = 27
 	safe_co2_max = 27
 
-	cold_message = "You can't stand the freezing cold with every breath you take!"
+	cold_message = "the freezing cold with every breath you take"
 	cold_level_1_threshold = 248
 	cold_level_2_threshold = 220
 	cold_level_3_threshold = 170
@@ -63,7 +63,7 @@
 	cold_damage_type = BRUTE
 
 
-	hot_message = "You can't stand the searing heat with every breath you take!"
+	hot_message = "the searing heat with every breath you take"
 	heat_level_1_threshold = 318
 	heat_level_2_threshold = 348
 	heat_level_3_threshold = 1000
@@ -79,7 +79,7 @@
 	icon_state = "lungs_toxin"
 	safe_oxygen_min = 5
 
-	hot_message = "You can't stand the searing heat with every breath you take!"
+	hot_message = "the searing heat with every breath you take"
 	heat_level_1_threshold = 318
 	heat_level_2_threshold = 348
 	heat_level_3_threshold = 1000
@@ -88,7 +88,7 @@
 	heat_level_3_damage = HEAT_GAS_DAMAGE_LEVEL_3
 	heat_damage_type = BURN
 
-	cold_message = "You can't stand the freezing cold with every breath you take!"
+	cold_message = "the freezing cold with every breath you take"
 	cold_level_1_threshold = 248
 	cold_level_2_threshold = 220
 	cold_level_3_threshold = 170


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The `hot_message` and `cold_message` for the augmented lung subtypes were in the wrong format, producing nonsense messages in-game.

Closes #10342

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Messages in game about your custom lungs are now real sentences.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
spellcheck: Fixed augmented lung messages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
