### PR TITLE
fixes icebox's lawyer office not having a drobe for some reason

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -29465,6 +29465,10 @@
 	dir = 5
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/structure/rack,
+/obj/item/storage/secure/briefcase,
+/obj/item/storage/briefcase,
+/obj/item/storage/briefcase,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "lgf" = (
@@ -48780,13 +48784,10 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "vsI" = (
-/obj/structure/rack,
-/obj/item/storage/briefcase,
-/obj/item/storage/briefcase,
-/obj/item/storage/secure/briefcase,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/iron/dark,
 /area/service/lawoffice)
 "vsR" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title
because we swapped the detective and lawyer's office around we didn't have the lawdrobe

## How This Contributes To The Skyrat Roleplay Experience

drobes should exist
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: icebox's lawyer office has always had a drobe, stop gaslighting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
