### PR TITLE
Prevents MCR cells being used in modsuits

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -352,6 +352,12 @@
 			return FALSE
 		install(attacking_item, user)
 		return TRUE
+	// SKYRAT EDIT ADD START
+	else if (istype(attacking_item, /obj/item/stock_parts/cell/microfusion))
+		balloon_alert(user, "that cell won't fit!")
+		playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
+		return FALSE
+	// SKYRAT EDIT ADD END
 	else if(istype(attacking_item, /obj/item/stock_parts/cell))
 		if(!open)
 			balloon_alert(user, "open the cover first!")


### PR DESCRIPTION
## About The Pull Request

You can no longer put an MCR cell in a modsuit.

## How This Contributes To The Skyrat Roleplay Experience

The cells were not designed with modsuits in mind - self-charging specifically is really not something that should be available to slot into your modsuit.

## Changelog
:cl:
balance: MODsuits can no longer be equipped with MCR cells.
/:cl: