### PR TITLE
Fixes microfusion cell emp_act

### DIFF
--- a/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
@@ -56,7 +56,7 @@ These are basically advanced cells.
 
 /obj/item/stock_parts/cell/microfusion/emp_act(severity)
 	var/prob_percent = charge / 100 * severity
-	if(prob(prob_percent) && !meltdown && !stabilised && parent_gun)
+	if(prob(prob_percent) && !meltdown && !stabilised)
 		process_instability()
 
 /obj/item/stock_parts/cell/microfusion/use(amount)


### PR DESCRIPTION
## About The Pull Request

microfusion cells no longer need to be in a gun when EMP'd for it to have an effect.
Calling parent if not in a gun is an alternative, but I figured that was a bit more boring.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/10930

This _could_ be intentional, but I figured it was more of an oversight. Lemme know if not.

## Changelog
:cl:
fix: Microfusion cells are no longer immune to EMPs when not in a gun.
/:cl: