### PR TITLE
Removes several duplicate catwalks that were causing mapload runtimes from the shipbreaker ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/salvagepost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/salvagepost.dmm
@@ -49,12 +49,12 @@
 /turf/open/floor/plastic,
 /area/ruin/powered)
 "cR" = (
+/obj/item/wallframe/airalarm,
 /obj/structure/lattice/catwalk/swarmer_catwalk{
 	color = "#318350";
 	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
 	name = "barge mesh"
 	},
-/obj/item/wallframe/airalarm,
 /turf/template_noop,
 /area/template_noop)
 "dd" = (
@@ -187,25 +187,25 @@
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "im" = (
+/obj/structure/frame/computer,
 /obj/structure/lattice/catwalk/swarmer_catwalk{
 	color = "#318350";
 	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
 	name = "barge mesh"
 	},
-/obj/structure/frame/computer,
 /turf/template_noop,
 /area/template_noop)
 "iT" = (
-/obj/structure/lattice/catwalk/swarmer_catwalk{
-	color = "#318350";
-	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
-	name = "barge mesh"
-	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
+	},
+/obj/structure/lattice/catwalk/swarmer_catwalk{
+	color = "#318350";
+	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
+	name = "barge mesh"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -230,16 +230,16 @@
 /turf/open/floor/iron/dark,
 /area/ruin/powered)
 "jV" = (
-/obj/structure/lattice/catwalk/swarmer_catwalk{
-	color = "#318350";
-	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
-	name = "barge mesh"
-	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
 /obj/item/wallframe/airalarm{
 	pixel_y = -7
+	},
+/obj/structure/lattice/catwalk/swarmer_catwalk{
+	color = "#318350";
+	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
+	name = "barge mesh"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -300,13 +300,13 @@
 /turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered/no_grav)
 "ni" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
 /obj/structure/lattice/catwalk/swarmer_catwalk{
 	color = "#318350";
 	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
 	name = "barge mesh"
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -322,7 +322,11 @@
 /turf/template_noop,
 /area/template_noop)
 "oN" = (
-/obj/structure/lattice/catwalk/swarmer_catwalk,
+/obj/structure/lattice/catwalk/swarmer_catwalk{
+	color = "#318350";
+	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
+	name = "barge mesh"
+	},
 /obj/structure/lattice/catwalk/swarmer_catwalk{
 	color = "#318350";
 	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
@@ -340,12 +344,12 @@
 /turf/template_noop,
 /area/template_noop)
 "pF" = (
+/obj/item/poster/random_contraband,
 /obj/structure/lattice/catwalk/swarmer_catwalk{
 	color = "#318350";
 	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
 	name = "barge mesh"
 	},
-/obj/item/poster/random_contraband,
 /turf/template_noop,
 /area/template_noop)
 "pT" = (
@@ -548,23 +552,18 @@
 /turf/template_noop,
 /area/template_noop)
 "Aq" = (
-/obj/structure/lattice/catwalk/swarmer_catwalk{
-	color = "#318350";
-	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
-	name = "barge mesh"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	anchored = 0;
 	dir = 8
 	},
-/turf/template_noop,
-/area/template_noop)
-"Ay" = (
 /obj/structure/lattice/catwalk/swarmer_catwalk{
 	color = "#318350";
 	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
 	name = "barge mesh"
 	},
+/turf/template_noop,
+/area/template_noop)
+"Ay" = (
 /obj/structure/window/reinforced/survival_pod,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
@@ -573,6 +572,11 @@
 	anchored = 0;
 	pixel_x = 3;
 	pixel_y = 10
+	},
+/obj/structure/lattice/catwalk/swarmer_catwalk{
+	color = "#318350";
+	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
+	name = "barge mesh"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -603,16 +607,16 @@
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "BM" = (
-/obj/structure/lattice/catwalk/swarmer_catwalk{
-	color = "#318350";
-	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
-	name = "barge mesh"
-	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
+	},
+/obj/structure/lattice/catwalk/swarmer_catwalk{
+	color = "#318350";
+	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
+	name = "barge mesh"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -624,19 +628,17 @@
 /turf/template_noop,
 /area/template_noop)
 "DB" = (
-/obj/item/gps/computer/space{
-	pixel_y = -5
-	},
+/obj/item/gps/computer/space,
 /turf/open/floor/plating/airless,
 /area/ruin/powered)
 "DX" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
 /obj/structure/lattice/catwalk/swarmer_catwalk{
 	color = "#318350";
 	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
 	name = "barge mesh"
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -763,12 +765,12 @@
 /turf/template_noop,
 /area/template_noop)
 "Iu" = (
+/obj/item/wallframe/apc,
 /obj/structure/lattice/catwalk/swarmer_catwalk{
 	color = "#318350";
 	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
 	name = "barge mesh"
 	},
-/obj/item/wallframe/apc,
 /turf/template_noop,
 /area/template_noop)
 "Jv" = (
@@ -795,16 +797,16 @@
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "Ko" = (
-/obj/structure/lattice/catwalk/swarmer_catwalk{
-	color = "#318350";
-	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
-	name = "barge mesh"
-	},
 /obj/structure/window/reinforced/survival_pod,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
+/obj/structure/lattice/catwalk/swarmer_catwalk{
+	color = "#318350";
+	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
+	name = "barge mesh"
+	},
 /turf/template_noop,
 /area/template_noop)
 "KP" = (
@@ -866,13 +868,13 @@
 /turf/open/floor/plating,
 /area/ruin/powered)
 "NI" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
 /obj/structure/lattice/catwalk/swarmer_catwalk{
 	color = "#318350";
 	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
 	name = "barge mesh"
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -893,13 +895,13 @@
 /turf/open/floor/carpet/red,
 /area/ruin/powered)
 "NY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+	anchored = 0
+	},
 /obj/structure/lattice/catwalk/swarmer_catwalk{
 	color = "#318350";
 	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
 	name = "barge mesh"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
-	anchored = 0
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -1058,12 +1060,12 @@
 	},
 /area/template_noop)
 "WR" = (
+/obj/structure/window/reinforced/survival_pod,
 /obj/structure/lattice/catwalk/swarmer_catwalk{
 	color = "#318350";
 	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
 	name = "barge mesh"
 	},
-/obj/structure/window/reinforced/survival_pod,
 /turf/template_noop,
 /area/template_noop)
 "WW" = (
@@ -1077,17 +1079,17 @@
 /turf/template_noop,
 /area/template_noop)
 "Xb" = (
-/obj/structure/lattice/catwalk/swarmer_catwalk{
-	color = "#318350";
-	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
-	name = "barge mesh"
-	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/plasma{
 	desc = "Plasma gas. Highly fuel efficient. Highly volatile. Highly toxic.";
 	name = "Fuel canister"
+	},
+/obj/structure/lattice/catwalk/swarmer_catwalk{
+	color = "#318350";
+	desc = "A catwalk-like mesh, used for the collection of space debris before processing.";
+	name = "barge mesh"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -1698,7 +1700,7 @@ AW
 OU
 PD
 OU
-OU
+oN
 cR
 WR
 Eu
@@ -2009,8 +2011,8 @@ Eu
 vA
 OU
 OU
-oN
-oN
+OU
+OU
 EJ
 Eu
 Eu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes a few catwalks that were stacked under some others in the shipbreaker ruin, which was throwing map error runtimes at roundstart.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Init will probably be like 0.001 seconds faster

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed catwalks stacked on top of each other in the shipbreaker ruin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
