### PR TITLE
[Modular] Tarkon 1.3 Update: Insert fancy title card here that i dont have because i cant think of one

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
@@ -195,9 +195,12 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/port_tarkon/storage)
 "by" = (
-/obj/structure/alien/weeds/node,
-/turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/iron/twenty,
+/obj/item/stack/sheet/iron/fifty,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/port_tarkon/forehall)
 "bA" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -857,11 +860,6 @@
 /obj/item/stack/sheet/mineral/uranium/five,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/atmos)
-"fw" = (
-/obj/structure/alien/weeds,
-/obj/structure/alien/resin/wall,
-/turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav)
 "fB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/window/westleft,
@@ -1119,7 +1117,7 @@
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
 /obj/effect/mob_spawn/corpse/human/damaged,
-/turf/open/floor/plating/asteroid/airless,
+/turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
 "hb" = (
 /obj/structure/alien/weeds,
@@ -2669,11 +2667,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
-"qw" = (
-/obj/structure/alien/weeds,
-/obj/structure/alien/egg/burst,
-/turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav)
 "qD" = (
 /obj/structure/lattice,
 /mob/living/simple_animal/hostile/carp,
@@ -2703,11 +2696,6 @@
 /obj/effect/turf_decal/tile/neutral/half,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
-"qM" = (
-/obj/structure/alien/weeds,
-/mob/living/simple_animal/hostile/alien/drone,
-/turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav)
 "qO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -3077,7 +3065,7 @@
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "ta" = (
 /obj/structure/alien/resin/wall,
-/turf/open/floor/plating/asteroid/airless,
+/turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
 "tc" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3594,8 +3582,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
-/obj/item/stack/sheet/iron/twenty,
-/obj/item/stack/sheet/iron/fifty,
+/obj/item/transfer_valve,
+/obj/item/transfer_valve,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "wa" = (
@@ -4042,16 +4030,6 @@
 "zf" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/port_tarkon/mining)
-"zk" = (
-/obj/structure/alien/resin/wall,
-/obj/structure/alien/weeds,
-/turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav)
-"zl" = (
-/obj/structure/alien/weeds,
-/mob/living/simple_animal/hostile/alien/sentinel,
-/turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav)
 "zm" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -4620,7 +4598,7 @@
 /obj/structure/bed/nest,
 /obj/effect/mob_spawn/corpse/human/damaged,
 /obj/item/raw_anomaly_core/random,
-/turf/open/floor/plating/asteroid/airless,
+/turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
 "De" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6284,7 +6262,7 @@
 /area/ruin/space/has_grav/port_tarkon/afthall)
 "Ng" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/tank_dispenser/oxygen,
+/obj/structure/tank_dispenser,
 /obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 1
@@ -7472,7 +7450,7 @@
 "Uz" = (
 /obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien/queen/large,
-/turf/open/floor/plating/asteroid/airless,
+/turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
 "UG" = (
 /obj/effect/decal/cleanable/glass,
@@ -7628,7 +7606,7 @@
 "VK" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/weeds/node,
-/turf/open/floor/plating/asteroid/airless,
+/turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
 "VN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7708,10 +7686,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/comms)
-"Wf" = (
-/obj/structure/alien/weeds,
-/turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav)
 "Wh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11105,7 +11079,7 @@ Fl
 jZ
 nZ
 jZ
-jZ
+by
 jZ
 Se
 Ki
@@ -11831,11 +11805,11 @@ PF
 Ks
 Uj
 Wa
-fw
-fw
-fw
-fw
-fw
+YJ
+YJ
+YJ
+YJ
+YJ
 Wa
 sv
 Wa
@@ -11904,12 +11878,12 @@ pk
 pk
 Uj
 ta
-fw
-qM
-qw
+YJ
+iU
+rE
 Dc
-zk
-fw
+Iu
+YJ
 Wa
 sv
 vC
@@ -11978,11 +11952,11 @@ YJ
 YJ
 YJ
 ha
-by
+DK
 Uz
-qM
+iU
 VK
-fw
+YJ
 Wa
 Wa
 vC
@@ -12050,12 +12024,12 @@ ZF
 un
 uw
 YJ
-fw
-qw
-Wf
-by
-qM
-fw
+YJ
+rE
+ZF
+DK
+iU
+YJ
 Wa
 Wa
 vC
@@ -12123,12 +12097,12 @@ pD
 YJ
 YJ
 YJ
-fw
+YJ
 Dc
-Wf
-zl
-Wf
-fw
+ZF
+oe
+ZF
+YJ
 sv
 Wa
 vC
@@ -12199,9 +12173,9 @@ LS
 YJ
 YJ
 YJ
-qw
-Wf
-fw
+rE
+ZF
+YJ
 Wa
 sv
 vC
@@ -12272,9 +12246,9 @@ ZF
 Kf
 oe
 YJ
-fw
-Wf
-fw
+YJ
+ZF
+YJ
 sv
 sv
 vC
@@ -12345,9 +12319,9 @@ YJ
 ZF
 cs
 mD
-fw
-Wf
-fw
+YJ
+ZF
+YJ
 Wa
 sv
 vC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the recently expanded empress next properly atmos'd so it isn't half filled but cold as dantes hell
Adds components around the ship so people can actually refine the anomaly core rewards in the nests.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

¯\_(ツ)_/¯
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Empress turned off the AC and Tarkon Engineers stopped using their rare transfer valves for urinals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
