### PR TITLE
Makes internships more viable by adding all the missing headsets to their appropriate vendors

### DIFF
--- a/modular_skyrat/modules/modular_vending/code/wardrobes.dm
+++ b/modular_skyrat/modules/modular_vending/code/wardrobes.dm
@@ -6,6 +6,7 @@
 
 /obj/machinery/vending/wardrobe/medi_wardrobe
 	skyrat_products = list(
+		/obj/item/radio/headset/headset_med = 3,
 		/obj/item/clothing/gloves/color/latex/nitrile = 2,
 		/obj/item/clothing/suit/toggle/labcoat/hospitalgown = 5,
 		/obj/item/storage/belt/medbandolier = 2,
@@ -17,6 +18,7 @@
 
 /obj/machinery/vending/wardrobe/engi_wardrobe
 	skyrat_products = list(
+		/obj/item/radio/headset/headset_eng = 3,
 		/obj/item/clothing/under/rank/engineering/engineer/trouser = 3,
 		/obj/item/clothing/under/utility/eng = 3,
 		/obj/item/clothing/suit/toggle/jacket/engi = 3,
@@ -78,13 +80,13 @@
 
 /obj/machinery/vending/wardrobe/bar_wardrobe
 	skyrat_products = list(
-	/obj/item/storage/bag/money = 2,
-	/obj/item/storage/fancy/candle_box/vanilla = 1,
-	/obj/item/storage/fancy/candle_box/pear = 1,
-	/obj/item/storage/fancy/candle_box/amber = 1,
-	/obj/item/storage/fancy/candle_box/jasmine = 1,
-	/obj/item/storage/fancy/candle_box/mint = 1,
-	/obj/item/clothing/suit/hooded/wintercoat/bartender = 2,
+		/obj/item/storage/bag/money = 2,
+		/obj/item/storage/fancy/candle_box/vanilla = 1,
+		/obj/item/storage/fancy/candle_box/pear = 1,
+		/obj/item/storage/fancy/candle_box/amber = 1,
+		/obj/item/storage/fancy/candle_box/jasmine = 1,
+		/obj/item/storage/fancy/candle_box/mint = 1,
+		/obj/item/clothing/suit/hooded/wintercoat/bartender = 2,
 	)
 
 /obj/machinery/vending/wardrobe/chap_wardrobe
@@ -99,6 +101,11 @@
 		/obj/item/clothing/neck/chaplain = 1,
 		/obj/item/clothing/neck/chaplain/black = 1,
 		/obj/item/implanter/mortis = 1,
+	)
+
+/obj/machinery/vending/cart
+	skyrat_products = list(
+		/obj/item/radio/headset/headset_srv = 3,
 	)
 
 /obj/machinery/vending/wardrobe/chem_wardrobe


### PR DESCRIPTION
## About The Pull Request
Adds medical headsets to the medical clothes vendor, adds engineering headsets to the engineering clothes vendor and adds service headsets to the Head of Personnel's PTech vendor (it's the one centralized location for all of Service with a vendor in it, fight me).

## How This Contributes To The Skyrat Roleplay Experience
Have you ever wanted to be an intern in Medical, Engineering or Service, but then discovered that you would remain forever severed from your new department's communication channel because you simply couldn't get your hand on one of their headsets?

Well, this won't happen anymore, you're welcome.

The goal is to make internships more viable, so that people will be more likely to do stuff as assistants, which is just a bliss to see.

## Changelog

:cl: GoldenAlpharex
fix: After a long series of tiresome meetings and heated debates, the Nanotrasen Executive Board is happy to announce that all departments will be able to obtain additional headsets for their departments from their clothing vendors, so more poorly-paid internships can occur! (N.B.: The Head of Personnel is reponsible for service headsets, refer to them if you'd like to acquire one for your service internship)
/:cl: