### PR TITLE
Revert "Bump pillow from 8.3.2 to 9.0.0 in /tools (#10655)"

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,6 +1,6 @@
 pygit2==1.6
 bidict==0.13.1
-Pillow==9.0.0
+Pillow==8.3.2
 
 # changelogs
 PyYaml==5.4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I checked on Coderbus, Pillow can't be updated or it breaks iconmerge. Better to let this get updated up stream first instead of locally

> SpaceManiac — Today at 12:28 PM
> /tg/station is currently pinned to Python 3.6, but Pillow 9 does not ship binary wheels for Python 3.6 anymore
> 
> ORCACommander — Today at 1:31 PM
> So in short, Compile failure due to missing dependencies
> 
> SpaceManiac — Today at 1:33 PM
> Failure of the icon merging tool that uses Pillow, specifically
> [1:35 PM]
> Attempting to install Pillow without a wheel could manifest as a "compile failure" of Pillow itself
> [1:36 PM]
> Or it could work, if your system was perfectly prepared
> 

## How This Contributes To The Skyrat Roleplay Experience

Development back end tools need to work as expected

## Changelog

Nothing User Facing