### PR TITLE
[SEMI-MODULAR] Re-implements the flavor text preview. Also tidies up some examine code and adds a bit of extra text to temp flavor text.

### DIFF
--- a/code/__DEFINES/~skyrat_defines/flavor_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/flavor_defines.dm
@@ -1,4 +1,2 @@
-/// How many characters will the flavor text preview tolerate before cutting it with with triple periods?
-#define FLAVOR_PREVIEW_LENGTH 70
-/// Default value for flavor preview text, is a global because it is used both as the default value, and used to check if the preview should be displayed.
-#define FLAVOR_PREVIEW_DEFAULT_VALUE "If this textbox is less than [FLAVOR_PREVIEW_LENGTH] characters, is not empty, and is NOT this, it will display whatever is put here on examine."
+/// How many characters will be displayed in the flavor text preview before we cut it off?
+#define FLAVOR_PREVIEW_LIMIT 60

--- a/code/__DEFINES/~skyrat_defines/flavor_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/flavor_defines.dm
@@ -1,0 +1,2 @@
+#define FLAVOR_PREVIEW_LENGTH 25 // How many characters will the flavor text preview tolerate before cutting it with with triple periods?
+#define FLAVOR_PREVIEW_DEFAULT_VALUE "If this textbox is less than [FLAVOR_PREVIEW_LENGTH] characters, is not empty, and is NOT this, it will display whatever is put here on examine."

--- a/code/__DEFINES/~skyrat_defines/flavor_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/flavor_defines.dm
@@ -1,2 +1,4 @@
-#define FLAVOR_PREVIEW_LENGTH 25 // How many characters will the flavor text preview tolerate before cutting it with with triple periods?
+/// How many characters will the flavor text preview tolerate before cutting it with with triple periods?
+#define FLAVOR_PREVIEW_LENGTH 25
+/// Default value for flavor preview text, is a global because it is used both as the default value, and used to check if the preview should be displayed.
 #define FLAVOR_PREVIEW_DEFAULT_VALUE "If this textbox is less than [FLAVOR_PREVIEW_LENGTH] characters, is not empty, and is NOT this, it will display whatever is put here on examine."

--- a/code/__DEFINES/~skyrat_defines/flavor_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/flavor_defines.dm
@@ -1,4 +1,4 @@
 /// How many characters will the flavor text preview tolerate before cutting it with with triple periods?
-#define FLAVOR_PREVIEW_LENGTH 25
+#define FLAVOR_PREVIEW_LENGTH 70
 /// Default value for flavor preview text, is a global because it is used both as the default value, and used to check if the preview should be displayed.
 #define FLAVOR_PREVIEW_DEFAULT_VALUE "If this textbox is less than [FLAVOR_PREVIEW_LENGTH] characters, is not empty, and is NOT this, it will display whatever is put here on examine."

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -493,7 +493,7 @@
 		//if the user has gone over the limit, only has 1 char (to prevent most accidental single spaces), or hasnt modified the default value, show the default
 		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
 	else
-		flavor_text_link = span_notice("[preview_text]...<a href='?src=[REF(src)];lookup_info=open_examine_panel'> Look closer?</a>")
+		flavor_text_link = span_notice("[preview_text]... <a href='?src=[REF(src)];lookup_info=open_examine_panel'>Look closer?</a>")
 	if (flavor_text_link) //i believe this is a sanity check
 		. += flavor_text_link
 	if(client)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -486,7 +486,7 @@
 					break
 
 	var/flavor_text_link
-	var/preview_text = copytext((dna.features["flavor_text"]), 1, FLAVOR_PREVIEW_LIMIT)
+	var/preview_text = copytext((dna.features["flavor_text"]), 1, FLAVOR_PREVIEW_LIMIT) //defined in flavor_defines.dm
 
 	if (!obscured)
 		flavor_text_link = span_notice("[preview_text]...<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Look closer?</a>")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -484,28 +484,28 @@
 				if(!(G.is_hidden(src)))
 					. += "<span class='notice'>[t_He] has exposed genitals... <a href='?src=[REF(src)];lookup_info=genitals'>Look closer...</a></span>"
 					break
