### PR TITLE
[SEMI-MODULAR] Changeling Reset

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -31,25 +31,25 @@
 	/// The original profile of this changeling.
 	var/datum/changeling_profile/first_profile = null
 	/// How many DNA strands the changeling can store for transformation.
-	var/dna_max = 8 // SKYRAT EDIT - ORIGINAL: 6
+	var/dna_max = 6
 	/// The amount of DNA gained. Includes DNA sting.
 	var/absorbed_count = 0
 	/// The amount of DMA gained using absorb, not DNA sting. Start with one (your original DNA)
 	var/true_absorbs = 0
 	/// The number of chemicals the changeling currently has.
-	var/chem_charges = 75 // SKYRAT EDIT - ORIGINAL: 20
+	var/chem_charges = 20
 	/// The max chemical storage the changeling currently has.
-	var/total_chem_storage = 100 // SKYRAT EDIT - ORIGINAL: 75
+	var/total_chem_storage = 75
 	/// The chemical recharge rate per life tick.
-	var/chem_recharge_rate = 1.5 // SKYRAT EDIT - ORIGINAL: 0.5
+	var/chem_recharge_rate = 0.5
 	/// Any additional modifiers triggered by changelings that modify the chem_recharge_rate.
 	var/chem_recharge_slowdown = 0
 	/// The range this ling can sting things.
 	var/sting_range = 2
 	/// The number of genetics points (to buy powers) this ling currently has.
-	var/genetic_points = 15 // SKYRAT EDIT - ORIGINAL: 10
+	var/genetic_points = 10
 	/// The max number of genetics points (to buy powers) this ling can have..
-	var/total_genetic_points = 15 // SKYRAT EDIT - ORIGINAL: 10
+	var/total_genetic_points = 10
 	/// List of all powers we start with.
 	var/list/innate_powers = list()
 	/// Associated list of all powers we have evolved / bought from the emporium. [path] = [instance of path]


### PR DESCRIPTION
## About The Pull Request

The Changeling can now only hold six strands of DNA at a time.
The Changeling's starting chemical charges have been reduced back down to 20.
The Changeling's starting maximum chemical charges have been reduced back down to 75.
The Changeling's recharge rate of chemicals has been reduced back down to 0.5.
The Changeling's Genetic Points have been reduced back down to 10.

## How This Contributes To The Skyrat Roleplay Experience

The changeling was, frankly, given an incredibly un-needed buff that only served to make the changeling able to be far more lethal against a playerbase that isn't allowed to be nearly as deadly as they could be. I'm not convinced Changelings need to be this deadly on a server where only 10~ players during a round are actively allowed to torch and pitchfork hunt down antagonists, when their previous level of deadliness was sufficient enough to handle high pop Terry levels of torch and pitchfork.

Additionally, this raw boost in power made Changelings not need to rely on stealth, deception, and social engineering nearly as much, which is a massive blow to an antagonist whose central thesis is "stealthy disguise monster".

By undoing these changes, Changelings will need to be more careful with going loud, and spend their chemicals carefully.

## Changelog

:cl:
balance: The Changeling can now only hold six strands of DNA at a time.
balance: The Changeling's starting chemical charges have been reduced back down to 20.
balance: The Changeling's starting maximum chemical charges have been reduced back down to 75.
balance: The Changeling's recharge rate of chemicals has been reduced back down to 0.5.
balance: The Changeling's Genetic Points have been reduced back down to 10.
/:cl: