### PR TITLE
Fixes numbing in stasis not working if already applied.

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -240,9 +240,8 @@
 		return
 	ADD_TRAIT(owner, TRAIT_IMMOBILIZED, TRAIT_STATUS_EFFECT(id))
 	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, TRAIT_STATUS_EFFECT(id))
-	if(!HAS_TRAIT(owner, TRAIT_NUMBED)) //SKYRAT EDIT START - STASIS PRESERVES NUMBING
-		ADD_TRAIT(owner, TRAIT_NUMBED, "stasis")
-		owner.throw_alert("numbed", /atom/movable/screen/alert/numbed) //SKYRAT EDIT END
+	ADD_TRAIT(owner, TRAIT_NUMBED, "stasis") //SKYRAT EDIT START - STASIS APPLIES NUMBING
+	owner.throw_alert("numbed", /atom/movable/screen/alert/numbed) //SKYRAT EDIT END
 	owner.add_filter("stasis_status_ripple", 2, list("type" = "ripple", "flags" = WAVE_BOUNDED, "radius" = 0, "size" = 2))
 	var/filter = owner.get_filter("stasis_status_ripple")
 	animate(filter, radius = 32, time = 15, size = 0, loop = -1)


### PR DESCRIPTION
## About The Pull Request

#10627 was good QOL for surgery by just making stasis tables apply numbing to begin with. However, the way this was done led to a problem: if you put somebody on with pre-surgical numbing already in effect, the numbing effect would not be applied by the stasis table. Because numbing effects come from chems, and chems don't process in stasis, this meant that any sort of chemical numbing would go away and no new numbing effect would be applied by the table - leading to your patient being un-numbed and your surgery being as slow/painful as if you hadn't bothered.

This just makes it so any stasis comes with numbing. Simple as. 

## How This Contributes To The Skyrat Roleplay Experience
If you do the thing you're supposed to do, you shouldn't get punished for it because the stasis table is already trying to do that for you. 

## Changelog
Fixes a slight oversight in the QOL fix to stasis tables and numbing. 

:cl:
fix: stasis tables no longer get rid of numbing if it was applied before surgery.
/:cl:
