### PR TITLE
[SEMI-MODULAR] Standardizes Armories, Wardens Room & Detectives Office | Renames the Kilo Execution Room | Security Lockers Spawn Vests | Minor Brig Fixes

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -11112,6 +11112,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/gun/grenadelauncher,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "bNu" = (
@@ -12192,11 +12193,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
-/obj/structure/closet/ammunitionlocker/useful,
-/obj/item/storage/box/lethalshot,
-/obj/item/storage/box/lethalshot,
-/obj/item/storage/box/lethalshot,
-/obj/item/storage/box/lethalshot,
+/obj/machinery/flasher/portable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "bTk" = (
@@ -12619,7 +12616,6 @@
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "bVp" = (
-/obj/vehicle/ridden/secway,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -12630,7 +12626,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/key/security,
+/obj/structure/closet/ammunitionlocker/useful,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "bVr" = (
@@ -13964,6 +13964,7 @@
 	name = "Armoury Access";
 	req_access_txt = "3"
 	},
+/obj/item/key/security,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "cbI" = (
@@ -87371,6 +87372,17 @@
 /turf/open/floor/iron/grimy,
 /area/service/library/abandoned)
 "sIg" = (
+/obj/vehicle/ridden/secway,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/effect/turf_decal/tile/red{
 	dir = 8

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -10233,30 +10233,31 @@
 /area/security/detectives_office)
 "bJh" = (
 /obj/structure/closet/secure_closet/detective,
-/obj/item/clothing/head/fedora/det_hat{
-	icon_state = "curator"
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/taperecorder,
+/obj/item/folder/yellow{
+	name = "Detective's Findings"
 	},
-/obj/item/clothing/suit/det_suit{
-	icon_state = "curator"
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/camera/detective,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/item/clothing/under/rank/security/detective,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "bJi" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/item/camera/detective,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -10271,7 +10272,6 @@
 /area/security/detectives_office)
 "bJj" = (
 /obj/structure/table/wood,
-/obj/item/taperecorder,
 /obj/item/restraints/handcuffs,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -11812,28 +11812,6 @@
 /area/ai_monitored/security/armory)
 "bRw" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/vest{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/vest,
-/obj/item/clothing/suit/armor/vest{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -11843,6 +11821,24 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec,
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/vest/security{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/vest/security,
+/obj/item/clothing/suit/armor/vest/security{
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -12156,6 +12152,14 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/item/stamp/denied{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/stamp{
+	pixel_x = 8;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "bTh" = (
@@ -12177,25 +12181,6 @@
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "bTi" = (
-/obj/structure/rack,
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -12207,6 +12192,11 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/structure/closet/ammunitionlocker/useful,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "bTk" = (
@@ -13949,7 +13939,6 @@
 /area/security/warden)
 "cbF" = (
 /obj/structure/closet/secure_closet/warden,
-/obj/item/clothing/under/rank/security/warden/grey,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -13957,6 +13946,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/gun/energy/laser,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "cbG" = (
@@ -13981,6 +13971,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/mob/living/simple_animal/bot/secbot/beepsky/armsky,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "cbJ" = (
@@ -42067,6 +42058,15 @@
 	dir = 8
 	},
 /obj/structure/rack/gunrack,
+/obj/item/gun/energy/disabler{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "fZP" = (
@@ -90250,13 +90250,15 @@
 /area/medical/medbay/central)
 "tAc" = (
 /obj/structure/closet/secure_closet/detective,
-/obj/item/clothing/head/fedora/det_hat{
-	icon_state = "curator"
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/taperecorder,
+/obj/item/folder/yellow{
+	name = "Detective's Findings"
 	},
-/obj/item/clothing/suit/det_suit{
-	icon_state = "curator"
-	},
-/obj/item/clothing/under/rank/security/detective,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/camera/detective,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "tAu" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -487,7 +487,6 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/storage/secure/safe/directional/east,
 /obj/structure/window/reinforced{
 	dir = 8
 	},

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -121,32 +121,29 @@
 /area/ai_monitored/security/armory)
 "abm" = (
 /obj/structure/rack,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_y = 5
-	},
-/obj/item/clothing/head/helmet/riot{
+/obj/item/clothing/head/helmet/sec{
 	pixel_x = -3;
-	pixel_y = 5
+	pixel_y = 3
 	},
-/obj/item/clothing/head/helmet/alt{
+/obj/item/clothing/head/helmet/sec,
+/obj/item/clothing/head/helmet/sec{
 	pixel_x = 3;
-	pixel_y = -5
+	pixel_y = -3
 	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_y = -5
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = -3;
-	pixel_y = -5
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/bot_blue,
+/obj/item/clothing/suit/armor/vest/security{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/vest/security,
+/obj/item/clothing/suit/armor/vest/security{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "abu" = (
@@ -194,18 +191,37 @@
 /area/security/range)
 "abY" = (
 /obj/structure/rack,
-/obj/item/shield/riot{
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot{
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/shield/riot,
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/item/shield/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
+/obj/item/shield/riot,
+/obj/item/shield/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aci" = (
@@ -255,6 +271,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/item/gun/ballistic/rifle/boltaction,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "acJ" = (
@@ -449,26 +466,32 @@
 "agp" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_y = 5
-	},
-/obj/item/clothing/suit/armor/bulletproof{
 	pixel_x = -3;
-	pixel_y = 5
+	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 3;
+	pixel_y = -3
 	},
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
 	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/storage/secure/safe/directional/east,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "agr" = (
@@ -478,6 +501,7 @@
 /obj/item/storage/box/lethalshot,
 /obj/effect/turf_decal/delivery/blue,
 /obj/structure/cable,
+/obj/item/storage/box/lethalshot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "agG" = (
@@ -507,10 +531,22 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ahX" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
+/obj/item/grenade/barrier{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/structure/rack,
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ahY" = (
@@ -15647,6 +15683,10 @@
 /area/science/misc_lab)
 "dNl" = (
 /obj/structure/table/wood,
+/obj/item/clothing/accessory/badge/holo/hos,
+/obj/item/stamp/hos{
+	pixel_x = 10
+	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "dNm" = (
@@ -16507,6 +16547,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/photocopier,
 /turf/open/floor/iron,
 /area/security/office)
 "elv" = (
@@ -26451,6 +26492,8 @@
 	pixel_x = 11;
 	pixel_y = 11
 	},
+/obj/item/clothing/accessory/badge,
+/obj/item/clothing/accessory/badge/holo/detective,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "jyi" = (
@@ -29877,10 +29920,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "lus" = (
-/obj/machinery/computer/security{
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
+/obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "luE" = (
@@ -31484,8 +31527,7 @@
 "mjP" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/structure/cable,
-/obj/item/clothing/accessory/badge/holo/warden,
-/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/gun/energy/laser,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 9
 	},
@@ -33337,6 +33379,14 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Security - Warden"
 	},
+/obj/item/stamp/denied{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/stamp{
+	pixel_x = 8;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark/blue/side,
 /area/security/brig)
 "nja" = (
@@ -33950,16 +34000,6 @@
 	dir = 4
 	},
 /area/science/misc_lab)
-"nyT" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_x = 3
-	},
-/obj/item/lighter,
-/obj/item/camera/detective,
-/obj/item/hand_labeler,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
 "nyY" = (
 /obj/machinery/computer/crew,
 /obj/effect/turf_decal/tile/green,
@@ -36018,8 +36058,8 @@
 /obj/item/folder/yellow{
 	name = "Detective's Findings"
 	},
-/obj/item/clothing/accessory/badge/holo/detective,
 /obj/item/clothing/glasses/sunglasses,
+/obj/item/camera/detective,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "oHg" = (
@@ -37547,7 +37587,8 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "pwJ" = (
-/obj/machinery/photocopier,
+/obj/effect/turf_decal/bot_blue,
+/obj/vehicle/ridden/secway,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "pwQ" = (
@@ -39487,7 +39528,13 @@
 /turf/open/floor/iron,
 /area/security/office)
 "qzL" = (
-/obj/structure/rack,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = 3
+	},
+/obj/item/lighter,
+/obj/item/camera/detective,
+/obj/item/hand_labeler,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
@@ -42710,6 +42757,7 @@
 	name = "Permabrig Lockdown";
 	pixel_y = 8
 	},
+/obj/item/clothing/accessory/badge/holo/warden,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "sjb" = (
@@ -49688,8 +49736,6 @@
 "vPG" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/closet/secure_closet/hos,
-/obj/item/clothing/accessory/badge/sheriff,
-/obj/item/clothing/accessory/badge/holo/hos,
 /obj/item/radio/intercom/directional/north,
 /obj/item/clothing/glasses/hud/security/sunglasses,
 /turf/open/floor/carpet,
@@ -80138,7 +80184,7 @@ azu
 jTQ
 nZC
 nel
-nyT
+oGY
 oGY
 arP
 axt

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -515,10 +515,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/filingcabinet/security,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "abY" = (
@@ -3188,6 +3188,25 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec,
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/vest/security{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/vest/security,
+/obj/item/clothing/suit/armor/vest/security{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "akE" = (
@@ -3533,7 +3552,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aly" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -3548,7 +3566,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/storage/box/armament_tokens_energy,
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/microfusion,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "alz" = (
@@ -3704,7 +3723,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/smartgun,
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/shotguns,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "alT" = (
@@ -5304,6 +5324,9 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/south{
+	pixel_x = 30
+	},
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "art" = (
@@ -8056,7 +8079,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/smartgun,
+/obj/structure/closet/ammunitionlocker/useful,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aCD" = (
@@ -8598,28 +8625,6 @@
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "aEX" = (
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/closet/secure_closet{
-	name = "shotgun rubber rounds";
-	req_access_txt = "1"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -21893,7 +21898,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/key/security,
+/obj/item/grenade/barrier{
+	pixel_x = 8
+	},
 /obj/item/key/security,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -30837,6 +30844,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/item/clothing/accessory/badge/holo/warden,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "coW" = (
@@ -33875,6 +33883,7 @@
 /obj/effect/spawner/random/contraband/armory,
 /obj/effect/spawner/random/maintenance/three,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/item/gun/ballistic/rifle/boltaction,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "czZ" = (
@@ -34003,13 +34012,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/fore)
-"cBm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port/aft)
 "cBn" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/security/telescreen/prison{
@@ -36194,7 +36196,6 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/hand_labeler,
-/obj/item/taperecorder,
 /turf/open/floor/carpet/green,
 /area/security/detectives_office)
 "cNz" = (
@@ -36204,8 +36205,8 @@
 "cNA" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
-/obj/item/folder/red,
-/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/accessory/badge,
+/obj/item/clothing/accessory/badge/holo/detective,
 /turf/open/floor/carpet/green,
 /area/security/detectives_office)
 "cNC" = (
@@ -48287,13 +48288,21 @@
 /turf/open/floor/iron/dark,
 /area/commons/storage/primary)
 "izm" = (
+/obj/structure/closet/secure_closet/detective,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/taperecorder,
+/obj/item/folder/yellow{
+	name = "Detective's Findings"
+	},
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/camera/detective,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/decal/cleanable/cobweb,
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "izy" = (
@@ -55897,11 +55906,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "lQa" = (
-/obj/structure/closet/secure_closet/detective,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /obj/structure/cable,
-/obj/item/book/manual/wiki/detective,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/filingcabinet/security,
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "lQg" = (
@@ -79434,6 +79441,24 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
+"wsE" = (
+/obj/structure/closet/secure_closet/detective,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/taperecorder,
+/obj/item/folder/yellow{
+	name = "Detective's Findings"
+	},
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/camera/detective,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/security/detectives_office)
 "wtb" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -81147,6 +81172,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/item/gun/energy/laser,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "xjT" = (
@@ -81807,6 +81833,14 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light/directional/west,
+/obj/item/stamp/denied{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/stamp{
+	pixel_x = 8;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "xwf" = (
@@ -108106,8 +108140,8 @@ ajd
 aer
 ajd
 czW
-cBm
-ajd
+aaY
+aaY
 bws
 bBk
 bBk
@@ -108363,8 +108397,8 @@ bGg
 ajd
 bWR
 bMR
-ajd
-ajd
+aaY
+wsE
 izm
 abU
 aci
@@ -108620,7 +108654,7 @@ bRb
 ajd
 aer
 bNF
-ajd
+aaY
 lQa
 cie
 chv

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -52645,13 +52645,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	id_tag = "justicedoor";
-	name = "Justice Chamber";
-	req_access_txt = "3"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable,
 /obj/machinery/button/door/directional/west{
 	id = "justicedoor";
@@ -52659,6 +52652,12 @@
 	normaldoorcontrol = 1;
 	req_access_txt = "3";
 	specialfunctions = 4
+	},
+/obj/machinery/door/airlock/security{
+	aiControlDisabled = 1;
+	id_tag = "prisonereducation";
+	name = "Prisoner Education Chamber";
+	req_access_txt = "3"
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -8630,6 +8630,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/smartgun,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aEZ" = (
@@ -69778,11 +69779,12 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/item/gun/grenadelauncher,
+/obj/structure/rack,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "scV" = (

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -691,12 +691,12 @@
 /area/security/brig)
 "agb" = (
 /obj/structure/rack,
-/obj/item/shield/riot{
+/obj/item/gun/energy/disabler{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
 	pixel_x = 3;
 	pixel_y = -3
 	},
@@ -714,14 +714,20 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "agd" = (
+/obj/item/grenade/barrier{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 6;
+	pixel_y = -2
+	},
 /obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_y = 6
-	},
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_y = 3
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "agf" = (
@@ -1289,18 +1295,33 @@
 /area/security/brig)
 "akC" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/item/storage/box/lethalshot,
-/obj/item/storage/box/lethalshot,
-/obj/item/storage/box/lethalshot,
+/obj/item/clothing/head/helmet/sec,
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/item/clothing/suit/armor/vest/security{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/vest/security,
+/obj/item/clothing/suit/armor/vest/security{
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -3113,6 +3134,8 @@
 	pixel_y = 5
 	},
 /obj/item/restraints/handcuffs,
+/obj/item/clothing/accessory/badge,
+/obj/item/clothing/accessory/badge/holo/detective,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "azW" = (
@@ -3278,7 +3301,6 @@
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/hand_labeler,
-/obj/item/camera/detective,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "aBo" = (
@@ -3806,6 +3828,7 @@
 /area/security/brig)
 "aGu" = (
 /obj/structure/filingcabinet,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "aGA" = (
@@ -7137,36 +7160,41 @@
 "bps" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/riot{
 	pixel_x = -3;
-	pixel_y = 2
+	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/bulletproof{
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot{
 	pixel_x = 3;
-	pixel_y = -2
+	pixel_y = -3
 	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
+/obj/item/clothing/head/helmet/riot{
 	pixel_x = -3;
-	pixel_y = -2
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/shield/riot,
+/obj/item/shield/riot{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /obj/machinery/requests_console/directional/north{
 	department = "Security";
 	departmentType = 3;
 	name = "Security Requests Console"
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "bpt" = (
@@ -34859,6 +34887,10 @@
 /obj/structure/closet/ammunitionlocker/useful,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/delivery/red,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/security/armory)
 "kuc" = (
@@ -35826,6 +35858,15 @@
 /area/engineering/supermatter/room)
 "kKH" = (
 /obj/structure/closet/secure_closet/detective,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/taperecorder,
+/obj/item/folder/yellow{
+	name = "Detective's Findings"
+	},
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/camera/detective,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "kKJ" = (
@@ -39591,11 +39632,11 @@
 /area/command/heads_quarters/captain/private)
 "mcV" = (
 /obj/structure/table/wood,
-/obj/item/stamp/hos,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/item/storage/box/holobadge/hos,
+/obj/item/stamp/hos,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
 "mds" = (
@@ -50168,9 +50209,17 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "pOs" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/landmark/blobstart,
 /obj/structure/closet/secure_closet/detective,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/taperecorder,
+/obj/item/folder/yellow{
+	name = "Detective's Findings"
+	},
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/camera/detective,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "pOz" = (
@@ -58980,9 +59029,6 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/seclite,
 /obj/item/storage/box/evidence,
-/obj/item/taperecorder{
-	pixel_x = 3
-	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "sWW" = (
@@ -59176,29 +59222,29 @@
 /area/medical/medbay/central)
 "taJ" = (
 /obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/machinery/light/directional/west,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_y = 2
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_y = -2
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = -3;
-	pixel_y = -2
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -2870,12 +2870,16 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "asb" = (
-/obj/structure/table/wood,
-/obj/item/hand_labeler{
-	pixel_x = 5
+/obj/structure/closet/secure_closet/detective,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/tape,
+/obj/item/taperecorder,
+/obj/item/folder/yellow{
+	name = "Detective's Findings"
 	},
-/obj/item/storage/box/evidence,
-/obj/item/radio/intercom/directional/south,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/camera/detective,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "asd" = (
@@ -5281,6 +5285,10 @@
 	},
 /obj/item/taperecorder,
 /obj/machinery/light_switch/directional/west,
+/obj/item/hand_labeler{
+	pixel_x = 5
+	},
+/obj/item/storage/box/evidence,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "aFc" = (
@@ -14284,9 +14292,7 @@
 /area/security/brig)
 "dwd" = (
 /obj/machinery/vending/wardrobe/det_wardrobe,
-/obj/structure/sign/poster/official/dick_gum{
-	pixel_y = -32
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "dwk" = (
@@ -16266,6 +16272,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/item/stamp/denied{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/stamp{
+	pixel_x = 8;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "efK" = (
@@ -17084,6 +17098,9 @@
 	pixel_x = 4
 	},
 /obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
+	pixel_x = 8
+	},
 /obj/item/grenade/barrier{
 	pixel_x = -4
 	},
@@ -18797,15 +18814,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/machinery/dish_drive/bullet{
+	succrange = 2
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -28484,7 +28494,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -31012,18 +31021,20 @@
 /area/maintenance/starboard/central)
 "jmW" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/dish_drive/bullet{
-	succrange = 2
-	},
+/obj/structure/closet/ammunitionlocker/useful,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "jmY" = (
@@ -31551,11 +31562,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/secondary)
-"jwy" = (
-/obj/structure/closet/secure_closet/detective,
-/obj/item/camera/detective,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
 "jwA" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -36008,6 +36014,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/item/gun/energy/laser,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "lbB" = (
@@ -37628,6 +37635,9 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
+	},
+/obj/structure/sign/poster/official/dick_gum{
+	pixel_y = -32
 	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
@@ -54407,6 +54417,25 @@
 	dir = 1
 	},
 /obj/machinery/status_display/ai/directional/north,
+/obj/structure/rack,
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec,
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/vest/security{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/vest/security,
+/obj/item/clothing/suit/armor/vest/security{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "rSJ" = (
@@ -63040,6 +63069,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
+/obj/item/clothing/accessory/badge/holo/warden,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "uQv" = (
@@ -64333,6 +64363,7 @@
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/effect/spawner/random/contraband/armory,
 /obj/effect/spawner/random/maintenance/three,
+/obj/item/gun/ballistic/rifle/boltaction,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "vrn" = (
@@ -68434,6 +68465,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/item/clothing/accessory/badge,
+/obj/item/clothing/accessory/badge/holo/detective,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "wRg" = (
@@ -161409,7 +161442,7 @@ wLS
 tuy
 ayS
 erz
-jwy
+asb
 anG
 nYR
 anG

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -17161,7 +17161,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/table,
 /obj/item/storage/box/teargas{
 	pixel_x = -3;
 	pixel_y = 3
@@ -17171,6 +17170,8 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/item/gun/grenadelauncher,
+/obj/structure/rack,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "esI" = (
@@ -17257,6 +17258,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/flasher/portable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "etK" = (

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -101,7 +101,7 @@
 
 /obj/structure/closet/secure_closet/security/PopulateContents()
 	..()
-	//new /obj/item/clothing/suit/armor/vest(src) SKYRAT EDIT REMOVAL
+	new /obj/item/clothing/suit/armor/vest/security(src) //SKYRAT EDIT CHANGE
 	new /obj/item/clothing/head/security_cap(src) //SKYRAT EDIT CHANGE
 	new /obj/item/clothing/head/beret/sec(src) //SKYRAT EDIT ADDITION
 	new /obj/item/clothing/head/helmet/sec(src) //SKYRAT EDIT ADDITION


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
### Standardizes Armories
Makes every armory spawn with more or less the same loadout. This includes:
4 Riot Shotguns via Spawner
4 MCR's and its ammo via Spawner
Ammo Locker with 4 Rubber and 4 Buckshot Boxes
SMART Spawner
3 Breaching Hammers and 2 DRAGnets
3 Sets of Standard, Riot and Bulletproof Armor
A contraband locker with a mosin, 3x maint loot spawner and one armory loot spawner 
3 CUCKS Boxes
4 Barrier Grenades
A Grenade Launcher, a box of flashbangs and a box of teargas grenades
Mindshield Lockbox, Chemical and Tracker Implants Boxes & 2 Boxes of Standard Firing Pins [MetaStation has a special room for this]
4 Flashers on all maps except Kilo which has 3 [MetaStation has a special room for this]
Ablative Trenchcoat, Ion and Temperature Gun
___
### Wardens Room & Detectives Office
Wardens locker now spawns with an Allstar SC-1 Lasergun. It is meant to be used on lethal threats against the brig and armory. 
Detective Offices now all have 2 detective lockers and all lockers spawn with a pair of shades, a detectives camera, a tape recorder and a nice folder. All detective offices spawn with one detective badge and one detective holobadge.
___
### Renames the Kilo Execution Room
Makes the room in line with other stations by renaming it to Prisoner Reeducation Centre. Also no longer starts bolted.
___
### Security Lockers Spawn Vests
Security Lockers now also spawn a skyrat variant of the armor vest. Thus officers have a way to replenish their armor in case of total equipment loss as well as give antags another way to acquire a security vest and also provide security a way to gear up crew in case of a Red Alert.
___
### Minor Brig Fixes
Wardens now spawn with Granted and Denied rubber stamps for maximum paperwork proficiency.
Fixed the Icebox HoS office to spawn a HoS rubber stamp.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
### Standardizes Armories, Wardens Room & Detectives Office
This makes the operation of armory & brig more streamlined for the wardens while letting security to be equipped in a standard loadout instead of having 8 shotguns in one map while having no lethals in the other. Also allows the 3 afformentioned maps to support having 2 Detectives as that is our rolecap.
___
### Renames the Kilo Execution Room
With Crewsimov comes great deception. We cant have a room named "Justice Room" and deceive the AI.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
___
### Security Lockers Spawn Vests
Lets the security properly gear up conscripts and deputies, provide ways to acquire vests for normal and minor antags and lets officers a way to get a standard issue armor both due to in round and loadout problems.
___
### Minor Brig Fixes
Overall QoL fixes.

## Media
### Armories
![metaarmory](https://user-images.githubusercontent.com/25566633/151167471-b88af859-057d-4ff1-bd99-0be514ebef62.png)
Metastation
![deltaarmory](https://user-images.githubusercontent.com/25566633/151167473-321af962-3942-4295-ac88-1d39ebc2f3f9.png)
Deltastation
![tramarmory](https://user-images.githubusercontent.com/25566633/151167475-88e8ee8f-5948-4042-9165-bd53e2a6e02e.png)
TramStation
![kiloarmory](https://user-images.githubusercontent.com/25566633/151167477-713da52c-7077-423e-8751-3b8df4c63a69.png)
KiloStation
![iceboxarmory](https://user-images.githubusercontent.com/25566633/151167479-e762187b-0f3b-48c9-8efa-a16286eb4ecf.png)
IceboxStation
___
### Detective Offices

![iceboxDet](https://user-images.githubusercontent.com/25566633/151167528-c7182f4e-b341-4e6f-bc65-bd119225ba63.png)
IceboxStation
![KiloDet](https://user-images.githubusercontent.com/25566633/151167532-c0ae235f-781e-40f6-ae0a-78dd3660e2e1.png)
KiloStation
![TramDet](https://user-images.githubusercontent.com/25566633/151167533-3ad4ab1d-b75d-4faf-a9dd-66af7ee44add.png)
TramStation

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Security Lockers now spawn Vests once more.
qol: Detectives now have shades, a camera, a recorder and a custom folder in their wardrobes.
qol: Wardens Office's now spawn with GRANTED and DENIED rubber stamps. Go make paperwork.
fix: All armories now start with more or less the same equipment.
fix: All Warden Lockers spawn with the same loadout.
fix: Made the KiloStation Execution Chamber non-offensive to Asimov Lawsets and alike.
fix: Icebox HoS Office now spawns with  rubber stamp.
fix: IceBox & KiloStation & TramStation Detective Office now has 2 Detective Lockers.
fix: Spare Vests & Helmets in armory now use proper security sprites.
fix: All maps now spawn with Detective & Warden Holobadges in their rooms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
