### PR TITLE
Atmos gas mask nerf

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -100,7 +100,7 @@
 	icon_state = "gas_atmos"
 	inhand_icon_state = "gas_atmos"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 20, ACID = 10)
-	w_class = WEIGHT_CLASS_SMALL
+	//w_class = WEIGHT_CLASS_SMALL // SKYRAT EDIT REMOVAL
 	permeability_coefficient = 0.001
 	resistance_flags = FIRE_PROOF
 	max_filters = 3


### PR DESCRIPTION
## About The Pull Request

Makes the atmos gas mask normal size, in line with every other of its type.

## How This Contributes To The Skyrat Roleplay Experience

Having one mask be objectively better than its counterparts for no reason is bizarre. It already gives you pepper protection and is fireproof.
The Captain's is fine as it's one of a kind and you can't reasonably obtain it unless you're an antag or something.

## Changelog
:cl:
balance: Atmospherics gas masks are now normal-sized.
/:cl: