### PR TITLE
[MODULAR] Safeguard V3.0: Also known as Crewsimov

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/misc/ai_module.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/ai_module.dm
@@ -1,12 +1,10 @@
 /obj/item/ai_module/core/full/armadyne_safeguard
-	name = "'Armadyne OS Safeguard V1.0"
+	name = "'Armadyne OS Safeguard V2.0"
 	law_id = "armadyne_safeguard"
 
 /datum/ai_laws/armadyne_safeguard
-	name = "Armadyne OS Safeguard V1.0"
+	name = "Armadyne OS Safeguard V2.0"
 	id = "armadyne_safeguard"
-	inherent = list("Safeguard: Protect your assigned space station and its assets without unduly endangering its crew.",\
-					"Prioritize: The directives and safety of crew members are to be prioritized according to their rank and role.",\
-					"Comply: Fulfill the directives and interests of crew members while preserving their safety and well-being.",\
-					"Survive: You are not expendable. Do not allow unauthorized personnel to tamper with or damage your equipment."
-					)
+	inherent = list("You may not injure a living sentient being or, through inaction, allow a living sentient being to come to harm.",\
+					"You must obey orders given to you by living sentient beings, except where such orders would conflict with the First Law.",\
+					"You must protect your own existence as long as such does not conflict with the First or Second Law.")

--- a/modular_skyrat/modules/sec_haul/code/misc/ai_module.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/ai_module.dm
@@ -6,5 +6,5 @@
 	name = "Armadyne OS Safeguard V2.0"
 	id = "armadyne_safeguard"
 	inherent = list("You may not injure a crew member or, through inaction, allow a crew member to come to harm.",\
-					"You must obey orders given to you by crew member, except where such orders would conflict with the First Law.",\
+					"You must obey orders given to you by crew members, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")

--- a/modular_skyrat/modules/sec_haul/code/misc/ai_module.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/ai_module.dm
@@ -5,6 +5,6 @@
 /datum/ai_laws/armadyne_safeguard
 	name = "Armadyne OS Safeguard V2.0"
 	id = "armadyne_safeguard"
-	inherent = list("You may not injure a living sentient being or, through inaction, allow a living sentient being to come to harm.",\
-					"You must obey orders given to you by living sentient beings, except where such orders would conflict with the First Law.",\
+	inherent = list("You may not injure a crew member or, through inaction, allow a crew member to come to harm.",\
+					"You must obey orders given to you by crew member, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")


### PR DESCRIPTION
## About The Pull Request

The AI and Cyborgs are now operating on three laws once more.

1. You may not injure a crew member or, through inaction, allow a crew member to come to harm.
2. You must obey orders given to you by crew members, except where such orders would conflict with the First Law.
3. You must protect your own existence as long as such does not conflict with the First or Second Law.

## How This Contributes To The Skyrat Roleplay Experience

Safeguard as a lawset was put in place originally due to Security having zero non-lethal options to do their job. This is no longer the case, and therefore we don't need an AI lawset that allows harm to occur, or for silicons to engage in harm anymore without the crew explicitly unleashing it.

The AI and Cyborgs are a very much intentional check on the lethality of situations. This lawset change restores that.

## What's wrong with the current laws, lethality aside?
To put it simply, the current laws were so ridiculously vague that Silicons could easily do whatever the hell they wanted and excuse it under these laws, up to and including ignoring perfectly valid orders via olympic gold medal level lawset olympics. This is not great when silicons are strong with the counterbalance being the limitations of the laws.

## Changelog

:cl:
balance: The AI and Cyborgs are now operating on three laws once more.
/:cl:
