### PR TITLE
Reverts x-ray and thermal implant removal

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -401,8 +401,6 @@
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-//SKYRAT EDIT REMOVAL BEGIN - Noxray
-/*
 /datum/design/cyberimp_xray
 	name = "X-ray Eyes"
 	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
@@ -424,8 +422,6 @@
 	build_path = /obj/item/organ/eyes/robotic/thermals
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-*/
-//SKYRAT EDIT REMOVAL END - Noxray
 
 /datum/design/cyberimp_antidrop
 	name = "Anti-Drop Implant"

--- a/modular_skyrat/modules/implants/code/medical_nodes.dm
+++ b/modular_skyrat/modules/implants/code/medical_nodes.dm
@@ -6,6 +6,6 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 
 /datum/techweb_node/combat_cyber_implants
-	design_ids = list("ci-nv", "ci-antidrop", "ci-antistun", "ci-antisleep", "ci-thrusters", "ci-mantis", "ci-flash")
+	design_ids = list("ci-xray", "ci-thermals", "ci-nv", "ci-antidrop", "ci-antistun", "ci-antisleep", "ci-thrusters", "ci-mantis", "ci-flash")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12000)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Re-enables x-ray and thermal vision eye implants.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
When these were disabled, Skyrat was largely two traitors with a creative writing prompt versus fourteen security with ballistic automatic weapons. Making life a bit easier for antags by disabling these was something I somewhat agreed with at the time. But in the 318 days since these were disabled, a few things have changed.

Many changes to both security and antagonists have resulted in player behavior changes, new tactics, new metas, and new balance concerns, and these do not need to be disabled anymore. This is just the implant version, not the genetics versions. The implant versions are on the tech tree in the right spot to be balanced for round time, player time, and effort to obtain.

Here are a few cases I expect to be influenced by putting these back in. Note that none of them were true at the time the implants were disabled, but are all highly prevalent now.

- Robotics/medbay work, which we need more of. Particularly robotics. Opening these up again gives opportunities for role play, job function, and even antaggery.
- Finding dead bodies: Upstream made EMP disable suit sensors. Thermal or X-ray will greatly assist paramedics in finding dead people, and are intended by upstream which still has these. This will also help paramedics differentiate themselves from medborgs, which as been a contemporary issue.
- Cheesing dorm rooms: More recently, dorm rooms on station have been somewhat opened up to antaggery. This has resulted in a huge number of weapon stashes, bluespace launch pads, and just plain hiding from security in dorm rooms. The counter to that, x-ray vision, is supposed to exist. 

Also a removal of non-modular code, for what ever that is worth.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: re-enabled some disabled implants
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
