### PR TITLE
Adds xenoarch to Icemoon

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
@@ -1246,6 +1246,11 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/plating,
 /area/mine/eva)
+"dE" = (
+/obj/structure/table,
+/obj/machinery/xenoarch/scanner,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "dF" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 5
@@ -1760,6 +1765,11 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"ff" = (
+/obj/effect/turf_decal/tile/purple/half,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "fg" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -2076,6 +2086,14 @@
 	dir = 1
 	},
 /area/service/hydroponics)
+"gk" = (
+/obj/structure/table,
+/obj/machinery/xenoarch/researcher,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "gl" = (
 /obj/structure/chair/greyscale{
 	dir = 1
@@ -2318,6 +2336,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/prison)
+"gV" = (
+/obj/structure/table,
+/obj/machinery/xenoarch/digger,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "gW" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bucket,
@@ -4017,6 +4043,12 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/service/hydroponics)
+"lQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "lR" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -4126,6 +4158,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
+"mm" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "mn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -4413,6 +4453,11 @@
 /obj/item/food/chococoin,
 /turf/open/floor/iron/smooth,
 /area/mine/eva)
+"nd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "ne" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 20
@@ -4774,6 +4819,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"ol" = (
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "om" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4853,6 +4901,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"oz" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "oB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
@@ -5021,6 +5076,14 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/security/prison/safe)
+"pa" = (
+/obj/structure/table,
+/obj/machinery/xenoarch/recoverer,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "pb" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -7251,6 +7314,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/eva)
+"vm" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "vn" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -7595,6 +7664,11 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"wo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "wq" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/decal/cleanable/dirt,
@@ -7893,6 +7967,15 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"xk" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "xm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8854,6 +8937,14 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
+"Af" = (
+/obj/structure/closet/xenoarch,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "Ag" = (
 /obj/structure/table,
 /obj/item/plate,
@@ -9186,6 +9277,14 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
+"Bb" = (
+/obj/structure/table,
+/obj/machinery/xenoarch/digger,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "Bc" = (
 /turf/open/openspace/icemoon,
 /area/icemoon/underground/unexplored/rivers)
@@ -9639,6 +9738,17 @@
 	},
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
+"Cs" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Xenoarchaeology Lab";
+	network = list("mine","rd")
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "Ct" = (
 /obj/structure/closet,
 /obj/item/mop,
@@ -10359,6 +10469,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/textured,
 /area/mine/mechbay)
+"EE" = (
+/obj/structure/table,
+/obj/machinery/xenoarch/scanner,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "EF" = (
 /obj/structure/cable,
 /obj/machinery/button/door/directional/west{
@@ -11543,6 +11661,10 @@
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"HZ" = (
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "Ia" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11611,6 +11733,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"Im" = (
+/obj/structure/closet/xenoarch,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "In" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -11824,6 +11954,13 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"Jg" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "Jh" = (
 /obj/structure/fence{
@@ -12230,6 +12367,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
+"Kq" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
+"Kr" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "Ks" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "73"
@@ -12319,6 +12470,12 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/chemistry)
+"KF" = (
+/obj/structure/table,
+/obj/machinery/xenoarch/researcher,
+/obj/effect/turf_decal/tile/purple/anticorner,
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "KH" = (
 /obj/structure/table,
 /obj/item/clothing/under/misc/burial,
@@ -12335,6 +12492,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
+"KK" = (
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/mine/production)
 "KL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14495,6 +14658,12 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"Rc" = (
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "Rd" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14770,6 +14939,12 @@
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
+"RW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "RX" = (
 /obj/machinery/light/directional/north,
@@ -15344,6 +15519,10 @@
 /obj/item/mop,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"TS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "TT" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -15819,6 +15998,12 @@
 	},
 /turf/open/floor/iron,
 /area/mine/living_quarters)
+"Vo" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "Vp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -16093,6 +16278,13 @@
 /obj/item/crowbar,
 /turf/open/floor/iron,
 /area/service/chapel)
+"VX" = (
+/obj/structure/closet/xenoarch,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/icemoon/underground/explored)
 "VY" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Xenobiology Exit";
@@ -33402,13 +33594,13 @@ mO
 cR
 Xw
 cR
-mO
-Rj
-mO
-mO
-mO
-mO
-mO
+TS
+TS
+TS
+TS
+TS
+TS
+TS
 mO
 mO
 mO
@@ -33659,13 +33851,13 @@ mO
 cR
 Xw
 cR
-mO
-Rj
-mO
-mO
-mO
-mO
-mO
+Bb
+pa
+Af
+VX
+pa
+gV
+TS
 mO
 mO
 mO
@@ -33916,13 +34108,13 @@ mO
 cR
 Xw
 cR
-mO
-Rj
-mO
-mO
-mO
-mO
-mO
+xk
+ol
+ol
+ol
+ol
+Kr
+TS
 mO
 mO
 mO
@@ -34173,13 +34365,13 @@ mO
 cR
 Xw
 cR
-mO
-Rj
-mO
-mO
-mO
-mO
-mO
+gk
+dE
+RW
+HZ
+EE
+KF
+TS
 mO
 mO
 mO
@@ -34430,13 +34622,13 @@ Rj
 bq
 iT
 bq
-Rj
-qs
-Rj
-Rj
-Rj
-Rj
-qs
+Cs
+nd
+wo
+ff
+TS
+TS
+TS
 Rj
 Rj
 Rj
@@ -34686,14 +34878,14 @@ Rj
 mO
 br
 OW
-br
-mO
-Rj
-mO
-mO
-mO
-mO
-mO
+KK
+mm
+nd
+lQ
+Vo
+pa
+gV
+TS
 mO
 mO
 mO
@@ -34943,14 +35135,14 @@ Rj
 mO
 br
 OW
-br
-mO
-Rj
-mO
-mO
-mO
-mO
-mO
+bq
+oz
+ol
+ol
+ol
+ol
+Jg
+TS
 mO
 mO
 mO
@@ -35201,13 +35393,13 @@ mO
 br
 OW
 br
-mO
-Rj
-mO
-mO
-mO
-mO
-mO
+Rc
+vm
+Kq
+Im
+EE
+KF
+TS
 mO
 mO
 ea
@@ -35458,13 +35650,13 @@ mO
 br
 OW
 br
-mO
-Rj
-mO
-mO
-mO
-mO
-mO
+TS
+TS
+TS
+TS
+TS
+TS
+TS
 mO
 mO
 Fp

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
@@ -909,6 +909,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/textured_half,
 /area/mine/production)
+"cJ" = (
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/mine/production)
 "cK" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -1248,9 +1254,11 @@
 /area/mine/eva)
 "dE" = (
 /obj/structure/table,
-/obj/machinery/xenoarch/scanner,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/mine/production)
 "dF" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 5
@@ -1765,11 +1773,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"ff" = (
-/obj/effect/turf_decal/tile/purple/half,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "fg" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -1793,6 +1796,13 @@
 /obj/item/pickaxe,
 /turf/open/floor/iron,
 /area/mine/living_quarters)
+"fk" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/mine/production)
 "fl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2086,14 +2096,6 @@
 	dir = 1
 	},
 /area/service/hydroponics)
-"gk" = (
-/obj/structure/table,
-/obj/machinery/xenoarch/researcher,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "gl" = (
 /obj/structure/chair/greyscale{
 	dir = 1
@@ -2336,14 +2338,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/prison)
-"gV" = (
-/obj/structure/table,
-/obj/machinery/xenoarch/digger,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "gW" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bucket,
@@ -2670,6 +2664,14 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/snowed/icemoon,
 /area/engineering/lobby)
+"hR" = (
+/obj/structure/table,
+/obj/machinery/xenoarch/scanner,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/mine/production)
 "hS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3193,6 +3195,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison/visit)
+"jt" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/mine/production)
 "ju" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -3775,6 +3783,13 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/security/courtroom)
+"lg" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/mine/production)
 "lh" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -4043,12 +4058,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/service/hydroponics)
-"lQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "lR" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -4158,14 +4167,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
-"mm" = (
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "mn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -4453,11 +4454,6 @@
 /obj/item/food/chococoin,
 /turf/open/floor/iron/smooth,
 /area/mine/eva)
-"nd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "ne" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 20
@@ -4597,6 +4593,12 @@
 	dir = 4
 	},
 /area/mine/eva)
+"nv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/mine/production)
 "nw" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -4819,9 +4821,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"ol" = (
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "om" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4901,13 +4900,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"oz" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "oB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
@@ -5076,14 +5068,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/security/prison/safe)
-"pa" = (
-/obj/structure/table,
-/obj/machinery/xenoarch/recoverer,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "pb" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -5533,6 +5517,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"qk" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/mine/production)
 "ql" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/west,
@@ -6083,6 +6076,13 @@
 	},
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"rI" = (
+/obj/structure/closet/xenoarch,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/mine/production)
 "rJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -6190,6 +6190,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"rY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/mine/production)
 "rZ" = (
 /obj/structure/closet,
 /obj/item/seeds/cotton/durathread,
@@ -6347,6 +6353,13 @@
 /obj/item/seeds/potato,
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp)
+"su" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron,
+/area/mine/production)
 "sv" = (
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
@@ -6389,6 +6402,11 @@
 	},
 /turf/open/floor/holofloor/white,
 /area/security/prison)
+"sC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/mine/production)
 "sD" = (
 /turf/open/floor/iron/dark/corner{
 	dir = 4
@@ -7315,11 +7333,12 @@
 /turf/open/floor/plating,
 /area/mine/eva)
 "vm" = (
+/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/purple/half{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/mine/production)
 "vn" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -7500,6 +7519,14 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/security/courtroom)
+"vL" = (
+/obj/structure/closet/xenoarch,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/mine/production)
 "vM" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -7664,11 +7691,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"wo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "wq" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/decal/cleanable/dirt,
@@ -7967,15 +7989,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"xk" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "xm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8938,13 +8951,10 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
 "Af" = (
-/obj/structure/closet/xenoarch,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
+/obj/structure/table,
+/obj/machinery/xenoarch/scanner,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/mine/production)
 "Ag" = (
 /obj/structure/table,
 /obj/item/plate,
@@ -9277,14 +9287,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
-"Bb" = (
-/obj/structure/table,
-/obj/machinery/xenoarch/digger,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "Bc" = (
 /turf/open/openspace/icemoon,
 /area/icemoon/underground/unexplored/rivers)
@@ -9311,6 +9313,11 @@
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"Bj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/mine/production)
 "Bl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9738,17 +9745,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
-"Cs" = (
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Xenoarchaeology Lab";
-	network = list("mine","rd")
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "Ct" = (
 /obj/structure/closet,
 /obj/item/mop,
@@ -10469,14 +10465,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/textured,
 /area/mine/mechbay)
-"EE" = (
-/obj/structure/table,
-/obj/machinery/xenoarch/scanner,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "EF" = (
 /obj/structure/cable,
 /obj/machinery/button/door/directional/west{
@@ -10754,6 +10742,13 @@
 /obj/item/wrench,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"Fz" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron,
+/area/mine/production)
 "FA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -11537,6 +11532,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/production)
+"HK" = (
+/obj/effect/turf_decal/tile/purple/half,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/mine/production)
 "HL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -11661,10 +11661,6 @@
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"HZ" = (
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "Ia" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11733,14 +11729,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"Im" = (
-/obj/structure/closet/xenoarch,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "In" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -11909,6 +11897,14 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
+"IV" = (
+/obj/structure/table,
+/obj/machinery/xenoarch/recoverer,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/mine/production)
 "IX" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -11954,13 +11950,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"Jg" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron,
 /area/icemoon/underground/explored)
 "Jh" = (
 /obj/structure/fence{
@@ -12367,20 +12356,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
-"Kq" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
-"Kr" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "Ks" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "73"
@@ -12470,12 +12445,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/chemistry)
-"KF" = (
-/obj/structure/table,
-/obj/machinery/xenoarch/researcher,
-/obj/effect/turf_decal/tile/purple/anticorner,
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "KH" = (
 /obj/structure/table,
 /obj/item/clothing/under/misc/burial,
@@ -12492,12 +12461,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
-"KK" = (
-/obj/machinery/door/airlock/glass,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/mine/production)
 "KL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12540,6 +12503,12 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"KP" = (
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/mine/production)
 "KQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -12690,6 +12659,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/department/medical)
+"Lp" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Xenoarchaeology Lab";
+	network = list("mine","rd")
+	},
+/turf/open/floor/iron,
+/area/mine/production)
 "Lr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13888,6 +13868,12 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"OY" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/mine/production)
 "OZ" = (
 /obj/structure/table,
 /obj/item/clothing/mask/gas,
@@ -14658,12 +14644,6 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"Rc" = (
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "Rd" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14870,6 +14850,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
+"RI" = (
+/obj/structure/table,
+/obj/machinery/xenoarch/researcher,
+/obj/effect/turf_decal/tile/purple/anticorner,
+/turf/open/floor/iron,
+/area/mine/production)
 "RJ" = (
 /obj/structure/table/reinforced,
 /obj/structure/reagent_dispensers/servingdish,
@@ -14940,12 +14926,14 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
-"RW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+"RV" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/icemoon/underground/explored)
+/area/mine/production)
 "RX" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
@@ -15042,6 +15030,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"Sn" = (
+/obj/structure/closet/xenoarch,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/mine/production)
 "So" = (
 /turf/closed/wall,
 /area/security/prison)
@@ -15055,6 +15051,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"Sq" = (
+/obj/structure/table,
+/obj/machinery/xenoarch/researcher,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/mine/production)
 "Sr" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -15519,10 +15523,6 @@
 /obj/item/mop,
 /turf/open/floor/iron/white,
 /area/security/prison)
-"TS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "TT" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -15998,12 +15998,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/living_quarters)
-"Vo" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "Vp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -16278,13 +16272,6 @@
 /obj/item/crowbar,
 /turf/open/floor/iron,
 /area/service/chapel)
-"VX" = (
-/obj/structure/closet/xenoarch,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/icemoon/underground/explored)
 "VY" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Xenobiology Exit";
@@ -16580,6 +16567,10 @@
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"WR" = (
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron,
+/area/mine/production)
 "WS" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron,
@@ -33594,13 +33585,13 @@ mO
 cR
 Xw
 cR
-TS
-TS
-TS
-TS
-TS
-TS
-TS
+br
+br
+br
+br
+br
+br
+br
 mO
 mO
 mO
@@ -33851,13 +33842,13 @@ mO
 cR
 Xw
 cR
-Bb
-pa
-Af
-VX
-pa
-gV
-TS
+lg
+IV
+Sn
+rI
+IV
+dE
+br
 mO
 mO
 mO
@@ -34108,13 +34099,13 @@ mO
 cR
 Xw
 cR
-xk
-ol
-ol
-ol
-ol
-Kr
-TS
+qk
+bP
+bP
+bP
+bP
+su
+br
 mO
 mO
 mO
@@ -34365,13 +34356,13 @@ mO
 cR
 Xw
 cR
-gk
-dE
-RW
-HZ
-EE
-KF
-TS
+Sq
+Af
+nv
+WR
+hR
+RI
+br
 mO
 mO
 mO
@@ -34622,13 +34613,13 @@ Rj
 bq
 iT
 bq
-Cs
-nd
-wo
-ff
-TS
-TS
-TS
+Lp
+Bj
+sC
+HK
+br
+br
+br
 Rj
 Rj
 Rj
@@ -34878,14 +34869,14 @@ Rj
 mO
 br
 OW
-KK
-mm
-nd
-lQ
-Vo
-pa
-gV
-TS
+cJ
+RV
+Bj
+rY
+jt
+IV
+dE
+br
 mO
 mO
 mO
@@ -35136,13 +35127,13 @@ mO
 br
 OW
 bq
-oz
-ol
-ol
-ol
-ol
-Jg
-TS
+vm
+bP
+bP
+bP
+bP
+Fz
+br
 mO
 mO
 mO
@@ -35393,13 +35384,13 @@ mO
 br
 OW
 br
-Rc
-vm
-Kq
-Im
-EE
-KF
-TS
+KP
+OY
+fk
+vL
+hR
+RI
+br
 mO
 mO
 ea
@@ -35650,13 +35641,13 @@ mO
 br
 OW
 br
-TS
-TS
-TS
-TS
-TS
-TS
-TS
+br
+br
+br
+br
+br
+br
+br
 mO
 mO
 Fp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds xenoarch to IcemoonUnderground_Above_skyrat.dmm because I forgor. :skull: 
![image](https://user-images.githubusercontent.com/42087567/148776473-4133eb24-c199-4d7a-8aa7-1b2308f1af86.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Xenoarch good and should be everywhere not only that one map that might not even roll.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Stalkeros
add: Adds xenoarch room to Icemoon's mining outpost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
