### PR TITLE
[MODULAR] Adds a BOH storage module for MODsuits.

### DIFF
--- a/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
+++ b/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
@@ -25,6 +25,7 @@
 		new result_path(get_turf(src))
 		qdel(src)
 		qdel(anomaly)
+		playsound(src, 'sound/items/rped.ogg', 40, TRUE) //Sound feedback is cool.
 	else
 		to_chat(user,span_notice("That doesnt seem to fit into the [src]'s socket. It seems to be perfectly size for a refined anomaly core.."))
 		return

--- a/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
+++ b/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
@@ -17,7 +17,10 @@
 
 /obj/item/mod/module/storage/boh/inert/attackby(obj/item/weapon, mob/living/user, params)
 	. = ..()
-	if(istype(weapon, /obj/item/assembly/signaler/anomaly/bluespace))
+	if(!istype(weapon, /obj/item/assembly/signaler/anomaly/bluespace))
+		to_chat(user,span_notice("That doesn't seem to fit into [src]'s socket. It seems to be the perfect size for a refined bluespace anomaly core.."))
+		return
+	else
 		var/obj/item/assembly/signaler/anomaly/anomaly = weapon
 		var/result_path = /obj/item/mod/module/storage/boh
 		to_chat(user, span_notice("You insert [anomaly] into the [src]'s socket, and the module gently hums to life."))
@@ -25,9 +28,6 @@
 		playsound(src, 'sound/items/rped.ogg', 40, TRUE) //Sound feedback is cool.
 		qdel(src)
 		qdel(anomaly)
-	else
-		to_chat(user,span_notice("That doesn't seem to fit into [src]'s socket. It seems to be the perfect size for a refined bluespace anomaly core.."))
-		return
 
 //TECHWEB
 

--- a/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
+++ b/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
@@ -29,3 +29,23 @@
 	else
 		to_chat(user,span_notice("That doesnt seem to fit into the [src]'s socket. It seems to be perfectly size for a refined anomaly core.."))
 		return
+
+//TECHWEB
+
+/datum/techweb_node/bohmod
+	id = "bohmod"
+	display_name = "Bluespace MODsuit Storage"
+	description = ""
+	prereq_ids = list("bluespace_storage", "mod_advanced")
+	design_ids = list(
+		"bohmod",
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+
+/datum/design/module/bohmod
+	name = "MOD Module: Inert Wormhole Storage"
+	desc = "An inert Wormhole Storage module."
+	id = "bohmod"
+	materials = list(/datum/material/gold = 3000, /datum/material/diamond = 1500, /datum/material/uranium = 250, /datum/material/bluespace = 2000)
+	build_path = /obj/item/mod/module/storage/bluespace/boh/inert
+	build_type = MECHFAB

--- a/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
+++ b/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
@@ -1,4 +1,4 @@
-/obj/item/mod/module/storage/bluespace/boh/inert //Inert state of the BOH mod. Requires a refined bluespace core.
+/obj/item/mod/module/storage/boh/inert //Inert state of the BOH mod. Requires a refined bluespace core.
 	name = "Inert MOD wormhole storage module"
 	desc = "An inert MOD Wormhole Storage Module. Without its anomaly core, it is simply just a strangely ornate metal lattice with a circular socket in the bottom of it. With its core however, it becomes a way to store large quantities of items within a compacted bluespace wormhole, akin to a Bag of Holding."
 	icon_state = "module"
@@ -7,7 +7,7 @@
 	max_combined_w_class = 0
 	max_items = 0 //So that nothing can be stored in it, since its inactive, just like a normal BOH.
 
-/obj/item/mod/module/storage/bluespace/boh/active //Active state of the BOH mod. Has a refined core socketed into it, making it active.
+/obj/item/mod/module/storage/boh/active //Active state of the BOH mod. Has a refined core socketed into it, making it active.
 	name = "MOD wormhole storage module"
 	desc = "An active MOD Wormhole Storage Module. It utilizes a refined bluespace anomaly core to create a stable bluespace wormhole inside of its lattice container, allowing mass storage of objects varying widely in size."
 	icon_state = "module"
@@ -16,11 +16,11 @@
 	max_combined_w_class = 35 //Same as a BOH. Maybe slightly less would be better? To be seen.
 	max_items = 21 //Unsure if this is required or not but I will tag it in anyway.
 
-/obj/item/mod/module/storage/bluespace/boh/inert/attackby(obj/item/weapon, mob/living/user, params)
+/obj/item/mod/module/storage/boh/inert/attackby(obj/item/weapon, mob/living/user, params)
 	. = ..()
 	if(istype(weapon, /obj/item/assembly/signaler/anomaly/bluespace))
 		var/obj/item/assembly/signaler/anomaly/anomaly = weapon
-		var/result_path = /obj/item/mod/module/storage/bluespace/boh/active
+		var/result_path = /obj/item/mod/module/storage/boh/active
 		to_chat(user, span_notice("You insert [anomaly] into the [src]'s socket, and the module gently hums to life."))
 		new result_path(get_turf(src))
 		qdel(src)
@@ -47,5 +47,5 @@
 	desc = "An inert Wormhole Storage module."
 	id = "bohmod"
 	materials = list(/datum/material/gold = 3000, /datum/material/diamond = 1500, /datum/material/uranium = 250, /datum/material/bluespace = 2000)
-	build_path = /obj/item/mod/module/storage/bluespace/boh/inert
+	build_path = /obj/item/mod/module/storage/boh/inert
 	build_type = MECHFAB

--- a/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
+++ b/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
@@ -23,9 +23,9 @@
 		var/result_path = /obj/item/mod/module/storage/boh
 		to_chat(user, span_notice("You insert [anomaly] into the [src]'s socket, and the module gently hums to life."))
 		new result_path(get_turf(src))
+		playsound(src, 'sound/items/rped.ogg', 40, TRUE) //Sound feedback is cool.
 		qdel(src)
 		qdel(anomaly)
-		playsound(src, 'sound/items/rped.ogg', 40, TRUE) //Sound feedback is cool.
 	else
 		to_chat(user,span_notice("That doesnt seem to fit into the [src]'s socket. It seems to be perfectly size for a refined anomaly core.."))
 		return

--- a/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
+++ b/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
@@ -20,14 +20,13 @@
 	if(!istype(weapon, /obj/item/assembly/signaler/anomaly/bluespace))
 		to_chat(user,span_notice("That doesn't seem to fit into [src]'s socket. It seems to be the perfect size for a refined bluespace anomaly core.."))
 		return
-	else
-		var/obj/item/assembly/signaler/anomaly/anomaly = weapon
-		var/result_path = /obj/item/mod/module/storage/boh
-		to_chat(user, span_notice("You insert [anomaly] into the [src]'s socket, and the module gently hums to life."))
-		new result_path(get_turf(src))
-		playsound(src, 'sound/items/rped.ogg', 40, TRUE) //Sound feedback is cool.
-		qdel(src)
-		qdel(anomaly)
+	var/obj/item/assembly/signaler/anomaly/anomaly = weapon
+	var/result_path = /obj/item/mod/module/storage/boh
+	to_chat(user, span_notice("You insert [anomaly] into the [src]'s socket, and the module gently hums to life."))
+	new result_path(get_turf(src))
+	playsound(src, 'sound/items/rped.ogg', 40, TRUE) //Sound feedback is cool.
+	qdel(src)
+	qdel(anomaly)
 
 //TECHWEB
 

--- a/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
+++ b/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
@@ -7,7 +7,7 @@
 	max_combined_w_class = 0
 	max_items = 0 //So that nothing can be stored in it, since its inactive, just like a normal BOH.
 
-/obj/item/mod/module/storage/boh/active //Active state of the BOH mod. Has a refined core socketed into it, making it active.
+/obj/item/mod/module/storage/boh //Active state of the BOH mod. Has a refined core socketed into it, making it active.
 	name = "MOD wormhole storage module"
 	desc = "An active MOD Wormhole Storage Module. It utilizes a refined bluespace anomaly core to create a stable bluespace wormhole inside of its lattice container, allowing mass storage of objects varying widely in size."
 	icon_state = "module"
@@ -20,7 +20,7 @@
 	. = ..()
 	if(istype(weapon, /obj/item/assembly/signaler/anomaly/bluespace))
 		var/obj/item/assembly/signaler/anomaly/anomaly = weapon
-		var/result_path = /obj/item/mod/module/storage/boh/active
+		var/result_path = /obj/item/mod/module/storage/boh
 		to_chat(user, span_notice("You insert [anomaly] into the [src]'s socket, and the module gently hums to life."))
 		new result_path(get_turf(src))
 		qdel(src)

--- a/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
+++ b/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
@@ -1,7 +1,6 @@
 /obj/item/mod/module/storage/boh/inert //Inert state of the BOH mod. Requires a refined bluespace core.
 	name = "Inert MOD wormhole storage module"
 	desc = "An inert MOD Wormhole Storage Module. Without its anomaly core, it is simply just a strangely ornate metal lattice with a circular socket in the bottom of it. With its core however, it becomes a way to store large quantities of items within a compacted bluespace wormhole, akin to a Bag of Holding."
-	icon_state = "module"
 	complexity = 0
 	max_w_class = WEIGHT_CLASS_TINY
 	max_combined_w_class = 0

--- a/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
+++ b/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
@@ -1,0 +1,30 @@
+/obj/item/mod/module/storage/bluespace/boh/inert //Inert state of the BOH mod. Requires a refined bluespace core.
+	name = "Inert MOD wormhole storage module"
+	desc = "placeholderdesc"
+	icon_state = "module" //placeholder
+	complexity = 0
+	max_w_class = WEIGHT_CLASS_TINY
+	max_combined_w_class = 0
+	max_items = 0 //So that nothing can be stored in it, since its inactive, just like a normal BOH.
+
+/obj/item/mod/module/storage/bluespace/boh/active //Active state of the BOH mod. Has a refined core socketed into it, making it active.
+	name = "MOD wormhole storage module"
+	desc = "placeholderdesc"
+	icon_state = "storage_large"
+	complexity = 5 //may be reasonable? unsure yet. The stock storage module has a complexity of 3.
+	max_w_class = WEIGHT_CLASS_GIGANTIC
+	max_combined_w_class = 35 //Same as a BOH. Maybe slightly less would be better? To be seen.
+	max_items = 21 //Unsure if this is required or not but I will tag it in anyway.
+
+/obj/item/mod/module/storage/bluespace/boh/inert/attackby(obj/item/weapon, mob/living/user, params)
+	. = ..()
+	if(istype(weapon, /obj/item/assembly/signaler/anomaly/bluespace))
+		var/obj/item/assembly/signaler/anomaly/anomaly = weapon
+		var/result_path = /obj/item/mod/module/storage/bluespace/boh/active
+		to_chat(user, span_notice("You insert [anomaly] into the [src]'s socket, and the module gently hums to life."))
+		new result_path(get_turf(src))
+		qdel(src)
+		qdel(anomaly)
+	else
+		to_chat(user,span_notice("That doesnt seem to fit into the [src]'s socket. It seems to be perfectly size for a refined anomaly core.."))
+		return

--- a/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
+++ b/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
@@ -27,7 +27,7 @@
 		qdel(anomaly)
 		playsound(src, 'sound/items/rped.ogg', 40, TRUE) //Sound feedback is cool.
 	else
-		to_chat(user,span_notice("That doesnt seem to fit into the [src]'s socket. It seems to be perfectly size for a refined anomaly core.."))
+		to_chat(user,span_notice("That doesn't seem to fit into [src]'s socket. It seems to be the perfect size for a refined bluespace anomaly core.."))
 		return
 
 //TECHWEB

--- a/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
+++ b/modular_skyrat/modules/modular_modsuit/module_of_holding.dm
@@ -1,7 +1,7 @@
 /obj/item/mod/module/storage/bluespace/boh/inert //Inert state of the BOH mod. Requires a refined bluespace core.
 	name = "Inert MOD wormhole storage module"
-	desc = "placeholderdesc"
-	icon_state = "module" //placeholder
+	desc = "An inert MOD Wormhole Storage Module. Without its anomaly core, it is simply just a strangely ornate metal lattice with a circular socket in the bottom of it. With its core however, it becomes a way to store large quantities of items within a compacted bluespace wormhole, akin to a Bag of Holding."
+	icon_state = "module"
 	complexity = 0
 	max_w_class = WEIGHT_CLASS_TINY
 	max_combined_w_class = 0
@@ -9,8 +9,8 @@
 
 /obj/item/mod/module/storage/bluespace/boh/active //Active state of the BOH mod. Has a refined core socketed into it, making it active.
 	name = "MOD wormhole storage module"
-	desc = "placeholderdesc"
-	icon_state = "storage_large"
+	desc = "An active MOD Wormhole Storage Module. It utilizes a refined bluespace anomaly core to create a stable bluespace wormhole inside of its lattice container, allowing mass storage of objects varying widely in size."
+	icon_state = "module"
 	complexity = 5 //may be reasonable? unsure yet. The stock storage module has a complexity of 3.
 	max_w_class = WEIGHT_CLASS_GIGANTIC
 	max_combined_w_class = 35 //Same as a BOH. Maybe slightly less would be better? To be seen.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4953,6 +4953,7 @@
 #include "modular_skyrat\modules\modular_items\lewd_items\code\lewd_structures\dancing_pole.dm"
 #include "modular_skyrat\modules\modular_items\lewd_items\code\lewd_structures\lustwish.dm"
 #include "modular_skyrat\modules\modular_items\lewd_items\code\lewd_structures\pillow.dm"
+#include "modular_skyrat\modules\modular_modsuit\module_of_holding.dm"
 #include "modular_skyrat\modules\modular_reagents\code\alert.dm"
 #include "modular_skyrat\modules\modular_reagents\code\reagents\medicine.dm"
 #include "modular_skyrat\modules\modular_reagents\code\recipes\medicine_recipes.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a BOH storage module for late-game modsuits, to provide another use for frequently overabundant anomaly cores besides making anomaly armor.

## How This Contributes To The Skyrat Roleplay Experience

I dont think a single module really adds or subtracts from the roleplay experience to be honest.

## Changelog

:cl: Gonenoculer5
add: Frontier stations have noticed a new techweb node available relating to a recently discovered advancement in bluespace storage technologies for the recently acquired MODsuits from Nakamura Engineering in collaboration with Nanotrasen.
/:cl: