### PR TITLE
[Modular] Adds the alien toy to loadout selection

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_toys.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_toys.dm
@@ -47,6 +47,11 @@ GLOBAL_LIST_INIT(loadout_toys, generate_loadout_items(/datum/loadout_item/toys))
 	item_path = /obj/item/toy/plush/ratplush
 	restricted_roles = list(JOB_CHAPLAIN)
 
+/datum/loadout_item/toys/donator/alien
+	name = "Alien Toy"
+	item_path = /obj/item/clothing/mask/facehugger/toy
+	donator_only = TRUE
+
 /datum/loadout_item/toys/rouny
 	name = "Rouny Plush"
 	item_path = /obj/item/toy/plush/rouny


### PR DESCRIPTION
## About The Pull Request

It's a donator only toy! (Like other items in loadout that commonly cost points in-round)

## How This Contributes To The Skyrat Roleplay Experience

I just think they're neat, I want to see them more often, I love the interaction they have with bags.

## Changelog


:cl:
add: Adds a new toy to the loadout selection
/:cl:
