### PR TITLE
Xenoarch researcher redesign

### DIFF
--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
@@ -59,10 +59,10 @@
 
 /obj/machinery/xenoarch/researcher
 	name = "xenoarch researcher"
-	desc = "A machine that is used to deconstruct strange rocks, useless relics, and broken objects for technology."
+	desc = "A machine that is used to condense strange rocks, useless relics, and broken objects into bigger artifacts."
 	icon_state = "researcher"
 	circuit = /obj/item/circuitboard/machine/xenoarch_researcher
-	///A variable that goes from 0 to 100. Depending on what is processed, increases the value. Once 100, spawns a tech disk.
+	///A variable that goes from 0 to 100. Depending on what is processed, increases the value. Once 100, spawns an anomalous crystal.
 	var/current_research = 0
 
 /obj/machinery/xenoarch/researcher/examine(mob/user)
@@ -115,7 +115,9 @@
 		current_research += 20
 	if(current_research >= 100)
 		current_research -= 100
-		new /obj/item/disk/tech_disk/major(get_turf(src))
+		var/list/choices = subtypesof(/obj/machinery/anomalous_crystal)
+		var/random_crystal = pick(choices)
+		new random_crystal(src)
 	qdel(remove_item)
 	playsound(src, 'sound/machines/click.ogg', 50, TRUE)
 	world_compare = world.time + process_speed

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
@@ -67,7 +67,7 @@
 
 /obj/machinery/xenoarch/researcher/examine(mob/user)
 	. = ..()
-	. += span_notice("[current_research]/100 research points. Research more xenoarchaeological items.")
+	. += span_notice("[current_research]/150 research points. Research more xenoarchaeological items.")
 
 /obj/machinery/xenoarch/researcher/attackby(obj/item/weapon, mob/user, params)
 	if(istype(weapon, /obj/item/storage/bag/xenoarch))
@@ -108,16 +108,16 @@
 		qdel(remove_item)
 		return
 	if(istype(remove_item, /obj/item/xenoarch/strange_rock))
-		current_research += 2
+		current_research += 1
 	if(istype(remove_item, /obj/item/xenoarch/useless_relic))
-		current_research += 10
+		current_research += 5
 	if(istype(remove_item, /obj/item/xenoarch/broken_item))
-		current_research += 20
-	if(current_research >= 100)
-		current_research -= 100
+		current_research += 10
+	if(current_research >= 150)
+		current_research -= 150
 		var/list/choices = subtypesof(/obj/machinery/anomalous_crystal)
 		var/random_crystal = pick(choices)
-		new random_crystal(src)
+		new random_crystal(get_turf(src))
 	qdel(remove_item)
 	playsound(src, 'sound/machines/click.ogg', 50, TRUE)
 	world_compare = world.time + process_speed


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changed xenoarch researcher's purpose: instead of outputting BEPIS disks, it eats a numerous amount of xenoarch items and then spits out bigger artifacts.
![image](https://user-images.githubusercontent.com/42087567/149152805-8c1345e3-f774-4e5f-abad-aa26e922ceaf.png)

(The one below is slightly outdated: it needs 150 points instead of 100)
![image](https://user-images.githubusercontent.com/42087567/149152910-6e649afd-337c-46fc-a022-cc2e1f9a1d97.png)

The amount it needs to consume has also been nerfed about three times so it doesn't become a literal artifact or money printer.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Jake thought it might be a good idea; I did too, and this might also give anomalists and xenoarchs some more work and cooperation. Also, Bay12 xenoarch vibes **very good**.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Stalkeros
expansion: Instead of generating research disks, xenoarch researcher has been made to generate Colossus artifacts instead, albeit at a higher costs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
