### PR TITLE
[MODULAR] Gives service cyborg shakers access to synthanol.

### DIFF
--- a/modular_skyrat/modules/borg_buffs/code/robot.dm
+++ b/modular_skyrat/modules/borg_buffs/code/robot.dm
@@ -52,7 +52,8 @@
 					/datum/reagent/consumable/ethanol/triple_sec,
 					/datum/reagent/consumable/ethanol/creme_de_coconut,
 					/datum/reagent/consumable/nothing,
-					/datum/reagent/consumable/laughter,)
+					/datum/reagent/consumable/laughter,
+					/datum/reagent/consumable/ethanol/synthanol,)
 
 /obj/item/reagent_containers/borghypo/borgshaker/specific/soda
 	name = "cyborg soda shaker"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Basically what it says on the title. It's a simple change that adds a single reagent to an already modularized list. Nothing complicated or complex
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Regular booze dispensers get access to synthanol. Service cyborgs are a walking booze/soda dispenser hybrid, and as such should get access to the same reagents, especially one as useful as synthanol. This opens ups the opportunity for cyborgs to mix synthanol-based drinks, enabling them to better serve any synthetic crew.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds Synthanol to service cyborgs shakers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
