### PR TITLE
[MODULAR] Fixes the Blueshield being able to get more access than their trim starts with.

### DIFF
--- a/modular_skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield.dm
@@ -50,7 +50,7 @@
 	uniform = /obj/item/clothing/under/rank/security/blueshield
 	suit = /obj/item/clothing/suit/armor/vest/blueshield
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
-	id = /obj/item/card/id/advanced/centcom
+	id = /obj/item/card/id/advanced/silver
 	shoes = /obj/item/clothing/shoes/jackboots
 	ears = /obj/item/radio/headset/heads/blueshield/alt
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses


### PR DESCRIPTION
## About The Pull Request

Fixes the Blueshield being able to get more access than their trim starts with.

## How This Contributes To The Skyrat Roleplay Experience

The blueshield was given the fancy CC ID card, which means there's an extra golden trim card on the station when there's only supposed to be two at max(the captain and the spare ID)

As a result they've been given a silver ID to properly respect the trim game design.

**"But I want all access as the blueshield!"**
Follow the Captain around then.

**"But I can't get into X room now!"**
How about you use any of the 500 ways we have to get into and out of rooms?

## Changelog

:cl:
fix: Fixes the Blueshield being able to get more access than their trim starts with.
/:cl: