### PR TITLE
Fixes Tramstation Disposals

### DIFF
--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -8026,8 +8026,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
-	name = "sorting disposal pipe (Civilan Wing)";
-	sortTypes = list(16,17)
+	name = "sorting disposal pipe (Civilian & Engineering Wing)";
+	sortType = "4;5;6;16;17;26"
 	},
 /obj/structure/sign/warning/docking{
 	desc = "A warning sign which reads 'KEEP CLEAR OF TRAM DOCKING AREA'.";
@@ -31679,14 +31679,12 @@
 /area/science/explab)
 "jAl" = (
 /obj/machinery/mineral/stacking_machine{
-	input_dir = 1;
+	input_dir = 4;
+	output_dir = 2;
 	stack_amt = 10
 	},
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -59711,6 +59709,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor{
+	id = "garbage"
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "tIU" = (
@@ -59971,6 +59972,10 @@
 	spawn_random_offset = 1
 	},
 /obj/effect/spawner/random/maintenance/two,
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 8;
+	pixel_x = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "tML" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* In Waste Disposals: Fixes tramstation stacking machine, along with a few minor things like giving it a console, adjusting the windows around it, and adding a conveyor on the backup output (which is never used unless the silo is blown, but you know)
* Fixes the mail sorting to port aft and central aft disposals, ie to chapel, dorms, library, engineering, CE office, and atmospherics.

Depends on code fixes in #10860, as otherwise multiz sorting is busted to start with.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Trying to make Tramstation less busted.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes most (hopefully all) Tramstation disposal issues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
