### PR TITLE
Removes secborgs from the techweb

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -197,19 +197,8 @@
 	)
 	if(!CONFIG_GET(flag/disable_peaceborg))
 		model_list["Peacekeeper"] = /obj/item/robot_model/peacekeeper
-	/* SKYRAT EDIT: DISABLED SECURITY CYBORG FOR TECHWEB SETUP
 	if(!CONFIG_GET(flag/disable_secborg))
 		model_list["Security"] = /obj/item/robot_model/security
-	*/
-	// SKYRAT EDIT ADDITION: Techweb locked cyborg modules
-	for(var/i in SSresearch.science_tech.researched_designs)
-		var/datum/design/cyborg_module/D = SSresearch.techweb_design_by_id(i)
-		if(!istype(D))
-			continue
-		if(D.unlocked_module_name == "Security" && CONFIG_GET(flag/disable_secborg))
-			continue
-		model_list[D.unlocked_module_name] = D.unlocked_module_path
-	// SKYRAT EDIT END
 	// Create radial menu for choosing borg model
 	var/list/model_icons = list()
 	for(var/option in model_list)

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -362,21 +362,3 @@
 	build_path = /obj/item/melee/baton/security/boomerang
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-// SKYRAT EDIT BEGIN: CYBORG SHIT
-/datum/design/cyborg_module
-	name = "Cyborg Design"
-	desc = "what"
-	id = "cyborg_module"
-	research_icon = 'icons/mob/robots.dmi'
-	research_icon_state = "robot"
-	var/unlocked_module_name
-	var/unlocked_module_path
-
-/datum/design/cyborg_module/security
-	name = "Security Cyborg Design"
-	desc = "A security focued cyborg module. "
-	id = "security_cyborg_module"
-	research_icon_state = "sec"
-	unlocked_module_name = "Security"
-	unlocked_module_path = /obj/item/robot_model/security
-// SKYRAT EDIT END

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1495,19 +1495,6 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	required_experiments = list(/datum/experiment/explosion/maxcap)
 
-// SKYRAT EDIT START: SECBORG TECHWEB
-/datum/techweb_node/secborg_node
-	id = "secborg_node"
-	display_name = "Cyborg Module: Security"
-	description = "Known to cause silicon law violations in all twelve sectors of space!"
-	prereq_ids = list("adv_weaponry")
-	design_ids = list(
-		"security_cyborg_module",
-	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
-	required_experiments = list(/datum/experiment/explosion/maxcap)
-// SKYRAT EDIT END: SECBORG TECHWEB
-
 /datum/techweb_node/ballistic_weapons
 	id = "ballistic_weapons"
 	display_name = "Ballistic Weaponry"


### PR DESCRIPTION
## About The Pull Request

Removes secborg techweb node
Revert of https://github.com/Skyrat-SS13/Skyrat-tg/pull/9445

## How This Contributes To The Skyrat Roleplay Experience

This isn't meant to be here. Secborg is (supposed to be) disabled in config so this node has no purpose.

I should probably put a great big fuck off disclaimer.

# Sec borgs are already disabled in config. The decision has been made a long time ago. This is a PR for removing redundant code, not a place to argue about getting them back.

## Changelog
:cl:
fix: The secborg research node has been removed, as they're supposed to be unobtainable.
/:cl: