### PR TITLE
[Modular][Fix] Runechat height adjusts for oversized quirk-holders

### DIFF
--- a/modular_skyrat/modules/oversized/code/oversized_quirk.dm
+++ b/modular_skyrat/modules/oversized/code/oversized_quirk.dm
@@ -14,7 +14,7 @@
 /datum/quirk/oversized/add()
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	human_holder.dna.features["body_size"] = 2
-	human_holder.maptext_height = 32 * features["body_size"] //Adjust runechat height
+	human_holder.maptext_height = 32 * human_holder.dna.features["body_size"] //Adjust runechat height
 	human_holder.dna.update_body_size()
 	human_holder.mob_size = MOB_SIZE_LARGE
 	human_holder.dna.species.punchdamagelow += OVERSIZED_HARM_DAMAGE_BONUS
@@ -26,6 +26,7 @@
 /datum/quirk/oversized/remove()
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	human_holder.dna.features["body_size"] = human_holder?.client?.prefs ?human_holder?.client?.prefs?.read_preference(/datum/preference/numeric/body_size) : 1
+	human_holder.maptext_height = 32 * human_holder.dna.features["body_size"]
 	human_holder.dna.update_body_size()
 	human_holder.mob_size = MOB_SIZE_HUMAN
 	human_holder.dna.species.punchdamagelow -= OVERSIZED_HARM_DAMAGE_BONUS

--- a/modular_skyrat/modules/oversized/code/oversized_quirk.dm
+++ b/modular_skyrat/modules/oversized/code/oversized_quirk.dm
@@ -14,6 +14,7 @@
 /datum/quirk/oversized/add()
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	human_holder.dna.features["body_size"] = 2
+	human_holder.maptext_height = 32 * features["body_size"] //Adjust runechat height
 	human_holder.dna.update_body_size()
 	human_holder.mob_size = MOB_SIZE_LARGE
 	human_holder.dna.species.punchdamagelow += OVERSIZED_HARM_DAMAGE_BONUS


### PR DESCRIPTION
## About The Pull Request

I overlooked the oversized quirk when making #10514.

## How This Contributes To The Skyrat Roleplay Experience

Better chat bubbles.

## Changelog
:cl:
fix: Runechat doesn't cover the sprites of oversized quirk-holders
/:cl:
