### PR TITLE
objectives in opfor roundend report are no longer bold

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -824,12 +824,12 @@
 	var/list/report = list("<br>")
 	report += span_greentext(mind_reference.current.real_name)
 	if(objectives.len)
-		report += "<b>Had an approved OPFOR appliation with the following objectives:</b><br>"
+		report += "<b>Had an approved OPFOR application with the following objectives:</b><br>"
 		for(var/datum/opposing_force_objective/opfor_objective in objectives)
 			if(opfor_objective.status != OPFOR_OBJECTIVE_STATUS_APPROVED)
 				continue
-			report += "</b>Title:<b> [opfor_objective.title]<br>"
-			report += "</b>Description:<b> [opfor_objective.description]<br>"
+			report += "<b>Title:</b> [opfor_objective.title]<br>"
+			report += "<b>Description:</b> [opfor_objective.description]<br>"
 			report += "<br>"
 
 	if(selected_equipment.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this annoyed me so I fixed it :)
![VbZGRDIuxe](https://user-images.githubusercontent.com/6972764/151150842-06ec4ba9-2eb9-4d75-94eb-9ae73d0a5d73.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
I will no longer see paragraphs of bold text at the end of a round
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: opfor roundend report objectives are no longer bold
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
