### PR TITLE
[MODULAR] Fixes Recycling room in Blueshift

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_lower.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_lower.dmm
@@ -10270,6 +10270,10 @@
 	id = "garbage";
 	name = "disposal conveyor"
 	},
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 2;
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "gDg" = (
@@ -14040,7 +14044,6 @@
 	},
 /area/engineering/atmos)
 "jMy" = (
-/obj/structure/window/reinforced,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "garbage"
@@ -14052,6 +14055,10 @@
 	icon_state = "left";
 	name = "Danger: Conveyor Access";
 	req_access_txt = "12"
+	},
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Danger: Conveyor Access"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -16193,14 +16200,6 @@
 	dir = 1
 	},
 /mob/living/simple_animal/bot/mulebot,
-/turf/open/floor/iron/dark,
-/area/cargo/warehouse)
-"luY" = (
-/obj/effect/turf_decal/delivery,
-/mob/living/simple_animal/bot/mulebot,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
 "lvx" = (
@@ -74677,7 +74676,7 @@ qvy
 xIc
 diF
 fiS
-luY
+luW
 yad
 oJz
 bGh
@@ -77240,7 +77239,7 @@ ylQ
 hyo
 iQj
 vWS
-vWS
+pXx
 gCj
 cuF
 nVb


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A couple of changes to the Blueshift waste disposal room:
- Blueshift's waste disposal room now has a windoor to the space between the recycler and the mass driver, making it possible to recover valuable trash that didn't get ground up, or just leave if you got pulled through the recycler.
- The stacking machine now has a console, to follow the standard for stacking machines. Yes I know they basically don't do anything, but stacking machines are supposed to have them.

![image](https://user-images.githubusercontent.com/1185434/148662154-9eafe97c-9ec1-43e5-94a2-0b937b7133a0.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Getting trapped in the recycling room and being forced to break reinforced glass with possibly no tools sucks.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
add: Adds a windoor to the last recycler->mass driver space in the Blueshift waste disposal room.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
