### PR TITLE
[NON-MODULAR] Gets rid of inaccurate info from human infocard

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/human.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/human.ts
@@ -5,7 +5,7 @@ const Human: Species = {
     kind extend from old Earth to the edges of known space.",
   features: {
     // SKYRAT EDIT BEGIN - HUMANS AREN'T SPECIAL
-    /*good: [{
+    /* good: [{
       icon: "robot",
       name: "Asimov Superiority",
       description: "The AI and their cyborgs are, by default, subservient only \

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/human.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/human.ts
@@ -4,7 +4,8 @@ const Human: Species = {
   description: "Humans are the dominant species in the known galaxy, their \
     kind extend from old Earth to the edges of known space.",
   features: {
-    good: [{
+    // SKYRAT EDIT BEGIN - HUMANS AREN'T SPECIAL
+    /*good: [{
       icon: "robot",
       name: "Asimov Superiority",
       description: "The AI and their cyborgs are, by default, subservient only \
@@ -15,7 +16,9 @@ const Human: Species = {
       name: "Chain of Command",
       description: "Nanotrasen only recognizes humans for command roles, such \
         as Captain.",
-    }],
+    }],*/
+    good: [],
+    // SKYRAT EDIT END
     neutral: [],
     bad: [],
   },


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR removes the Asimov Superiority and Chain of Command good features from the human TGUI infocard.

## How This Contributes To The Skyrat Roleplay Experience

- While the Asimov one is _technically_ true, we don't use Asimov at the time of writing, and can give people the wrong impression.
- Skyrat's disabled the setting that requires command staff to be human.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: Corrected human info in their race infocard
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
