### PR TITLE
Adds firelock override range check

### DIFF
--- a/modular_skyrat/master_files/code/game/machinery/doors/firedoor.dm
+++ b/modular_skyrat/master_files/code/game/machinery/doors/firedoor.dm
@@ -1,5 +1,7 @@
 /obj/machinery/door/firedoor/AltClick(mob/user)
 	. = ..()
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	try_manual_override(user)
 
 /obj/machinery/door/firedoor/examine(mob/user)


### PR DESCRIPTION
Overriding them from range ruins my immersion

## Changelog
:cl:
fix: You can no longer override a firelock's closing mechanisms from range.
/:cl: