### PR TITLE
[Modular] Someone forgot the briefs smh my head

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
@@ -389,7 +389,6 @@ GLOBAL_LIST_EMPTY(cached_mutant_icon_files)
 /datum/sprite_accessory/underwear/digibriefs
 	name = "Digi Briefs"
 	icon_state = "briefs_d"
-	use_static = TRUE
 
 /datum/sprite_accessory/underwear/male_briefs
 	has_digitigrade = TRUE

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
@@ -385,6 +385,11 @@ GLOBAL_LIST_EMPTY(cached_mutant_icon_files)
 	name = "LIZARED Underwear"
 	icon_state = "lizared"
 	use_static = TRUE
+	
+/datum/sprite_accessory/underwear/digibriefs
+	name = "Digi Briefs"
+	icon_state = "briefs_d"
+	use_static = TRUE
 
 /datum/sprite_accessory/underwear/male_briefs
 	has_digitigrade = TRUE


### PR DESCRIPTION
## About The Pull Request

An anonymous individual has requested I make these briefs available cause SOMEONE forgot to add it to the sprite_accessories.dmi

## How This Contributes To The Skyrat Roleplay Experience

Hey some people like the classics, don't judge.

## Changelog

:cl:
add: missing line of code to allow choosing digitigrade briefs, obvious anthro h8, no other explaination
/:cl:
