### PR TITLE
[MODULAR] Fixes Blueshield Bowman Not Protecting Against Flashbangs, and Removes Loudmode

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_upper.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_upper.dmm
@@ -63939,7 +63939,7 @@
 /obj/item/storage/backpack/duffel/blueshield,
 /obj/item/storage/backpack/satchel/blueshield,
 /obj/item/clothing/gloves/tackler/combat/insulated/blueshield,
-/obj/item/radio/headset/heads/blueshield/alt,
+/obj/item/radio/headset/headset_bs/alt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},

--- a/modular_skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield.dm
@@ -53,7 +53,7 @@
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
 	id = /obj/item/card/id/advanced/centcom
 	shoes = /obj/item/clothing/shoes/jackboots
-	ears = /obj/item/radio/headset/heads/blueshield/alt
+	ears = /obj/item/radio/headset/headset_bs/alt
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	backpack_contents = list(/obj/item/melee/baton/security/loaded = 1)
 	implants = list(/obj/item/implant/mindshield)

--- a/modular_skyrat/modules/blueshield/code/blueshield_clothing.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield_clothing.dm
@@ -46,7 +46,7 @@
     resistance_flags = FIRE_PROOF |  ACID_PROOF
     armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "fire" = 100, "acid" = 100)
 
-/obj/item/radio/headset/heads/blueshield
+/obj/item/radio/headset/headset_bs
 	name = "\proper the blueshield's headset"
 	icon = 'modular_skyrat/modules/blueshield/icons/radio.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/ears.dmi'
@@ -54,8 +54,12 @@
 	keyslot = new /obj/item/encryptionkey/heads/blueshield
 	keyslot2 = new /obj/item/encryptionkey/headset_cent
 
-/obj/item/radio/headset/heads/blueshield/alt
+/obj/item/radio/headset/headset_bs/alt
 	icon_state = "bshield_headset_alt"
+
+/obj/item/radio/headset/headset_sec/alt/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
 
 /obj/item/clothing/under/plasmaman/blueshield
 	name = "blueshield envirosuit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Read the tin.

## How This Contributes To The Skyrat Roleplay Experience

The bowman thing was an oversight. And the Blueshield isn't a head of staff, and shouldn't have loud mode. They have no need to make announcements, they are basically an observer in all aspects.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Blueshield's headset now protects against flashbangs as it should
del: Removed blueshield loudmode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
