### PR TITLE
tramstation fixes (part 1 of X)

### DIFF
--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -65,10 +65,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
-"aaO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/security/execution/education)
 "aaP" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -4194,15 +4190,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/service/bar)
-"ayM" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/spray/pepper,
-/obj/item/assembly/flash/handheld{
-	pixel_x = -6
-	},
-/turf/open/floor/iron/white,
-/area/security/execution/education)
 "ayR" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -4355,12 +4342,16 @@
 /area/commons/dorms)
 "azN" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
+	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/left)
 "azP" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
+	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
 "azQ" = (
@@ -4497,7 +4488,9 @@
 /area/hallway/primary/tram/center)
 "aAJ" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
+	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/right)
 "aAK" = (
@@ -7871,7 +7864,6 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "baV" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -7880,9 +7872,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Isolation Cell B";
-	req_access_txt = "2"
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 4";
+	name = "Cell 4"
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -8526,8 +8518,10 @@
 /area/cargo/miningdock)
 "bnl" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/effect/landmark/event_spawn,
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
+	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/right)
 "bnm" = (
@@ -8814,13 +8808,17 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "btd" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	name = "sorting disposal pipe (Robotics)";
-	sortType = 14
+/obj/machinery/light/small/directional/west,
+/obj/item/radio/intercom/prison/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
-/turf/open/floor/iron/white,
-/area/science/research)
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "bto" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -9801,6 +9799,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/bar)
+"bLp" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "bLs" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
@@ -10950,6 +10953,15 @@
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron,
 /area/security/prison)
+"cil" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "cim" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10958,8 +10970,10 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/east,
-/obj/structure/disposalpipe/junction{
-	dir = 2
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1;
+	name = "sorting disposal pipe (Janitor)";
+	sortType = 22
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/central)
@@ -12206,9 +12220,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
@@ -12639,7 +12650,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Upper Mid-Right Service";
-	dir = 10
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -13332,6 +13343,9 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood/parquet,
 /area/command/heads_quarters/captain/private/nt_rep)
 "dcY" = (
@@ -13555,7 +13569,6 @@
 	pixel_x = 5;
 	pixel_y = -1
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -14040,8 +14053,10 @@
 /area/cargo/miningdock)
 "dsc" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/structure/fluff/tram_rail/floor,
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
+	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/right)
 "dse" = (
@@ -14067,23 +14082,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dsD" = (
-/obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
-/obj/item/clothing/mask/balaclava,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5
-	},
-/obj/structure/sign/poster/official/do_not_question{
-	pixel_y = 32
-	},
-/obj/machinery/button/flasher{
-	id = "reeducation";
-	pixel_x = -24;
-	pixel_y = -8;
-	req_access_txt = "2"
-	},
+/obj/structure/bed/roller,
 /turf/open/floor/iron/white,
 /area/security/execution/education)
 "dsL" = (
@@ -14133,9 +14132,25 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "dtB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/space/basic,
-/area/space)
+/obj/structure/table/glass,
+/obj/item/storage/backpack/duffelbag/sec/surgery{
+	pixel_y = 5
+	},
+/obj/item/clothing/mask/balaclava,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 5
+	},
+/obj/structure/sign/poster/official/do_not_question{
+	pixel_y = 32
+	},
+/obj/machinery/button/flasher{
+	id = "reeducation";
+	pixel_x = -24;
+	pixel_y = -8;
+	req_access_txt = "2"
+	},
+/turf/open/floor/iron/white,
+/area/security/execution/education)
 "dtL" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -15167,6 +15182,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"dMA" = (
+/obj/structure/table/glass,
+/obj/item/folder/red{
+	pixel_x = 3
+	},
+/obj/item/taperecorder{
+	pixel_x = -3
+	},
+/obj/structure/sign/poster/official/obey{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/white,
+/area/security/execution/education)
 "dMF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15411,7 +15439,7 @@
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/camera{
 	c_tag = "Hallway - Mid-Right Service";
-	dir = 10
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -16652,8 +16680,16 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "ele" = (
-/turf/closed/wall,
-/area/security/execution/education)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/door_timer{
+	id = "Cell 1";
+	name = "Cell 1";
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "elh" = (
 /obj/machinery/door/airlock/research{
 	id_tag = "ResearchExt";
@@ -17547,6 +17583,14 @@
 /obj/structure/chair/plastic,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
+"eze" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1;
+	name = "sorting disposal pipe (Robotics)";
+	sortType = 14
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "ezo" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain/private)
@@ -17677,7 +17721,6 @@
 	name = "Mining Maintenance Access";
 	req_access_txt = "48"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -18152,15 +18195,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
 "eLS" = (
-/obj/structure/table/glass,
-/obj/item/folder/red{
-	pixel_x = 3
-	},
-/obj/item/taperecorder{
-	pixel_x = -3
-	},
-/obj/structure/sign/poster/official/obey{
-	pixel_y = -32
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/injection{
+	name = "educational injections";
+	pixel_x = 2
 	},
 /turf/open/floor/iron/white,
 /area/security/execution/education)
@@ -18200,11 +18238,8 @@
 	desc = "A photo frame to commemorate Nanotrasen's Employee of the Month - an entirely unbiased decision made by the NT Representative.";
 	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/ash{
-	desc = "Well, that's the end of that.";
-	name = "burnt employment contract"
-	},
-/obj/item/lighter,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/wood/parquet,
 /area/command/heads_quarters/captain/private/nt_rep)
 "eME" = (
@@ -18911,7 +18946,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/external{
@@ -19287,7 +19321,6 @@
 "fgr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/caution{
 	dir = 1
 	},
@@ -19541,7 +19574,6 @@
 /turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "fkL" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -20047,8 +20079,10 @@
 /area/security/brig)
 "fsL" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/structure/fluff/tram_rail/floor,
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
+	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
 "fth" = (
@@ -21122,7 +21156,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Central Tram Platform North";
-	dir = 10
+	dir = 8
 	},
 /obj/effect/turf_decal/caution{
 	dir = 1
@@ -22653,7 +22687,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "gmM" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -22662,9 +22695,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Isolation Cell C";
-	req_access_txt = "2"
+/obj/machinery/door/window/brigdoor/security/cell{
+	dir = 1;
+	id = "Cell 1";
+	name = "Cell 1"
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -23000,17 +23034,14 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "grV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
+/obj/machinery/airalarm/directional/north,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/assembly/flash/handheld{
+	pixel_x = -6
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/iron/white,
+/area/security/execution/education)
 "gsa" = (
 /obj/machinery/exodrone_launcher,
 /turf/open/floor/plating,
@@ -24169,7 +24200,6 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "gPp" = (
-/obj/structure/chair/stool/bar/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -24177,7 +24207,7 @@
 	dir = 10
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Isolation Chamber A";
+	c_tag = "Security - Holding Cell 2";
 	dir = 8;
 	network = list("ss13","Security","prison")
 	},
@@ -24372,13 +24402,10 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "gTj" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/light_switch/directional/east{
-	pixel_x = 22;
-	pixel_y = -9
+/obj/machinery/flasher/directional/north{
+	id = "reeducation"
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/textured_large,
 /area/security/execution/education)
 "gTo" = (
 /obj/structure/bed,
@@ -24618,7 +24645,6 @@
 /turf/open/floor/catwalk_floor,
 /area/hallway/primary/tram/center)
 "gYp" = (
-/obj/structure/chair/stool/bar/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -24626,7 +24652,7 @@
 	dir = 10
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Isolation Chamber C";
+	c_tag = "Security - Holding Cell 1";
 	dir = 8;
 	network = list("ss13","Security","prison")
 	},
@@ -25533,8 +25559,10 @@
 /area/ai_monitored/turret_protected/aisat/hallway)
 "hnh" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/effect/landmark/event_spawn,
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
+	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
 "hnF" = (
@@ -25835,8 +25863,11 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/executive,
-/area/command/gateway)
+/area/command/heads_quarters/captain/private/nt_rep)
 "htX" = (
 /obj/structure/ladder,
 /obj/machinery/door/window/westleft{
@@ -26029,8 +26060,6 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
@@ -26325,7 +26354,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -27319,6 +27347,15 @@
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
+"hYP" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	name = "Cell 3";
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "hZc" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -27760,6 +27797,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"iht" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port/aft)
 "ihH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -27876,6 +27923,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor,
 /area/hallway/primary/tram/center)
+"ijM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "ijR" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -28168,9 +28225,11 @@
 /area/maintenance/tram/left)
 "ioT" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/machinery/camera/directional/south{
 	c_tag = "Hallway - North-East Tram Bridge"
+	},
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
@@ -28745,6 +28804,18 @@
 /obj/structure/chair,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"izt" = (
+/obj/machinery/light/small/directional/west,
+/obj/item/radio/intercom/prison/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 4";
+	name = "Cell 4 Locker"
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "izv" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/east,
@@ -29951,7 +30022,6 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/command/nuke_storage)
 "iUO" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -29960,9 +30030,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Isolation Cell D";
-	req_access_txt = "2"
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 3";
+	name = "Cell 3"
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -31023,10 +31093,8 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "joQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_large,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
 /area/security/execution/education)
 "joT" = (
 /obj/structure/closet/emcloset,
@@ -33189,7 +33257,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kcc" = (
@@ -34157,7 +34227,6 @@
 /area/command/heads_quarters/ce)
 "kuX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
@@ -35104,11 +35173,11 @@
 "kPu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/central)
 "kPK" = (
@@ -35174,7 +35243,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Aux Base Construction";
-	dir = 9
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
@@ -35197,6 +35266,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/central)
 "kRF" = (
@@ -36042,8 +36114,11 @@
 /turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "leM" = (
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/textured_large,
+/area/security/execution/education)
 "leY" = (
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
@@ -36434,7 +36509,6 @@
 	req_one_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/maintenance/starboard/secondary)
 "lnR" = (
@@ -36586,7 +36660,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Isolation Chambers";
-	dir = 6;
+	dir = 4;
 	network = list("ss13","Security","prison")
 	},
 /turf/open/floor/iron,
@@ -36822,7 +36896,6 @@
 /turf/closed/wall,
 /area/mine/explored)
 "lvI" = (
-/obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -36830,7 +36903,7 @@
 	dir = 9
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Isolation Chamber D";
+	c_tag = "Security - Holding Cell 3";
 	dir = 8;
 	network = list("ss13","Security","prison")
 	},
@@ -36983,6 +37056,9 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/effect/landmark/start/nanotrasen_representative,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/carpet/executive,
 /area/command/heads_quarters/captain/private/nt_rep)
 "lAf" = (
@@ -37219,11 +37295,19 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "lFw" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
+/obj/machinery/door/airlock/security{
+	name = "Reeducation Center";
+	req_access_txt = "2"
+	},
+/turf/open/floor/iron/white,
 /area/security/execution/education)
 "lFD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -37330,7 +37414,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
 	autoclose = 0;
@@ -38083,12 +38166,12 @@
 "lUD" = (
 /obj/docking_port/stationary{
 	dir = 8;
-	dwidth = 3;
-	height = 15;
+	dwidth = 1;
+	height = 13;
 	id = "arrivals_stationary";
 	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/box;
-	width = 7
+	roundstart_template = null;
+	width = 5
 	},
 /turf/open/space/openspace,
 /area/space)
@@ -38276,7 +38359,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/cytology)
+"lXI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "lYa" = (
+/obj/item/toy/plush/moth{
+	desc = "The moth wonders why you are out this far..."
+	},
 /turf/closed/mineral/random/stationside/asteroid/porus,
 /area/space)
 "lYr" = (
@@ -38716,8 +38812,10 @@
 /area/maintenance/starboard/central)
 "mjd" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/effect/landmark/event_spawn,
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
+	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/left)
 "mjf" = (
@@ -39981,9 +40079,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -40167,6 +40262,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"mMG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "mNe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40632,6 +40737,9 @@
 	name = "Nanotrasen Representative's Office";
 	req_access_txt = "101"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/captain/private/nt_rep)
 "mVq" = (
@@ -40963,7 +41071,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "naT" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate{
@@ -41455,10 +41562,10 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "nnQ" = (
-/obj/machinery/flasher/directional/north{
-	id = "reeducation"
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 4
 	},
-/turf/open/floor/iron/textured_large,
 /area/security/execution/education)
 "nnT" = (
 /obj/effect/turf_decal/bot,
@@ -42283,6 +42390,11 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	name = "Cell 2";
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "nDb" = (
@@ -42472,6 +42584,7 @@
 "nFO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "nGf" = (
@@ -42906,9 +43019,11 @@
 /area/science/mixing)
 "nNK" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/structure/fluff/tram_rail/floor{
 	dir = 1
+	},
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/left)
@@ -43805,7 +43920,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/turf/open/space/basic,
+/turf/open/floor/iron,
 /area/service/janitor)
 "ofp" = (
 /obj/structure/cable,
@@ -43934,9 +44049,11 @@
 /area/service/lawoffice)
 "ohl" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/structure/fluff/tram_rail/floor{
 	dir = 1
+	},
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
@@ -43956,7 +44073,14 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "ohx" = (
-/turf/open/floor/iron/textured_large,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/iron/white,
 /area/security/execution/education)
 "ohz" = (
 /obj/effect/spawner/structure/window,
@@ -44222,6 +44346,15 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"olW" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door_timer{
+	id = "Cell 4";
+	name = "Cell 4";
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "omb" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
@@ -45403,6 +45536,9 @@
 	network = list("ss13","Security")
 	},
 /obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "oIo" = (
@@ -45528,6 +45664,16 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"oKk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/central)
 "oKp" = (
 /obj/structure/railing/corner,
 /obj/structure/railing/corner{
@@ -46688,9 +46834,11 @@
 /area/engineering/main)
 "peH" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/machinery/camera/directional/south{
 	c_tag = "Hallway - North-East Tram Bridge"
+	},
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/left)
@@ -46803,7 +46951,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Upper Mid-Left Service";
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -46869,7 +47017,6 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "piH" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate{
@@ -47212,6 +47359,9 @@
 	},
 /obj/item/stamp/denied{
 	pixel_x = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet/executive,
 /area/command/heads_quarters/captain/private/nt_rep)
@@ -51195,6 +51345,7 @@
 	dir = 5
 	},
 /obj/machinery/status_display/ai/directional/north,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
 "qME" = (
@@ -51385,9 +51536,11 @@
 /area/medical/pharmacy)
 "qQJ" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/machinery/camera/directional/south{
 	c_tag = "Hallway - North-East Tram Bridge"
+	},
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/right)
@@ -52042,7 +52195,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Lower Mid-Right Service";
-	dir = 10
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -52488,7 +52641,7 @@
 /turf/open/floor/engine,
 /area/science/cytology)
 "rkL" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
@@ -52518,9 +52671,12 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "rlg" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/tram/center)
+/area/security/prison)
 "rlq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -52905,6 +53061,9 @@
 "rtC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/nanotrasen_representative,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood/parquet,
 /area/command/heads_quarters/captain/private/nt_rep)
 "rtH" = (
@@ -53760,12 +53919,9 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "rMf" = (
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/light/directional/west,
+/obj/structure/bed,
+/turf/open/floor/iron/textured_large,
 /area/security/execution/education)
 "rMG" = (
 /obj/effect/turf_decal/sand/plating,
@@ -54240,6 +54396,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "rVq" = (
@@ -55217,7 +55374,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/item/stack/sheet/plasteel/fifty,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/hfr_box/body/fuel_input,
 /obj/item/hfr_box/body/interface,
 /obj/item/hfr_box/body/moderator_input,
@@ -57670,19 +57826,11 @@
 /turf/open/floor/plating,
 /area/service/janitor)
 "tfA" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
 	},
-/obj/machinery/door/airlock/security{
-	name = "Reeducation Center";
-	req_access_txt = "2"
-	},
-/turf/open/floor/iron/white,
 /area/security/execution/education)
 "tfB" = (
 /turf/open/openspace/airless/planetary,
@@ -58773,12 +58921,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "twg" = (
@@ -59140,8 +59288,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "tCW" = (
-/obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/iron/white/smooth_corner,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/security/execution/education)
 "tDc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -59799,10 +59951,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/central)
 "tPo" = (
@@ -60204,11 +60354,14 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "tVi" = (
-/obj/structure/table,
 /obj/machinery/light/small/directional/west,
 /obj/item/radio/intercom/prison/directional/south,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -60452,9 +60605,11 @@
 /area/engineering/atmospherics_engine)
 "tZs" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/structure/fluff/tram_rail/floor{
 	dir = 1
+	},
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/right)
@@ -60904,6 +61059,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"uiV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/command/heads_quarters/captain/private/nt_rep)
 "uiX" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 10
@@ -61243,11 +61407,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/turf/open/floor/iron/white,
-/area/security/execution/education)
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "upr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -62644,6 +62810,30 @@
 /obj/machinery/keycard_auth/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
+"uNM" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/bottle/toxin{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/facid{
+	name = "fluorosulfuric acid bottle";
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/bottle/morphine{
+	name = "nyquil bottle";
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/syringe{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/white,
+/area/security/execution/education)
 "uNV" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
@@ -62723,6 +62913,18 @@
 "uQe" = (
 /turf/open/floor/plating,
 /area/science/mixing)
+"uQg" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "uQu" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/table,
@@ -63375,8 +63577,10 @@
 /area/service/lawoffice)
 "vdk" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/structure/fluff/tram_rail/floor,
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
+	},
 /turf/open/floor/vault,
 /area/hallway/primary/tram/left)
 "vdn" = (
@@ -63760,10 +63964,13 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "vly" = (
-/obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 4
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/light_switch/directional/east{
+	pixel_x = 22;
+	pixel_y = -9
 	},
+/turf/open/floor/iron/white,
 /area/security/execution/education)
 "vlG" = (
 /turf/closed/mineral/random/stationside/asteroid/porus,
@@ -63855,6 +64062,15 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/science/research)
+"vnD" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Tunnel Access";
+	req_one_access_txt = "12"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/central)
 "vnK" = (
 /obj/machinery/rnd/server,
 /turf/open/floor/circuit/telecomms/server,
@@ -64375,7 +64591,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vzH" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -64384,9 +64599,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Isolation Cell A";
-	req_access_txt = "2"
+/obj/machinery/door/window/brigdoor/security/cell{
+	dir = 1;
+	id = "Cell 2";
+	name = "Cell 2"
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -64807,12 +65023,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
 "vHL" = (
-/obj/structure/cable,
-/obj/structure/closet/secure_closet/injection{
-	name = "educational injections";
-	pixel_x = 2
-	},
-/turf/open/floor/iron/white,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/iron/white/smooth_corner,
 /area/security/execution/education)
 "vHM" = (
 /obj/effect/turf_decal/siding/thinplating/end,
@@ -64884,6 +65096,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"vIH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/central)
 "vIS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65868,7 +66090,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "waG" = (
-/obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -65876,7 +66097,7 @@
 	dir = 9
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Isolation Chamber B";
+	c_tag = "Security - Holding Cell 4";
 	dir = 8;
 	network = list("ss13","Security","prison")
 	},
@@ -66381,7 +66602,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "wmb" = (
-/obj/structure/bed/roller,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/security/execution/education)
 "wmA" = (
@@ -66630,6 +66853,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
+"wra" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "wrc" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
@@ -67060,7 +67293,6 @@
 /area/commons/lounge)
 "wxO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -67356,30 +67588,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"wCa" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/toxin{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/bottle/facid{
-	name = "fluorosulfuric acid bottle";
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	name = "nyquil bottle";
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe{
-	pixel_y = 5
-	},
-/turf/open/floor/iron/white,
-/area/security/execution/education)
 "wCq" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -67444,8 +67652,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "wCW" = (
-/obj/machinery/light/directional/west,
-/obj/structure/bed,
 /turf/open/floor/iron/textured_large,
 /area/security/execution/education)
 "wDb" = (
@@ -68456,9 +68662,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/south,
@@ -68912,6 +69115,16 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/cargo/storage)
+"xeW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "xeY" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -69092,6 +69305,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/central/secondary)
 "xhE" = (
@@ -69824,10 +70038,7 @@
 /turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "xuN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
+/turf/closed/wall,
 /area/security/execution/education)
 "xuO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -70369,7 +70580,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
-/turf/open/space/basic,
+/turf/open/floor/iron/smooth,
 /area/service/janitor)
 "xEz" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -71242,11 +71453,14 @@
 /turf/open/floor/plating,
 /area/security/interrogation)
 "xRK" = (
-/obj/structure/table,
 /obj/machinery/light/small/directional/west,
 /obj/item/radio/intercom/prison/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -72126,7 +72340,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/limb,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
@@ -83682,11 +83895,11 @@ ajc
 ajc
 ajc
 ajc
-ajc
-ajc
-ajc
-ajc
-ajc
+aBM
+aBM
+aBM
+aBM
+aBM
 ajc
 ajc
 ajc
@@ -83938,15 +84151,15 @@ ajc
 ajc
 ajc
 ajc
-ajc
-ajc
-ajc
-ajc
-ajc
-ajc
-ajc
-ajc
-ajc
+dhe
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
+aBM
 ajc
 ajc
 dhe
@@ -84195,17 +84408,17 @@ ajc
 ajc
 ajc
 ajc
-ajc
-ajc
-ajc
-ajc
-ajc
-ajc
-ajc
-ajc
-ajc
-ajc
 dhe
+dhe
+dhe
+dhe
+dhe
+dhe
+aBM
+aBM
+aBM
+aBM
+aBM
 dhe
 dhe
 dhe
@@ -84452,17 +84665,17 @@ ajc
 ajc
 ajc
 ajc
-ajc
-ajc
-ajc
-ajc
-ajc
-ajc
-ajc
 dhe
 dhe
 dhe
 dhe
+dhe
+dhe
+dhe
+dhe
+aBM
+aBM
+aBM
 dhe
 dhe
 dhe
@@ -84706,20 +84919,20 @@ ajc
 ajc
 ajc
 ajc
-ajc
-ajc
-ajc
-ajc
-ajc
-ajc
-aBM
-aBM
-aBM
-aBM
-aBM
-aBM
-aBM
-aBM
+dhe
+dhe
+dhe
+dhe
+dhe
+nBT
+nBT
+nBT
+nBT
+nBT
+dhe
+dhe
+dhe
+dhe
 dhe
 dhe
 dhe
@@ -84963,21 +85176,21 @@ ajc
 ajc
 ajc
 ajc
-ajc
-ajc
-ajc
-ajc
-aBM
-aBM
-aBM
-aBM
-aBM
-aBM
-aBM
-aBM
-aBM
-aBM
-aBM
+dhe
+dhe
+dhe
+dhe
+dhe
+nBT
+gTj
+rMf
+wCW
+nBT
+dhe
+dhe
+dhe
+dhe
+dhe
 dhe
 dhe
 dhe
@@ -85220,18 +85433,18 @@ ajc
 ajc
 dhe
 aBM
-aBM
-aBM
-aBM
-aBM
+dhe
+dhe
+dhe
 dhe
 nBT
 nBT
+leM
+leM
+leM
 nBT
 nBT
-nBT
-aBM
-aBM
+dhe
 dhe
 dhe
 dhe
@@ -85481,13 +85694,13 @@ dhe
 dhe
 dhe
 dhe
-dhe
 nBT
+dtB
 nnQ
 wCW
-ohx
+vHL
+dMA
 nBT
-dhe
 dhe
 dhe
 dhe
@@ -85739,11 +85952,11 @@ dhe
 dhe
 dhe
 nBT
-nBT
+grV
 joQ
-joQ
-joQ
-nBT
+tfA
+wmb
+uNM
 nBT
 dhe
 dhe
@@ -86253,11 +86466,11 @@ dhe
 dhe
 dhe
 nBT
-ayM
-aaO
+xuN
+xuN
 lFw
 xuN
-wCa
+xuN
 nBT
 dhe
 dhe
@@ -86509,13 +86722,13 @@ dhe
 dhe
 dhe
 dhe
-nBT
-wmb
-gTj
+dhe
+ccM
+qHR
 upe
-rMf
-vHL
-nBT
+fJq
+ccM
+dhe
 xTS
 dhe
 dhe
@@ -86766,13 +86979,13 @@ dhe
 dhe
 nTn
 nTn
-nBT
+nTn
+ccM
 ele
-ele
-tfA
-ele
-ele
-nBT
+jbD
+hYP
+ccM
+nTn
 nTn
 nTn
 dhe
@@ -87024,11 +87237,11 @@ dhe
 nTn
 xRK
 gYp
-ccM
-qHR
-grV
-fJq
-ccM
+tHg
+rlg
+jbD
+bLp
+tHg
 lvI
 tVi
 nTn
@@ -87541,7 +87754,7 @@ ccM
 ccM
 nCq
 jbD
-pmL
+olW
 ccM
 ccM
 ccM
@@ -87793,15 +88006,15 @@ dhe
 dhe
 dhe
 nTn
-xRK
+btd
 gPp
-ccM
-pCM
+tHg
+rlg
 jbD
 rVl
-ccM
+tHg
 waG
-tVi
+izt
 nTn
 nTn
 nTn
@@ -89142,7 +89355,7 @@ mtH
 vpE
 aKl
 dYq
-myE
+iht
 myE
 myE
 myE
@@ -97627,7 +97840,7 @@ dhe
 dhe
 dhe
 aJo
-xhD
+wra
 aJo
 dhe
 dhe
@@ -97884,7 +98097,7 @@ dhe
 dhe
 dhe
 aJo
-xhD
+wra
 aJo
 dhe
 dhe
@@ -98141,7 +98354,7 @@ aBM
 dhe
 dhe
 aJo
-xhD
+wra
 aJy
 sXN
 sXN
@@ -98398,7 +98611,7 @@ aBM
 dhe
 dhe
 aJo
-xhD
+wra
 aJy
 rrm
 duJ
@@ -98655,7 +98868,7 @@ aBM
 aBM
 dhe
 aJo
-xhD
+wra
 aJy
 jEz
 cdF
@@ -98912,7 +99125,7 @@ dhe
 dhe
 dhe
 aJo
-xhD
+wra
 aJy
 nWz
 ptQ
@@ -99169,7 +99382,7 @@ dhe
 dhe
 dhe
 aJo
-xhD
+wra
 aJy
 qrK
 ioa
@@ -99426,7 +99639,7 @@ aJo
 aJo
 aJo
 aJo
-xhD
+wra
 aJy
 qeq
 iVr
@@ -99674,6 +99887,7 @@ dhe
 dhe
 dhe
 aJo
+mMG
 xhD
 xhD
 xhD
@@ -99681,9 +99895,8 @@ xhD
 xhD
 xhD
 xhD
-xhD
-xhD
-xhD
+ijM
+lXI
 aJy
 mrp
 vrn
@@ -99931,7 +100144,7 @@ dhe
 dhe
 dhe
 aJo
-xhD
+wra
 aJy
 aJy
 aJy
@@ -100188,7 +100401,7 @@ aJo
 aJo
 aJo
 aJo
-xhD
+wra
 aJy
 ame
 buL
@@ -100442,10 +100655,10 @@ doC
 cBt
 aJy
 sIz
-qIr
+xeW
 xhD
 xhD
-xhD
+lXI
 aJy
 asV
 acC
@@ -100969,7 +101182,7 @@ oOY
 agA
 odO
 aPb
-leM
+aUb
 lxE
 pyh
 aUj
@@ -101226,7 +101439,7 @@ cMo
 cMo
 lvc
 azk
-dtB
+aJS
 iPb
 jED
 cni
@@ -112211,9 +112424,9 @@ knV
 dCA
 dCA
 dCA
-cwr
-cwr
-cwr
+dCA
+dCA
+dCA
 dhe
 dhe
 aBM
@@ -112470,7 +112683,7 @@ aBM
 aBM
 aBM
 aBM
-cwr
+dCA
 aBM
 aBM
 aBM
@@ -112727,7 +112940,7 @@ aBM
 aBM
 aBM
 aBM
-cwr
+dCA
 aBM
 aBM
 aBM
@@ -113822,8 +114035,8 @@ aJy
 eSj
 cLn
 hxD
-mRB
-mRB
+tFQ
+tFQ
 aJo
 dhe
 dhe
@@ -115338,7 +115551,7 @@ lNf
 rvc
 uom
 hft
-sIh
+vnD
 mJr
 mJr
 mJr
@@ -117383,7 +117596,7 @@ aeu
 aeu
 aeu
 aeu
-dUI
+vIH
 dUI
 iUp
 sIh
@@ -117640,7 +117853,7 @@ tPe
 tPe
 tPe
 tPe
-tPe
+oKk
 adS
 oZh
 adS
@@ -118668,7 +118881,7 @@ adS
 gGN
 uds
 adS
-tPe
+rpZ
 oZh
 adS
 lCc
@@ -118925,7 +119138,7 @@ adS
 vPZ
 aet
 adS
-tPe
+rpZ
 adS
 adS
 knx
@@ -148245,7 +148458,7 @@ aVR
 aVR
 aVR
 kca
-cOo
+okd
 awZ
 pNP
 pNP
@@ -148502,7 +148715,7 @@ aVR
 aVR
 aVR
 lKD
-cOo
+okd
 awZ
 pNP
 pNP
@@ -155149,7 +155362,7 @@ sUI
 eVW
 ieT
 iwX
-iwX
+uiV
 rzM
 pII
 cUB
@@ -155663,7 +155876,7 @@ cxh
 ieT
 ssT
 cKe
-sjf
+cil
 qgI
 bSa
 csN
@@ -168539,8 +168752,8 @@ bgI
 ayd
 aBR
 tvO
-rlg
-rlg
+avK
+avK
 mJq
 hfy
 plF
@@ -180374,7 +180587,7 @@ lJk
 wfS
 pfN
 mJd
-pfN
+uQg
 pfN
 pfN
 pfN
@@ -180630,8 +180843,8 @@ lar
 jLP
 wwN
 nYd
-btd
 nYd
+eze
 nYd
 nYd
 nYd

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -624,12 +624,9 @@
 /turf/open/floor/engine/cult,
 /area/service/library)
 "aeG" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air to Distro"
-	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/plating,
 /area/medical/virology)
 "aeK" = (
@@ -1286,6 +1283,8 @@
 	pixel_y = 4
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "aiF" = (
@@ -2975,8 +2974,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -5909,7 +5906,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -8817,6 +8813,10 @@
 	id = "Cell 2";
 	name = "Cell 2 Locker"
 	},
+/obj/machinery/flasher/directional/west{
+	id = "Cell 2";
+	pixel_y = 22
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "bto" = (
@@ -9076,6 +9076,16 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"bxK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "bxO" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
@@ -9493,6 +9503,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"bFC" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door_timer{
+	id = "Cell 4";
+	name = "Cell 4";
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "bFO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -9588,6 +9607,16 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"bGw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port/aft)
 "bGP" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/disposalpipe/segment,
@@ -9799,11 +9828,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/bar)
-"bLp" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "bLs" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
@@ -9854,6 +9878,19 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/service)
+"bMP" = (
+/obj/structure/table/glass,
+/obj/item/folder/red{
+	pixel_x = 3
+	},
+/obj/item/taperecorder{
+	pixel_x = -3
+	},
+/obj/structure/sign/poster/official/obey{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/white,
+/area/security/execution/education)
 "bNj" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -10888,6 +10925,16 @@
 "che" = (
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
+"chg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/central)
 "chm" = (
 /obj/structure/rack,
 /obj/item/weldingtool,
@@ -10953,15 +11000,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron,
 /area/security/prison)
-"cil" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "cim" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10977,6 +11015,22 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/central)
+"ciA" = (
+/obj/machinery/light/small/directional/west,
+/obj/item/radio/intercom/prison/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 4";
+	name = "Cell 4 Locker"
+	},
+/obj/machinery/flasher/directional/west{
+	id = "Cell 4";
+	pixel_y = -22
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "ciL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -11380,6 +11434,15 @@
 /obj/structure/cable,
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"csL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "csN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -14167,7 +14230,6 @@
 "dul" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -15182,19 +15244,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"dMA" = (
-/obj/structure/table/glass,
-/obj/item/folder/red{
-	pixel_x = 3
-	},
-/obj/item/taperecorder{
-	pixel_x = -3
-	},
-/obj/structure/sign/poster/official/obey{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/white,
-/area/security/execution/education)
 "dMF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16112,8 +16161,6 @@
 /area/maintenance/tram/right)
 "ecC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
 "ecF" = (
@@ -16823,6 +16870,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/port/central)
 "emU" = (
@@ -17272,6 +17320,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "etK" = (
@@ -17583,14 +17633,6 @@
 /obj/structure/chair/plastic,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"eze" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	name = "sorting disposal pipe (Robotics)";
-	sortType = 14
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "ezo" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain/private)
@@ -17962,6 +18004,9 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "eFB" = (
@@ -19617,6 +19662,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "flP" = (
@@ -20397,6 +20443,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "fxm" = (
@@ -20894,6 +20943,7 @@
 	name = "Perma Officer";
 	req_access_txt = "2"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/brigofficer)
 "fFO" = (
@@ -21384,6 +21434,9 @@
 "fOK" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/carpet/executive,
 /area/blueshield)
 "fOO" = (
@@ -22760,6 +22813,15 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/security/office)
+"gob" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	name = "Cell 3";
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "goh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -23736,6 +23798,30 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
+"gGA" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/bottle/toxin{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/facid{
+	name = "fluorosulfuric acid bottle";
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/bottle/morphine{
+	name = "nyquil bottle";
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/syringe{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/white,
+/area/security/execution/education)
 "gGE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -24794,6 +24880,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
 "haX" = (
@@ -25491,6 +25578,16 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
+"hmj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "hmp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -25883,6 +25980,11 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"huc" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "huk" = (
 /obj/structure/chair,
 /obj/machinery/airalarm/directional/north,
@@ -26243,7 +26345,6 @@
 /area/cargo/storage)
 "hBq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad/secure,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
@@ -27042,7 +27143,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "hRG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall,
 /area/medical/treatment_center)
 "hRI" = (
@@ -27347,15 +27448,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
-"hYP" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "hZc" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -27797,16 +27889,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"iht" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/port/aft)
 "ihH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -27923,16 +28005,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor,
 /area/hallway/primary/tram/center)
-"ijM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/central/secondary)
 "ijR" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -28804,18 +28876,6 @@
 /obj/structure/chair,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"izt" = (
-/obj/machinery/light/small/directional/west,
-/obj/item/radio/intercom/prison/directional/south,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 4";
-	name = "Cell 4 Locker"
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "izv" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/east,
@@ -29794,6 +29854,7 @@
 "iPj" = (
 /obj/structure/table/wood,
 /obj/item/toy/figure/captain,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet/executive,
 /area/blueshield)
 "iPv" = (
@@ -31487,6 +31548,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
+"jvU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/command/heads_quarters/captain/private/nt_rep)
 "jwa" = (
 /turf/closed/wall/rock/porous,
 /area/maintenance/central)
@@ -32008,6 +32078,12 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"jGn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/port/central)
 "jGq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -32922,6 +32998,15 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/item/stamp{
+	pixel_x = -5
+	},
+/obj/item/stamp/centcom{
+	pixel_y = 9
+	},
+/obj/item/stamp/denied{
+	pixel_x = 5
+	},
 /turf/open/floor/carpet/executive,
 /area/command/heads_quarters/captain/private/nt_rep)
 "jXg" = (
@@ -33630,7 +33715,9 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "kiH" = (
@@ -35048,6 +35135,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"kNz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/port/central)
 "kNJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
@@ -35953,6 +36047,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
 "lbS" = (
@@ -36056,6 +36151,9 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
+"ldV" = (
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private)
 "lef" = (
 /obj/machinery/door/airlock{
 	id_tag = "restroom_6";
@@ -36613,6 +36711,16 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
+"lpt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "lpU" = (
 /obj/structure/table,
 /obj/item/ai_module/supplied/quarantine,
@@ -37051,11 +37159,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/structure/chair/office{
-	dir = 4
-	},
 /obj/machinery/light/directional/west,
-/obj/effect/landmark/start/nanotrasen_representative,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -38359,16 +38463,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/cytology)
-"lXI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/central/secondary)
 "lYa" = (
 /obj/item/toy/plush/moth{
 	desc = "The moth wonders why you are out this far..."
@@ -40262,16 +40356,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"mMG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/central/secondary)
 "mNe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41614,6 +41698,8 @@
 /area/cargo/office)
 "nom" = (
 /obj/structure/closet/secure_closet/blueshield,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/executive,
 /area/blueshield)
 "nos" = (
@@ -42585,6 +42671,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "nGf" = (
@@ -43853,6 +43940,10 @@
 /area/ai_monitored/turret_protected/aisat/hallway)
 "odD" = (
 /obj/effect/landmark/start/blueshield,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/executive,
 /area/blueshield)
 "odK" = (
@@ -44346,15 +44437,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"olW" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door_timer{
-	id = "Cell 4";
-	name = "Cell 4";
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "omb" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
@@ -44685,6 +44767,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "otN" = (
@@ -45509,6 +45592,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/brigoff,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/brigofficer)
 "oIh" = (
@@ -45664,16 +45748,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"oKk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard/central)
 "oKp" = (
 /obj/structure/railing/corner,
 /obj/structure/railing/corner{
@@ -47350,19 +47424,11 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/table/wood,
-/obj/item/stamp/centcom{
-	pixel_y = 9
-	},
-/obj/item/stamp{
-	pixel_x = -5
-	},
-/obj/item/stamp/denied{
-	pixel_x = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/chair/office,
+/obj/effect/landmark/start/nanotrasen_representative,
 /turf/open/floor/carpet/executive,
 /area/command/heads_quarters/captain/private/nt_rep)
 "pov" = (
@@ -48040,6 +48106,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"pBS" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "pCq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -48652,6 +48730,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "pLK" = (
@@ -49233,6 +49312,8 @@
 	name = "Brig Officer's Locker";
 	req_one_access_txt = list(2)
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/brigofficer)
 "pWI" = (
@@ -50487,7 +50568,6 @@
 /area/maintenance/central)
 "qvh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "qvl" = (
@@ -52718,6 +52798,10 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"rlM" = (
+/obj/machinery/suit_storage_unit/captain,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private)
 "rmz" = (
 /obj/machinery/power/tracker,
 /obj/effect/turf_decal/sand/plating,
@@ -53453,6 +53537,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
+"rBb" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "rBt" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -54028,6 +54121,9 @@
 /area/security/brig)
 "rON" = (
 /obj/machinery/light_switch/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/executive,
 /area/blueshield)
 "rOO" = (
@@ -55671,9 +55767,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ssV" = (
@@ -56372,7 +56466,8 @@
 /turf/open/floor/iron,
 /area/service/salon)
 "sFC" = (
-/obj/machinery/suit_storage_unit/captain,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "sFL" = (
@@ -56502,6 +56597,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/three,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "sIA" = (
@@ -57541,6 +57638,8 @@
 /area/commons/locker)
 "taq" = (
 /obj/machinery/light/small/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/carpet/executive,
 /area/blueshield)
 "tat" = (
@@ -58325,6 +58424,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
+"tnr" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1;
+	name = "sorting disposal pipe (Robotics)";
+	sortType = 14
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "tns" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -60363,6 +60470,10 @@
 	id = "Cell 3";
 	name = "Cell 3 Locker"
 	},
+/obj/machinery/flasher/directional/west{
+	id = "Cell 3";
+	pixel_y = -22
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "tVj" = (
@@ -61059,15 +61170,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"uiV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
-/area/command/heads_quarters/captain/private/nt_rep)
 "uiX" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 10
@@ -61305,6 +61407,22 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
+"unh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "unm" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/box,
@@ -61573,6 +61691,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/port/central)
 "urU" = (
@@ -62233,6 +62352,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "uDS" = (
@@ -62636,6 +62758,9 @@
 	name = "Blueshield's Office";
 	req_access_txt = "20"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/blueshield)
 "uKe" = (
@@ -62810,30 +62935,6 @@
 /obj/machinery/keycard_auth/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"uNM" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/toxin{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/bottle/facid{
-	name = "fluorosulfuric acid bottle";
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	name = "nyquil bottle";
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe{
-	pixel_y = 5
-	},
-/turf/open/floor/iron/white,
-/area/security/execution/education)
 "uNV" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
@@ -62913,18 +63014,6 @@
 "uQe" = (
 /turf/open/floor/plating,
 /area/science/mixing)
-"uQg" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "uQu" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/table,
@@ -63438,6 +63527,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor,
 /area/hallway/primary/tram/center)
+"vaS" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Tunnel Access";
+	req_one_access_txt = "12"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/central)
 "vaX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
@@ -64062,15 +64160,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/science/research)
-"vnD" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Tunnel Access";
-	req_one_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard/central)
 "vnK" = (
 /obj/machinery/rnd/server,
 /turf/open/floor/circuit/telecomms/server,
@@ -65096,16 +65185,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"vIH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard/central)
 "vIS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66211,6 +66290,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/vault,
 /area/hallway/primary/tram/left)
+"wcN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "wcU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
@@ -66433,6 +66522,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "wiA" = (
@@ -66581,6 +66671,16 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"wlt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/central)
 "wly" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -66853,16 +66953,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
-"wra" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/central/secondary)
 "wrc" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
@@ -66893,6 +66983,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
+"wrz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "wrF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -67389,6 +67489,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "wyB" = (
@@ -67595,6 +67696,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
 "wCt" = (
@@ -68693,6 +68795,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
 "wYx" = (
@@ -69115,16 +69218,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/cargo/storage)
-"xeW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/central/secondary)
 "xeY" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -71281,6 +71374,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/port/central)
 "xPm" = (
@@ -71461,6 +71555,10 @@
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
 	name = "Cell 1 Locker"
+	},
+/obj/machinery/flasher/directional/west{
+	id = "Cell 1";
+	pixel_y = 22
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -72338,10 +72436,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/robot_debris/limb,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/central/secondary)
 "ygD" = (
@@ -85699,7 +85794,7 @@ dtB
 nnQ
 wCW
 vHL
-dMA
+bMP
 nBT
 dhe
 dhe
@@ -85956,7 +86051,7 @@ grV
 joQ
 tfA
 wmb
-uNM
+gGA
 nBT
 dhe
 dhe
@@ -86983,7 +87078,7 @@ nTn
 ccM
 ele
 jbD
-hYP
+gob
 ccM
 nTn
 nTn
@@ -87240,7 +87335,7 @@ gYp
 tHg
 rlg
 jbD
-bLp
+huc
 tHg
 lvI
 tVi
@@ -87754,7 +87849,7 @@ ccM
 ccM
 nCq
 jbD
-olW
+bFC
 ccM
 ccM
 ccM
@@ -88014,7 +88109,7 @@ jbD
 rVl
 tHg
 waG
-izt
+ciA
 nTn
 nTn
 nTn
@@ -88273,7 +88368,7 @@ baV
 htz
 jut
 ccM
-ccM
+gAn
 gAn
 nTn
 nTn
@@ -89355,7 +89450,7 @@ mtH
 vpE
 aKl
 dYq
-iht
+bGw
 myE
 myE
 myE
@@ -92663,7 +92758,7 @@ ffu
 yiT
 gCU
 aaB
-fPR
+kNz
 tpS
 tpS
 tpS
@@ -92920,7 +93015,7 @@ fnv
 yiT
 gCU
 aaB
-fPR
+jGn
 iti
 iti
 iti
@@ -93177,7 +93272,7 @@ yiT
 yiT
 gCU
 aaB
-fPR
+jGn
 iti
 iti
 iti
@@ -93434,7 +93529,7 @@ yiT
 iti
 gCU
 aaB
-fPR
+jGn
 uFJ
 nsG
 iti
@@ -97840,7 +97935,7 @@ dhe
 dhe
 dhe
 aJo
-wra
+wcN
 aJo
 dhe
 dhe
@@ -98097,7 +98192,7 @@ dhe
 dhe
 dhe
 aJo
-wra
+wcN
 aJo
 dhe
 dhe
@@ -98354,7 +98449,7 @@ aBM
 dhe
 dhe
 aJo
-wra
+wcN
 aJy
 sXN
 sXN
@@ -98611,7 +98706,7 @@ aBM
 dhe
 dhe
 aJo
-wra
+wcN
 aJy
 rrm
 duJ
@@ -98868,7 +98963,7 @@ aBM
 aBM
 dhe
 aJo
-wra
+wcN
 aJy
 jEz
 cdF
@@ -99125,7 +99220,7 @@ dhe
 dhe
 dhe
 aJo
-wra
+wcN
 aJy
 nWz
 ptQ
@@ -99382,7 +99477,7 @@ dhe
 dhe
 dhe
 aJo
-wra
+wcN
 aJy
 qrK
 ioa
@@ -99639,7 +99734,7 @@ aJo
 aJo
 aJo
 aJo
-wra
+wcN
 aJy
 qeq
 iVr
@@ -99887,7 +99982,7 @@ dhe
 dhe
 dhe
 aJo
-mMG
+lpt
 xhD
 xhD
 xhD
@@ -99895,8 +99990,8 @@ xhD
 xhD
 xhD
 xhD
-ijM
-lXI
+bxK
+hmj
 aJy
 mrp
 vrn
@@ -100144,7 +100239,7 @@ dhe
 dhe
 dhe
 aJo
-wra
+wcN
 aJy
 aJy
 aJy
@@ -100401,7 +100496,7 @@ aJo
 aJo
 aJo
 aJo
-wra
+wcN
 aJy
 ame
 buL
@@ -100655,10 +100750,10 @@ doC
 cBt
 aJy
 sIz
-xeW
+wrz
 xhD
 xhD
-lXI
+hmj
 aJy
 asV
 acC
@@ -115551,7 +115646,7 @@ lNf
 rvc
 uom
 hft
-vnD
+vaS
 mJr
 mJr
 mJr
@@ -117596,7 +117691,7 @@ aeu
 aeu
 aeu
 aeu
-vIH
+chg
 dUI
 iUp
 sIh
@@ -117853,7 +117948,7 @@ tPe
 tPe
 tPe
 tPe
-oKk
+wlt
 adS
 oZh
 adS
@@ -144848,7 +144943,7 @@ aGH
 kbZ
 hON
 qLX
-aOv
+aBa
 did
 aOv
 aOv
@@ -150460,11 +150555,11 @@ puC
 puC
 puC
 puC
-puC
-puC
-puC
-puC
-puC
+jpF
+jpF
+jpF
+jpF
+jpF
 puC
 puC
 aBM
@@ -150717,11 +150812,11 @@ puC
 puC
 puC
 sRq
-puC
-puC
-puC
-puC
-puC
+jpF
+jpF
+jpF
+jpF
+jpF
 puC
 puC
 aBM
@@ -155362,7 +155457,7 @@ sUI
 eVW
 ieT
 iwX
-uiV
+jvU
 rzM
 pII
 cUB
@@ -155876,7 +155971,7 @@ cxh
 ieT
 ssT
 cKe
-cil
+rBb
 qgI
 bSa
 csN
@@ -158160,9 +158255,9 @@ dhe
 dhe
 hNf
 etz
-etz
-etz
-etz
+unh
+unh
+unh
 laC
 lsi
 uwy
@@ -158419,7 +158514,7 @@ hNf
 erD
 hdj
 cJU
-etz
+unh
 lbN
 eog
 qqK
@@ -159192,7 +159287,7 @@ dhe
 hNf
 hNf
 rSI
-etz
+unh
 iKn
 hNf
 hNf
@@ -160501,7 +160596,7 @@ erH
 fPE
 erH
 uDD
-pmi
+csL
 pmi
 xYg
 dYz
@@ -162302,8 +162397,8 @@ xvl
 ecC
 xzk
 ezo
-ezo
-ezo
+rlM
+ldV
 ezo
 wLS
 wLS
@@ -162560,8 +162655,8 @@ ezo
 ezo
 erH
 erH
-dhe
-dhe
+ezo
+ezo
 dhe
 dhe
 dhe
@@ -180587,7 +180682,7 @@ lJk
 wfS
 pfN
 mJd
-uQg
+pBS
 pfN
 pfN
 pfN
@@ -180844,7 +180939,7 @@ jLP
 wwN
 nYd
 nYd
-eze
+tnr
 nYd
 nYd
 nYd

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -669,6 +669,16 @@
 	dir = 1
 	},
 /area/service/chapel)
+"afa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "afe" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/button/crematorium{
@@ -9076,16 +9086,6 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"bxK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/central/secondary)
 "bxO" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
@@ -9503,15 +9503,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"bFC" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door_timer{
-	id = "Cell 4";
-	name = "Cell 4";
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "bFO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -9607,16 +9598,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"bGw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/port/aft)
 "bGP" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/disposalpipe/segment,
@@ -9878,19 +9859,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/service)
-"bMP" = (
-/obj/structure/table/glass,
-/obj/item/folder/red{
-	pixel_x = 3
-	},
-/obj/item/taperecorder{
-	pixel_x = -3
-	},
-/obj/structure/sign/poster/official/obey{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/white,
-/area/security/execution/education)
 "bNj" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -10925,16 +10893,6 @@
 "che" = (
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
-"chg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard/central)
 "chm" = (
 /obj/structure/rack,
 /obj/item/weldingtool,
@@ -11015,22 +10973,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/central)
-"ciA" = (
-/obj/machinery/light/small/directional/west,
-/obj/item/radio/intercom/prison/directional/south,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 4";
-	name = "Cell 4 Locker"
-	},
-/obj/machinery/flasher/directional/west{
-	id = "Cell 4";
-	pixel_y = -22
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "ciL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -11434,15 +11376,6 @@
 /obj/structure/cable,
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"csL" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "csN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -13277,6 +13210,7 @@
 	req_one_access_txt = "47"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/maintenance/department/science)
 "daq" = (
@@ -13333,7 +13267,6 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "dca" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
@@ -15885,6 +15818,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"dYS" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	name = "Cell 3";
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "dYV" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
@@ -19794,6 +19736,11 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/command/nuke_storage)
+"fnz" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "fnK" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
@@ -20032,6 +19979,12 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
+"frb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/port/central)
 "frk" = (
 /obj/structure/railing,
 /obj/structure/chair/sofa/left{
@@ -20442,10 +20395,10 @@
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "fxm" = (
@@ -22813,15 +22766,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/security/office)
-"gob" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "goh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -23798,30 +23742,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
-"gGA" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/toxin{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/bottle/facid{
-	name = "fluorosulfuric acid bottle";
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	name = "nyquil bottle";
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe{
-	pixel_y = 5
-	},
-/turf/open/floor/iron/white,
-/area/security/execution/education)
 "gGE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -25578,16 +25498,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
-"hmj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/central/secondary)
 "hmp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -25946,7 +25856,6 @@
 	name = "Permabrig Showers"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
@@ -25980,11 +25889,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/central)
-"huc" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "huk" = (
 /obj/structure/chair,
 /obj/machinery/airalarm/directional/north,
@@ -26807,6 +26711,8 @@
 "hKW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "hLi" = (
@@ -29695,6 +29601,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
+"iMU" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "iMV" = (
 /obj/machinery/computer/department_orders/science{
 	dir = 4
@@ -30287,6 +30202,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
+"iXX" = (
+/obj/machinery/suit_storage_unit/captain,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private)
 "iYg" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/decal/cleanable/dirt,
@@ -31548,15 +31467,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
-"jvU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
-/area/command/heads_quarters/captain/private/nt_rep)
 "jwa" = (
 /turf/closed/wall/rock/porous,
 /area/maintenance/central)
@@ -32078,12 +31988,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"jGn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/warning,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/port/central)
 "jGq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -32474,6 +32378,16 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"jNp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/central)
 "jND" = (
 /turf/open/floor/glass/reinforced,
 /area/security/brig)
@@ -33159,6 +33073,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"jZI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/maintenance/department/medical)
 "jZP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34312,6 +34231,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
+"kuG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/port/central)
 "kuX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
@@ -34584,6 +34510,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"kBA" = (
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private)
 "kBI" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/status_display/evac/directional/north,
@@ -34790,6 +34719,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"kGV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/command/heads_quarters/captain/private/nt_rep)
 "kGW" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
@@ -35135,13 +35073,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"kNz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/warning,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/port/central)
 "kNJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
@@ -36151,9 +36082,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
-"ldV" = (
-/turf/open/floor/wood,
-/area/command/heads_quarters/captain/private)
 "lef" = (
 /obj/machinery/door/airlock{
 	id_tag = "restroom_6";
@@ -36711,16 +36639,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
-"lpt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/central/secondary)
 "lpU" = (
 /obj/structure/table,
 /obj/item/ai_module/supplied/quarantine,
@@ -37139,6 +37057,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"lyW" = (
+/obj/structure/table/glass,
+/obj/item/folder/red{
+	pixel_x = 3
+	},
+/obj/item/taperecorder{
+	pixel_x = -3
+	},
+/obj/structure/sign/poster/official/obey{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/white,
+/area/security/execution/education)
 "lzb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -37754,6 +37685,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"lKK" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1;
+	name = "sorting disposal pipe (Robotics)";
+	sortType = 14
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "lKM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -38607,6 +38546,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
+"mbm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/maintenance/department/science)
 "mbt" = (
 /obj/machinery/conveyor{
 	id = "packageSort2"
@@ -39077,6 +39022,7 @@
 	dir = 1
 	},
 /obj/vehicle/ridden/secway,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "mlV" = (
@@ -40981,6 +40927,15 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"mXM" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Tunnel Access";
+	req_one_access_txt = "12"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/central)
 "mXQ" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -44875,6 +44830,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"owk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "owr" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -45054,6 +45019,7 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/brigoff,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/brigofficer)
 "ozF" = (
@@ -47640,6 +47606,16 @@
 	},
 /turf/open/floor/iron,
 /area/service/kitchen)
+"ptC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "ptQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -48106,18 +48082,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"pBS" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "pCq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -48467,7 +48431,6 @@
 /turf/open/floor/iron,
 /area/security/prison/work)
 "pGT" = (
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
@@ -51997,6 +51960,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/explored)
+"qXW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port/aft)
 "qYa" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -52798,10 +52771,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
-"rlM" = (
-/obj/machinery/suit_storage_unit/captain,
-/turf/open/floor/wood,
-/area/command/heads_quarters/captain/private)
 "rmz" = (
 /obj/machinery/power/tracker,
 /obj/effect/turf_decal/sand/plating,
@@ -53537,15 +53506,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
-"rBb" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "rBt" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -55057,6 +55017,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"seo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "seE" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/four,
@@ -58009,8 +57979,6 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "thh" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/structure/sink{
 	pixel_y = 15
 	},
@@ -58424,14 +58392,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
-"tnr" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	name = "sorting disposal pipe (Robotics)";
-	sortType = 14
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "tns" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -58972,6 +58932,7 @@
 	network = list("ss13","Security")
 	},
 /obj/structure/cable,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "tuA" = (
@@ -59117,6 +59078,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"tyF" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door_timer{
+	id = "Cell 4";
+	name = "Cell 4";
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "tyJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
@@ -61119,6 +61089,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"uin" = (
+/obj/machinery/light/small/directional/west,
+/obj/item/radio/intercom/prison/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 4";
+	name = "Cell 4 Locker"
+	},
+/obj/machinery/flasher/directional/west{
+	id = "Cell 4";
+	pixel_y = -22
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "uir" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -61407,22 +61393,6 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
-"unh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
 "unm" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/box,
@@ -63527,15 +63497,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor,
 /area/hallway/primary/tram/center)
-"vaS" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Tunnel Access";
-	req_one_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard/central)
 "vaX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
@@ -64599,6 +64560,7 @@
 /area/mine/explored)
 "vxQ" = (
 /obj/machinery/holopad,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood/parquet,
 /area/command/heads_quarters/captain/private/nt_rep)
 "vyw" = (
@@ -66290,16 +66252,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/vault,
 /area/hallway/primary/tram/left)
-"wcN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/central/secondary)
 "wcU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
@@ -66671,16 +66623,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"wlt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard/central)
 "wly" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -66983,16 +66925,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
-"wrz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/central/secondary)
 "wrF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -69087,6 +69019,15 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"xcl" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "xcv" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
@@ -69141,6 +69082,16 @@
 	dir = 5
 	},
 /area/science/breakroom)
+"xdG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/central)
 "xdO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69182,6 +69133,22 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
+"xeF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "xeG" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -70459,6 +70426,30 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
+"xzp" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/bottle/toxin{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/facid{
+	name = "fluorosulfuric acid bottle";
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/bottle/morphine{
+	name = "nyquil bottle";
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/syringe{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/white,
+/area/security/execution/education)
 "xzO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/warning,
@@ -70704,6 +70695,16 @@
 /obj/item/clothing/head/welding,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"xFa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/central/secondary)
 "xFg" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -71086,6 +71087,7 @@
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/wood/parquet,
 /area/command/heads_quarters/captain/private/nt_rep)
 "xJM" = (
@@ -71562,6 +71564,18 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"xRW" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "xRY" = (
 /obj/item/radio/intercom{
 	pixel_y = -29
@@ -85794,7 +85808,7 @@ dtB
 nnQ
 wCW
 vHL
-bMP
+lyW
 nBT
 dhe
 dhe
@@ -86051,7 +86065,7 @@ grV
 joQ
 tfA
 wmb
-gGA
+xzp
 nBT
 dhe
 dhe
@@ -87078,7 +87092,7 @@ nTn
 ccM
 ele
 jbD
-gob
+dYS
 ccM
 nTn
 nTn
@@ -87335,7 +87349,7 @@ gYp
 tHg
 rlg
 jbD
-huc
+fnz
 tHg
 lvI
 tVi
@@ -87849,7 +87863,7 @@ ccM
 ccM
 nCq
 jbD
-bFC
+tyF
 ccM
 ccM
 ccM
@@ -88109,7 +88123,7 @@ jbD
 rVl
 tHg
 waG
-ciA
+uin
 nTn
 nTn
 nTn
@@ -89450,7 +89464,7 @@ mtH
 vpE
 aKl
 dYq
-bGw
+qXW
 myE
 myE
 myE
@@ -92758,7 +92772,7 @@ ffu
 yiT
 gCU
 aaB
-kNz
+kuG
 tpS
 tpS
 tpS
@@ -93015,7 +93029,7 @@ fnv
 yiT
 gCU
 aaB
-jGn
+frb
 iti
 iti
 iti
@@ -93272,7 +93286,7 @@ yiT
 yiT
 gCU
 aaB
-jGn
+frb
 iti
 iti
 iti
@@ -93529,7 +93543,7 @@ yiT
 iti
 gCU
 aaB
-jGn
+frb
 uFJ
 nsG
 iti
@@ -97935,7 +97949,7 @@ dhe
 dhe
 dhe
 aJo
-wcN
+seo
 aJo
 dhe
 dhe
@@ -98192,7 +98206,7 @@ dhe
 dhe
 dhe
 aJo
-wcN
+seo
 aJo
 dhe
 dhe
@@ -98449,7 +98463,7 @@ aBM
 dhe
 dhe
 aJo
-wcN
+seo
 aJy
 sXN
 sXN
@@ -98706,7 +98720,7 @@ aBM
 dhe
 dhe
 aJo
-wcN
+seo
 aJy
 rrm
 duJ
@@ -98963,7 +98977,7 @@ aBM
 aBM
 dhe
 aJo
-wcN
+seo
 aJy
 jEz
 cdF
@@ -99220,7 +99234,7 @@ dhe
 dhe
 dhe
 aJo
-wcN
+seo
 aJy
 nWz
 ptQ
@@ -99477,7 +99491,7 @@ dhe
 dhe
 dhe
 aJo
-wcN
+seo
 aJy
 qrK
 ioa
@@ -99734,7 +99748,7 @@ aJo
 aJo
 aJo
 aJo
-wcN
+seo
 aJy
 qeq
 iVr
@@ -99982,7 +99996,7 @@ dhe
 dhe
 dhe
 aJo
-lpt
+owk
 xhD
 xhD
 xhD
@@ -99990,8 +100004,8 @@ xhD
 xhD
 xhD
 xhD
-bxK
-hmj
+afa
+xFa
 aJy
 mrp
 vrn
@@ -100239,7 +100253,7 @@ dhe
 dhe
 dhe
 aJo
-wcN
+seo
 aJy
 aJy
 aJy
@@ -100496,7 +100510,7 @@ aJo
 aJo
 aJo
 aJo
-wcN
+seo
 aJy
 ame
 buL
@@ -100750,10 +100764,10 @@ doC
 cBt
 aJy
 sIz
-wrz
+ptC
 xhD
 xhD
-hmj
+xFa
 aJy
 asV
 acC
@@ -115646,7 +115660,7 @@ lNf
 rvc
 uom
 hft
-vaS
+mXM
 mJr
 mJr
 mJr
@@ -117691,7 +117705,7 @@ aeu
 aeu
 aeu
 aeu
-chg
+jNp
 dUI
 iUp
 sIh
@@ -117948,7 +117962,7 @@ tPe
 tPe
 tPe
 tPe
-wlt
+xdG
 adS
 oZh
 adS
@@ -155457,7 +155471,7 @@ sUI
 eVW
 ieT
 iwX
-jvU
+kGV
 rzM
 pII
 cUB
@@ -155971,7 +155985,7 @@ cxh
 ieT
 ssT
 cKe
-rBb
+iMU
 qgI
 bSa
 csN
@@ -158255,9 +158269,9 @@ dhe
 dhe
 hNf
 etz
-unh
-unh
-unh
+xeF
+xeF
+xeF
 laC
 lsi
 uwy
@@ -158514,7 +158528,7 @@ hNf
 erD
 hdj
 cJU
-unh
+xeF
 lbN
 eog
 qqK
@@ -159287,7 +159301,7 @@ dhe
 hNf
 hNf
 rSI
-unh
+xeF
 iKn
 hNf
 hNf
@@ -160596,7 +160610,7 @@ erH
 fPE
 erH
 uDD
-csL
+xcl
 pmi
 xYg
 dYz
@@ -162397,8 +162411,8 @@ xvl
 ecC
 xzk
 ezo
-rlM
-ldV
+iXX
+kBA
 ezo
 wLS
 wLS
@@ -162653,8 +162667,8 @@ ezo
 ezo
 ezo
 ezo
-erH
-erH
+ezo
+ezo
 ezo
 ezo
 dhe
@@ -174769,8 +174783,8 @@ vni
 vni
 lbM
 hKW
-gaa
-gaa
+jZI
+jZI
 xMQ
 xMQ
 xMQ
@@ -180177,7 +180191,7 @@ jHx
 inS
 jhg
 ceK
-wol
+mbm
 ceK
 wnG
 rdU
@@ -180682,7 +180696,7 @@ lJk
 wfS
 pfN
 mJd
-pBS
+xRW
 pfN
 pfN
 pfN
@@ -180939,7 +180953,7 @@ jLP
 wwN
 nYd
 nYd
-tnr
+lKK
 nYd
 nYd
 nYd

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -36,6 +36,7 @@ endmap
 
 map tramstation
 	minplayers 35
+endmap
 
 map waterkilostation
 	votable


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes some issues with tram
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
fixes some issues with tram
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes the random space tiles on tramstation
fix: places some missing APCs on tramstation
fix: places some missing Air Alarms on tramstation
fix: fixes some wiring on tramstation
fix: fixes some atmos piping on tramstation
fix: fixes some disposal piping on tramstation
fix: fixed the map config for tramstation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
