### PR TITLE
[MODULAR]Adds #10937 and Removes the Firelocks from Tram SM

### DIFF
--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -22686,8 +22686,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/entry)
 "gnw" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/spawner/structure/window/reinforced/no_firelock,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "gnx" = (

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -1,9 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security/processing)
 "aac" = (
@@ -2299,16 +2299,6 @@
 /obj/machinery/computer/secure_data,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
-"aoR" = (
-/obj/machinery/computer/security/labor{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
-/area/security/processing)
 "aoT" = (
 /obj/structure/railing{
 	dir = 1
@@ -8228,15 +8218,6 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
-"bgT" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "bgX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -8336,14 +8317,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "bjD" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/computer/security/labor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/security/processing)
 "bjE" = (
@@ -10405,10 +10385,10 @@
 /area/science/robotics/lab)
 "bWZ" = (
 /obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/security/processing)
 "bXd" = (
@@ -10624,13 +10604,6 @@
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor/iron,
 /area/science/mixing)
-"cbm" = (
-/obj/machinery/gulag_teleporter,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "cbV" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -11866,8 +11839,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/closet/emcloset,
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/light_switch/directional/north,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron/dark,
 /area/security/processing)
 "cER" = (
@@ -13838,11 +13812,11 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "dmS" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/security/processing)
@@ -14412,16 +14386,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
-"dyS" = (
-/obj/machinery/computer/security/labor{
-	dir = 4
-	},
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "dyY" = (
 /obj/machinery/light_switch/directional/south{
 	pixel_y = -40
@@ -15215,11 +15179,15 @@
 /turf/open/floor/iron/smooth,
 /area/maintenance/port/central)
 "dOd" = (
-/obj/machinery/computer/shuttle/labor,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/gulag_item_reclaimer{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron,
 /area/security/processing)
 "dOi" = (
@@ -17605,11 +17573,14 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "ezZ" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/iron,
 /area/security/processing)
 "eAh" = (
@@ -19220,15 +19191,13 @@
 /turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "ffb" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/security/processing)
 "ffk" = (
@@ -22286,13 +22255,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"gfw" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/processing)
 "gfA" = (
 /obj/machinery/navbeacon/wayfinding/dorms,
 /obj/structure/disposalpipe/segment{
@@ -22655,6 +22617,17 @@
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"gmj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/iron,
+/area/security/processing)
 "gmm" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
@@ -22714,6 +22687,7 @@
 /area/hallway/secondary/entry)
 "gnw" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "gnx" = (
@@ -22935,11 +22909,13 @@
 	},
 /area/service/chapel)
 "gqf" = (
+/obj/machinery/light/directional/east,
+/obj/structure/chair/office{
+	dir = 1
+	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/security/processing)
 "gqg" = (
@@ -23352,6 +23328,15 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
+"gyS" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "gyV" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/shower{
@@ -26826,13 +26811,13 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
 "hNm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/processing)
 "hNq" = (
@@ -30808,13 +30793,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"jjB" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/security/processing)
 "jjI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -31321,7 +31299,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "jsk" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/processing)
 "jsm" = (
@@ -33138,7 +33119,6 @@
 	name = "Supermatter Chamber";
 	req_one_access_txt = "10;24"
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -33171,9 +33151,20 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "kaw" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron,
+/obj/machinery/computer/prisoner/gulag_teleporter_computer{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "kay" = (
 /obj/effect/decal/cleanable/dirt,
@@ -37015,14 +37006,11 @@
 /turf/open/floor/plating,
 /area/service/janitor)
 "lxq" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Security - Labor Dock";
-	network = list("ss13","Security")
-	},
-/obj/machinery/firealarm/directional/south,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/security/processing)
 "lxE" = (
@@ -42912,6 +42900,7 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "nKW" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
@@ -43167,10 +43156,10 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "nOn" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/processing)
 "nOu" = (
@@ -44575,6 +44564,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"ook" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/security/processing)
 "ooo" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 4
@@ -44625,8 +44621,15 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "oqn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/processing)
@@ -47388,12 +47391,12 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
 "pnc" = (
-/obj/machinery/gulag_item_reclaimer{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/computer/shuttle/labor,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/processing)
@@ -48100,6 +48103,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
+"pAN" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/processing)
 "pAW" = (
 /turf/closed/wall/r_wall,
 /area/engineering/main)
@@ -52658,13 +52669,13 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "riy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/processing)
 "riB" = (
@@ -53094,7 +53105,7 @@
 	height = 5;
 	id = "laborcamp_home";
 	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/skyrat;
+	roundstart_template = /datum/map_template/shuttle/labour/box;
 	width = 9
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -53906,10 +53917,12 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "rIY" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/box/prisoner,
 /turf/open/floor/iron,
 /area/security/processing)
 "rJa" = (
@@ -54412,6 +54425,23 @@
 /obj/effect/landmark/start/science_guard,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
+"rSL" = (
+/obj/machinery/door/airlock/security{
+	name = "Labor Shuttle";
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "rSW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -56067,20 +56097,10 @@
 	},
 /area/command/heads_quarters/rd)
 "svV" = (
-/obj/machinery/door/airlock/security{
-	name = "Labor Shuttle";
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/brig)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/processing)
 "swb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58952,11 +58972,7 @@
 /turf/open/openspace,
 /area/cargo/storage)
 "ttW" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/processing)
 "ttX" = (
@@ -59822,13 +59838,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
-"tKq" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "tKK" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	dir = 8
@@ -59909,7 +59918,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/closet/emcloset,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/security/processing)
 "tLF" = (
@@ -59992,14 +60004,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/research)
-"tMQ" = (
-/obj/structure/table,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/obj/item/storage/box/prisoner,
-/turf/open/floor/iron,
-/area/security/processing)
 "tMR" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - Main West";
@@ -61262,9 +61266,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ujQ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/processing)
@@ -63076,11 +63077,22 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "uRO" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
+/obj/machinery/gulag_teleporter,
+/obj/machinery/camera/directional/south{
+	c_tag = "Security - Labor Dock";
+	network = list("ss13","Security")
 	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/security/processing)
 "uRZ" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
@@ -63296,12 +63308,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"uVW" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "uWf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/emp_proof{
@@ -63456,6 +63462,18 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
+"uZI" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/processing)
 "uZJ" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/iron,
@@ -64006,7 +64024,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/heavy,
 /obj/structure/cable,
 /obj/structure/cable/layer3,
 /turf/open/floor/iron,
@@ -67594,6 +67612,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"wBB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/processing)
 "wBH" = (
 /obj/machinery/computer/security/hos,
 /obj/machinery/light/directional/north,
@@ -69032,7 +69059,6 @@
 	name = "Supermatter Chamber";
 	req_one_access_txt = "10;24"
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -153650,7 +153676,7 @@ dhe
 dhe
 dhe
 dhe
-wkE
+ktC
 ktC
 ktC
 ktC
@@ -153902,12 +153928,12 @@ aBM
 aBM
 aBM
 aBM
-wkE
-wkE
-wkE
-wkE
-wkE
-wkE
+dhe
+dhe
+dhe
+dhe
+dhe
+ktC
 uoR
 geQ
 mxr
@@ -154159,12 +154185,12 @@ aBM
 aBM
 aBM
 aBM
-wkE
-cbm
-dyS
-aoR
-tMQ
-dOV
+dhe
+dhe
+dhe
+dhe
+dhe
+ktC
 yjM
 cQo
 ipv
@@ -154417,11 +154443,11 @@ aBM
 aBM
 aBM
 wkE
-bgT
-jjB
-gfw
-dHX
-tHK
+wkE
+wkE
+wkE
+wkE
+ktC
 yld
 cQo
 qZW
@@ -154675,8 +154701,8 @@ sck
 sck
 sck
 oqn
-qiW
-tew
+pAN
+gmj
 ezZ
 svV
 rXB
@@ -154928,14 +154954,14 @@ aBM
 aBM
 aBM
 rrl
-srM
+ook
 nww
-tNh
-oqn
+gyS
+uZI
 qiW
 tew
 jsk
-tHK
+rSL
 yld
 cQo
 tSC
@@ -155192,7 +155218,7 @@ dOd
 aaa
 hNm
 lxq
-dOV
+svV
 yld
 jfZ
 cGX
@@ -155959,7 +155985,7 @@ aBM
 srM
 nww
 tNh
-tKq
+uZI
 ujQ
 bWZ
 kaw
@@ -156217,9 +156243,9 @@ sck
 sck
 sck
 dmS
-uVW
-aZq
-jsk
+qiW
+wBB
+dHX
 tHK
 bTy
 tRQ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As stated, adds the #10937 PR to the skyrat variant and removes the unneeded firelocks from SM chamber
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Engineers are no longer crashed by firelocks so OSHA is no longer violated.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Tramstation's gulag processing room has been rearranged so prisoners can disembark on their own instead of being trapped.
fix: Removed the firelocks in the TramStation SM chamber
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
