### PR TITLE
[NON-MODULAR] Adjusts Plasma Fixation Balance

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -492,8 +492,8 @@
 			. += power * 0.5
 	if(M.reagents.has_reagent(/datum/reagent/toxin/plasma, needs_metabolizing = TRUE))
 		. += power * 0.75
-	if(M.reagents.has_reagent(/datum/reagent/stable_plasma))
-		. += power * 0.5
+	if(M.reagents.has_reagent(/datum/reagent/stable_plasma)) //SKYRAT ADDITION
+		. += power * 0.5 //SKYRAT ADDITION
 
 /datum/symptom/heal/plasma/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
 	var/heal_amt = 4 * actual_power

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -492,6 +492,8 @@
 			. += power * 0.5
 	if(M.reagents.has_reagent(/datum/reagent/toxin/plasma, needs_metabolizing = TRUE))
 		. += power * 0.75
+	if(M.reagents.has_reagent(/datum/reagent/stable_plasma))
+		. += power * 0.5
 
 /datum/symptom/heal/plasma/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
 	var/heal_amt = 4 * actual_power


### PR DESCRIPTION
## About The Pull Request

Allows for use of stable plasma as a weaker healing alternative to pure plasma for the Plasma Fixation Virus Symptom

## How This Contributes To The Skyrat Roleplay Experience

Ethereals and other species whose body temperatures are above normal, make pure plasma boil upon ingestion or injection- this causes the effected individual to "fart" plasma gas and toxify aswell as create a fire hazard in the room they are in. 
Adding Stable plasma as an alternative allows for the same (albeit weaker) healing effect without giving atmospherics a headache

## Changelog

:cl: MegaDrone

balance: allows for stable plasma to also heal when in the blood stream if you have the plasma fixation virus symptom; Stable plasma heals slower than pure plasma

/:cl:

