### PR TITLE
[nonmodular]lets condoms be put into wallets

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -41,7 +41,6 @@
 		/obj/item/screwdriver,
 		// SKYRAT EDIT BEGIN
 		/obj/item/condom_pack,
-		/obj/item/clothing/sextoy/condom,
 		// SKYRAT EDIT END
 		/obj/item/stamp),
 		list(/obj/item/screwdriver/power))

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -39,6 +39,10 @@
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/pill,
 		/obj/item/screwdriver,
+		// SKYRAT EDIT BEGIN
+		/obj/item/condom_pack,
+		/obj/item/clothing/sextoy/condom,
+		// SKYRAT EDIT END
 		/obj/item/stamp),
 		list(/obj/item/screwdriver/power))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title
## How This Contributes To The Skyrat Roleplay Experience

there are three things in every wallet
some special coin you got as change one time
dust
and a condom that's probably older than the civil rights movement
now the third can fit in, for IMMERSION

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: condoms have been shrunk to fit wallets, some how
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
