### PR TITLE
Revert "[NON MODULAR] Baton 'rebalance' (nerf)"

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -25,7 +25,7 @@
 	/// The length of the knockdown applied to the user on clumsy_check()
 	var/clumsy_knockdown_time = 18 SECONDS
 	/// How much stamina damage we deal on a successful hit against a living, non-cyborg mob.
-	var/stamina_damage = 35 // SKYRAT EDIT - Less Stamina Damage (Original: 55)
+	var/stamina_damage = 55
 	/// Can we stun cyborgs?
 	var/affect_cyborg = FALSE
 	/// The path of the default sound to play when we stun something.
@@ -345,7 +345,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 0, FIRE = 80, ACID = 80)
 
 	throwforce = 7
-	stamina_damage = 35 // SKYRAT EDIT - 4 baton crit now (Original: 45)
+	stamina_damage = 45 // 3 baton crit.
 	knockdown_time = 5 SECONDS
 	clumsy_knockdown_time = 15 SECONDS
 	cooldown = 2.5 SECONDS
@@ -513,7 +513,7 @@
  */
 /obj/item/melee/baton/security/additional_effects_non_cyborg(mob/living/target, mob/living/user)
 	target.Jitter(20)
-//	target.set_confusion(max(10, target.get_confusion())) SKYRAT EDIT - Less CC on an already strong melee weapon.
+	target.set_confusion(max(10, target.get_confusion()))
 	target.stuttering = max(8, target.stuttering)
 
 	SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK)

--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -418,7 +418,7 @@
 	icon = 'modular_skyrat/modules/goofsec/icons/departmental_batons.dmi'
 	var/list/valid_areas = list()
 	var/emagged = FALSE
-	var/non_departmental_uses_left = 4
+	var/non_departmental_uses_left = 3
 
 /obj/item/melee/baton/security/loaded/departmental/baton_attack(mob/living/target, mob/living/user, modifiers)
 	if(active && !emagged && cooldown_check <= world.time)
@@ -446,9 +446,9 @@
 		var/area/current_area = get_area(user)
 		if(!is_type_in_list(current_area, valid_areas))
 			return
-		if(non_departmental_uses_left < 4)
+		if(non_departmental_uses_left < 3)
 			say("Non-departmental uses refreshed!")
-			non_departmental_uses_left = 4
+			non_departmental_uses_left = 3
 
 /obj/item/melee/baton/security/loaded/departmental/emag_act(mob/user)
 	if(!emagged)


### PR DESCRIPTION
Reverts Skyrat-SS13/Skyrat-tg#10665

![chrome_GjV0p4bgfO](https://user-images.githubusercontent.com/4081722/150014864-fb76fcd3-d24f-4d91-af36-07e6b02a9adb.png)

![Discord_sYumIoNrsB](https://user-images.githubusercontent.com/4081722/150014879-1ac07805-2009-41e5-a5cd-468da87a319b.png)

this PR should have been testmerged before being sent to live, even the OP of the PR said to do so
