### PR TITLE
Icebox brig fixes part two

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -600,6 +600,9 @@
 	dir = 1
 	},
 /obj/machinery/modular_computer/console/preset/cargochat/security,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "aiY" = (
@@ -10215,6 +10218,7 @@
 "bTY" = (
 /obj/structure/railing,
 /obj/item/trash/popcorn,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "bUn" = (
@@ -11197,6 +11201,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -15937,6 +15944,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "ejr" = (
@@ -18049,6 +18059,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "fqu" = (
@@ -19612,6 +19623,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "gdc" = (
@@ -21241,6 +21253,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -22875,6 +22890,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "hOt" = (
@@ -23269,6 +23285,9 @@
 	dir = 8
 	},
 /obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -24306,6 +24325,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "iEa" = (
@@ -26281,6 +26301,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "jGf" = (
@@ -27619,6 +27640,10 @@
 "kqh" = (
 /obj/structure/railing{
 	dir = 10
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -29663,6 +29688,9 @@
 	dir = 1
 	},
 /obj/machinery/computer/department_orders/security,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "lyW" = (
@@ -31854,6 +31882,9 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "mIM" = (
@@ -31908,6 +31939,9 @@
 /obj/item/food/popcorn{
 	pixel_x = -3;
 	pixel_y = -3
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -33959,6 +33993,7 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "nOl" = (
@@ -35405,6 +35440,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "oBY" = (
@@ -36291,6 +36329,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "pcw" = (
@@ -36535,6 +36576,7 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "pij" = (
@@ -36850,6 +36892,9 @@
 /area/maintenance/starboard/fore)
 "prk" = (
 /obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -41695,6 +41740,9 @@
 	dir = 1
 	},
 /obj/structure/table,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "rRr" = (
@@ -44942,6 +44990,7 @@
 /obj/structure/chair/plastic{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "tAY" = (
@@ -46899,6 +46948,9 @@
 	dir = 4
 	},
 /obj/item/chair/plastic,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "uzG" = (
@@ -48478,6 +48530,9 @@
 	dir = 1
 	},
 /obj/machinery/holopad/secure,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "vtr" = (
@@ -48518,6 +48573,9 @@
 "vuv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -50975,6 +51033,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "wHz" = (
@@ -51067,6 +51128,10 @@
 /obj/structure/railing{
 	dir = 6
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "wJz" = (
@@ -51283,6 +51348,9 @@
 	dir = 4
 	},
 /obj/structure/chair/plastic{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -54027,6 +54095,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "ylY" = (

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
@@ -5527,6 +5527,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
+"oc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "lowerbrigshutters";
+	name = "Anti-Fauna Shutters"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "od" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/west,
@@ -18019,6 +18028,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"TO" = (
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "lowerbrigshutters";
+	name = "Panic Button"
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "TP" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/directional/north,
@@ -50134,7 +50153,7 @@ ba
 uO
 gc
 ll
-UL
+oc
 lR
 tI
 PN
@@ -50901,12 +50920,12 @@ yL
 Zl
 wh
 So
-fR
+TO
 Yq
 ha
 dz
 Cd
-UL
+oc
 tI
 PN
 JZ
@@ -51163,7 +51182,7 @@ gW
 LF
 qe
 Ye
-UL
+oc
 kL
 PN
 JZ
@@ -51420,7 +51439,7 @@ lT
 tg
 dz
 uO
-UL
+oc
 tI
 PN
 JZ
@@ -52190,7 +52209,7 @@ BL
 ie
 zQ
 hz
-UL
+oc
 XT
 ok
 PN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You know how fauna on icebox break into the brig and then the whole brig is depressurized? Firedoors, my boy, fire doors. They're in now, on the railing. I also added shutters to the maintenance-facing windows in the botany room because that's the only way to practically stop fauna attacks without electrochromic windows, which we don't have.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
It's seriously just better. 'nuff said.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Shutters can now be found in the icebox permabrig's farming room, able to be closed to prevent fauna attacks.
fix: Icebox brig now has firelocks around the upper railings, mitigating the damage caused by breaches
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
