### PR TITLE
[NON MODULAR] A small deny cooldown for airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -115,6 +115,7 @@
 	var/list/obj/machinery/door/airlock/close_others = list()
 	var/obj/item/electronics/airlock/electronics
 	COOLDOWN_DECLARE(shockCooldown)
+	COOLDOWN_DECLARE(denyCooldown)//SKYRAT EDIT ADDITION - DENY_SPAM_COOLDOWN
 	var/obj/item/note //Any papers pinned to the airlock
 	/// The seal on the airlock
 	var/obj/item/seal
@@ -601,8 +602,14 @@
 		if("deny")
 			if(!machine_stat)
 				update_icon(ALL, AIRLOCK_DENY)
-				playsound(src,doorDeni,50,FALSE,3)
+				//SKYRAT EDIT MOVING LINE, ORIGINAL - playsound(src,doorDeni,50,FALSE,3) - DENY_SPAM_COOLDOWN
 				addtimer(CALLBACK(src, /atom/proc/update_icon, ALL, AIRLOCK_CLOSED), AIRLOCK_DENY_ANIMATION_TIME)
+				//SKYRAT EDIT ADDITION BEGIN - DENY_SPAM_COOLDOWN
+				if(!COOLDOWN_FINISHED(src, denyCooldown)) //please, stop spamming with the sound
+					return
+				COOLDOWN_START(src, denyCooldown, 1.5 SECONDS)
+				playsound(src,doorDeni,50,FALSE,3)
+				//SKYRAT EDIT ADDITION END - DENY_SPAM_COOLDOWN
 
 /obj/machinery/door/airlock/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Adds a cooldown for airlocks deny sound.
It was [denied in TG repository](https://github.com/tgstation/tgstation/pull/64300). Round 2, I guess 🗿 

## How This Contributes To The Skyrat Roleplay Experience

Less frustrating sounds from unwanting to cooperate or say a thing people, but still visible indicator of "OPEN THE DOOR NOW NOW NOW!"

## Changelog

:cl: SishTis
qol: Airlocks have a small cooldown of deny sound.
/:cl: