### PR TITLE
[MODULAR] Makes the screwdriver and wirecutters sprites use the correct versions

### DIFF
--- a/modular_skyrat/modules/aesthetics/tools/code/tools.dm
+++ b/modular_skyrat/modules/aesthetics/tools/code/tools.dm
@@ -4,17 +4,11 @@
 /obj/item/crowbar
 	icon = 'modular_skyrat/modules/aesthetics/tools/tools.dmi'
 
-/obj/item/screwdriver
-	icon = 'modular_skyrat/modules/aesthetics/tools/tools.dmi'
-
 /obj/item/wrench
 	icon = 'modular_skyrat/modules/aesthetics/tools/tools.dmi'
 
 /obj/item/wrench/combat
 	icon = 'icons/obj/tools.dmi'
-
-/obj/item/wirecutters
-	icon = 'modular_skyrat/modules/aesthetics/tools/tools.dmi'
 
 /obj/item/construction/plumbing
 	icon = 'modular_skyrat/modules/aesthetics/tools/tools.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the vendor/map icons for screwdriver and wirecutters their actual sprites.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
![image](https://user-images.githubusercontent.com/25566633/151243997-b8d41129-8abe-44dc-92c4-00f8851e9732.png)

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Makes the screwdriver and wirecutters sprites use the correct versions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
