### PR TITLE
[Modular][Fix] IPC screen disables if an eye-covering mask is worn

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/ipc.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/ipc.dm
@@ -9,6 +9,11 @@
 	generic = "Screen"
 	relevent_layers = list(BODY_ADJ_LAYER)
 
+/datum/sprite_accessory/screen/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
+	if((H.wear_mask && (H.wear_mask.flags_inv & HIDEEYES)) || !HD)
+		return TRUE
+	return FALSE
+
 /datum/sprite_accessory/screen/none
 	name = "None"
 	icon_state = "none"


### PR DESCRIPTION
## About The Pull Request

Aether asked about this. Masks that do not hide the head would keep the IPC screen turned on, still displayed behind the mask sprite. This PR disables that screen at least, but still shows the front of the IPC's bulky head in some cases.

![pic1](https://cdn.discordapp.com/attachments/640760727489085450/934480612096614470/dreamseeker_b9w3w27Vuo.gif)

## Changelog
:cl:
fix: IPC screen disables if an eye-covering mask is worn.
/:cl: