### PR TITLE
[SEMI-MODULAR] Fixes Interdyne & DS-2 Id card registrations

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -298,7 +298,12 @@
 	implants = list(/obj/item/implant/weapons_auth)
 	id_trim = /datum/id_trim/chameleon/operative
 
-// SKYRAT EDIT DELETION of /datum/outfit/lavaland_syndicate/post_equip -- mapping
+// SKYRAT EDIT REMOVAL BEGIN -- mapping
+/*
+/datum/outfit/lavaland_syndicate/post_equip(mob/living/carbon/human/syndicate, visualsOnly = FALSE)
+	syndicate.faction |= ROLE_SYNDICATE
+*/
+// SKYRAT EDIT REMOVAL END
 
 /datum/outfit/lavaland_syndicate/comms
 	name = "Lavaland Syndicate Comms Agent"

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -298,8 +298,7 @@
 	implants = list(/obj/item/implant/weapons_auth)
 	id_trim = /datum/id_trim/chameleon/operative
 
-/datum/outfit/lavaland_syndicate/post_equip(mob/living/carbon/human/syndicate, visualsOnly = FALSE)
-	syndicate.faction |= ROLE_SYNDICATE
+// SKYRAT EDIT DELETION of /datum/outfit/lavaland_syndicate/post_equip -- mapping
 
 /datum/outfit/lavaland_syndicate/comms
 	name = "Lavaland Syndicate Comms Agent"

--- a/modular_skyrat/modules/mapping/code/lavaland_ruin_code.dm
+++ b/modular_skyrat/modules/mapping/code/lavaland_ruin_code.dm
@@ -22,6 +22,17 @@
 	uniform = /obj/item/clothing/under/utility/sci/syndicate
 	ears = /obj/item/radio/headset/interdyne
 
+/datum/outfit/lavaland_syndicate/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	H.faction |= ROLE_SYNDICATE
+
+	var/obj/item/card/id/C = H.wear_id
+	if(istype(C))
+		C.registered_name = H.real_name
+		C.update_label()
+		C.update_icon()
+
+	return ..()
+
 /datum/outfit/lavaland_syndicate/ice
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/hooded/wintercoat/syndicate

--- a/modular_skyrat/modules/mapping/code/lavaland_ruin_code.dm
+++ b/modular_skyrat/modules/mapping/code/lavaland_ruin_code.dm
@@ -22,14 +22,14 @@
 	uniform = /obj/item/clothing/under/utility/sci/syndicate
 	ears = /obj/item/radio/headset/interdyne
 
-/datum/outfit/lavaland_syndicate/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	H.faction |= ROLE_SYNDICATE
+/datum/outfit/lavaland_syndicate/post_equip(mob/living/carbon/human/syndicate, visualsOnly = FALSE)
+	syndicate.faction |= ROLE_SYNDICATE
 
-	var/obj/item/card/id/C = H.wear_id
-	if(istype(C))
-		C.registered_name = H.real_name
-		C.update_label()
-		C.update_icon()
+	var/obj/item/card/id/id_card = syndicate.wear_id
+	if(istype(id_card))
+		id_card.registered_name = syndicate.real_name
+		id_card.update_label()
+		id_card.update_icon()
 
 	return ..()
 

--- a/modular_skyrat/modules/mapping/code/mob_spawns.dm
+++ b/modular_skyrat/modules/mapping/code/mob_spawns.dm
@@ -81,6 +81,15 @@
 	ears = /obj/item/radio/headset/cybersun/captain
 	id_trim = /datum/id_trim/syndicom/skyrat/captain
 
+/datum/outfit/ds2/post_equip(mob/living/carbon/human/syndicate, visualsOnly = FALSE)
+	var/obj/item/card/id/C = syndicate.wear_id
+	if(istype(C))
+		C.registered_name = syndicate.real_name
+		C.update_label()
+		C.update_icon()
+
+	return ..()
+
 /datum/outfit/ds2/prisoner
 	name = "Syndicate Prisoner"
 	uniform = /obj/item/clothing/under/rank/prisoner
@@ -161,6 +170,7 @@
 
 /datum/outfit/ds2/syndicate/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE
+	return ..()
 
 //Lost Space Truckers: Six people stranded in deep space aboard a cargo freighter. They must survive their marooning and cooperate.
 

--- a/modular_skyrat/modules/mapping/code/mob_spawns.dm
+++ b/modular_skyrat/modules/mapping/code/mob_spawns.dm
@@ -82,11 +82,11 @@
 	id_trim = /datum/id_trim/syndicom/skyrat/captain
 
 /datum/outfit/ds2/post_equip(mob/living/carbon/human/syndicate, visualsOnly = FALSE)
-	var/obj/item/card/id/C = syndicate.wear_id
-	if(istype(C))
-		C.registered_name = syndicate.real_name
-		C.update_label()
-		C.update_icon()
+	var/obj/item/card/id/id_card = syndicate.wear_id
+	if(istype(id_card))
+		id_card.registered_name = syndicate.real_name
+		id_card.update_label()
+		id_card.update_icon()
 
 	return ..()
 
@@ -168,8 +168,8 @@
 	id_trim = /datum/id_trim/syndicom/skyrat/assault/stationadmiral
 	ears = /obj/item/radio/headset/interdyne/command
 
-/datum/outfit/ds2/syndicate/post_equip(mob/living/carbon/human/H)
-	H.faction |= ROLE_SYNDICATE
+/datum/outfit/ds2/syndicate/post_equip(mob/living/carbon/human/syndicate)
+	syndicate.faction |= ROLE_SYNDICATE
 	return ..()
 
 //Lost Space Truckers: Six people stranded in deep space aboard a cargo freighter. They must survive their marooning and cooperate.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

SyndiCom would like to assure its stockholders that the lazy HR rep who kept distributing blank ID cards to staff has been repeatedly shot with DonkCo™ foam darts.

Interdyne and DS-2 ID cards are now registered to their owners again. I could have sworn I or someone else made an incident for this, but I guess not.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Even though it's a ghost role, cards should be registered to their owners. Especially the DS-2 ones that aren't agent ID's.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
fix: Interdyne and DS-2 ID cards are now registered to their owner again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
