### PR TITLE
[Non-modular] An attempt at fixing runechat offset

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -195,7 +195,7 @@
 	message.plane = RUNECHAT_PLANE
 	message.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 	message.alpha = 0
-	message.pixel_y = (owner.maptext_height = owner.maptext_height) //SKYRAT EDIT (owner.maptext_height)
+	message.pixel_y = (owner.maptext_height = owner.maptext_height) //SKYRAT EDIT `owner.maptext_height`
 	message.pixel_x = (owner.maptext_width * 0.5) - 16
 	message.maptext_width = CHAT_MESSAGE_WIDTH
 	message.maptext_height = mheight

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -195,11 +195,11 @@
 	message.plane = RUNECHAT_PLANE
 	message.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 	message.alpha = 0
-	//SKYRAT EDIT `message.pixel_y = owner.maptext_height`
+	//SKYRAT EDIT
 	var/y_offset = owner.maptext_height
 	owner.maptext_height = y_offset
-	message.pixel_y = owner.maptext_height
 	//SKYRAT EDIT END
+	message.pixel_y = owner.maptext_height
 	message.pixel_x = (owner.maptext_width * 0.5) - 16
 	message.maptext_width = CHAT_MESSAGE_WIDTH
 	message.maptext_height = mheight

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -195,7 +195,7 @@
 	message.plane = RUNECHAT_PLANE
 	message.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 	message.alpha = 0
-	message.pixel_y = owner.maptext_height
+	message.pixel_y = (owner.maptext_height = owner.maptext_height) //SKYRAT EDIT (owner.maptext_height)
 	message.pixel_x = (owner.maptext_width * 0.5) - 16
 	message.maptext_width = CHAT_MESSAGE_WIDTH
 	message.maptext_height = mheight

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -195,7 +195,11 @@
 	message.plane = RUNECHAT_PLANE
 	message.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 	message.alpha = 0
-	message.pixel_y = (owner.maptext_height = owner.maptext_height) //SKYRAT EDIT `owner.maptext_height`
+	//SKYRAT EDIT `message.pixel_y = owner.maptext_height`
+	var/y_offset = owner.maptext_height
+	owner.maptext_height = y_offset
+	message.pixel_y = owner.maptext_height
+	//SKYRAT EDIT END
 	message.pixel_x = (owner.maptext_width * 0.5) - 16
 	message.maptext_width = CHAT_MESSAGE_WIDTH
 	message.maptext_height = mheight


### PR DESCRIPTION
## About The Pull Request

I've been making updates to runechat having a y axis offset on both upstream and for our larger species and silicons here on skyrat, but it seems to break on our live server. It's hard for me to test because of that.
Being unable to get it to break on my own host, I asked for a staffmember to help test and I found out if I update the variable it applies the offset correctly.
So this is me trying to get `maptext_height` to update itself with the value it already contains, every time a message is generated.

If this works, I could just do it upstream, but I have no way of knowing this will fix the bug without seeing implemented.

## Changelog
N/a