### PR TITLE
lowers blob weight, increases time between events

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -8,8 +8,8 @@ SUBSYSTEM_DEF(events)
 	var/list/currentrun = list()
 
 	var/scheduled = 0 //The next world.time that a naturally occuring random event can be selected.
-	var/frequency_lower = 1800 //3 minutes lower bound.
-	var/frequency_upper = 6000 //10 minutes upper bound. Basically an event will happen every 3 to 10 minutes.
+	var/frequency_lower = 4 MINUTES //SKYRAT EDIT: Original: 1800 3 minutes lower bound.
+	var/frequency_upper = 13 MINUTES //SKYRAT EDIT: Original: 6000 10 minutes upper bound. Basically an event will happen every 3 to 10 minutes.
 
 	var/list/holidays //List of all holidays occuring today or null if no holidays
 	var/wizardmode = FALSE

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -79,10 +79,10 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/midround_injection_cooldown = 0
 
 	/// The minimum time the recurring midround ruleset timer is allowed to be.
-	var/midround_delay_min = (15 MINUTES)
+	var/midround_delay_min = (20 MINUTES) //SKYRAT EDIT: Original: (15 MINUTES)
 
 	/// The maximum time the recurring midround ruleset timer is allowed to be.
-	var/midround_delay_max = (35 MINUTES)
+	var/midround_delay_max = (45 MINUTES) //SKYRAT EDIT: Original: (35 MINUTES)
 
 	/// If above this threat, increase the chance of injection
 	var/higher_injection_chance_minimum_threat = 70

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -510,8 +510,8 @@
 	)
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
-	weight = 2
-	cost = 10
+	weight = 1 //SKYRAT EDIT: Original: 1
+	cost = 20 //SKYRAT EDIT: Original: 10
 	requirements = list(101,101,101,80,60,50,30,20,10,10)
 	repeatable = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
blob is being pulled out of the magicians hat far too frequently, almost once a round. We still want blob for that added chaos, but lord-- not every round; every round means it loses its touch.

This PR lowers the blob's weight and increases its cost, so that it gets pulled less.
This PR increases the time between each event, so that people have some cooldown... ( I know you admins are injecting events, I can see the roundend report!)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Less blob means that it's special when it does roll, rather than every single round (it's becoming a chore at this point when it rolls every round). 

Less frequent events means more downtime for people to RP and be left to their own devices...
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Blob will appear less frequently
balance: There is now more wait time between each event
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
