### PR TITLE
(Semi-modular) Re-enables Expander upgrade on Dogborgs, Adds a change to add a 4-pixel y offset when expanded

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -559,8 +559,7 @@
 			return FALSE
 		// SKYRAT EDIT BEGIN
 		if(R_TRAIT_WIDE in R.model.model_features)
-			to_chat(usr, span_warning("This unit's chassis cannot be enlarged any further."))
-			return FALSE
+			R.set_base_pixel_y(4)
 		// SKYRAT EDIT END
 
 		R.notransform = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now, I'm not trying to start a PR war here. 
But i have a feeling that the removal of the expand upgrade for dogborgs was not made in the best heart or faith towards the dogborg playerbase, Nor was it made with sound reasoning.

What does this PR accomplish? 
This Re-enables the expander. Ontop of that, It adds a Y pixel offset so that the the borgs feet, when moving, aren't clipping through walls or windows. While it _does_ mean they _appear_ taller, Them clipping above walls _above_ them makes more sense than ones _below_ them. 
![image](https://user-images.githubusercontent.com/28457065/149443708-8c62fb92-7d27-4389-9808-972fb0e74a69.png)


## How This Contributes To The Skyrat Roleplay Experience

Ontop of giving the dogborg players that used to get the expander upgrade happy once more, it also re-enables them to have the character gimmick of being "Big" once again.

## Changelog

:cl:
code: re-enables the borg expander for dogborgs
code: adds a y_pixel_offset to dogborgs when expanded
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
