### PR TITLE
[Non-modular] Changes runechat's message height var to one that is nicer

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -195,7 +195,7 @@
 	message.plane = RUNECHAT_PLANE
 	message.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 	message.alpha = 0
-	message.pixel_y = owner.bound_height * 0.95
+	message.pixel_y = owner.maptext_height * 0.95 //SKYRAT CHANGE, message.pixel_y = owner.bound_height * 0.95
 	message.maptext_width = CHAT_MESSAGE_WIDTH
 	message.maptext_height = mheight
 	message.maptext_x = (CHAT_MESSAGE_WIDTH - owner.bound_width) * -0.5

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -195,7 +195,8 @@
 	message.plane = RUNECHAT_PLANE
 	message.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 	message.alpha = 0
-	message.pixel_y = owner.maptext_height * 0.95 //SKYRAT CHANGE, message.pixel_y = owner.bound_height * 0.95
+	message.pixel_y = owner.maptext_height //SKYRAT CHANGE, message.pixel_y = owner.bound_height * 0.95
+	message.pixel_x = (owner.maptext_width * 0.5) - 16 //SKYRAT ADDITION
 	message.maptext_width = CHAT_MESSAGE_WIDTH
 	message.maptext_height = mheight
 	message.maptext_x = (CHAT_MESSAGE_WIDTH - owner.bound_width) * -0.5

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -74,6 +74,10 @@
 	icon = 'icons/effects/64x64.dmi'
 	icon_state = "drake_statue"
 	pixel_x = -16
+	//SKYRAT ADD
+	maptext_height = 64
+	maptext_width = 64
+	//
 	density = TRUE
 	deconstructible = FALSE
 	layer = EDGED_TURF_LAYER

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -4,6 +4,10 @@
 	status_flags = 0
 	pixel_x = -16
 	base_pixel_x = -16
+	//SKYRAT ADD
+	maptext_height = 64
+	maptext_width = 64
+	//
 	bubble_icon = "alienroyal"
 	mob_size = MOB_SIZE_LARGE
 	layer = LARGE_MOB_LAYER //above most mobs, but below speechbubbles

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -55,6 +55,10 @@ Difficulty: Hard
 	ranged = TRUE
 	pixel_x = -32
 	base_pixel_x = -32
+	//SKYRAT ADD
+	maptext_height = 96
+	maptext_width = 96
+	//
 	del_on_death = TRUE
 	crusher_loot = list(/obj/structure/closet/crate/necropolis/bubblegum/crusher)
 	loot = list(/obj/structure/closet/crate/necropolis/bubblegum)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -44,6 +44,10 @@
 	ranged = TRUE
 	pixel_x = -32
 	base_pixel_x = -32
+	//SKYRAT ADD
+	maptext_height = 96
+	maptext_width = 96
+	//
 	del_on_death = TRUE
 	gps_name = "Angelic Signal"
 	achievement_type = /datum/award/achievement/boss/colossus_kill

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -58,6 +58,10 @@
 	ranged = TRUE
 	pixel_x = -16
 	base_pixel_x = -16
+	//SKYRAT ADD
+	maptext_height = 64
+	maptext_width = 64
+	//
 	crusher_loot = list(/obj/structure/closet/crate/necropolis/dragon/crusher)
 	loot = list(/obj/structure/closet/crate/necropolis/dragon)
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -47,6 +47,10 @@
 	base_pixel_x = -32
 	pixel_y = -16
 	base_pixel_y = -16
+	//SKYRAT ADD
+	maptext_height = 96
+	maptext_width = 96
+	//
 	loot = list(/obj/item/stack/sheet/bone = 3)
 	vision_range = 13
 	wander = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -54,6 +54,10 @@
 	armour_penetration = 30
 	pixel_x = -16
 	base_pixel_x = -16
+	//SKYRAT ADD
+	maptext_height = 64
+	maptext_width = 64
+	//
 	turns_per_move = 5
 	ranged = TRUE
 	mouse_opacity = MOUSE_OPACITY_ICON

--- a/modular_skyrat/modules/altborgs/code/robot_model.dm
+++ b/modular_skyrat/modules/altborgs/code/robot_model.dm
@@ -13,12 +13,10 @@
 	if (model_features && (R_TRAIT_WIDE in model_features))
 		hat_offset = INFINITY
 		cyborg.set_base_pixel_x(-16)
-		cyborg.maptext_width = 64 //Runechat offset
 		add_verb(cyborg, /mob/living/silicon/robot/proc/robot_lay_down)
 		add_verb(cyborg, /mob/living/silicon/robot/proc/rest_style)
 	else
 		cyborg.set_base_pixel_x(0)
-		cyborg.maptext_width = 32
 		remove_verb(cyborg, /mob/living/silicon/robot/proc/robot_lay_down)
 		remove_verb(cyborg, /mob/living/silicon/robot/proc/rest_style)
 

--- a/modular_skyrat/modules/altborgs/code/robot_model.dm
+++ b/modular_skyrat/modules/altborgs/code/robot_model.dm
@@ -13,10 +13,12 @@
 	if (model_features && (R_TRAIT_WIDE in model_features))
 		hat_offset = INFINITY
 		cyborg.set_base_pixel_x(-16)
+		cyborg.maptext_width = 64 //Runechat offset
 		add_verb(cyborg, /mob/living/silicon/robot/proc/robot_lay_down)
 		add_verb(cyborg, /mob/living/silicon/robot/proc/rest_style)
 	else
 		cyborg.set_base_pixel_x(0)
+		cyborg.maptext_width = 32
 		remove_verb(cyborg, /mob/living/silicon/robot/proc/robot_lay_down)
 		remove_verb(cyborg, /mob/living/silicon/robot/proc/rest_style)
 

--- a/modular_skyrat/modules/customization/datums/dna.dm
+++ b/modular_skyrat/modules/customization/datums/dna.dm
@@ -180,6 +180,7 @@ GLOBAL_LIST_EMPTY(total_uf_len_by_block)
 	var/translate = ((change_multiplier-1) * 32)/2
 	holder.transform = holder.transform.Scale(change_multiplier)
 	holder.transform = holder.transform.Translate(0, translate)
+	holder.maptext_height = 32 * features["body_size"] // Adjust runechat height
 	current_body_size = features["body_size"]
 
 /mob/living/carbon/set_species(datum/species/mrace, icon_update = TRUE, pref_load = FALSE, list/override_features, list/override_mutantparts, list/override_markings, retain_features = FALSE, retain_mutantparts = FALSE)


### PR DESCRIPTION
## About The Pull Request

Currently the chat uses `bound_height` which is essentially the tile hitbox of an atom, meaning it raises or lowers by increments of 32 **only**. Changing the value on a player also causes them to be unable to move at all, it's simply not a good variable to use. I changed it to use `maptext_height`, this variable is used for ui atoms typically, and is thus safe to use for players. It's name also still makes sense to use like this.

## How This Contributes To The Skyrat Roleplay Experience

For the sake of demonstration I added a line to the `update_body_size()` proc.

Before:
![pic1](https://puu.sh/IAyxQ/1542e7274d.jpg)

After:
![pic2](https://puu.sh/IAyxX/cfe98510a7.jpg)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Runechat's message height is easier to update, does so for alternative body sizes.
/:cl: