### PR TITLE
[Modular] Adds a toggle option to overlay effects for emotes

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/emote_overlay.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/emote_overlay.dm
@@ -1,5 +1,5 @@
-/datum/preference/toggle/see_emote_overlay
+/datum/preference/toggle/do_emote_overlay
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	default_value = TRUE
-	savefile_key = "see_emote_overlay"
+	savefile_key = "do_emote_overlay"
 	savefile_identifier = PREFERENCE_PLAYER

--- a/modular_skyrat/master_files/code/modules/client/preferences/emote_overlay.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/emote_overlay.dm
@@ -1,0 +1,5 @@
+/datum/preference/toggle/see_emote_overlay
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	default_value = TRUE
+	savefile_key = "see_emote_overlay"
+	savefile_identifier = PREFERENCE_PLAYER

--- a/modular_skyrat/modules/emotes/code/additionalemotes/overlay_emote.dm
+++ b/modular_skyrat/modules/emotes/code/additionalemotes/overlay_emote.dm
@@ -1,13 +1,20 @@
 /datum/emote
 	var/overlay_emote = 'modular_skyrat/master_files/icons/effects/overlay_effects.dmi'
 
+/datum/emote/proc/get_toggle(mob/living/user)
+	if(user.client)
+		if(!user.client.prefs.read_preference(/datum/preference/toggle/see_emote_overlay))
+			return FALSE
+	return TRUE
+
+
 /datum/emote/living/sweatdrop
 	key = "sweatdrop"
 	key_third_person = "sweatdrops"
 
 /datum/emote/living/sweatdrop/run_emote(mob/living/user, params, type_override, intentional)
 	. = ..()
-	if(isliving(user))
+	if(isliving(user) && get_toggle(user))
 		var/mutable_appearance/overlay = mutable_appearance(overlay_emote, "sweatdrop", ABOVE_MOB_LAYER)
 		overlay.pixel_x = 10
 		overlay.pixel_y = 10
@@ -20,7 +27,7 @@
 
 /datum/emote/living/exclaim/run_emote(mob/living/user, params, type_override, intentional)
 	. = ..()
-	if(isliving(user))
+	if(isliving(user) && get_toggle(user))
 		var/mutable_appearance/overlay = mutable_appearance(overlay_emote, "exclamation", ABOVE_MOB_LAYER)
 		overlay.pixel_x = 10
 		overlay.pixel_y = 28
@@ -33,7 +40,7 @@
 
 /datum/emote/living/question/run_emote(mob/living/user, params, type_override, intentional)
 	. = ..()
-	if(isliving(user))
+	if(isliving(user) && get_toggle(user))
 		var/mutable_appearance/overlay = mutable_appearance(overlay_emote, "question", ABOVE_MOB_LAYER)
 		overlay.pixel_x = 10
 		overlay.pixel_y = 28
@@ -47,7 +54,7 @@
 
 /datum/emote/living/realize/run_emote(mob/living/user, params, type_override, intentional)
 	. = ..()
-	if(isliving(user))
+	if(isliving(user) && get_toggle(user))
 		var/mutable_appearance/overlay = mutable_appearance(overlay_emote, "realize", ABOVE_MOB_LAYER)
 		overlay.pixel_y = 15
 		flick_overlay_static(overlay, user, 50)
@@ -59,7 +66,7 @@
 
 /datum/emote/living/annoyed/run_emote(mob/living/user, params, type_override, intentional)
 	. = ..()
-	if(isliving(user))
+	if(isliving(user) && get_toggle(user))
 		var/mutable_appearance/overlay = mutable_appearance(overlay_emote, "annoyed", ABOVE_MOB_LAYER)
 		overlay.pixel_x = 10
 		overlay.pixel_y = 10
@@ -75,7 +82,7 @@
 /datum/emote/living/glasses/run_emote(mob/living/carbon/human/user, params, type_override, intentional)
 	. = ..()
 	var/obj/O = user.get_item_by_slot(ITEM_SLOT_EYES)
-	if(istype(O, /obj/item/clothing/glasses))
+	if((istype(O, /obj/item/clothing/glasses)) && get_toggle(user))
 		var/mutable_appearance/overlay = mutable_appearance(overlay_emote, "glasses", ABOVE_MOB_LAYER)
 		flick_overlay_static(overlay, user, 10)
 	else
@@ -89,7 +96,7 @@
 
 /datum/emote/living/blush/run_emote(mob/living/carbon/human/user, params, type_override, intentional)
 	. = ..()
-	if(iscarbon(user))
+	if(iscarbon(user) && get_toggle(user))
 		var/mutable_appearance/overlay = mutable_appearance(overlay_emote, "blush", ABOVE_MOB_LAYER)
 		flick_overlay_static(overlay, user, 50)
 		playsound(get_turf(user), 'modular_skyrat/modules/emotes/sound/emotes/blush.ogg', 25, TRUE)
@@ -100,7 +107,7 @@
 
 /datum/emote/living/snore/run_emote(mob/living/carbon/human/user, params, type_override, intentional)
 	. = ..()
-	if(isliving(user))
+	if(isliving(user) && get_toggle(user))
 		var/mutable_appearance/overlay = mutable_appearance(overlay_emote, "snore", ABOVE_MOB_LAYER)
 		overlay.pixel_y = 6
 		flick_overlay_static(overlay, user, 100)
@@ -111,6 +118,6 @@
 
 /datum/emote/living/sigh/run_emote(mob/living/carbon/human/user, params, type_override, intentional)
 	. = ..()
-	if(isliving(user))
+	if(isliving(user) && get_toggle(user))
 		var/mutable_appearance/overlay = mutable_appearance(overlay_emote, "sigh", ABOVE_MOB_LAYER)
 		flick_overlay_static(overlay, user, 50)

--- a/modular_skyrat/modules/emotes/code/additionalemotes/overlay_emote.dm
+++ b/modular_skyrat/modules/emotes/code/additionalemotes/overlay_emote.dm
@@ -3,7 +3,7 @@
 
 /datum/emote/proc/get_toggle(mob/living/user)
 	if(user.client)
-		if(!user.client.prefs.read_preference(/datum/preference/toggle/see_emote_overlay))
+		if(!user.client.prefs.read_preference(/datum/preference/toggle/do_emote_overlay))
 			return FALSE
 	return TRUE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4282,6 +4282,7 @@
 #include "modular_skyrat\master_files\code\modules\client\preferences\body_type.dm"
 #include "modular_skyrat\master_files\code\modules\client\preferences\cursed_shit.dm"
 #include "modular_skyrat\master_files\code\modules\client\preferences\delete_sparks.dm"
+#include "modular_skyrat\master_files\code\modules\client\preferences\emote_overlay.dm"
 #include "modular_skyrat\master_files\code\modules\client\preferences\erp_preferences.dm"
 #include "modular_skyrat\master_files\code\modules\client\preferences\face_cursor_combat_mode.dm"
 #include "modular_skyrat\master_files\code\modules\client\preferences\flavor_text.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/skyrat/emote_overlay.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/skyrat/emote_overlay.tsx
@@ -1,0 +1,8 @@
+import { CheckboxInput, FeatureToggle } from "../../base";
+
+export const see_emote_overlay: FeatureToggle = {
+  name: "Show/Hide emote effect overlays",
+  category: "CHAT",
+  description: "This shows/hides the animated overlays displayed on emotes.",
+  component: CheckboxInput,
+};

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/skyrat/emote_overlay.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/skyrat/emote_overlay.tsx
@@ -1,8 +1,8 @@
 import { CheckboxInput, FeatureToggle } from "../../base";
 
-export const see_emote_overlay: FeatureToggle = {
-  name: "Show/Hide emote effect overlays",
+export const do_emote_overlay: FeatureToggle = {
+  name: "Show/Hide my emote effect overlays",
   category: "CHAT",
-  description: "This shows/hides the animated overlays displayed on emotes.",
+  description: "This shows/hides the animated overlays displayed on emotes for yourself.",
   component: CheckboxInput,
 };


### PR DESCRIPTION
## About The Pull Request

It appears in the CHAT category.

## How This Contributes To The Skyrat Roleplay Experience

It was requested!

## Changelog

:cl:
qol: You can disable emote overlay effects for yourself in the CHAT category of 'game preferences'
/:cl: