### PR TITLE
[MODULAR] De-overhauls the sec-helmet crate.

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -331,6 +331,7 @@
 					/obj/item/clothing/head/fedora/det_hat)
 	crate_name = "forensics crate"
 
+/* SKYRAT EDIT: Moved to Bloat.dm	name = "Helmets Crate"
 /datum/supply_pack/security/helmets
 	name = "Helmets Crate"
 	desc = "Contains three standard-issue brain buckets. Requires Security access to open."
@@ -338,7 +339,7 @@
 	contains = list(/obj/item/clothing/head/helmet/sec,
 					/obj/item/clothing/head/helmet/sec,
 					/obj/item/clothing/head/helmet/sec)
-	crate_name = "helmet crate"
+	crate_name = "helmet crate"  */
 
 
 /datum/supply_pack/security/laser

--- a/modular_skyrat/modules/cargo/code/bloat.dm
+++ b/modular_skyrat/modules/cargo/code/bloat.dm
@@ -52,7 +52,7 @@
 	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/clothing/head/helmet,
 					/obj/item/clothing/head/helmet,
-					/obj/item/clothing/head/helmet)
+					/obj/item/clothing/head/helmet,)
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Science /////////////////////////////////////////

--- a/modular_skyrat/modules/cargo/code/bloat.dm
+++ b/modular_skyrat/modules/cargo/code/bloat.dm
@@ -46,6 +46,13 @@
 					/obj/item/clothing/suit/armor/vest/alt)
 	crate_name = "armor crate"
 
+/datum/supply_pack/security/helmets
+	name = "Helmets Crate"
+	desc = "Contains three surplus brain buckets. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/clothing/head/helmet/,
+					/obj/item/clothing/head/helmet/,
+					/obj/item/clothing/head/helmet/)
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Science /////////////////////////////////////////

--- a/modular_skyrat/modules/cargo/code/bloat.dm
+++ b/modular_skyrat/modules/cargo/code/bloat.dm
@@ -50,9 +50,9 @@
 	name = "Helmets Crate"
 	desc = "Contains three surplus brain buckets. Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 2
-	contains = list(/obj/item/clothing/head/helmet/,
-					/obj/item/clothing/head/helmet/,
-					/obj/item/clothing/head/helmet/)
+	contains = list(/obj/item/clothing/head/helmet,
+					/obj/item/clothing/head/helmet,
+					/obj/item/clothing/head/helmet)
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Science /////////////////////////////////////////


### PR DESCRIPTION
## About The Pull Request
The other crate provides the old-fashioned vests, it makes sense the helmet crate should aswell, namely to keep sec's new drip exclusive to them, and not having the crew wearing half-and-half combos of old and new sec-gear.

## How This Contributes To The Skyrat Roleplay Experience

Keeps security's new drip as a way to easily identify them, and makes the crew-'available' equivalents both different, and 'identifiable.' Also allows dep-guards and other unofficial ne'erdowells to not have to wear the ultra-brite-visored sec helmet, while also letting sec still wear it. (TL:DR that doesn't sound good at a glance, reverts the cargo-available helmets to the non 'security' version of helmets)
(i don't know what to tag this as because its not a rebalance)

## Changelog



:cl:
code: swapped the helmet crate to use the un-overhauled security helmet.
/:cl:

