### PR TITLE
Icebox brig Fixes plus improvement

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -600,6 +600,9 @@
 	dir = 1
 	},
 /obj/machinery/modular_computer/console/preset/cargochat/security,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "aiY" = (
@@ -10215,6 +10218,7 @@
 "bTY" = (
 /obj/structure/railing,
 /obj/item/trash/popcorn,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "bUn" = (
@@ -11197,6 +11201,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -15937,6 +15944,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "ejr" = (
@@ -18049,6 +18059,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "fqu" = (
@@ -19612,6 +19623,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "gdc" = (
@@ -21241,6 +21253,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -22875,6 +22890,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "hOt" = (
@@ -23269,6 +23285,9 @@
 	dir = 8
 	},
 /obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -24306,6 +24325,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "iEa" = (
@@ -26281,6 +26301,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "jGf" = (
@@ -27619,6 +27640,10 @@
 "kqh" = (
 /obj/structure/railing{
 	dir = 10
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -29663,6 +29688,9 @@
 	dir = 1
 	},
 /obj/machinery/computer/department_orders/security,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "lyW" = (
@@ -31854,6 +31882,9 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "mIM" = (
@@ -31908,6 +31939,9 @@
 /obj/item/food/popcorn{
 	pixel_x = -3;
 	pixel_y = -3
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -33959,6 +33993,7 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "nOl" = (
@@ -35405,6 +35440,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "oBY" = (
@@ -36291,6 +36329,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "pcw" = (
@@ -36535,6 +36576,7 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "pij" = (
@@ -36850,6 +36892,9 @@
 /area/maintenance/starboard/fore)
 "prk" = (
 /obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -41695,6 +41740,9 @@
 	dir = 1
 	},
 /obj/structure/table,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "rRr" = (
@@ -44942,6 +44990,7 @@
 /obj/structure/chair/plastic{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "tAY" = (
@@ -46899,6 +46948,9 @@
 	dir = 4
 	},
 /obj/item/chair/plastic,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "uzG" = (
@@ -48478,6 +48530,9 @@
 	dir = 1
 	},
 /obj/machinery/holopad/secure,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "vtr" = (
@@ -48518,6 +48573,9 @@
 "vuv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -50975,6 +51033,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "wHz" = (
@@ -51067,6 +51128,10 @@
 /obj/structure/railing{
 	dir = 6
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "wJz" = (
@@ -51283,6 +51348,9 @@
 	dir = 4
 	},
 /obj/structure/chair/plastic{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -54027,6 +54095,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "ylY" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -13789,13 +13789,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/engineering/main)
-"cZp" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/blue/side{
-	dir = 1
-	},
-/area/security/brig)
 "cZu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -82395,7 +82388,7 @@ ppR
 dBM
 gvm
 atz
-cZp
+ycC
 siR
 niQ
 atz

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -1411,6 +1411,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
+"aqY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/warden)
 "arb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -8695,7 +8700,7 @@
 	name = "warden office shutters"
 	},
 /turf/open/floor/plating,
-/area/security/brig)
+/area/security/warden)
 "bGo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Firefighting Equipment";
@@ -12964,7 +12969,7 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/security/brig)
+/area/security/warden)
 "cEt" = (
 /obj/machinery/computer/upload/ai{
 	dir = 1
@@ -13769,7 +13774,7 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 6
 	},
-/area/security/brig)
+/area/security/warden)
 "cXp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15410,6 +15415,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"dSP" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/warden)
 "dTn" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
@@ -15476,7 +15487,7 @@
 /obj/effect/landmark/start/warden,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/blue/side,
-/area/security/brig)
+/area/security/warden)
 "dVt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -17276,7 +17287,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/warden)
 "eTk" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -17315,7 +17326,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/warden)
 "eUr" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown{
@@ -19469,7 +19480,7 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 5
 	},
-/area/security/brig)
+/area/security/warden)
 "fYE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19584,7 +19595,7 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/blue/side,
-/area/security/brig)
+/area/security/warden)
 "gbv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22151,10 +22162,14 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "huh" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north{
+	cell_type = /obj/item/stock_parts/cell/high
+	},
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/security/brig)
+/area/security/warden)
 "hup" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -22575,7 +22590,7 @@
 /obj/structure/bed/dogbed/mcgriff,
 /mob/living/simple_animal/pet/dog/pug/mcgriff,
 /turf/open/floor/iron/dark/blue/side,
-/area/security/brig)
+/area/security/warden)
 "hDQ" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -23780,7 +23795,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/warden)
 "inE" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/requests_console/directional/west{
@@ -23830,7 +23845,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/warden)
 "ioq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28241,7 +28256,7 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/area/security/brig)
