### PR TITLE
[MODULAR] All Shotguns in the armory are now Riot Shotguns that load normal shotgun shells.

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/gun_spawns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/gun_spawns.dm
@@ -49,16 +49,17 @@
 	icon_state = "random_shotgun"
 	gun_count = 4
 	guns = list(
-		/obj/item/gun/ballistic/shotgun/m23,
-		/obj/item/gun/ballistic/shotgun/automatic/as2,
-		/obj/item/gun/ballistic/shotgun/sas14,
+		/obj/item/gun/ballistic/shotgun/riot,
+		/obj/item/gun/ballistic/shotgun/riot,
+		/obj/item/gun/ballistic/shotgun/riot,
+		/obj/item/gun/ballistic/shotgun/riot,
 	)
 
 /obj/structure/closet/ammunitionlocker/useful/PopulateContents()
-	new /obj/item/storage/box/rubbershot_14gauge(src)
-	new /obj/item/storage/box/rubbershot_14gauge(src)
-	new /obj/item/storage/box/rubbershot_14gauge(src)
-	new /obj/item/storage/box/rubbershot_14gauge(src)
+	new /obj/item/storage/box/rubbershot(src)
+	new /obj/item/storage/box/rubbershot(src)
+	new /obj/item/storage/box/rubbershot(src)
+	new /obj/item/storage/box/rubbershot(src)
 
 //////////////////////////AMMO BOXES
 /obj/item/storage/box/ammo_box


### PR DESCRIPTION

## About The Pull Request

All Shotguns in the armory are now Riot Shotguns that load normal shotgun shells.
The armory shotgun ammunition storage now contains normal shotgun shells.

## How This Contributes To The Skyrat Roleplay Experience

When Security is in need of a ballistic option, due to EMPs or power outages or lack of cells, the Shotgun is their go-to weapon. However, this wasn't the case due to the 14 gauge shell requirement and such on most armory shotguns. This rendered them ineffective in using any of the alternative shells in the techfab or the autolathe, and meant Security would quickly run out of ballistic availability.

This change will restore Security's ability to handle situations where they need a gun that doesn't miss. And EMP situations.

## Changelog

:cl:
balance: All Shotguns in the armory are now Riot Shotguns that load normal shotgun shells.
balance: The armory shotgun ammunition storage now contains normal shotgun shells.
/:cl: