### PR TITLE
[NON-MODULAR] Adds pronouns to Ethereals, as well as underwear

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -15,7 +15,7 @@
 	payday_modifier = 0.75
 	attack_type = BURN //burn bish
 	damage_overlay_type = "" //We are too cool for regular damage overlays
-	species_traits = list(DYNCOLORS, AGENDER, NO_UNDERWEAR, HAIR, FACEHAIR, HAS_FLESH, HAS_BONE) // i mean i guess they have blood so they can have wounds too
+	species_traits = list(DYNCOLORS, HAIR, FACEHAIR, HAS_FLESH, HAS_BONE) // i mean i guess they have blood so they can have wounds too //SKYRAT EDIT: Removed [AGENDER, NO_UNDERWEAR] traits
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/ethereal
 	sexes = TRUE //SKYRAT EDIT - ORIGINAL: FALSE

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -18,7 +18,7 @@
 	species_traits = list(DYNCOLORS, AGENDER, NO_UNDERWEAR, HAIR, FACEHAIR, HAS_FLESH, HAS_BONE) // i mean i guess they have blood so they can have wounds too
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/ethereal
-	sexes = FALSE //no fetish content allowed
+	sexes = TRUE //SKYRAT EDIT - ORIGINAL: FALSE
 	toxic_food = NONE
 	// Body temperature for ethereals is much higher then humans as they like hotter environments
 	bodytemp_normal = (BODYTEMP_NORMAL + 50)


### PR DESCRIPTION
## About The Pull Request

Gives Ethereals the option to chose their pronouns instead of being forced into non-binary, also allows Ethereals to wear underwear.

## How This Contributes To The Skyrat Roleplay Experience

Ethereals should be able to chose their pronouns and underwear for the personal preference of their players

## Changelog

:cl:
qol: Gives Ethereals the option to chose a their pronouns instead of being forced into non-binary, also allows them to wear underwear if they wish to do so
/:cl:
