### PR TITLE
Blueshield office on Blueshift tweak

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_upper.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_upper.dmm
@@ -1283,7 +1283,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/upper)
 "akv" = (
-/obj/machinery/computer/secure_data,
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop,
 /turf/open/floor/carpet/executive,
 /area/blueshield)
 "akz" = (
@@ -17325,10 +17326,6 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
-"fvK" = (
-/obj/machinery/photocopier,
-/turf/open/floor/carpet/executive,
-/area/blueshield)
 "fvM" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -56741,9 +56738,8 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "upt" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop,
 /obj/machinery/bounty_board/directional/north,
+/obj/machinery/photocopier,
 /turf/open/floor/carpet/executive,
 /area/blueshield)
 "upu" = (
@@ -95907,7 +95903,7 @@ lUO
 rVY
 vKM
 avA
-fvK
+fum
 qdo
 jjC
 ami


### PR DESCRIPTION
## About The Pull Request

Proposed change
Re-arranges the furniture and removes a redundant security records console. Allows button access.
![image](https://user-images.githubusercontent.com/84706993/147999600-348eefc8-238b-4bc0-9bb1-7442ec7777b9.png)
Additionally, resolves #10377 

## How This Contributes To The Skyrat Roleplay Experience

Currently as a Blueshield you cannot operate your office curtains or the lock on your door on blueshift due to both the medical laptop and the photocopier impeding your reach. This simply removes the second security records console, since the blueshield already has a security records console in his room that is adjacent, and moves the laptop in it's place. Now the Blue has all his stuff still but can now use his buttons!

## Changelog

:cl: Deek-Za
qol: Blueshield Office on Blueshift has accessible locks and curtains again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