+/area/security/warden)
 "kFS" = (
 /obj/machinery/chem_dispenser,
 /obj/structure/window/reinforced{
@@ -31058,7 +31073,7 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 9
 	},
-/area/security/brig)
+/area/security/warden)
 "mjR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/reagent_dispensers/plumbed{
@@ -32903,7 +32918,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/iron/dark/blue/side,
-/area/security/brig)
+/area/security/warden)
 "niR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42376,7 +42391,7 @@
 	},
 /obj/item/clothing/accessory/badge/holo/warden,
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/warden)
 "sjb" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -44741,7 +44756,7 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 8
 	},
-/area/security/brig)
+/area/security/warden)
 "ttz" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -45966,7 +45981,7 @@
 	name = "warden office shutters"
 	},
 /turf/open/floor/iron,
-/area/security/brig)
+/area/security/warden)
 "ubI" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	name = "mix to port"
@@ -46351,7 +46366,7 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 10
 	},
-/area/security/brig)
+/area/security/warden)
 "uly" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Teleporter"
@@ -49579,7 +49594,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/warden)
 "vUg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -51749,6 +51764,9 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"wZb" = (
+/turf/closed/wall/r_wall,
+/area/security/warden)
 "wZf" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
@@ -52170,7 +52188,7 @@
 /turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
-/area/security/brig)
+/area/security/warden)
 "xlf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -52520,7 +52538,7 @@
 /obj/item/folder/red,
 /obj/item/folder/red,
 /turf/open/floor/iron,
-/area/security/brig)
+/area/security/warden)
 "xuf" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -81684,11 +81702,11 @@ adI
 ppR
 tdT
 hqS
-atz
-pUB
+wZb
+aqY
 eTC
-pUB
-atz
+aqY
+wZb
 rpn
 rpn
 rpn
@@ -81941,7 +81959,7 @@ aee
 ppR
 tdT
 hqS
-pUB
+aqY
 mjP
 ttw
 ulm
@@ -82198,7 +82216,7 @@ mQq
 ppR
 qLM
 gvm
-pUB
+aqY
 kFP
 imM
 hDN
@@ -82455,11 +82473,11 @@ ahQ
 ppR
 dBM
 gvm
-atz
+wZb
 huh
 siR
 niQ
-atz
+wZb
 mFs
 sYs
 iIK
@@ -82713,7 +82731,7 @@ aeP
 tdT
 gvm
 xtO
-huh
+dSP
 iog
 gbl
 bGn
@@ -83226,7 +83244,7 @@ ahX
 ppR
 sgV
 gvm
-pUB
+aqY
 fYD
 xkX
 cXg
@@ -83483,11 +83501,11 @@ ppR
 ppR
 sXr
 pQh
-atz
-atz
+wZb
+wZb
 bGn
 bGn
-atz
+wZb
 kKS
 dTI
 xpk

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -53660,7 +53660,6 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "ycC" = (
-/obj/structure/cable,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
@@ -5527,6 +5527,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
+"oc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "lowerbrigshutters";
+	name = "Anti-Fauna Shutters"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "od" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/west,
@@ -18019,6 +18028,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"TO" = (
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "lowerbrigshutters";
+	name = "Panic Button"
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "TP" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/directional/north,
@@ -50134,7 +50153,7 @@ ba
 uO
 gc
 ll
-UL
+oc
 lR
 tI
 PN
@@ -50901,12 +50920,12 @@ yL
 Zl
 wh
 So
-fR
+TO
 Yq
 ha
 dz
 Cd
-UL
+oc
 tI
 PN
 JZ
@@ -51163,7 +51182,7 @@ gW
 LF
 qe
 Ye
-UL
+oc
 kL
 PN
 JZ
@@ -51420,7 +51439,7 @@ lT
 tg
 dz
 uO
-UL
+oc
 tI
 PN
 JZ
@@ -52190,7 +52209,7 @@ BL
 ie
 zQ
 hz
-UL
+oc
 XT
 ok
 PN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
~~Icebox' brig had two APCs. Power would, as far as I could tell, draw from both unevenly, and either being off would affect the area as if it were the only one. (yes I tested it yes it works)~~ Turns out that room was the warden's office not set to the right area.

Also adds firedoors to the upper brig where the railing is, reducing issues with breaches.

Also adds shutters to the plant-grow-area-place, to keep fauna out.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
It's just better, what can I say?

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Sets the warden's office to the correct area
add: Shutters can now be found in the icebox permabrig's farming room, able to be closed to prevent fauna attacks.
fix: Icebox brig now has firelocks around the upper railings, mitigating the damage caused by breaches
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
