### PR TITLE
[Modular] Horns will not be hidden, unless you want them to be.

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/horns.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/horns.dm
@@ -7,8 +7,7 @@
 	genetic = TRUE
 
 /datum/sprite_accessory/horns/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-//	Horns are forever  //	if(H.head && (H.head.flags_inv & HIDEHAIR) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR)) || !HD)
-	if(!HD)
+	if(H.head && ((H.head.flags_inv & HIDEHAIR) && H.try_hide_mutant_parts) || !HD)
 		return TRUE
 	return FALSE
 

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/horns.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/horns.dm
@@ -7,7 +7,8 @@
 	genetic = TRUE
 
 /datum/sprite_accessory/horns/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	if(H.head && (H.head.flags_inv & HIDEHAIR) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR)) || !HD)
+//	Horns are forever  //	if(H.head && (H.head.flags_inv & HIDEHAIR) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR)) || !HD)
+	if(!HD)
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

No longer will horns enter the bluespace dimension whenever you wear a helmet or particular kind of hat/mask.

## How This Contributes To The Skyrat Roleplay Experience

🍌

## Changelog
theOOZ
qol: Horns now have to manually be hidden with the 'hide mutant parts' verb.