### PR TITLE
Changes Blueshift openspace turf type and misc bug fixes

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -44698,10 +44698,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"rlN" = (
-/obj/effect/landmark/start/bouncer,
-/turf/open/space/openspace,
-/area/space)
 "rmd" = (
 /obj/machinery/camera{
 	c_tag = "Service Hallway - Starboard";
@@ -79133,7 +79129,7 @@ ylQ
 ylQ
 ylQ
 ylQ
-rlN
+ylQ
 ylQ
 ylQ
 ylQ
@@ -110753,7 +110749,7 @@ ylQ
 ylQ
 ylQ
 ylQ
-rlN
+ylQ
 ylQ
 ylQ
 ylQ

--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -1707,7 +1707,7 @@
 "aoQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "aoU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -6641,7 +6641,7 @@
 /area/maintenance/starboard/central)
 "bRc" = (
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "bRf" = (
 /obj/structure/table/wood/poker,
@@ -6988,7 +6988,7 @@
 "bXx" = (
 /obj/structure/lattice,
 /obj/structure/grille,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "bXD" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -7982,7 +7982,7 @@
 "cus" = (
 /obj/structure/lattice,
 /obj/structure/marker_beacon/burgundy,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "cuv" = (
 /obj/structure/railing/corner{
@@ -15648,7 +15648,7 @@
 /area/tcommsat/computer)
 "fzn" = (
 /obj/structure/shuttle/engine/huge,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/port/aft)
 "fzC" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -16690,7 +16690,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "fVz" = (
 /obj/structure/shuttle/engine/large,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/starboard/aft)
 "fVJ" = (
 /obj/structure/railing/corner{
@@ -21578,7 +21578,7 @@
 "hYB" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/carpspawn,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "hYD" = (
 /obj/structure/trash_pile,
@@ -23367,7 +23367,7 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "iFN" = (
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/starboard/aft)
 "iGI" = (
 /obj/machinery/disposal/bin,
@@ -23945,7 +23945,7 @@
 /area/maintenance/starboard/central)
 "iPL" = (
 /obj/structure/shuttle/engine/large,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/department/engine)
 "iPU" = (
 /obj/structure/cable,
@@ -25532,7 +25532,7 @@
 /area/hallway/primary/port)
 "jwq" = (
 /obj/structure/shuttle/engine/huge,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/department/engine)
 "jwv" = (
 /obj/effect/turf_decal/siding/wood{
@@ -31964,7 +31964,7 @@
 /area/service/kitchen)
 "mfq" = (
 /obj/structure/shuttle/engine/large,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/port/aft)
 "mfu" = (
 /obj/effect/turf_decal/bot{
@@ -35379,7 +35379,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 5
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "nwZ" = (
 /obj/structure/table,
@@ -40548,7 +40548,7 @@
 	name = "Blueshift emergency evac bay";
 	width = 32
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "pzD" = (
 /obj/structure/cable,
@@ -44700,7 +44700,7 @@
 /area/security/office)
 "rlN" = (
 /obj/effect/landmark/start/bouncer,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "rmd" = (
 /obj/machinery/camera{
@@ -48043,7 +48043,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "sEf" = (
 /obj/structure/urinal{
@@ -49730,7 +49730,7 @@
 	id = "pod_lavaland";
 	name = "lavaland"
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "toF" = (
 /obj/effect/turf_decal/delivery,
@@ -50519,7 +50519,7 @@
 /area/security/brig)
 "tEH" = (
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "tFf" = (
 /obj/effect/turf_decal/delivery,
@@ -51162,7 +51162,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "tRg" = (
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/port/aft)
 "tRt" = (
 /turf/closed/wall,
@@ -56805,7 +56805,7 @@
 /area/hallway/primary/central)
 "vYW" = (
 /obj/structure/shuttle/engine/huge,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/starboard/aft)
 "vYZ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -59646,7 +59646,7 @@
 /area/engineering/supermatter/room)
 "xal" = (
 /obj/effect/landmark/carpspawn,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "xap" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -62504,7 +62504,7 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "yao" = (
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/department/engine)
 "yat" = (
 /obj/structure/chair/sofa/bench/left{
@@ -63124,7 +63124,7 @@
 /turf/open/openspace,
 /area/engineering/lobby)
 "ylQ" = (
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "ylX" = (
 /turf/closed/wall/r_wall,

--- a/_maps/map_files/Blueshift/BlueShift_upper.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_upper.dmm
@@ -4217,7 +4217,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "aSv" = (
 /obj/structure/trash_pile,
@@ -8966,7 +8966,7 @@
 "cnO" = (
 /obj/structure/lattice,
 /obj/structure/grille,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "cnW" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -9399,7 +9399,7 @@
 "cus" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "cut" = (
 /obj/structure/cable,
@@ -9428,7 +9428,7 @@
 /area/science/explab)
 "cvz" = (
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "cvW" = (
 /obj/structure/table,
@@ -10517,7 +10517,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "cTB" = (
 /obj/structure/table/wood/fancy/red,
@@ -14575,7 +14575,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "eus" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -15234,7 +15234,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "eIp" = (
 /obj/structure/railing{
@@ -17127,7 +17127,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "frM" = (
 /obj/structure/table/reinforced,
@@ -18960,7 +18960,7 @@
 "fZE" = (
 /obj/structure/lattice,
 /obj/effect/landmark/carpspawn,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "gac" = (
 /obj/structure/chair/comfy/black{
@@ -19520,7 +19520,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "glO" = (
 /turf/closed/wall/r_wall,
@@ -22944,7 +22944,7 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
 "hHm" = (
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/aft/upper)
 "hHr" = (
 /obj/structure/cable,
@@ -23392,7 +23392,7 @@
 /area/hallway/primary/upper)
 "hRC" = (
 /obj/structure/window/reinforced,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "hSb" = (
 /obj/machinery/shower{
@@ -29768,7 +29768,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "kjg" = (
 /obj/effect/turf_decal/delivery,
@@ -29887,7 +29887,7 @@
 /area/medical/medbay/lobby)
 "kly" = (
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "klA" = (
 /obj/structure/disposalpipe/segment,
@@ -30998,7 +30998,7 @@
 /area/maintenance/fore/upper)
 "kFN" = (
 /obj/structure/shuttle/engine/huge,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/department/science)
 "kFQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -31165,7 +31165,7 @@
 	dir = 1
 	},
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "kIQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -34539,7 +34539,7 @@
 	name = "SS13: Auxiliary Dock, Station-Port";
 	width = 35
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "lTh" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -39380,7 +39380,7 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "nIQ" = (
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/department/science)
 "nIY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -42889,7 +42889,7 @@
 "pel" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "pex" = (
 /obj/effect/turf_decal/tile/purple,
@@ -42952,7 +42952,7 @@
 /area/medical/treatment_center)
 "pfS" = (
 /obj/effect/landmark/carpspawn,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "pgb" = (
 /obj/item/kirbyplants/random,
@@ -48262,7 +48262,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "rhJ" = (
 /obj/structure/chair/sofa/bench{
@@ -51566,7 +51566,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "sqz" = (
 /obj/machinery/vending/coffee,
@@ -52783,7 +52783,7 @@
 /area/maintenance/department/medical/central)
 "sNj" = (
 /obj/structure/shuttle/engine/large,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/aft/upper)
 "sNt" = (
 /obj/structure/mirror{
@@ -56390,7 +56390,7 @@
 	dir = 8
 	},
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "uju" = (
 /obj/structure/cable,
@@ -57138,7 +57138,7 @@
 "uwZ" = (
 /obj/structure/lattice,
 /obj/item/target,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "uxi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -57893,7 +57893,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "uIM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -59094,7 +59094,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "vin" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -59869,7 +59869,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "vwX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -60498,7 +60498,7 @@
 "vIt" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/carpspawn,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "vIv" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -61708,7 +61708,7 @@
 	dir = 4
 	},
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "wbY" = (
 /obj/machinery/camera/directional/east{
@@ -63984,7 +63984,7 @@
 /area/medical/morgue)
 "wTY" = (
 /obj/structure/shuttle/engine/huge,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/aft/upper)
 "wUf" = (
 /obj/structure/bed/roller,
@@ -65089,7 +65089,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "xpp" = (
 /obj/structure/cable,
@@ -65770,7 +65770,7 @@
 /area/command/heads_quarters/captain/private/nt_rep)
 "xzm" = (
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "xzn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -67440,7 +67440,7 @@
 /area/medical/cryo)
 "yal" = (
 /obj/structure/shuttle/engine/large,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/maintenance/department/science)
 "yao" = (
 /obj/structure/shuttle/engine/large,
@@ -68023,7 +68023,7 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "ylQ" = (
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "ylX" = (
 /obj/machinery/door/window/brigdoor{

--- a/_maps/map_files/Blueshift/BlueShift_upper.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_upper.dmm
@@ -50256,7 +50256,7 @@
 /area/maintenance/department/science)
 "rUv" = (
 /obj/machinery/door/poddoor/shutters{
-	id = "teleporterhubshutters";
+	id = "teleportershutters";
 	name = "Teleporter Shutters"
 	},
 /obj/effect/turf_decal/delivery,


### PR DESCRIPTION
## About The Pull Request

Changes `/turf/open/openspace/airless/planetary` to `/turf/open/space/openspace`.
It should've been updated when I introduced the turf type but I guess nobody ever got around to it.

Also fixes #11124

Also removes two bouncer spawn locations that were (assumedly mistakenly) placed in space.

## How This Contributes To The Skyrat Roleplay Experience

Performance improvement.

## Changelog
:cl:
fix: The teleporter room shutters on Blueshift are now functional
/:cl: