### PR TITLE
[NON MODULAR] Changes toxins experiments from requirement to discounts.

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1420,8 +1420,8 @@
 		"tele_shield",
 		"ammoworkbench_disk_lethal", //SKYRAT EDIT ADDITION
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
-	required_experiments = list(/datum/experiment/explosion/calibration)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 15000) //SKYRAT EDIT
+	discount_experiments = list(/datum/experiment/explosion/calibration = 10000) //SKYRAT EDIT
 
 /datum/techweb_node/adv_weaponry
 	id = "adv_weaponry"
@@ -1432,8 +1432,8 @@
 		"pin_loyalty",
 		"ammo_workbench", //SKYRAT EDIT ADDITION
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
-	required_experiments = list(/datum/experiment/explosion/medium)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 15000) //SKYRAT EDIT
+	discount_experiments = list(/datum/experiment/explosion/medium = 10000) //SKYRAT EDIT
 
 /datum/techweb_node/electric_weapons
 	id = "electronic_weapons"
@@ -1491,8 +1491,8 @@
 		"large_Grenade",
 		"pyro_Grenade",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-	required_experiments = list(/datum/experiment/explosion/maxcap)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 20000) //SKYRAT EDIT
+	discount_experiments = list(/datum/experiment/explosion/maxcap = 17500) //SKYRAT EDIT
 
 // SKYRAT EDIT START: SECBORG TECHWEB
 /datum/techweb_node/secborg_node


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the three current toxins-related experiments from reqs to heavy discounts. Makes the base price way higher to compensate.

![image](https://user-images.githubusercontent.com/65850818/149645423-08079aa1-21ff-4df3-9e0d-86a78f6ec885.png)


## How This Contributes To The Skyrat Roleplay Experience

Science has a shit ton of experiments and things to do, and not a lot of people have the knowledge on how to produce good toxins bomb with the new atmos systems and such. This ensures that the weapon techs and all associated techs are still doable in such cases (remember that MCRs are extremely reliant on those and that sec is currently decently reliant on MCRs since we removed other lasers), while still heavily rewarding scientists who do the toxins experiments.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Toxins experiments are now discounts and not requirements.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
