### PR TITLE
Upgrades Tramstation's 'Service Lathe' not-even-a-real-area to the Service Hallway

### DIFF
--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -8496,7 +8496,7 @@
 /obj/machinery/light/directional/east,
 /obj/machinery/computer/department_orders/service,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "bmx" = (
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating/asteroid/airless,
@@ -10781,7 +10781,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "cem" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/tcomms_all,
@@ -13318,9 +13318,9 @@
 /turf/open/floor/wood/parquet,
 /area/command/heads_quarters/captain/private/nt_rep)
 "dcM" = (
-/mob/living/carbon/human/species/monkey,
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/leafybush,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
 "dcR" = (
@@ -14323,9 +14323,9 @@
 /area/security/checkpoint/engineering)
 "dwH" = (
 /obj/structure/flora/ausbushes/lavendergrass,
-/mob/living/carbon/human/species/monkey,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/science/genetics)
 "dwP" = (
@@ -18272,6 +18272,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"eNS" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/service)
 "eNX" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -18511,10 +18521,6 @@
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "eRZ" = (
-/obj/machinery/door/airlock{
-	name = "Service Lathe Access";
-	req_one_access_txt = "73"
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -18526,8 +18532,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/service/glass{
+	name = "Service Hall";
+	req_one_access_txt = "73"
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "eSj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
@@ -20917,7 +20927,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "fFR" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23384,6 +23394,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/department/security)
+"gzZ" = (
+/turf/closed/wall,
+/area/hallway/secondary/service)
 "gAb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -23463,7 +23476,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "gCn" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -25888,7 +25901,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "huk" = (
 /obj/structure/chair,
 /obj/machinery/airalarm/directional/north,
@@ -30984,7 +30997,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "jmz" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -34699,8 +34712,10 @@
 	c_tag = "Service - Department Lathe Access";
 	network = list("ss13","Service")
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "kFO" = (
 /obj/structure/table/glass,
 /obj/item/stack/medical/mesh,
@@ -36616,10 +36631,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "loo" = (
-/obj/machinery/door/airlock{
-	name = "Service Lathe Access";
-	req_one_access_txt = "73"
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -36631,8 +36642,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/service/glass{
+	name = "Service Hall";
+	req_one_access_txt = "73"
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "loK" = (
 /obj/machinery/door/airlock{
 	id_tag = "restroom_5";
@@ -38926,7 +38941,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "mjF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -42879,7 +42894,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "nJR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -44773,7 +44788,7 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "otD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46862,7 +46877,7 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "pdm" = (
-/obj/machinery/door/airlock{
+/obj/machinery/door/airlock/service/glass{
 	name = "Kitchen Access";
 	req_access_txt = "28"
 	},
@@ -47172,7 +47187,7 @@
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "pji" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -49002,7 +49017,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "pPr" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Atmospherics N2O Chamber";
@@ -52917,7 +52932,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "rnn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
@@ -53119,7 +53134,7 @@
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "rsl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -53533,7 +53548,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "ryW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54333,7 +54348,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "rRU" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/cafeteria,
@@ -65803,7 +65818,7 @@
 "vUo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "vUv" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -68136,8 +68151,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/mob/living/simple_animal/pet/cat/runtime,
 /obj/item/radio/intercom/directional/north,
+/mob/living/simple_animal/pet/cat/runtime,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "wLS" = (
@@ -169342,9 +169357,9 @@ nrP
 lgI
 amK
 amK
-kqz
+gzZ
 loo
-kqz
+gzZ
 aGY
 aGY
 xTf
@@ -171142,7 +171157,7 @@ irr
 cEY
 amK
 bmm
-cGf
+eNS
 nJA
 aGY
 pcP
@@ -171398,9 +171413,9 @@ dlE
 olk
 amK
 amK
-kqz
+gzZ
 eRZ
-kqz
+gzZ
 aGY
 aGY
 xJG


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes Tramstation's chunk of the central primary hallway weirdly called "Service Lathe Access" to a real service hallway, with service airlocks.

The service ordering console technically requires this area (or the bar atrium) to exist for the crate delivery destinations to be valid, but it's also easier for engineering, etc if the areas are intuitive.

![image](https://user-images.githubusercontent.com/1185434/150616617-01960605-6254-486c-b303-44c9d9ad8710.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Rooms should be their correct areas. Also it's nice for the service dept console to not send errors to the map log on mapload.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
add: The Tramstation's confusing 'service lathe room' is now a real Service Hallway.
fix: On Tramstation, service orders now have their destination to Service Hallway, since it now exists.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
