### PR TITLE
[MODULAR] Food Flavor Fix III: Fixes these NUTS

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
@@ -28,8 +28,8 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	payday_modifier = 0.75
-	liked_food = SEAFOOD | MEAT | FRUIT
-	disliked_food = NUTS | CLOTH | DAIRY
+	liked_food = SEAFOOD | RAW
+	disliked_food = CLOTH | DAIRY
 	toxic_food = TOXIC
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/akula_parts_greyscale.dmi'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
@@ -32,7 +32,7 @@
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	payday_modifier = 0.75
 	liked_food = SEAFOOD | MEAT | FRUIT
-	disliked_food = NUTS | CLOTH | DAIRY
+	disliked_food = CLOTH | GROSS
 	toxic_food = TOXIC
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/akula_parts_greyscale.dmi'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
@@ -20,7 +20,6 @@
 	)
 	use_skintones = 1
 	skinned_type = /obj/item/stack/sheet/animalhide/human
-	disliked_food = GROSS | RAW
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	payday_modifier = 0.75
 	liked_food = ALCOHOL | MEAT | DAIRY //Dwarves like alcohol, meat, and dairy products.

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
@@ -34,8 +34,8 @@
 	attack_effect = ATTACK_EFFECT_CLAW
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
-	liked_food = GRAIN | RAW | MEAT
-	disliked_food = NUTS | CLOTH
+	liked_food = GRAIN | MEAT
+	disliked_food = CLOTH | GROSS
 	toxic_food = TOXIC
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
@@ -95,3 +95,4 @@
 	if(BMS)
 		markings = assemble_body_markings_from_set(BMS, passed_features, src)
 	return markings
+

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
@@ -27,7 +27,7 @@
 	mutant_bodyparts = list()
 	toxic_food = DAIRY | MEAT
 	disliked_food = RAW | CLOTH
-	liked_food = TOXIC | FRUIT | VEGETABLE
+	liked_food = TOXIC | FRUIT | VEGETABLES
 	payday_modifier = 0.75
 	default_mutant_bodyparts = list("skrell_hair" = ACC_RANDOM)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
@@ -25,7 +25,9 @@
 	bodytemp_cold_damage_limit = (T20C - 10)
 	species_language_holder = /datum/language_holder/skrell
 	mutant_bodyparts = list()
-	liked_food = TOXIC | DAIRY | FRUIT
+	toxic_food = DAIRY | MEAT
+	disliked_food = RAW | CLOTH
+	liked_food = TOXIC | FRUIT | VEGETABLE
 	payday_modifier = 0.75
 	default_mutant_bodyparts = list("skrell_hair" = ACC_RANDOM)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -28,9 +28,8 @@
 	attack_effect = ATTACK_EFFECT_CLAW
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
-	liked_food = GRAIN | RAW | MEAT
-	disliked_food = NUTS | CLOTH
-	toxic_food = TOXIC
+	disliked_food = RAW | CLOTH
+	liked_food = GRAIN | MEAT
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon = 'modular_skyrat/master_files/icons/mob/species/mammal_parts_greyscale.dmi'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -28,7 +28,7 @@
 	attack_effect = ATTACK_EFFECT_CLAW
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
-	disliked_food = RAW | CLOTH
+	disliked_food = CLOTH
 	liked_food = GRAIN | MEAT
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
@@ -30,8 +30,8 @@
 	attack_effect = ATTACK_EFFECT_CLAW
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
-	liked_food = NUTS | FRUIT | MEAT
 	disliked_food = GRAIN | DAIRY | CLOTH
+	liked_food = GROSS | MEAT | SEAFOOD | NUTS
 	toxic_food = TOXIC
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
@@ -27,8 +27,8 @@
 	attack_effect = ATTACK_EFFECT_CLAW
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
-	liked_food = GRAIN | RAW | MEAT
-	disliked_food = NUTS | CLOTH
+	liked_food = RAW | MEAT
+	disliked_food = CLOTH
 	toxic_food = TOXIC
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The latest Food Pref "fix" revenge of vegans fucked up the food prefs (by forgetting a vegetarian food quirk exists) to the point of making almost everyone hate Lizard Cuisine and NUTS somehow. This PR gives all the affected races simpler food prefs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Having 80% of the crew hate nuts is bad for Cooks, Lizards and Teshari. This makes everyone have far more sane food prefs.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes the food prefs to enjoy eating (these) nuts and streamlines food prefs. Please make sure to check your species tab to check your liked and disliked foods.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
