### PR TITLE
[NON-MODULAR] You can no longer use Dwarfism and Gigantism if you've got an already smaller/larger body respectively.

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -98,7 +98,7 @@
 	// SKYRAT EDIT BEGIN
 	if(owner.dna.features["body_size"] < 1)
 		to_chat(owner, "You feel your body shrinking even further, but your organs aren't! Uh oh!")
-		owner.gib(FALSE, FALSE, TRUE) // Don't try to become unclickable!
+		owner.adjustBruteLoss(25)
 		return
 	// SKYRAT EDIT END
 	ADD_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
@@ -374,8 +374,8 @@
 		return
 	// SKYRAT EDIT BEGIN
 	if(owner.dna.features["body_size"] > 1)
-		to_chat(owner, "You feel your body expanding even further, but it feels like your bones are expanding too much! Uh oh!")
-		owner.gib(FALSE, FALSE, TRUE) // "lmao 200% big lemme just grab gigantism too"
+		to_chat(owner, "You feel your body expanding even further, but it feels like your bones are expanding too much!")
+		owner.adjustBruteLoss(25) // take some DAMAGE
 		return
 	// SKYRAT EDIT END
 	ADD_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -95,6 +95,12 @@
 /datum/mutation/human/dwarfism/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
+	// SKYRAT EDIT BEGIN
+	if(owner.dna.features["body_size"] < 1)
+		to_chat(owner, "You feel your body shrinking even further, but your organs aren't! Uh oh!")
+		owner.gib(FALSE, FALSE, TRUE) // Don't try to become unclickable!
+		return
+	// SKYRAT EDIT END
 	ADD_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
 	var/matrix/new_transform = matrix()
 	new_transform.Scale(1, 0.8)
@@ -366,6 +372,12 @@
 /datum/mutation/human/gigantism/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
+	// SKYRAT EDIT BEGIN
+	if(owner.dna.features["body_size"] > 1)
+		to_chat(owner, "You feel your body expanding even further, but it feels like your bones are expanding too much! Uh oh!")
+		owner.gib(FALSE, FALSE, TRUE) // "lmao 200% big lemme just grab gigantism too"
+		return
+	// SKYRAT EDIT END
 	ADD_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)
 	owner.resize = 1.25
 	owner.update_transform()


### PR DESCRIPTION
## About The Pull Request

You can no longer use Dwarfism and Gigantism if you've got an already smaller/larger body respectively.

## How This Contributes To The Skyrat Roleplay Experience

i sure do love unclickable 80%ers + dwarfism, or excessively large tileblocking oversized users getting even bigger with gigantism

## Changelog

:cl:
balance: The Galactic Gene Therapy Consortium would like to issue a PSA regarding size gene mods and abnormally sized humanoids. It is not advised to use size adjusting gene modifications while abnormally sized, as adverse side effects can occur, up to and including a very painful death.
/:cl: