### PR TITLE
[NONMODULAR] Radio jammer starts with a bluespace cell

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -266,7 +266,7 @@ effective or pretty fucking useless.
 	//SKYRAT EDIT ADDITION BEGIN
 /obj/item/jammer/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/cell, null, CALLBACK(src, .proc/turn_off))
+	AddComponent(/datum/component/cell, cell_override, CALLBACK(src, .proc/turn_off))
 
 /obj/item/jammer/proc/turn_on()
 	active = TRUE

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -261,6 +261,7 @@ effective or pretty fucking useless.
 	special_desc = "This is a black market radio jammer. Used to disrupt nearby radio communication."
 	var/active = FALSE
 	var/range = 20 //SKYRAT EDIT CHANGE - ORIGINAL:12
+	var/cell_override = /obj/item/stock_parts/cell/bluespace //SKYRAT ADDITION
 
 	//SKYRAT EDIT ADDITION BEGIN
 /obj/item/jammer/ComponentInitialize()


### PR DESCRIPTION
## About The Pull Request
puts a better cell in the jammer
The default radio jammer lasts about a minute because it eats through the powercell. now it starts with a bluespace one.

## How This Contributes To The Skyrat Roleplay Experience
It would be nice to actually attempt a roleplay while using a radio jammer before the battery dies
It should already be equipped with the means to use it when you buy it, there's no reason you should have to hunt down a cell as soon as you get one.

## Alternatives considered:
Removing the cell component. Un-needed nerf to an antagonist item that didn't ask for one. It's under-utilized as it is.

## Changelog

:cl:
qol: The radio jammer now starts with a decent battery so it can jam radios for longer than a minute before the battery dies.
/:cl: