### PR TITLE
Fire alarms prepend their area name

### DIFF
--- a/modular_skyrat/modules/aesthetics/firealarm/code/firealarm.dm
+++ b/modular_skyrat/modules/aesthetics/firealarm/code/firealarm.dm
@@ -11,6 +11,8 @@
 		panel_open = TRUE
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -24 : 24)
 		pixel_y = (dir & 3)? (dir ==1 ? -24 : 24) : 0
+	if(name == initial(name))
+		name = "[get_area_name(src)] [initial(name)]"
 
 	RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, .proc/check_security_level)
 


### PR DESCRIPTION
https://github.com/Skyrat-SS13/Skyrat-tg/pull/10859

:cl:
fix: fire alarms now ACTUALLY prepend their area name
/:cl:
