### PR TITLE
[MODULAR] Adds the pirate eyepatch to crafting menu

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -407,7 +407,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	null, \
 	new/datum/stack_recipe("blindfold", /obj/item/clothing/glasses/blindfold, 2), \
 	new/datum/stack_recipe("eyepatch wrap", /obj/item/clothing/glasses/eyepatch/wrap, 2), /*SKYRAT EDIT ADDITION*/ \
-	new/datum/stack_recipe("eyepatch", /obj/item/clothing/glasses/eyepatch, 2), \
+	new/datum/stack_recipe("eyepatch", /obj/item/clothing/glasses/eyepatch, 2), \ /*SKYRAT EDIT ADDITION*/
 	null, \
 	new/datum/stack_recipe("19x19 canvas", /obj/item/canvas/nineteen_nineteen, 3), \
 	new/datum/stack_recipe("23x19 canvas", /obj/item/canvas/twentythree_nineteen, 4), \

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -379,7 +379,6 @@ GLOBAL_LIST_INIT(bamboo_recipes, list ( \
 GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("white jumpskirt", /obj/item/clothing/under/color/jumpskirt/white, 3), /*Ladies first*/ \
 	new/datum/stack_recipe("white jumpsuit", /obj/item/clothing/under/color/white, 3), \
-	new/datum/stack_recipe("Eyepatch", /obj/item/clothing/glasses/eyepatch, 1), \
 	new/datum/stack_recipe("white shoes", /obj/item/clothing/shoes/sneakers/white, 2), \
 	new/datum/stack_recipe("white scarf", /obj/item/clothing/neck/scarf, 1), \
 	new/datum/stack_recipe("loincloth", /obj/item/clothing/under/costume/loincloth/cloth, 2), /*SKYRAT EDIT ADDITION*/ \
@@ -408,6 +407,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	null, \
 	new/datum/stack_recipe("blindfold", /obj/item/clothing/glasses/blindfold, 2), \
 	new/datum/stack_recipe("eyepatch wrap", /obj/item/clothing/glasses/eyepatch/wrap, 2), /*SKYRAT EDIT ADDITION*/ \
+	new/datum/stack_recipe("eyepatch", /obj/item/clothing/glasses/eyepatch, 2), \
 	null, \
 	new/datum/stack_recipe("19x19 canvas", /obj/item/canvas/nineteen_nineteen, 3), \
 	new/datum/stack_recipe("23x19 canvas", /obj/item/canvas/twentythree_nineteen, 4), \

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -379,6 +379,7 @@ GLOBAL_LIST_INIT(bamboo_recipes, list ( \
 GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("white jumpskirt", /obj/item/clothing/under/color/jumpskirt/white, 3), /*Ladies first*/ \
 	new/datum/stack_recipe("white jumpsuit", /obj/item/clothing/under/color/white, 3), \
+	new/datum/stack_recipe("Eyepatch", /obj/item/clothing/glasses/eyepatch, 1), \
 	new/datum/stack_recipe("white shoes", /obj/item/clothing/shoes/sneakers/white, 2), \
 	new/datum/stack_recipe("white scarf", /obj/item/clothing/neck/scarf, 1), \
 	new/datum/stack_recipe("loincloth", /obj/item/clothing/under/costume/loincloth/cloth, 2), /*SKYRAT EDIT ADDITION*/ \

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -407,7 +407,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	null, \
 	new/datum/stack_recipe("blindfold", /obj/item/clothing/glasses/blindfold, 2), \
 	new/datum/stack_recipe("eyepatch wrap", /obj/item/clothing/glasses/eyepatch/wrap, 2), /*SKYRAT EDIT ADDITION*/ \
-	new/datum/stack_recipe("eyepatch", /obj/item/clothing/glasses/eyepatch, 2), \ /*SKYRAT EDIT ADDITION*/
+	new/datum/stack_recipe("eyepatch", /obj/item/clothing/glasses/eyepatch, 2), /*SKYRAT EDIT ADDITION*/ \
 	null, \
 	new/datum/stack_recipe("19x19 canvas", /obj/item/canvas/nineteen_nineteen, 3), \
 	new/datum/stack_recipe("23x19 canvas", /obj/item/canvas/twentythree_nineteen, 4), \

--- a/modular_skyrat/modules/crafting/crafting_skyrat.dm
+++ b/modular_skyrat/modules/crafting/crafting_skyrat.dm
@@ -30,10 +30,3 @@
 /datum/crafting_recipe/beam_rifle/New()
 	..()
 	blacklist += subtypesof(/obj/item/gun/energy/laser)
-
-/datum/crafting_recipe/pirate_eyepatch
-	name = "Pirate Eyepatch"
-	result = /obj/item/clothing/glasses/eyepatch
-	time = 5
-	reqs = list(/obj/item/stack/sheet/cloth = 1)
-	category = CAT_CLOTHING

--- a/modular_skyrat/modules/crafting/crafting_skyrat.dm
+++ b/modular_skyrat/modules/crafting/crafting_skyrat.dm
@@ -30,3 +30,10 @@
 /datum/crafting_recipe/beam_rifle/New()
 	..()
 	blacklist += subtypesof(/obj/item/gun/energy/laser)
+
+/datum/crafting_recipe/pirate_eyepatch
+	name = "Pirate Eyepatch"
+	result = /obj/item/clothing/glasses/eyepatch
+	time = 5
+	reqs = list(/obj/item/stack/sheet/cloth = 1)
+	category = CAT_CLOTHING


### PR DESCRIPTION
## About The Pull Request
adds the pirate eyepatch as a craftable item for one cloth in the clothing category of the crafting menu

## How This Contributes To The Skyrat Roleplay Experience
The black pirate eyepatch currently can only be acquired in-game by either spawning with one in your loadout or finding it on the corpse of a space-pirate; effectively barring ghost roles from being able to get it.
This pull request fixes this issue, as well as adds a way to finally craft eyepatch huds

## Changelog

:cl: MegaDrone

qol: Adds a way for ghost roles to get the pirate eyepatch without needing to kill space-pirates, and allows for easier crafting of eyepatch huds

/:cl: