### PR TITLE
adds disease and plasma generating vine

### DIFF
--- a/modular_skyrat/master_files/code/modules/events/spacevine.dm
+++ b/modular_skyrat/master_files/code/modules/events/spacevine.dm
@@ -477,6 +477,17 @@
 	var/turf/vine_object_turf = get_turf(vine_object)
 	vine_object_turf.atmos_spawn_air("miasma=100;TEMP=[T20C]")
 
+// Generates plasma on growth
+/datum/spacevine_mutation/plasma_generating
+	name = "Plasma producing"
+	hue = "#470566"
+	severity = 5
+	quality = NEGATIVE
+
+/datum/spacevine_mutation/plasma_generating/on_grow(obj/structure/spacevine/vine_object)
+	var/turf/vine_object_turf = get_turf(vine_object)
+	vine_object_turf.atmos_spawn_air("plasma=100;TEMP=[T20C]")
+
 // Heals crossing or eating mobs
 /datum/spacevine_mutation/flesh_mending
 	name = "Flesh mending"
@@ -533,6 +544,32 @@
 			continue
 		space_turf.ChangeTurf(/turf/open/floor/plating/kudzu)
 		space_turf.color = hue
+
+//Hitting/crossing has a chance to infect you with a disease
+/datum/spacevine_mutation/disease_carrying
+	name = "Disease carrying"
+	hue = "#dcf597"
+	severity = 5
+	quality = NEGATIVE
+
+/datum/spacevine_mutation/disease_carrying/on_hit(obj/structure/spacevine/vine_object, mob/hitter, obj/item/item_used, expected_damage)
+	if(isliving(hitter))
+		var/mob/living/living_hitter = hitter
+		if(isvineimmune(living_hitter))
+			return
+		if(prob(20))
+			var/datum/disease/new_disease = new /datum/disease/advance/random(5, 5)
+			living_hitter.ForceContractDisease(new_disease, FALSE, TRUE)
+	. = expected_damage
+
+/datum/spacevine_mutation/disease_carrying/on_cross(obj/structure/spacevine/vine_object, mob/crosser)
+	if(isliving(crosser))
+		var/mob/living/living_crosser = crosser
+		if(isvineimmune(living_crosser))
+			return
+		if(prob(20))
+			var/datum/disease/new_disease = new /datum/disease/advance/random(5, 5)
+			living_crosser.ForceContractDisease(new_disease, FALSE, TRUE)
 
 /turf/open/floor/plating/kudzu
 	name = "vine flooring"
@@ -659,7 +696,6 @@
 				playsound(src, 'sound/weapons/tap.ogg', 50, TRUE)
 		if(BURN)
 			playsound(src.loc, 'sound/items/welder.ogg', 100, TRUE)
-
 
 /// Applies effects when a mob enters the same turf as a vine
 /obj/structure/spacevine/proc/on_entered(datum/source, atom/movable/moving_atom)

--- a/modular_skyrat/master_files/code/modules/events/spacevine.dm
+++ b/modular_skyrat/master_files/code/modules/events/spacevine.dm
@@ -477,17 +477,6 @@
 	var/turf/vine_object_turf = get_turf(vine_object)
 	vine_object_turf.atmos_spawn_air("miasma=100;TEMP=[T20C]")
 
-// Generates plasma on growth
-/datum/spacevine_mutation/plasma_generating
-	name = "Plasma producing"
-	hue = "#470566"
-	severity = 5
-	quality = NEGATIVE
-
-/datum/spacevine_mutation/plasma_generating/on_grow(obj/structure/spacevine/vine_object)
-	var/turf/vine_object_turf = get_turf(vine_object)
-	vine_object_turf.atmos_spawn_air("plasma=100;TEMP=[T20C]")
-
 // Heals crossing or eating mobs
 /datum/spacevine_mutation/flesh_mending
 	name = "Flesh mending"
@@ -567,7 +556,7 @@
 		var/mob/living/living_crosser = crosser
 		if(isvineimmune(living_crosser))
 			return
-		if(prob(20))
+		if(prob(10))
 			var/datum/disease/new_disease = new /datum/disease/advance/random(5, 5)
 			living_crosser.ForceContractDisease(new_disease, FALSE, TRUE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds a plasma generating vine and a disease carrying vine
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
more difficulty versus the vines... also increasing the amount of mutations means more variety for the vine as well as lower chance to get a different mutation (that could be worse or better)
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: added disease carrying and plasma generating kudzu mutations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
