### PR TITLE
MCR patch

### DIFF
--- a/modular_skyrat/modules/microfusion/code/microfusion_gun_attachments.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_gun_attachments.dm
@@ -99,8 +99,8 @@ The cell is stable and will not emit sparks when firing.
 	. = ..()
 	microfusion_gun.recoil -= recoil_to_add
 	microfusion_gun.spread -= spread_to_add
-	microfusion_gun.microfusion_lens.pellets -= microfusion_gun.microfusion_lens.pellets
-	microfusion_gun.microfusion_lens.variance -= microfusion_gun.microfusion_lens.variance
+	microfusion_gun.microfusion_lens.pellets -= pellets_to_add
+	microfusion_gun.microfusion_lens.variance -= variance_to_add
 
 /*
 REPEATER ATTACHMENT


### PR DESCRIPTION
## About The Pull Request

Adding then removing one would reset the pellets and variance to zero. It would still fire a single pellet, but with perfect accuracy every time. Not great. You also cannot get back up to 3.

Also yes, webedit bad, but my PC is not playing nice.

## How This Contributes To The Skyrat Roleplay Experience

Bugfix

## Changelog
:cl:
fix: MCR scatter attachments will no longer permanently reduce the number of pellets in your gun.
/:cl: