### PR TITLE
Fixes double lattices issues on salvagepost

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/salvagepost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/salvagepost.dmm
@@ -7,7 +7,6 @@
 /turf/open/floor/plastic,
 /area/ruin/powered)
 "aW" = (
-/obj/structure/lattice,
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
 /obj/structure/railing/corner{
@@ -27,7 +26,6 @@
 	},
 /area/template_noop)
 "bj" = (
-/obj/structure/lattice,
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 5
@@ -65,7 +63,6 @@
 /turf/open/floor/plating,
 /area/ruin/powered)
 "dk" = (
-/obj/structure/lattice,
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 9
@@ -141,14 +138,7 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
-"gq" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/template_noop)
 "gA" = (
-/obj/structure/lattice,
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 1
@@ -173,7 +163,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/powered)
 "hL" = (
-/obj/structure/lattice,
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
 /obj/structure/railing/corner{
@@ -435,7 +424,6 @@
 /turf/template_noop,
 /area/template_noop)
 "ss" = (
-/obj/structure/lattice,
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/template_noop)
@@ -629,7 +617,6 @@
 /turf/template_noop,
 /area/template_noop)
 "Dn" = (
-/obj/structure/lattice,
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 4
@@ -836,7 +823,6 @@
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "LC" = (
-/obj/structure/lattice,
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
 /turf/template_noop,
@@ -1001,7 +987,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/powered)
 "RA" = (
-/obj/structure/lattice,
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 8
@@ -2369,7 +2354,7 @@ Eu
 ss
 fW
 fW
-gq
+ss
 fW
 fW
 fW


### PR DESCRIPTION
## About The Pull Request
My DreamDaemon was screaming when it got rolled as a random ruin. Now it won't scream no more :)

## How This Contributes To The Skyrat Roleplay Experience
Less runtimes == more better

## Changelog

:cl: GoldenAlpharex
fix: Fixed a few instances of catwalks being on the same tile as lattices on the salvage post ruin, which means less runtimes trying to load that space ruin. Yay!
/:cl:
