### PR TITLE
[Modular] Adds emag to the loadout selection... of OPFOR

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/opposing_force_equipment.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_equipment.dm
@@ -406,6 +406,11 @@
 /datum/opposing_force_equipment/gear/
 	category = OPFOR_EQUIPMENT_CATEGORY_UTILITY
 
+/datum/opposing_force_equipment/gear/emag
+	name = "Cryptographic Sequencer"
+	item_type = /obj/item/card/emag
+	description = "An electromagnetic ID card used to break machinery and disable safeties. Notoriously used by Syndicate agents, now commonly traded hardware at blackmarkets."
+
 /datum/opposing_force_equipment/gear/stoolbox
 	item_type = /obj/item/storage/toolbox/syndicate
 	description = "A fully-kitted toolbox scavenged from maintenance by our highly-paid monkeys. The toolbox \


### PR DESCRIPTION
## About The Pull Request

It adds the emag to the utility category of the opposing force. This item has funny mechanics :)

## How This Contributes To The Skyrat Roleplay Experience

I asked if this was a good idea, and some people said yes. ✔

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added the emag to OPFOR's item selection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
