### PR TITLE
Ewelder now visually turns off when turned off

### DIFF
--- a/modular_skyrat/modules/electric_welder/code/electric_welder.dm
+++ b/modular_skyrat/modules/electric_welder/code/electric_welder.dm
@@ -46,6 +46,7 @@
 
 /obj/item/weldingtool/electric/switched_off(mob/user)
 	powered = FALSE
+	welding = FALSE
 	light_on = FALSE
 	force = initial(force)
 	damtype = BRUTE


### PR DESCRIPTION


## About The Pull Request

The E-welder didn't visually turn off when you turned it off, giving an unclear indication of its powered state.

So i fixed it

## How This Contributes To The Skyrat Roleplay Experience

It bugged me.


## Changelog


:cl:
fix: E-welder flame no longer ethereal and infinite even when turned off.
/:cl:
