### PR TITLE
Tarkon 1.4 Hotfix

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
@@ -388,9 +388,7 @@
 /obj/machinery/door/firedoor/closed{
 	opacity = 1
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Port Primary Hallway"
-	},
+/obj/machinery/door/airlock/public,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/porthall)
 "cY" = (
@@ -429,16 +427,10 @@
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "dg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/closed{
-	opacity = 1
-	},
-/obj/effect/spawner/structure/window/reinforced/no_firelock,
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/porthall)
 "dh" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Fore Primary Hallway"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -447,6 +439,7 @@
 	opacity = 1
 	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/public,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "di" = (
@@ -1204,9 +1197,6 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/port_tarkon/porthall)
 "hA" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Port Primary Hallway"
-	},
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1214,6 +1204,7 @@
 	opacity = 1
 	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/public,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/porthall)
 "hB" = (
@@ -3714,10 +3705,7 @@
 /area/ruin/space/has_grav/port_tarkon/mining)
 "xa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/reinforced/no_firelock,
-/obj/machinery/door/firedoor/closed{
-	opacity = 1
-	},
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "xc" = (
@@ -4178,10 +4166,7 @@
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "AL" = (
-/obj/effect/spawner/structure/window/reinforced/no_firelock,
-/obj/machinery/door/firedoor/closed{
-	opacity = 1
-	},
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "AM" = (
@@ -4275,15 +4260,13 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "BI" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Fore Primary Hallway"
-	},
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/door/firedoor/closed{
 	opacity = 1
 	},
+/obj/machinery/door/airlock/public,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "BJ" = (
@@ -4421,7 +4404,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "Cs" = (
-/obj/machinery/door/airlock/mining/glass,
+/obj/machinery/door/airlock/mining/glass{
+	id_tag = "ptmining"
+	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand,
 /obj/structure/alien/weeds,
@@ -4522,10 +4507,10 @@
 /obj/machinery/door/firedoor/closed{
 	opacity = 1
 	},
-/obj/machinery/door/airlock/mining/glass,
 /obj/structure/alien/weeds,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/mining,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "CP" = (
@@ -4800,10 +4785,8 @@
 /obj/machinery/door/firedoor/closed{
 	opacity = 1
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Port Primary Hallway"
-	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/public,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/porthall)
 "Eu" = (
@@ -5404,10 +5387,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/comms)
 "Ig" = (
-/obj/effect/spawner/structure/window/reinforced/no_firelock,
-/obj/machinery/door/firedoor/closed{
-	opacity = 1
-	},
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/porthall)
 "Ih" = (
@@ -5678,10 +5658,15 @@
 /area/ruin/space/has_grav/port_tarkon/dorms)
 "Jw" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/ore_box,
 /obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/south{
+	id = "ptmining";
+	name = "mining airlock bolt";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
@@ -5885,8 +5870,8 @@
 /obj/machinery/door/firedoor/closed{
 	opacity = 1
 	},
-/obj/machinery/door/airlock/mining/glass,
 /obj/structure/alien/weeds,
+/obj/machinery/door/airlock/mining,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "KD" = (
@@ -6288,9 +6273,7 @@
 /obj/machinery/door/firedoor/closed{
 	opacity = 1
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Fore Primary Hallway"
-	},
+/obj/machinery/door/airlock/public,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "Nk" = (
@@ -6739,13 +6722,11 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "Qs" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Port Primary Hallway"
-	},
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/door/firedoor/closed{
 	opacity = 1
 	},
+/obj/machinery/door/airlock/public,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/porthall)
 "Qx" = (
@@ -7857,9 +7838,7 @@
 /obj/machinery/door/firedoor/closed{
 	opacity = 1
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Fore Primary Hallway"
-	},
+/obj/machinery/door/airlock/public,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "XN" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
@@ -4405,7 +4405,8 @@
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "Cs" = (
 /obj/machinery/door/airlock/mining/glass{
-	id_tag = "ptmining"
+	id_tag = "ptmining";
+	locked = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Because for some reason firelock-less windows aren't spawning on live and firedoor/closed aren't spawning closed i'm putting this here

## How This Contributes To The Skyrat Roleplay Experience

Makes tarkon not spaced on roundstart until other issues are resolved
Also puts opaque structures and bolts on places depending why closed firedoors were there, Since firedoors under teh /closed subtype are being stupid

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Tarkon now doesn't auto-space on round start, Despite having 0 idea why it does when test server runs perfectly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
