### PR TITLE
Removes the HF Blade from Traitor Loadouts

### DIFF
--- a/modular_skyrat/modules/moretraitoritems/code/syndicate_loadout.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/syndicate_loadout.dm
@@ -115,7 +115,7 @@
 	new /obj/item/reagent_containers/glass/rag(src)
 
 /obj/item/storage/backpack/duffelbag/syndie/loadout/ninja/PopulateContents()
-	new /obj/item/vibro_weapon/ninjasr(src)
+	new /obj/item/energy_katana(src)
 	new /obj/item/reagent_containers/hypospray/medipen/stimulants(src)
 	for(var/i in 1 to 3)
 		new /obj/item/throwing_star(src)

--- a/modular_skyrat/modules/moretraitoritems/code/weaponry.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/weaponry.dm
@@ -1,7 +1,3 @@
-/obj/item/vibro_weapon/ninjasr
-	block_chance = 25
-	force = 13
-
 /obj/item/clothing/head/sus_bowler
 	name = "odd bowler"
 	desc = "A deep black bowler. Inside the hat, there is a sleek red S, with a smaller X insignia embroidered within. On closer inspection, the brim feels oddly weighted..."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does what it says on the tin. Due to reworked item paths upstream and general incoming changes to the weapon, this PR replaces the ninja loadout’s variant of the vibroblade with the energy katana, which has equal damage to an energy sword but added mobility and can only be stored openly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

It doesn’t! But broken object subtypes is bad, and wildly overpowered gear isn’t better.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The cyborg ninja traitor loadout now wields an energy katana instead of a vibroblade.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
