### PR TITLE
[SEMI-MODULAR] Fixes random colored skirts (assistant skirts) and makes species (teshari) clothing support GAGS outfits

### DIFF
--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -37,7 +37,7 @@
 
 /obj/item/clothing/under/color/random/Initialize(mapload)
 	..()
-	var/obj/item/clothing/under/color/C = get_random_jumpsuit()
+	var/obj/item/clothing/under/color/C = get_random_variant() // SKYRAT EDIT CHANGE - MODULAR_ITEMS - use local proc that handles prefs
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		H.equip_to_slot_or_del(new C(H), ITEM_SLOT_ICLOTHING, initial=TRUE) //or else you end up with naked assistants running around everywhere...

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -37,7 +37,7 @@
 
 /obj/item/clothing/under/color/random/Initialize(mapload)
 	..()
-	var/obj/item/clothing/under/color/C = get_random_variant() // SKYRAT EDIT CHANGE - MODULAR_ITEMS - use local proc that handles prefs
+	var/obj/item/clothing/under/color/C = get_random_variant() // SKYRAT EDIT CHANGE - use local proc that handles prefs
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		H.equip_to_slot_or_del(new C(H), ITEM_SLOT_ICLOTHING, initial=TRUE) //or else you end up with naked assistants running around everywhere...

--- a/modular_skyrat/master_files/code/modules/clothing/clothing.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/clothing.dm
@@ -20,23 +20,45 @@
 
 	if(state_to_use in clothing_states)
 		//checks if the overriden icon has the correct sprite, and uses it...
-		GLOB.species_clothing_icons[species]["[file_to_use]-[state_to_use]"] = human_clothing_icon
+		GLOB.species_clothing_icons[species][get_species_clothing_key(file_to_use, state_to_use)] = human_clothing_icon
 		return
 
 	//...or else it will generate one
 	var/icon/species_icon = icon(species, species_clothing_icon_state)
 	var/list/final_list = list()
-	for(var/i in 1 to 3)
-		if(length(species_clothing_colors) < i)
-			final_list += "#00000000"
-			continue
-		var/color = species_clothing_colors[i]
-		if(islist(color)) // The entry is a list of x, y coordinates; find the color at this point
-			final_list += default_clothing_icon.GetPixel(color[1], color[2]) || "#00000000"
-		else if(istext(color))
-			final_list += color
+
+	// Is this a GAGS outfit?
+	if(greyscale_config_worn)
+		// Just use the colors already given to us.
+		var/list/colors = SSgreyscale.ParseColorString(greyscale_colors)
+		var/default_color = (length(colors) >= 1) ? colors[1] : "#00000000"
+		for(var/i in 1 to 3)
+			final_list += (i < length(colors)) ? colors[i] : default_color
+	else
+		// Not GAGS, guess using color picking
+		for(var/i in 1 to 3)
+			if(length(species_clothing_colors) < i)
+				final_list += "#00000000"
+				continue
+			var/color = species_clothing_colors[i]
+			if(islist(color)) // The entry is a list of x, y coordinates; find the color at this point
+				final_list += default_clothing_icon.GetPixel(color[1], color[2]) || "#00000000"
+			else if(istext(color))
+				final_list += color
 
 	species_icon.MapColors(final_list[1], final_list[2], final_list[3])
 	species_icon = fcopy_rsc(species_icon)
 	// Stores the icon in a global list; if it already exists, this proc is skipped
-	GLOB.species_clothing_icons[species]["[file_to_use]-[state_to_use]"] = species_icon
+	GLOB.species_clothing_icons[species][get_species_clothing_key(file_to_use, state_to_use)] = species_icon
+
+/**
+ * Get the name to cache this clothing's icon with
+ * @param file_to_use icon file we're using
+ * @param state_to_use icon state we're using
+ * @return key string to use in cache
+ */
+/obj/item/clothing/proc/get_species_clothing_key(file_to_use, state_to_use)
+	if(greyscale_config_worn)
+		return "[file_to_use]-[state_to_use]-[greyscale_colors]"
+	else
+		return "[file_to_use]-[state_to_use]"

--- a/modular_skyrat/master_files/code/modules/clothing/under/color.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/color.dm
@@ -1,0 +1,11 @@
+/**
+ * Random jumpsuit is the preferred style of the wearer if loaded as an outfit.
+ * This is cleaner than creating a ../skirt variant as skirts are precached into SSwardrobe
+ * and that causes runtimes for runtimes for this class as it qdels on Initialize.
+ */
+/obj/item/clothing/under/color/random/proc/get_random_variant()
+	var/mob/living/carbon/human/wearer = loc
+	if(istype(wearer) && wearer.jumpsuit_style == PREF_SKIRT)
+		return get_random_jumpskirt()
+
+	return get_random_jumpsuit()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_update_icons.dm
@@ -382,7 +382,7 @@
 
 /**
  * Generates a species-specific clothing icon.
- * 
+ *
  * Arguments:
  * * file_to_use - Icon file to use for clothing sprite
  * * state_to_use - Icon state to use within file_to_use
@@ -392,7 +392,7 @@
  */
 /obj/item/clothing/wear_species_version(file_to_use, state_to_use, layer, species, default_file_to_use)
 	LAZYINITLIST(GLOB.species_clothing_icons[species])
-	var/icon/species_clothing_icon = GLOB.species_clothing_icons[species]["[file_to_use]-[state_to_use]"] // Check if the icon we want already exists
+	var/icon/species_clothing_icon = GLOB.species_clothing_icons[species][get_species_clothing_key(file_to_use, state_to_use)] // Check if the icon we want already exists
 	if(!species_clothing_icon) 	// Create standing/laying icons if they don't exist
 		generate_species_clothing(file_to_use, state_to_use, species, default_file_to_use)
-	return mutable_appearance(GLOB.species_clothing_icons[species]["[file_to_use]-[state_to_use]"], layer = -layer)
+	return mutable_appearance(GLOB.species_clothing_icons[species][get_species_clothing_key(file_to_use, state_to_use)], layer = -layer)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4319,6 +4319,7 @@
 #include "modular_skyrat\master_files\code\modules\clothing\glasses\nerve_staple.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\head\monkey_magnification_helmet.dm"
 #include "modular_skyrat\master_files\code\modules\clothing\outfits\ert.dm"
+#include "modular_skyrat\master_files\code\modules\clothing\under\color.dm"
 #include "modular_skyrat\master_files\code\modules\events\spacevine.dm"
 #include "modular_skyrat\master_files\code\modules\jobs\departments\departments.dm"
 #include "modular_skyrat\master_files\code\modules\jobs\job_types\cyborg.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Skyrat branch made changes to how assistants get their jumpsuits, using the normal outfits system, but there's no `/obj/item/clothing/under/color/random/skirt` so skirt wearers just weren't getting skirts as assistants anymore. In fact, I found that adding the skirt variant forced me to make 3 non-modular changes to prevent SSwardrobe from attempting to cache it (causes runtimes on random outfits), so instead I changed `/obj/item/clothing/under/color/random` to give you a skirt instead if placed on a skirt wearer on spawn.

I realized teshari GAGS-utilizing clothing (all colored jumpsuits, and prison jumpsuits) appear to be a completely random but frozen color because our species clothing system was just caching the first GAGS outfit spawned and using that for all of them regardless of color (once for suits, once for skirts).
It also didn't use the spoon-fed colors that GAGS already provides, so I updated the species clothing system to just defer to `greyscale_colors` if GAGS was meant to be used on the item, and also cache by the colors if used, since just icon and icon state are meaningless in that case.

### Here's a teshari rainbow + teshari prisoner
![image](https://user-images.githubusercontent.com/1185434/150702555-ef60d71a-4a42-4f63-800b-8547c2c49b56.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Unscuffs some of the main issues with our clothing system.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
fix: Skirt-wearing assistants now actually get skirts.
fix: Teshari clothing colors are now more correct for a large portion of the generated clothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
