### PR TITLE
[NON MODULAR] Baton 'rebalance' (nerf)

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -25,7 +25,7 @@
 	/// The length of the knockdown applied to the user on clumsy_check()
 	var/clumsy_knockdown_time = 18 SECONDS
 	/// How much stamina damage we deal on a successful hit against a living, non-cyborg mob.
-	var/stamina_damage = 35 // SKYRAT EDIT - Less Stamina Damage (Original: 50)
+	var/stamina_damage = 35 // SKYRAT EDIT - Less Stamina Damage (Original: 55)
 	/// Can we stun cyborgs?
 	var/affect_cyborg = FALSE
 	/// The path of the default sound to play when we stun something.

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -25,7 +25,7 @@
 	/// The length of the knockdown applied to the user on clumsy_check()
 	var/clumsy_knockdown_time = 18 SECONDS
 	/// How much stamina damage we deal on a successful hit against a living, non-cyborg mob.
-	var/stamina_damage = 55
+	var/stamina_damage = 35 // SKYRAT EDIT - Less Stamina Damage (Original: 50)
 	/// Can we stun cyborgs?
 	var/affect_cyborg = FALSE
 	/// The path of the default sound to play when we stun something.
@@ -345,7 +345,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 0, FIRE = 80, ACID = 80)
 
 	throwforce = 7
-	stamina_damage = 45 // 3 baton crit.
+	stamina_damage = 35 // SKYRAT EDIT - 4 baton crit now (Original: 45)
 	knockdown_time = 5 SECONDS
 	clumsy_knockdown_time = 15 SECONDS
 	cooldown = 2.5 SECONDS
@@ -513,7 +513,7 @@
  */
 /obj/item/melee/baton/security/additional_effects_non_cyborg(mob/living/target, mob/living/user)
 	target.Jitter(20)
-	target.set_confusion(max(10, target.get_confusion()))
+//	target.set_confusion(max(10, target.get_confusion())) SKYRAT EDIT - Less CC on an already strong melee weapon.
 	target.stuttering = max(8, target.stuttering)
 
 	SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK)

--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -418,7 +418,7 @@
 	icon = 'modular_skyrat/modules/goofsec/icons/departmental_batons.dmi'
 	var/list/valid_areas = list()
 	var/emagged = FALSE
-	var/non_departmental_uses_left = 3
+	var/non_departmental_uses_left = 4
 
 /obj/item/melee/baton/security/loaded/departmental/baton_attack(mob/living/target, mob/living/user, modifiers)
 	if(active && !emagged && cooldown_check <= world.time)
@@ -446,9 +446,9 @@
 		var/area/current_area = get_area(user)
 		if(!is_type_in_list(current_area, valid_areas))
 			return
-		if(non_departmental_uses_left < 3)
+		if(non_departmental_uses_left < 4)
 			say("Non-departmental uses refreshed!")
-			non_departmental_uses_left = 3
+			non_departmental_uses_left = 4
 
 /obj/item/melee/baton/security/loaded/departmental/emag_act(mob/user)
 	if(!emagged)


### PR DESCRIPTION

## About The Pull Request

Nerfs stunbatons (and police batons, due to the detective, and the british police crate giving them/ways to get them) to be (slightly) more inline with how everything else is affected by the health increase, namely, another hit to down (which is a generously low increase), and removal of the confusion so it's less debilitating on the first-hit.
## Testmerge first.
## How This Contributes To The Skyrat Roleplay Experience
Brings batons to be slightly more inline with every other weapon in the game, and not the end-all-be-all of melee, regardless of armor.

## Changelog



:cl:
balance: Stun batons deal ten less damage, or equal to another hit to stamcrit, and no longer 'confuse' people whom get hit by one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