+
 	var/flavor_text_link
-	var/preview_text = client.prefs.read_preference(/datum/preference/text/flavor_preview)
-	if (!preview_text && preview_text != "") //sanity check, not sure if preview_text being "" counts as null but want to make sure it doesnt trip up
-		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
-		. += flavor_text_link //no need for an if statement if we KNOW we just defined it as something
-	else if ((length_char(preview_text) > FLAVOR_PREVIEW_LENGTH || length_char(preview_text) < 2) || (preview_text == FLAVOR_PREVIEW_DEFAULT_VALUE))
-		//if the user has gone over the limit, only has 1 char (to prevent most accidental single spaces), or hasnt modified the default value, show the default
-		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
+	var/preview_text = copytext((dna.features["flavor_text"]), 1, FLAVOR_PREVIEW_LIMIT)
+
+	if (!obscured)
+		flavor_text_link = span_notice("[preview_text]...<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Look closer?</a>")
 	else
-		flavor_text_link = span_notice("[preview_text]... <a href='?src=[REF(src)];lookup_info=open_examine_panel'>Look closer?</a>")
-	if (flavor_text_link) //i believe this is a sanity check
+		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=1'>Examine closely...</a>")
+	if (flavor_text_link)
 		. += flavor_text_link
+
 	if(client)
 		var/erp_status_pref = client.prefs.read_preference(/datum/preference/choiced/erp_status)
 		if(erp_status_pref && erp_status_pref != "disabled")
 			. += span_notice("ERP STATUS: [erp_status_pref]")
+
 	//Temporary flavor text addition:
 	if(temporary_flavor_text)
 		if(length_char(temporary_flavor_text) <= 40)
-			. += span_notice("<b> They look different than usual:</b> [temporary_flavor_text]")
+			. += span_notice("<b>They look different than usual:</b> [temporary_flavor_text]")
 		else
-			. += span_notice("<b> They look different than usual:</b> [copytext_char(temporary_flavor_text, 1, 37)]... <a href='?src=[REF(src)];temporary_flavor=1'>More...</a>")
+			. += span_notice("<b>They look different than usual:</b> [copytext_char(temporary_flavor_text, 1, 37)]... <a href='?src=[REF(src)];temporary_flavor=1'>More...</a>")
 	//. += "*---------*</span>" SKYRAT EDIT REMOVAL
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -484,9 +484,17 @@
 				if(!(G.is_hidden(src)))
 					. += "<span class='notice'>[t_He] has exposed genitals... <a href='?src=[REF(src)];lookup_info=genitals'>Look closer...</a></span>"
 					break
-	var/line = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
-	if(line)
-		. += line
+	var/flavor_text_link
+	var/preview_text = client.prefs.read_preference(/datum/preference/text/flavor_preview)
+	if (!preview_text && preview_text != "") //sanity check, not sure if preview_text being "" counts as null but want to make sure it doesnt trip up
+		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
+		. += flavor_text_link
+	else if ((length_char(preview_text) > FLAVOR_PREVIEW_LENGTH) || (preview_text == FLAVOR_PREVIEW_DEFAULT_VALUE))
+		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
+	else
+		flavor_text_link = span_notice("[preview_text]...<a href='?src=[REF(src)];lookup_info=open_examine_panel'> Look closer?</a>")
+	if (flavor_text_link)
+		. += flavor_text_link
 	if(client)
 		var/erp_status_pref = client.prefs.read_preference(/datum/preference/choiced/erp_status)
 		if(erp_status_pref && erp_status_pref != "disabled")
@@ -494,9 +502,9 @@
 	//Temporary flavor text addition:
 	if(temporary_flavor_text)
 		if(length_char(temporary_flavor_text) <= 40)
-			. += "<span class='notice'>[temporary_flavor_text]</span>"
+			. += span_notice("<b> They look different than usual:</b> [temporary_flavor_text]")
 		else
