### PR TITLE
[MODULAR] Botany implant refresh + emag mode

### DIFF
--- a/modular_skyrat/modules/implants/code/augments_arms.dm
+++ b/modular_skyrat/modules/implants/code/augments_arms.dm
@@ -46,6 +46,11 @@
 	desc = "A rather simple arm implant containing tools used in gardening and botanical research."
 	items_to_create = list(/obj/item/cultivator, /obj/item/shovel/spade, /obj/item/hatchet, /obj/item/gun/energy/floragun, /obj/item/plant_analyzer, /obj/item/geneshears, /obj/item/secateurs, /obj/item/storage/bag/plants, /obj/item/storage/bag/plants/portaseeder)
 
+/obj/item/organ/cyberimp/arm/botany/emag_act()
+	for(var/datum/weakref/created_item in items_list)
+	to_chat(usr, span_notice("You unlock [src]'s deluxe landscaping equipment!"))
+	items_list += WEAKREF(new /obj/item/chainsaw(src)) //time to landscape the station
+
 /obj/item/multitool/abductor/implant
 	name = "multitool"
 	desc = "An optimized, highly advanced stripped-down multitool able to interface with electronics far better than its standard counterpart."

--- a/modular_skyrat/modules/implants/code/augments_arms.dm
+++ b/modular_skyrat/modules/implants/code/augments_arms.dm
@@ -44,7 +44,7 @@
 /obj/item/organ/cyberimp/arm/botany
 	name = "botany arm implant"
 	desc = "A rather simple arm implant containing tools used in gardening and botanical research."
-	items_to_create = list(/obj/item/cultivator, /obj/item/shovel/spade, /obj/item/hatchet, /obj/item/gun/energy/floragun, /obj/item/plant_analyzer, /obj/item/reagent_containers/glass/beaker/plastic, /obj/item/storage/bag/plants, /obj/item/storage/bag/plants/portaseeder)
+	items_to_create = list(/obj/item/cultivator, /obj/item/shovel/spade, /obj/item/hatchet, /obj/item/gun/energy/floragun, /obj/item/plant_analyzer, /obj/item/geneshears, /obj/item/secateurs, /obj/item/storage/bag/plants, /obj/item/storage/bag/plants/portaseeder)
 
 /obj/item/multitool/abductor/implant
 	name = "multitool"

--- a/modular_skyrat/modules/implants/code/augments_arms.dm
+++ b/modular_skyrat/modules/implants/code/augments_arms.dm
@@ -46,10 +46,28 @@
 	desc = "A rather simple arm implant containing tools used in gardening and botanical research."
 	items_to_create = list(/obj/item/cultivator, /obj/item/shovel/spade, /obj/item/hatchet, /obj/item/gun/energy/floragun, /obj/item/plant_analyzer, /obj/item/geneshears, /obj/item/secateurs, /obj/item/storage/bag/plants, /obj/item/storage/bag/plants/portaseeder)
 
+/obj/item/implant_mounted_chainsaw
+	name = "Integrated Chainsaw"
+	desc = "A chainsaw that conceals inside your arm."
+	icon_state = "chainsaw_on"
+	inhand_icon_state = "mounted_chainsaw"
+	lefthand_file = 'icons/mob/inhands/weapons/chainsaw_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
+	force = 24
+	throwforce = 0
+	throw_range = 0
+	throw_speed = 0
+	sharpness = SHARP_EDGED
+	attack_verb_continuous = list("saws", "tears", "lacerates", "cuts", "chops", "dices")
+	attack_verb_simple = list("saw", "tear", "lacerate", "cut", "chop", "dice")
+	hitsound = 'sound/weapons/chainsawhit.ogg'
+	tool_behaviour = TOOL_SAW
+	toolspeed = 1
+
 /obj/item/organ/cyberimp/arm/botany/emag_act()
 	for(var/datum/weakref/created_item in items_list)
 	to_chat(usr, span_notice("You unlock [src]'s deluxe landscaping equipment!"))
-	items_list += WEAKREF(new /obj/item/chainsaw(src)) //time to landscape the station
+	items_list += WEAKREF(new /obj/item/implant_mounted_chainsaw(src)) //time to landscape the station
 	return TRUE
 
 /obj/item/multitool/abductor/implant

--- a/modular_skyrat/modules/implants/code/augments_arms.dm
+++ b/modular_skyrat/modules/implants/code/augments_arms.dm
@@ -47,7 +47,7 @@
 	items_to_create = list(/obj/item/cultivator, /obj/item/shovel/spade, /obj/item/hatchet, /obj/item/gun/energy/floragun, /obj/item/plant_analyzer, /obj/item/geneshears, /obj/item/secateurs, /obj/item/storage/bag/plants, /obj/item/storage/bag/plants/portaseeder)
 
 /obj/item/implant_mounted_chainsaw
-	name = "Integrated Chainsaw"
+	name = "integrated chainsaw"
 	desc = "A chainsaw that conceals inside your arm."
 	icon_state = "chainsaw_on"
 	inhand_icon_state = "mounted_chainsaw"

--- a/modular_skyrat/modules/implants/code/augments_arms.dm
+++ b/modular_skyrat/modules/implants/code/augments_arms.dm
@@ -50,6 +50,7 @@
 	for(var/datum/weakref/created_item in items_list)
 	to_chat(usr, span_notice("You unlock [src]'s deluxe landscaping equipment!"))
 	items_list += WEAKREF(new /obj/item/chainsaw(src)) //time to landscape the station
+	return TRUE
 
 /obj/item/multitool/abductor/implant
 	name = "multitool"

--- a/modular_skyrat/modules/implants/code/medical_designs.dm
+++ b/modular_skyrat/modules/implants/code/medical_designs.dm
@@ -40,7 +40,7 @@
 	construction_time = 200
 	build_path = /obj/item/organ/cyberimp/arm/botany
 	category = list("Misc", "Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SERVICE
 
 /datum/design/cyberimp_nv
 	name = "Night Vision Eyes"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is an update to the botany arm implant. That implant seems to have been ported directly from old base with cit code botany tools. This updates it to have tools for TG botany. It also adds a murderous botanist flavored emag mode to the implant.
Because the emag mode requires you to hit the implant with an emag _before_ it is installed, the implant has also been placed in the service lathe. This gives antags a chance to emag it first, then take it to medical, robotics, or a dark alley way ripperdoc for installation. Normally, they would likely not have a chance to handle it before it is installed. This is also the reason why the janitorial toolset implant is in the service lathe already.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
For one, it's a sorely needed refresh. The tools being wrong was an oversight that sat for a year. Updating those for TG was the primary goal of this PR.
It also adds a moderately effective weapon that is accessible to antags and not the general station, yet is tied to research tree round progression and requires independent time and effort to obtain.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new functionality to the botany toolset arm implant
balance: Made a moderately strong weapon available if emagged
/:cl:
(is this even balance? Should have had it all along)
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
