### PR TITLE
[MODULAR] Sidearm Tokens Crate, and Sidearms Alert Change

### DIFF
--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -176,6 +176,13 @@
 					/obj/item/gun/ballistic/automatic/pistol/toy) //they just hate you.
 	crate_name = "dusty crate"
 
+/datum/supply_pack/security/armory/sidearm
+	name = "Armadyne Sidearm Tokens Crate"
+	desc = "Contains one set of Armadyne branded Sidearm Tokens, to be redeemed at an appropriate vending machine."
+	cost = CARGO_CRATE_VALUE * 7
+	contains = list(/obj/item/storage/box/armament_tokens_sidearm)
+	crate_name = "sidearm token crate"
+
 //////////////////////////////////////////////////////////////////////////////
 ///////////////////////////// Engineering ////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
@@ -73,7 +73,7 @@
 	name = "sidearm armament holochip"
 	desc = "A holochip used in any armament vendor, this is for sidearms. Do not bend."
 	icon_state = "token_sidearm"
-	minimum_sec_level = SEC_LEVEL_BLUE
+	minimum_sec_level = SEC_LEVEL_AMBER
 
 /obj/item/armament_token/sidearm/get_available_gunsets()
 	return list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a sidearm token crate to Cargo, and changes the alert level needed for sidearms to be amber.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Carrying around a rifle at all times is impractical, and dumb. What happens is the alert level raises, and suddenly Sec is packing incendiary over-powered rifles. This allows for a stopgap for this, so they aren't carrying around Rifles/Primaries 24/7. Yes, they are ballistic, but so are WTs, and you have to go out of your way to order those. The same applies here.

They've also had the needed alert level for them upped to amber, this is to enforce that they're a downgrade to a proper primary when that's not needed. Not having it on Blue should reduce "sec carry around gun 24/7" syndrome.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Sidearms Token Crate to Cargo
balance: Sidearm tokens now require amber alert to use
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