-			. += "<span class='notice'>[copytext_char(temporary_flavor_text, 1, 37)]... <a href='?src=[REF(src)];temporary_flavor=1'>More...</a></span>"
+			. += span_notice("<b> They look different than usual:</b> [copytext_char(temporary_flavor_text, 1, 37)]... <a href='?src=[REF(src)];temporary_flavor=1'>More...</a>")
 	//. += "*---------*</span>" SKYRAT EDIT REMOVAL
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -488,12 +488,13 @@
 	var/preview_text = client.prefs.read_preference(/datum/preference/text/flavor_preview)
 	if (!preview_text && preview_text != "") //sanity check, not sure if preview_text being "" counts as null but want to make sure it doesnt trip up
 		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
-		. += flavor_text_link
-	else if ((length_char(preview_text) > FLAVOR_PREVIEW_LENGTH) || (preview_text == FLAVOR_PREVIEW_DEFAULT_VALUE))
+		. += flavor_text_link //no need for an if statement if we KNOW we just defined it as something
+	else if ((length_char(preview_text) > FLAVOR_PREVIEW_LENGTH || length_char(preview_text) < 2) || (preview_text == FLAVOR_PREVIEW_DEFAULT_VALUE))
+		//if the user has gone over the limit, only has 1 char (to prevent most accidental single spaces), or hasnt modified the default value, show the default
 		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
 	else
 		flavor_text_link = span_notice("[preview_text]...<a href='?src=[REF(src)];lookup_info=open_examine_panel'> Look closer?</a>")
-	if (flavor_text_link)
+	if (flavor_text_link) //i believe this is a sanity check
 		. += flavor_text_link
 	if(client)
 		var/erp_status_pref = client.prefs.read_preference(/datum/preference/choiced/erp_status)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -486,7 +486,8 @@
 					break
 
 	var/flavor_text_link
-	var/preview_text = copytext((dna.features["flavor_text"]), 1, FLAVOR_PREVIEW_LIMIT) //defined in flavor_defines.dm
+	/// The first 1-FLAVOR_PREVIEW_LIMIT characters in the mob's "flavor_text" DNA feature. FLAVOR_PREVIEW_LIMIT is defined in flavor_defines.dm.
+	var/preview_text = copytext((dna.features["flavor_text"]), 1, FLAVOR_PREVIEW_LIMIT)
 
 	if (!obscured)
 		flavor_text_link = span_notice("[preview_text]...<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Look closer?</a>")

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -45,7 +45,8 @@
 			. += "<span class='deadsay'>It looks like its system is corrupted and requires a reset.</span>"
 	//SKYRAT EDIT ADDITION BEGIN - CUSTOMIZATION
 	var/flavor_text_link
-	var/silicon_preview_text = copytext((client.prefs.read_preference(/datum/preference/text/silicon_flavor_text)), 1, FLAVOR_PREVIEW_LIMIT) //defined in flavor_defines.dm
+	/// The first 1-FLAVOR_PREVIEW_LIMIT characters in the mob's client's silicon_flavor_text preference datum. FLAVOR_PREVIEW_LIMIT is defined in flavor_defines.dm.
+	var/silicon_preview_text = copytext((client.prefs.read_preference(/datum/preference/text/silicon_flavor_text)), 1, FLAVOR_PREVIEW_LIMIT)
 
 	flavor_text_link = span_notice("[silicon_preview_text]...<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Look closer?</a>")
 

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -53,7 +53,7 @@
 		//if the user has gone over the limit, only has 1 char (to prevent most accidental single spaces), or hasnt modified the default value, show the default
 		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
 	else
-		flavor_text_link = span_notice("[silicon_preview_text]...<a href='?src=[REF(src)];lookup_info=open_examine_panel'> Look closer?</a>")
+		flavor_text_link = span_notice("[silicon_preview_text]... <a href='?src=[REF(src)];lookup_info=open_examine_panel'>Look closer?</a>")
 	if (flavor_text_link) //i believe this is a sanity check
 		. += flavor_text_link
 	if(client)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -44,18 +44,26 @@
 		if(DEAD)
 			. += "<span class='deadsay'>It looks like its system is corrupted and requires a reset.</span>"
 	//SKYRAT EDIT ADDITION BEGIN - CUSTOMIZATION
-	var/line = span_notice("<a href='?src=[REF(src)];lookup_info=1'>Examine closely...</a>")
-	if(line)
-		. += line
+	var/flavor_text_link
+	var/silicon_preview_text = client.prefs.read_preference(/datum/preference/text/silicon_flavor_preview)
+	if (!silicon_preview_text && silicon_preview_text != "") //sanity check, not sure if silicon_preview_text being "" counts as null but want to make sure it doesnt trip up
+		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
+		. += flavor_text_link
+	else if ((length_char(silicon_preview_text) > FLAVOR_PREVIEW_LENGTH) || (silicon_preview_text == FLAVOR_PREVIEW_DEFAULT_VALUE))
+		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
+	else
+		flavor_text_link = span_notice("[silicon_preview_text]...<a href='?src=[REF(src)];lookup_info=open_examine_panel'> Look closer?</a>")
+	if (flavor_text_link)
+		. += flavor_text_link
 	if(client)
 		var/erp_status_pref = client.prefs.read_preference(/datum/preference/choiced/erp_status)
 		if(erp_status_pref && erp_status_pref != "disabled")
 			. += span_notice("ERP STATUS: [erp_status_pref]")
 	if(temporary_flavor_text)
 		if(length_char(temporary_flavor_text) <= 40)
-			. += "<span class='notice'>[temporary_flavor_text]</span>"
+			. += span_notice("<b> They look different than usual:</b> [temporary_flavor_text]")
 		else
-			. += "<span class='notice'>[copytext_char(temporary_flavor_text, 1, 37)]... <a href='?src=[REF(src)];temporary_flavor=1'>More...</a></span>"
+			. += span_notice("<b> They look different than usual:</b> [copytext_char(temporary_flavor_text, 1, 37)]... <a href='?src=[REF(src)];temporary_flavor=1'>More...</a>")
 	//SKYRAT EDIT ADDITION END
 	//. += "*---------*</span>"
 

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -45,26 +45,22 @@
 			. += "<span class='deadsay'>It looks like its system is corrupted and requires a reset.</span>"
 	//SKYRAT EDIT ADDITION BEGIN - CUSTOMIZATION
 	var/flavor_text_link
-	var/silicon_preview_text = client.prefs.read_preference(/datum/preference/text/silicon_flavor_preview)
-	if (!silicon_preview_text && silicon_preview_text != "") //sanity check, not sure if silicon_preview_text being "" counts as null but want to make sure it doesnt trip up
-		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
-		. += flavor_text_link //no need for an if statement if we KNOW we just defined it as something
-	else if ((length_char(silicon_preview_text) > FLAVOR_PREVIEW_LENGTH || length_char(silicon_preview_text) < 2) || (silicon_preview_text == FLAVOR_PREVIEW_DEFAULT_VALUE))
-		//if the user has gone over the limit, only has 1 char (to prevent most accidental single spaces), or hasnt modified the default value, show the default
-		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
-	else
-		flavor_text_link = span_notice("[silicon_preview_text]... <a href='?src=[REF(src)];lookup_info=open_examine_panel'>Look closer?</a>")
+	var/silicon_preview_text = copytext((client.prefs.read_preference(/datum/preference/text/silicon_flavor_text)), 1, FLAVOR_PREVIEW_LIMIT)
+
+	flavor_text_link = span_notice("[silicon_preview_text]...<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Look closer?</a>")
+
 	if (flavor_text_link) //i believe this is a sanity check
 		. += flavor_text_link
+
 	if(client)
 		var/erp_status_pref = client.prefs.read_preference(/datum/preference/choiced/erp_status)
 		if(erp_status_pref && erp_status_pref != "disabled")
 			. += span_notice("ERP STATUS: [erp_status_pref]")
 	if(temporary_flavor_text)
 		if(length_char(temporary_flavor_text) <= 40)
-			. += span_notice("<b> They look different than usual:</b> [temporary_flavor_text]")
+			. += span_notice("<b>They look different than usual:</b> [temporary_flavor_text]")
 		else
-			. += span_notice("<b> They look different than usual:</b> [copytext_char(temporary_flavor_text, 1, 37)]... <a href='?src=[REF(src)];temporary_flavor=1'>More...</a>")
+			. += span_notice("<b>They look different than usual:</b> [copytext_char(temporary_flavor_text, 1, 37)]... <a href='?src=[REF(src)];temporary_flavor=1'>More...</a>")
 	//SKYRAT EDIT ADDITION END
 	//. += "*---------*</span>"
 

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -48,12 +48,13 @@
 	var/silicon_preview_text = client.prefs.read_preference(/datum/preference/text/silicon_flavor_preview)
 	if (!silicon_preview_text && silicon_preview_text != "") //sanity check, not sure if silicon_preview_text being "" counts as null but want to make sure it doesnt trip up
 		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
-		. += flavor_text_link
-	else if ((length_char(silicon_preview_text) > FLAVOR_PREVIEW_LENGTH) || (silicon_preview_text == FLAVOR_PREVIEW_DEFAULT_VALUE))
+		. += flavor_text_link //no need for an if statement if we KNOW we just defined it as something
+	else if ((length_char(silicon_preview_text) > FLAVOR_PREVIEW_LENGTH || length_char(silicon_preview_text) < 2) || (silicon_preview_text == FLAVOR_PREVIEW_DEFAULT_VALUE))
+		//if the user has gone over the limit, only has 1 char (to prevent most accidental single spaces), or hasnt modified the default value, show the default
 		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Examine closely...</a>")
 	else
 		flavor_text_link = span_notice("[silicon_preview_text]...<a href='?src=[REF(src)];lookup_info=open_examine_panel'> Look closer?</a>")
-	if (flavor_text_link)
+	if (flavor_text_link) //i believe this is a sanity check
 		. += flavor_text_link
 	if(client)
 		var/erp_status_pref = client.prefs.read_preference(/datum/preference/choiced/erp_status)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -45,11 +45,11 @@
 			. += "<span class='deadsay'>It looks like its system is corrupted and requires a reset.</span>"
 	//SKYRAT EDIT ADDITION BEGIN - CUSTOMIZATION
 	var/flavor_text_link
-	var/silicon_preview_text = copytext((client.prefs.read_preference(/datum/preference/text/silicon_flavor_text)), 1, FLAVOR_PREVIEW_LIMIT)
+	var/silicon_preview_text = copytext((client.prefs.read_preference(/datum/preference/text/silicon_flavor_text)), 1, FLAVOR_PREVIEW_LIMIT) //defined in flavor_defines.dm
 
 	flavor_text_link = span_notice("[silicon_preview_text]...<a href='?src=[REF(src)];lookup_info=open_examine_panel'>Look closer?</a>")
 
-	if (flavor_text_link) //i believe this is a sanity check
+	if (flavor_text_link)
 		. += flavor_text_link
 
 	if(client)

--- a/modular_skyrat/master_files/code/modules/client/preferences/flavor_text.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/flavor_text.dm
@@ -6,6 +6,17 @@
 /datum/preference/text/flavor_text/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	target.dna.features["flavor_text"] = value
 
+/datum/preference/text/flavor_preview
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "flavor_preview"
+
+/datum/preference/text/flavor_preview/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	target.dna.features["flavor_preview"] = value
+
+/datum/preference/text/flavor_preview/create_default_value()
+	return FLAVOR_PREVIEW_DEFAULT_VALUE
+
 /datum/preference/text/silicon_flavor_text
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER
@@ -14,6 +25,18 @@
 
 /datum/preference/text/silicon_flavor_text/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE // To prevent the not-implemented runtime
+
+/datum/preference/text/silicon_flavor_preview
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "silicon_flavor_preview"
+	// same as above
+
+/datum/preference/text/silicon_flavor_preview/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE // again, above
+
+/datum/preference/text/silicon_flavor_preview/create_default_value()
+	return FLAVOR_PREVIEW_DEFAULT_VALUE
 
 /datum/preference/text/ooc_notes
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
@@ -39,7 +62,7 @@
 /datum/preference/text/custom_species_lore/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	target.dna.features["custom_species_lore"] = value
 
-// SKYRAT EDIT ADDITION BEGIN -- RP RECORDS REJUVINATION
+// SKYRAT EDIT ADDITION BEGIN -- RP RECORDS REJUVINATION - All of these are handled in datacore, so we dont apply it to the human.
 /datum/preference/text/general
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER

--- a/modular_skyrat/master_files/code/modules/client/preferences/flavor_text.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/flavor_text.dm
@@ -6,17 +6,6 @@
 /datum/preference/text/flavor_text/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	target.dna.features["flavor_text"] = value
 
-/datum/preference/text/flavor_preview
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
-	savefile_identifier = PREFERENCE_CHARACTER
-	savefile_key = "flavor_preview"
-
-/datum/preference/text/flavor_preview/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	target.dna.features["flavor_preview"] = value
-
-/datum/preference/text/flavor_preview/create_default_value()
-	return FLAVOR_PREVIEW_DEFAULT_VALUE
-
 /datum/preference/text/silicon_flavor_text
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER
@@ -25,18 +14,6 @@
 
 /datum/preference/text/silicon_flavor_text/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE // To prevent the not-implemented runtime
-
-/datum/preference/text/silicon_flavor_preview
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
-	savefile_identifier = PREFERENCE_CHARACTER
-	savefile_key = "silicon_flavor_preview"
-	// same as above
-
-/datum/preference/text/silicon_flavor_preview/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	return FALSE // again, above
-
-/datum/preference/text/silicon_flavor_preview/create_default_value()
-	return FLAVOR_PREVIEW_DEFAULT_VALUE
 
 /datum/preference/text/ooc_notes
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -251,6 +251,7 @@
 #include "code\__DEFINES\~skyrat_defines\examine_defines.dm"
 #include "code\__DEFINES\~skyrat_defines\faction.dm"
 #include "code\__DEFINES\~skyrat_defines\factions.dm"
+#include "code\__DEFINES\~skyrat_defines\flavor_defines.dm"
 #include "code\__DEFINES\~skyrat_defines\game_options.dm"
 #include "code\__DEFINES\~skyrat_defines\gun.dm"
 #include "code\__DEFINES\~skyrat_defines\integrated_electronics.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
@@ -20,21 +20,9 @@ export const flavor_text: Feature<string> = {
   component: FeatureTextInput,
 };
 
-export const flavor_preview: Feature<string> = {
-  name: "Flavor Text Preview",
-  description: "Describe your character, but short!",
-  component: FeatureTextInput,
-};
-
 export const silicon_flavor_text: Feature<string> = {
   name: "Flavor Text (Silicon)",
   description: "Describe your cyborg/AI shell!",
-  component: FeatureTextInput,
-};
-
-export const silicon_flavor_preview: Feature<string> = {
-  name: "Flavor Text Preview (Silicon)",
-  description: "Describe your cyborg/AI shell, but short!",
   component: FeatureTextInput,
 };
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
@@ -20,9 +20,21 @@ export const flavor_text: Feature<string> = {
   component: FeatureTextInput,
 };
 
+export const flavor_preview: Feature<string> = {
+  name: "Flavor Text Preview",
+  description: "Describe your character, but short!",
+  component: FeatureTextInput,
+};
+
 export const silicon_flavor_text: Feature<string> = {
   name: "Flavor Text (Silicon)",
   description: "Describe your cyborg/AI shell!",
+  component: FeatureTextInput,
+};
+
+export const silicon_flavor_preview: Feature<string> = {
+  name: "Flavor Text Preview (Silicon)",
+  description: "Describe your cyborg/AI shell, but short!",
   component: FeatureTextInput,
 };
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Re-implements the pre-tgui prefs refactor flavor text preview, as a new pref option that is handled seperately from normal flavor text. Uses a few global vars to control crucial components of it.

Also I added a bold "They look different" to the beginning of temp flavor text since I found it didnt grab my attention before, and, changed temp flavor text to use span_notice procs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
I hate using TGUI. I love shift clicking.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Re-adds the old flavor text preview! Check your character creation screens, there should be new text boxes by both normal and silicon flavor text.
code: Adds a few more span thingies. YOu know what I mean.
change: Temp flavor text now makes it more clear when someone has temp flavor text.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## TODO

- [x] make it work
- [x] documentation