### PR TITLE
Makes pipes/vents/scrubbers/wiring slightly more sane on icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -228,7 +228,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
 	c_tag = "Security - Armory West"
@@ -656,7 +655,6 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "ajs" = (
@@ -809,6 +807,7 @@
 "alk" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "als" = (
@@ -1084,7 +1083,6 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "aoa" = (
@@ -1732,6 +1730,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "aud" = (
@@ -1995,6 +1996,9 @@
 /area/hallway/secondary/entry)
 "awP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "awV" = (
@@ -2098,6 +2102,9 @@
 "axC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "axF" = (
@@ -2105,13 +2112,13 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "axI" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -2167,6 +2174,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ays" = (
@@ -2212,6 +2222,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ayE" = (
@@ -2245,15 +2258,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"ayY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "ayZ" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -2313,6 +2317,9 @@
 "azG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -2596,14 +2603,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aCN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai_upload)
-"aCP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai_upload)
 "aCS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -2686,7 +2685,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -2926,11 +2925,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"aHn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "aHr" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -3010,7 +3004,6 @@
 /area/cargo/miningdock)
 "aHZ" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "aIi" = (
@@ -3038,6 +3031,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aIl" = (
@@ -3198,7 +3192,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aJF" = (
@@ -3245,6 +3238,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aKw" = (
@@ -3428,6 +3422,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aLP" = (
@@ -3473,6 +3468,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aMc" = (
@@ -3510,7 +3506,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aMI" = (
@@ -4786,6 +4781,8 @@
 "bcf" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "bch" = (
@@ -4910,6 +4907,8 @@
 /area/icemoon/surface/outdoors)
 "bdg" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "bdh" = (
@@ -4925,7 +4924,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -4956,7 +4955,6 @@
 /area/hallway/primary/starboard)
 "bdt" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
@@ -4998,14 +4996,6 @@
 	},
 /obj/structure/sign/poster/random{
 	pixel_x = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bdD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -5278,12 +5268,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "bfu" = (
@@ -5664,6 +5652,9 @@
 	},
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bhO" = (
@@ -5890,13 +5881,17 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bjB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bjC" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"bjE" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "bjI" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -6068,12 +6063,6 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/central)
-"bkW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bkY" = (
@@ -6108,15 +6097,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/salon)
-"blf" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/processing)
 "bli" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical/glass{
@@ -6572,6 +6552,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "boM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/corner,
 /area/science/research)
 "boN" = (
@@ -7080,6 +7061,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"btI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "btN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -7107,7 +7094,7 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "btW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
@@ -8085,6 +8072,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "bBg" = (
@@ -8093,6 +8081,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "bBh" = (
@@ -8957,6 +8946,9 @@
 /obj/machinery/shower{
 	pixel_y = 16
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "bIw" = (
@@ -9036,6 +9028,9 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -9162,6 +9157,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "bJN" = (
@@ -9301,6 +9299,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/glass/reinforced,
@@ -9480,7 +9481,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -9908,7 +9908,6 @@
 /turf/closed/wall/r_wall,
 /area/security/range)
 "bQN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -10011,16 +10010,14 @@
 "bRT" = (
 /turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
-"bRY" = (
-/obj/structure/lattice/catwalk,
-/turf/open/openspace,
-/area/science/xenobiology)
 "bSa" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/openspace,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
 "bSd" = (
 /obj/effect/turf_decal/stripes/line{
@@ -10062,6 +10059,12 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bSq" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/openspace,
+/area/science/xenobiology)
 "bSs" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -10205,6 +10208,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"bTG" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/service/salon)
 "bTI" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -10239,6 +10252,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "bUt" = (
@@ -10306,7 +10321,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "bVu" = (
@@ -10621,7 +10635,6 @@
 /area/commons/locker)
 "bZb" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
 	},
@@ -10875,11 +10888,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
-"cba" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/science/misc_lab)
 "cbh" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -11192,12 +11200,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ceW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/brig)
@@ -11292,6 +11299,15 @@
 	},
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
+"chq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "chw" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -11379,6 +11395,7 @@
 /area/maintenance/starboard/fore)
 "cjr" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cjD" = (
@@ -11458,6 +11475,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
 "cli" = (
@@ -11655,7 +11674,6 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "cop" = (
@@ -11913,8 +11931,6 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "csh" = (
@@ -13160,11 +13176,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"cIa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/science/robotics/lab)
 "cIb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -13201,7 +13212,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cIi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen{
 	name = "Solitary Monitoring";
@@ -13210,7 +13220,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
 	c_tag = "Security - East"
@@ -13259,6 +13268,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"cIW" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing,
+/turf/open/openspace,
+/area/science/xenobiology)
 "cJx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -13288,12 +13305,16 @@
 /area/commons/vacant_room/office)
 "cLp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
 /area/science/misc_lab)
 "cLx" = (
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "cLH" = (
@@ -13808,9 +13829,8 @@
 "cZv" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "cZL" = (
@@ -13965,6 +13985,10 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "ddi" = (
@@ -14445,13 +14469,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/teleporter)
-"dqL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "dqP" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14606,14 +14623,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
-"dwp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white/side{
-	dir = 6
-	},
-/area/science/research)
 "dwB" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/girder,
@@ -14676,7 +14685,6 @@
 "dyG" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/corner,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "dze" = (
@@ -14767,6 +14775,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "dBM" = (
@@ -14849,6 +14858,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "dEh" = (
@@ -14966,6 +14976,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "dFW" = (
@@ -15155,7 +15166,6 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "dKZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -15296,6 +15306,7 @@
 	},
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "dPu" = (
@@ -15364,11 +15375,16 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"dSd" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/turf/open/floor/iron,
+/area/security/brig)
 "dSx" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "dSz" = (
@@ -15816,10 +15832,13 @@
 "efN" = (
 /obj/structure/cable,
 /obj/machinery/status_display/evac/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "efT" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "egc" = (
@@ -15871,6 +15890,8 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "egN" = (
@@ -16036,14 +16057,9 @@
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"ekC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/darkblue/filled/line,
-/turf/open/floor/iron,
-/area/security/brig)
 "ekI" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -16314,6 +16330,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "ert" = (
@@ -16557,7 +16576,6 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "eyd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16983,7 +17001,6 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "eKy" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
@@ -17095,12 +17112,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"eOk" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "eOE" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -17211,7 +17222,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "eSD" = (
@@ -17309,6 +17319,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"eVO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain)
 "eVV" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -17426,6 +17442,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"eZk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "eZm" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/checker,
@@ -17619,6 +17640,7 @@
 	c_tag = "Xenobiology Pens Observation - Starboard Aft";
 	network = list("ss13","rd","xeno")
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/openspace,
 /area/science/xenobiology)
 "fex" = (
@@ -17728,7 +17750,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "fhE" = (
@@ -17848,6 +17869,12 @@
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"fkM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "fkR" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/requests_console/directional/north{
@@ -18018,6 +18045,8 @@
 /area/maintenance/department/medical/central)
 "fql" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "fqn" = (
@@ -18077,7 +18106,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "frv" = (
@@ -18197,6 +18225,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/smooth_large,
 /area/science/genetics)
+"fuw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "fuG" = (
 /obj/machinery/shower{
 	dir = 8
@@ -18363,7 +18395,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fyU" = (
@@ -18371,9 +18402,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -18410,6 +18439,14 @@
 "fzZ" = (
 /turf/closed/wall,
 /area/command/teleporter)
+"fAO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 6
+	},
+/area/science/research)
 "fAQ" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
@@ -18728,7 +18765,6 @@
 /area/service/salon)
 "fIU" = (
 /obj/machinery/monkey_recycler,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -19179,6 +19215,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
 "fUn" = (
@@ -19418,6 +19457,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "fYH" = (
@@ -19442,11 +19482,6 @@
 /obj/item/storage/box,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"gai" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/command/bridge)
 "gao" = (
 /obj/item/stack/ore/iron,
 /obj/effect/turf_decal/stripes/line{
@@ -19549,10 +19584,6 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/security/processing)
-"gbZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "gcf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19628,13 +19659,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"gdm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/command/heads_quarters/captain)
 "gdr" = (
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
@@ -19645,8 +19669,7 @@
 /area/maintenance/starboard/aft)
 "gdY" = (
 /obj/machinery/light_switch/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/command/gateway)
 "geb" = (
@@ -19735,6 +19758,7 @@
 	icon_state = "L6"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ggl" = (
@@ -19875,7 +19899,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "glg" = (
@@ -20172,6 +20195,8 @@
 	c_tag = "Security - North West"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "gsX" = (
@@ -20195,6 +20220,15 @@
 /obj/structure/chair/office,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
+"gtI" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "gtS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -20275,6 +20309,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "gxf" = (
@@ -20287,6 +20322,7 @@
 /obj/machinery/light_switch/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "gxu" = (
@@ -20786,6 +20822,15 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"gKh" = (
+/obj/machinery/light/directional/east,
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing,
+/turf/open/openspace,
+/area/science/xenobiology)
 "gKO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20879,7 +20924,6 @@
 /area/command/heads_quarters/cmo)
 "gMS" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "gMW" = (
@@ -21035,11 +21079,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/office)
-"gQt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "gQC" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -21085,6 +21124,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "gRe" = (
@@ -21153,7 +21193,6 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "gSQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /mob/living/simple_animal/pet/dog/corgi/borgi,
@@ -21207,6 +21246,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/processing)
 "gTp" = (
@@ -21237,14 +21277,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"gUG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "gUO" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -21260,11 +21292,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"gUR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "gUT" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -21295,6 +21322,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "gWm" = (
@@ -21417,7 +21445,6 @@
 /area/engineering/supermatter/room)
 "gZH" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -21431,10 +21458,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"gZY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/science/misc_lab)
 "hax" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
@@ -21776,12 +21799,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/fitness)
-"hmj" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/commons/fitness)
 "hmp" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -22199,6 +22219,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
 "hwA" = (
@@ -22330,6 +22353,9 @@
 "hAe" = (
 /obj/machinery/computer/pod/old/mass_driver_controller/chapelgun{
 	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
@@ -22567,9 +22593,6 @@
 "hFw" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -22990,6 +23013,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/storage/mining)
+"hRu" = (
+/obj/machinery/door/window/westright,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced,
+/area/science/xenobiology)
 "hRB" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet,
@@ -23046,6 +23076,8 @@
 "hSG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "hSM" = (
@@ -23381,6 +23413,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "idc" = (
@@ -23417,6 +23450,11 @@
 	dir = 1
 	},
 /area/service/hydroponics)
+"idl" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/science/robotics/lab)
 "idF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23856,7 +23894,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
 "iqf" = (
@@ -24033,8 +24070,8 @@
 /area/security/processing)
 "ivV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "iwa" = (
@@ -24094,6 +24131,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/meeting_room)
 "ixQ" = (
@@ -24113,6 +24151,8 @@
 /area/service/library)
 "iyA" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "iyF" = (
@@ -24325,11 +24365,6 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
-"iEH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "iEJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod One"
@@ -24468,6 +24503,13 @@
 /obj/machinery/navbeacon/wayfinding,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"iGY" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "iHl" = (
 /obj/structure/railing/corner,
 /obj/machinery/door/firedoor/border_only{
@@ -24482,6 +24524,7 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "iHD" = (
@@ -24666,7 +24709,9 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/processing)
 "iMA" = (
@@ -24763,6 +24808,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "iPJ" = (
@@ -25156,6 +25202,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "jbR" = (
@@ -25191,7 +25238,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "jcy" = (
@@ -25255,6 +25301,16 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
+"jep" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "jeK" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -25276,6 +25332,8 @@
 "jfz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "jfY" = (
@@ -25401,11 +25459,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"jjL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/security/brig)
 "jjN" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/transit_tube,
@@ -25435,6 +25488,8 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "jkl" = (
@@ -25626,12 +25681,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing,
+/obj/structure/window/reinforced,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "jnp" = (
@@ -25687,11 +25743,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "joT" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced,
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/openspace,
+/turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
+"joU" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "joZ" = (
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
@@ -25719,6 +25780,9 @@
 "jpE" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jpF" = (
@@ -25743,6 +25807,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "jsw" = (
@@ -25883,9 +25948,6 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "juO" = (
@@ -25928,7 +25990,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
 "jwq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -25992,14 +26053,6 @@
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/medical)
-"jxD" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
-/area/security/brig)
 "jxN" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -26135,13 +26188,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"jCV" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "jDm" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -26180,6 +26226,9 @@
 /area/engineering/atmos)
 "jEF" = (
 /obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
@@ -26325,8 +26374,6 @@
 	dir = 1;
 	name = "Security Station"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
 "jHR" = (
@@ -26338,12 +26385,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/bridge)
 "jIw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "jIx" = (
@@ -26522,6 +26570,8 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "jOT" = (
@@ -26558,7 +26608,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -26830,9 +26880,6 @@
 /area/cargo/miningdock)
 "jWq" = (
 /obj/machinery/holopad,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/command/bridge)
@@ -27209,8 +27256,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "keP" = (
@@ -27236,13 +27281,21 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "kfi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"kft" = (
+/obj/machinery/light/directional/west,
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing,
+/turf/open/openspace,
+/area/science/xenobiology)
 "kgg" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light/directional/east,
@@ -27423,6 +27476,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
+"kkE" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/brig)
 "kkF" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/red/line{
@@ -27542,6 +27606,7 @@
 "kmY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "knu" = (
@@ -27622,6 +27687,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"kqm" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "kqo" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -27784,10 +27854,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
-"kvq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/science/xenobiology)
 "kvr" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -27837,6 +27903,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/bridge)
 "kwv" = (
@@ -27877,8 +27946,10 @@
 /turf/open/floor/iron/large,
 /area/engineering/storage)
 "kxf" = (
-/obj/structure/cable,
 /mob/living/simple_animal/sloth/paperwork,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "kxh" = (
@@ -27967,6 +28038,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/status_display/ai/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "kyN" = (
@@ -28090,6 +28162,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "kCv" = (
@@ -28657,6 +28731,12 @@
 	},
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
+"kTt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/hallway/primary/central)
 "kTD" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/turf_decal/bot,
@@ -28767,6 +28847,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "kYa" = (
@@ -28971,9 +29052,6 @@
 /area/cargo/sorting)
 "lfw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
@@ -29066,6 +29144,8 @@
 /area/hallway/primary/central)
 "ljS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/gateway)
 "ljT" = (
@@ -29120,7 +29200,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "lmh" = (
@@ -29209,6 +29288,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "lpR" = (
@@ -29461,14 +29541,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"lvF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/command/gateway)
 "lvJ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -29528,7 +29600,6 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
@@ -29639,7 +29710,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/processing)
 "lyx" = (
@@ -29650,6 +29720,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "lyT" = (
@@ -29729,6 +29800,7 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - West"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "lAY" = (
@@ -29955,6 +30027,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "lIs" = (
@@ -29987,6 +30062,13 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"lJe" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "lJG" = (
 /obj/structure/sign/warning/deathsposal{
 	pixel_y = 32
@@ -30136,6 +30218,7 @@
 /obj/structure/cable,
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "lNw" = (
@@ -30165,9 +30248,6 @@
 "lOw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white/corner{
@@ -30206,11 +30286,6 @@
 /obj/item/seeds/tower,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"lQH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "lQK" = (
 /obj/structure/railing/corner,
 /obj/machinery/door/firedoor/border_only,
@@ -30340,8 +30415,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -30409,6 +30482,7 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "lUy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
@@ -30498,10 +30572,9 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "lXc" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light/directional/south,
-/turf/open/openspace,
+/turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
 "lXl" = (
 /obj/machinery/door/firedoor/border_only{
@@ -30522,8 +30595,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/openspace,
+/turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
 "lXI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30572,6 +30644,8 @@
 	name = "Gateway Access Shutter Control";
 	req_access_txt = "31"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/gateway)
 "lYg" = (
@@ -30663,6 +30737,12 @@
 	},
 /turf/open/floor/engine/cult,
 /area/service/library)
+"mau" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain)
 "maG" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -30857,8 +30937,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
@@ -30885,7 +30963,6 @@
 /area/maintenance/starboard)
 "mgw" = (
 /obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -31017,6 +31094,14 @@
 	dir = 9
 	},
 /area/security/brig)
+"mjQ" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "mjR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/reagent_dispensers/plumbed{
@@ -31376,6 +31461,9 @@
 /area/commons/storage/mining)
 "mxo" = (
 /obj/machinery/light_switch/directional/east,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -31457,6 +31545,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
@@ -31634,7 +31725,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "mCT" = (
@@ -31734,6 +31824,9 @@
 /area/maintenance/fore)
 "mGc" = (
 /obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -32095,6 +32188,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/bridge)
 "mNH" = (
@@ -32153,6 +32249,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "mPJ" = (
@@ -32173,6 +32270,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "mPR" = (
@@ -32191,6 +32289,7 @@
 /area/cargo/miningdock)
 "mQd" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "mQh" = (
@@ -32355,8 +32454,6 @@
 /area/hallway/primary/central)
 "mVa" = (
 /obj/structure/chair,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "mVc" = (
@@ -32455,6 +32552,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"mYx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "mYE" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
@@ -32506,7 +32608,6 @@
 /turf/open/floor/wood,
 /area/command/meeting_room)
 "mZP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -32528,13 +32629,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"nav" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "naT" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment,
@@ -32738,6 +32832,7 @@
 "nfO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "nfR" = (
@@ -33054,7 +33149,7 @@
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "nlk" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "nlu" = (
@@ -33087,7 +33182,6 @@
 /turf/open/floor/iron/textured,
 /area/medical/medbay)
 "nlQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -33139,6 +33233,7 @@
 	dir = 1
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -33252,6 +33347,9 @@
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "nqI" = (
@@ -33527,13 +33625,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "nAk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "nAn" = (
@@ -33699,6 +33797,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "nFy" = (
@@ -33874,6 +33973,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -34207,13 +34307,6 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"nTS" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "nUj" = (
 /obj/machinery/vending/clothing,
 /obj/effect/turf_decal/tile/neutral{
@@ -34323,6 +34416,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/bridge)
 "nXI" = (
@@ -34824,13 +34918,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"onG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "onK" = (
 /obj/machinery/research/explosive_compressor,
 /obj/effect/turf_decal/bot,
@@ -34896,7 +34983,6 @@
 	dir = 8
 	},
 /obj/machinery/navbeacon/wayfinding,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "opE" = (
@@ -35358,7 +35444,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "ozG" = (
@@ -35509,6 +35594,16 @@
 /obj/structure/flora/tree/pine,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
+"oDd" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "oDi" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -35561,6 +35656,15 @@
 /obj/structure/ladder,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"oFM" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/processing)
 "oGo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
@@ -35668,6 +35772,13 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"oIS" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "oIU" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/warning,
@@ -36099,7 +36210,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "oWr" = (
@@ -36266,8 +36376,9 @@
 	},
 /area/science/lab)
 "pcf" = (
-/obj/structure/railing,
+/obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "pcj" = (
@@ -36305,6 +36416,7 @@
 "pcK" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "pcL" = (
@@ -36380,8 +36492,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
 "peN" = (
@@ -36620,6 +36730,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/grimy,
 /area/security/brig)
+"ple" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "plK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/turbine_computer{
@@ -36695,7 +36812,6 @@
 	pixel_x = -1;
 	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "pnK" = (
@@ -36806,6 +36922,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
 "ppR" = (
@@ -36872,7 +36991,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "prx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door_timer{
 	id = "solitary3";
 	pixel_x = 32
@@ -36880,7 +36998,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "prA" = (
@@ -37144,6 +37261,11 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"pwf" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/brig)
 "pwg" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -37297,12 +37419,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"pzi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "pAh" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Chemistry Lab Utilities";
@@ -37392,6 +37508,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"pDb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "pDc" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -37579,12 +37702,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"pHl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "pHM" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -37594,7 +37711,6 @@
 /area/engineering/atmos)
 "pHO" = (
 /obj/machinery/light/small/directional/south,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
@@ -37634,14 +37750,17 @@
 /area/service/hydroponics)
 "pIG" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "pIZ" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/security/brig)
+"pJC" = (
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "pJI" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -37731,9 +37850,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "pMQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -38008,11 +38124,10 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "pSw" = (
@@ -38155,9 +38270,11 @@
 /turf/closed/wall,
 /area/service/library)
 "pXC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "pXJ" = (
@@ -38208,7 +38325,6 @@
 /area/engineering/atmos)
 "pYR" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/south{
 	c_tag = "Security - South West"
 	},
@@ -38218,8 +38334,15 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"pYW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "pYX" = (
 /mob/living/simple_animal/pet/dog/markus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "pZf" = (
@@ -38298,7 +38421,7 @@
 /area/engineering/storage/tech)
 "qbP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/command/meeting_room)
@@ -38550,7 +38673,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "qjJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/structure/railing/corner{
 	dir = 4
@@ -38715,6 +38837,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
 "qnG" = (
@@ -38973,7 +39097,6 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/openspace,
 /area/cargo/storage)
 "qtX" = (
@@ -39213,13 +39336,11 @@
 /turf/open/floor/iron/dark,
 /area/brigofficer)
 "qCP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "qCV" = (
@@ -39286,6 +39407,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "qEs" = (
@@ -39299,6 +39421,7 @@
 	icon_state = "L2"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "qFn" = (
@@ -39497,7 +39620,6 @@
 /area/maintenance/department/electrical)
 "qNH" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/requests_console/directional/south{
 	announcementConsole = 1;
 	department = "Bridge";
@@ -39973,6 +40095,7 @@
 	icon_state = "L10"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "qZe" = (
@@ -40066,14 +40189,6 @@
 	dir = 9
 	},
 /area/science/research)
-"rdg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/brig)
 "rdE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -40140,6 +40255,7 @@
 /area/commons/storage/mining)
 "rfh" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "rfn" = (
@@ -40333,7 +40449,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rky" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -40495,7 +40610,6 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "roq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/sorting/wrap/flip{
 	dir = 1
 	},
@@ -40611,7 +40725,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "rrK" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -40877,6 +40990,9 @@
 	name = "Barbershop"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/salon)
 "ryQ" = (
@@ -40930,7 +41046,6 @@
 	},
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/meeting_room)
 "rzu" = (
@@ -41218,9 +41333,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "rDV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/brig)
@@ -41246,6 +41363,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/construction)
+"rEK" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/openspace,
+/area/science/xenobiology)
 "rFe" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
@@ -41364,7 +41489,6 @@
 "rIp" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -41472,12 +41596,6 @@
 	},
 /turf/open/floor/plating,
 /area/command/teleporter)
-"rLb" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/brig)
 "rLc" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -41625,12 +41743,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/bridge)
 "rOY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "rPl" = (
@@ -41709,8 +41829,6 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "rRB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock";
 	req_access_txt = "48"
@@ -41810,7 +41928,6 @@
 /area/maintenance/space_hut/cabin)
 "rUv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -41825,7 +41942,6 @@
 /area/science/xenobiology)
 "rUR" = (
 /obj/structure/chair/comfy/black,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron,
 /area/science/xenobiology)
@@ -42280,6 +42396,7 @@
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "shJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/security/processing)
 "sis" = (
@@ -42383,12 +42500,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
-"sjR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "sjW" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -42417,7 +42528,7 @@
 /area/science/robotics/lab)
 "skv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -42448,6 +42559,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/salon)
 "slJ" = (
@@ -42455,13 +42567,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/large,
 /area/engineering/atmos)
-"slV" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "slW" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
@@ -42556,7 +42661,6 @@
 /area/cargo/storage)
 "sph" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
@@ -42855,10 +42959,8 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "syC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "syN" = (
@@ -43021,6 +43123,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"sBS" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "sBW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 1
@@ -43208,6 +43317,7 @@
 	icon_state = "L8"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "sGR" = (
@@ -43225,7 +43335,9 @@
 /area/science/genetics)
 "sHk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -43279,6 +43391,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
 "sIo" = (
@@ -43297,12 +43411,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"sIV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/hallway/primary/central)
 "sIZ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -43325,9 +43433,6 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
 "sKa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -43547,6 +43652,8 @@
 "sPz" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "sPC" = (
@@ -43613,7 +43720,6 @@
 /area/security/execution/education)
 "sSy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/holopad,
 /turf/open/floor/iron/white/smooth_large,
@@ -43637,6 +43743,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "sSW" = (
@@ -43867,14 +43974,6 @@
 	},
 /turf/open/floor/iron/dark/red,
 /area/security/execution/education)
-"sZK" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "sZL" = (
 /turf/closed/wall/r_wall,
 /area/security/brig/upper)
@@ -43937,7 +44036,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -44201,7 +44299,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -44311,6 +44408,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "tkm" = (
@@ -44418,7 +44516,6 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Dormitory South"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "tmU" = (
@@ -44465,6 +44562,7 @@
 	name = "Research Director Observation";
 	req_access_txt = "30"
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "tnZ" = (
@@ -44632,6 +44730,8 @@
 	dir = 1;
 	sortType = 7
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "tra" = (
@@ -44996,6 +45096,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/bridge)
 "tBP" = (
@@ -45188,6 +45291,16 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"tHv" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "tHM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -45311,8 +45424,8 @@
 "tKC" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/item/bikehorn/rubberducky,
-/obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "tKH" = (
@@ -45362,6 +45475,14 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"tMh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 5
+	},
+/area/science/research)
 "tMj" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -45439,6 +45560,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "tOT" = (
@@ -45542,6 +45664,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "tSm" = (
@@ -45725,12 +45848,25 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"tXI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "tXP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/iron,
 /area/science/storage)
+"tXX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 6
+	},
+/area/science/research)
 "tYk" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -45803,6 +45939,7 @@
 /obj/structure/railing,
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "tZa" = (
@@ -45906,6 +46043,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"ubC" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/service/salon)
 "ubI" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	name = "mix to port"
@@ -46015,7 +46160,6 @@
 	dir = 1;
 	name = "Logistics Station"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
 "uef" = (
@@ -46036,9 +46180,6 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "uel" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -46048,14 +46189,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
-"ueQ" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "ueT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46131,6 +46264,9 @@
 "ugF" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "uhn" = (
@@ -46215,6 +46351,12 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"uiU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "ujt" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance";
@@ -46375,6 +46517,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "umY" = (
@@ -46465,7 +46609,6 @@
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/meeting_room)
 "uqR" = (
@@ -46544,6 +46687,12 @@
 	},
 /turf/open/floor/iron,
 /area/science/storage)
+"usz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "usL" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -46660,12 +46809,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/command/bridge)
-"uvx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/side{
-	dir = 6
-	},
-/area/science/research)
 "uvA" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -46733,6 +46876,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "uwv" = (
@@ -46775,9 +46919,6 @@
 "uxz" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/processing)
@@ -46970,11 +47111,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"uAz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "uAI" = (
 /turf/open/floor/iron,
 /area/security/brig)
@@ -47213,6 +47349,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"uGo" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/service/library)
 "uGw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -47285,9 +47428,6 @@
 "uIu" = (
 /obj/item/storage/secure/safe/directional/south,
 /obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -47319,7 +47459,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "uKv" = (
@@ -47479,6 +47618,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -47590,6 +47732,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/bridge)
 "uTf" = (
@@ -48101,8 +48246,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "vhT" = (
@@ -48368,6 +48513,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"vqb" = (
+/obj/machinery/door/window/eastleft,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/glass/reinforced,
+/area/science/xenobiology)
 "vqw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -48435,6 +48587,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/mixing)
+"vrJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "vrW" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -48481,6 +48642,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "vtr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_half,
 /area/service/chapel)
 "vts" = (
@@ -48516,7 +48678,6 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "vuv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing{
 	dir = 4
 	},
@@ -48580,6 +48741,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "vvZ" = (
@@ -48833,6 +48995,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/bridge)
 "vBr" = (
@@ -48843,6 +49008,7 @@
 /area/cargo/storage)
 "vBt" = (
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/command/meeting_room)
 "vBu" = (
@@ -48960,6 +49126,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/meeting_room)
 "vDE" = (
@@ -49020,6 +49187,7 @@
 	icon_state = "L14"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "vEN" = (
@@ -49195,6 +49363,11 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"vJu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "vJL" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -49219,6 +49392,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"vKq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/brig)
 "vKw" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating{
@@ -49574,6 +49754,12 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
+"vVs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "vVt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -49811,6 +49997,7 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "wco" = (
@@ -49820,7 +50007,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wcx" = (
@@ -50159,6 +50345,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "wlw" = (
@@ -50232,6 +50419,15 @@
 /obj/structure/janitorialcart,
 /turf/open/floor/iron,
 /area/service/janitor)
+"wmT" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "wnf" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -50278,6 +50474,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "woD" = (
@@ -50312,6 +50509,8 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "wpt" = (
@@ -50359,13 +50558,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"wrn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "wru" = (
 /obj/machinery/firealarm/directional/north,
 /obj/structure/table,
@@ -50546,7 +50738,6 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/darkblue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/south{
 	c_tag = "Security - South"
 	},
@@ -50629,6 +50820,12 @@
 	},
 /turf/open/floor/plating,
 /area/service/chapel)
+"wAB" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "wAG" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light/directional/east,
@@ -50796,13 +50993,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
-"wCU" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "wCX" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -50843,6 +51033,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"wDZ" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/openspace,
+/area/science/xenobiology)
 "wEa" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
@@ -50850,7 +51044,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "wEd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -51029,7 +51222,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -51057,9 +51249,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -51084,6 +51273,9 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/cargo/office)
+"wKH" = (
+/turf/open/floor/carpet,
+/area/command/heads_quarters/captain)
 "wKL" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/curtain/cloth/fancy/mechanical{
@@ -51113,6 +51305,12 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"wLG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "wMc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -51251,26 +51449,12 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/science/genetics)
-"wPq" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "wPt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 6
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"wPv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/processor/slime,
-/turf/open/floor/iron,
-/area/science/xenobiology)
 "wPD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -51375,11 +51559,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
-"wRD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/command/bridge)
 "wRF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51572,9 +51751,6 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
 "wVx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/large,
 /area/hallway/primary/starboard)
@@ -51682,6 +51858,9 @@
 /area/hallway/primary/starboard)
 "wYJ" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "wYY" = (
@@ -52192,6 +52371,11 @@
 "xnd" = (
 /turf/open/floor/iron/textured_half,
 /area/service/hydroponics)
+"xnj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "xnt" = (
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
@@ -52273,9 +52457,18 @@
 "xpS" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
+"xpT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "xqa" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -52341,9 +52534,18 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Fitness"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness)
+"xrH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "xrV" = (
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/icemoon,
@@ -52386,6 +52588,15 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/commons/storage/emergency/port)
+"xsB" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "xta" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -52473,6 +52684,11 @@
 	network = list("ss13","rd","xeno")
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing,
 /turf/open/openspace,
 /area/science/xenobiology)
 "xuS" = (
@@ -52483,7 +52699,6 @@
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
 "xvI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -52599,7 +52814,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -52627,11 +52841,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
-"xxF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/darkblue/filled/warning,
-/turf/open/floor/iron,
-/area/security/brig)
 "xyn" = (
 /obj/structure/railing{
 	dir = 1
@@ -52688,13 +52897,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/mining)
-"xzP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet)
 "xAh" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -52736,12 +52938,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
-"xBn" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "xBs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 5
@@ -52853,6 +53053,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "xEg" = (
@@ -53040,10 +53243,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "xII" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/light/directional/south,
-/turf/open/openspace,
+/turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
 "xIN" = (
 /obj/structure/disposalpipe/segment{
@@ -53232,6 +53434,7 @@
 /mob/living/simple_animal/bot/secbot/beepsky,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "xPm" = (
@@ -53537,13 +53740,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/science/research)
-"xYQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/darkblue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "yag" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/warning{
 	dir = 4
@@ -53629,6 +53825,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "yce" = (
@@ -53640,11 +53837,13 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
 "yck" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/openspace,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
 "ycs" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -53686,10 +53885,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"ycP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/command/meeting_room)
 "ydc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53704,7 +53899,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "ydU" = (
@@ -65449,7 +65643,7 @@ asF
 asF
 apJ
 fyU
-aIK
+chq
 azy
 auP
 iWt
@@ -65706,7 +65900,7 @@ atI
 auc
 avp
 axI
-crz
+oDd
 awW
 aAD
 awW
@@ -66220,7 +66414,7 @@ xPm
 nsn
 apJ
 wJm
-aIK
+chq
 jRi
 arB
 arB
@@ -66757,7 +66951,7 @@ aAc
 cdn
 jRZ
 pAx
-onG
+pAx
 ayl
 beM
 asE
@@ -67271,7 +67465,7 @@ mAJ
 dYC
 rNY
 aPz
-kQe
+bdR
 aPz
 beQ
 pLn
@@ -67528,7 +67722,7 @@ sjw
 iWX
 uOC
 aPz
-kQe
+bdR
 aPz
 beP
 qWw
@@ -67785,7 +67979,7 @@ fXg
 uwv
 xVU
 aPz
-kQe
+bdR
 aPz
 eTt
 vKg
@@ -68042,7 +68236,7 @@ dze
 tAY
 eOE
 aPz
-kQe
+bdR
 aPz
 beR
 qWw
@@ -68299,7 +68493,7 @@ uRz
 rsx
 jNw
 aPz
-kQe
+bdR
 aPz
 beU
 bgk
@@ -68556,7 +68750,7 @@ fYH
 fYH
 fYH
 aPz
-kQe
+bdR
 aPz
 xrz
 xrz
@@ -69843,7 +70037,7 @@ kqF
 wpt
 aSg
 aSg
-bdD
+eyd
 pMs
 pFG
 tdl
@@ -72933,12 +73127,12 @@ bhO
 bjl
 jbJ
 kmY
-gQt
-oKH
-oKH
-oKH
+dCr
+dCr
+dCr
+dCr
 dKZ
-oKH
+dCr
 ybV
 ybV
 ybV
@@ -73190,16 +73384,16 @@ aPz
 aPz
 aPz
 xqa
-hmj
+dCr
+dCr
+jXp
 dCr
 dCr
 dCr
 dCr
-oKH
-oKH
-oKH
-oKH
-wCU
+dCr
+dCr
+rjq
 ybV
 jIx
 boP
@@ -73446,17 +73640,17 @@ bgw
 aPz
 fVD
 dAT
-skv
-hmj
-ojs
-jXp
-ojs
-dCr
-skv
-dCr
-dCr
-dCr
+btI
+vJu
+joU
+vJu
+bjE
 oKH
+skv
+dCr
+dCr
+dCr
+dCr
 dCr
 jIx
 boP
@@ -73704,9 +73898,9 @@ aPz
 kdG
 eXg
 jpE
-hmj
+dCr
 ojs
-gbZ
+dCr
 ojs
 kcH
 ggA
@@ -73960,10 +74154,10 @@ aSX
 aPz
 uap
 dCr
+btI
 dCr
-hmj
 ojs
-gbZ
+dCr
 jAn
 pGx
 fGe
@@ -74217,10 +74411,10 @@ aTv
 aPz
 fkF
 dCr
+btI
 dCr
-hmj
 ojs
-gbZ
+dCr
 ojs
 pGx
 fGe
@@ -74473,11 +74667,11 @@ aPz
 aPz
 aPz
 lqX
-hmj
-kxf
-hmj
 dCr
-gbZ
+kxf
+dCr
+dCr
+dCr
 dCr
 pGx
 fGe
@@ -74731,10 +74925,10 @@ phO
 ota
 kjD
 dCr
+btI
 dCr
-hmj
-gbZ
-gbZ
+dCr
+dCr
 dCr
 vzZ
 qQV
@@ -74990,7 +75184,7 @@ vxY
 mPL
 mPL
 kfi
-gbZ
+dCr
 udk
 hBg
 hBg
@@ -75239,8 +75433,8 @@ vpz
 jJD
 iGJ
 hkc
-eFk
 jJD
+eFk
 mQh
 ota
 szW
@@ -75255,7 +75449,7 @@ mmg
 uIw
 itD
 dCr
-oKH
+dCr
 jIx
 boP
 boP
@@ -75512,7 +75706,7 @@ gnP
 gnP
 gnP
 dCr
-oKH
+dCr
 gnP
 boP
 boP
@@ -76026,7 +76220,7 @@ oTY
 uDw
 oOH
 tZP
-lQH
+omo
 omo
 gaT
 sHr
@@ -76283,7 +76477,7 @@ cQW
 ykf
 oOH
 pcK
-eOk
+gSs
 omo
 omo
 nec
@@ -77278,7 +77472,7 @@ tfL
 iXr
 pfZ
 stc
-lvF
+kwf
 lXU
 wxV
 aLN
@@ -77555,7 +77749,7 @@ lXL
 plT
 jJX
 kHP
-kIT
+fuw
 pYX
 mQd
 nCS
@@ -77806,13 +78000,13 @@ plT
 rCw
 nxv
 djZ
-aST
-qgx
+ubC
+bTG
 pMQ
 plT
 emT
 lFU
-kIT
+pYW
 kIT
 fvc
 tel
@@ -78026,12 +78220,12 @@ ajs
 rvj
 tsU
 xTr
-blf
+xTr
 fMH
 sfU
-oUb
+oFM
 uxz
-wPq
+oUb
 gbP
 hYy
 hMo
@@ -78321,8 +78515,8 @@ bCA
 rdP
 eJv
 kyl
+kTt
 rdP
-sIV
 plT
 tel
 tel
@@ -78578,20 +78772,20 @@ aJq
 aJq
 aJq
 fGw
+vVs
 aJq
-bjx
-gUR
+aJq
 crV
 keD
-sZK
-nav
+bfo
+bfo
 bfo
 wrj
 bfo
 bfo
 aJq
 aOv
-btz
+jep
 btz
 bwf
 vFS
@@ -78835,11 +79029,11 @@ bBi
 bBi
 bBi
 bBi
-bBi
+xpT
 sPz
-bBi
-swA
-uAz
+aTh
+iGY
+aTh
 ivV
 iCx
 bjx
@@ -79060,7 +79254,7 @@ vXA
 aih
 xAV
 vvS
-cxz
+dSd
 ayE
 arP
 arP
@@ -79098,8 +79292,8 @@ aYl
 svg
 bgG
 oQp
-aYl
-aHn
+ple
+bBi
 fGw
 bnN
 boY
@@ -79109,7 +79303,7 @@ aJq
 aYl
 aKF
 oXL
-fGw
+kqm
 ova
 aJq
 aJw
@@ -79609,11 +79803,11 @@ vkz
 nth
 wiW
 nEf
-ycP
+xQa
 uqG
 rzq
 bjB
-bkW
+vRc
 bmp
 bjz
 vGP
@@ -79831,7 +80025,7 @@ lgf
 lXI
 pUB
 gVQ
-ueQ
+dSd
 azu
 jTQ
 nZC
@@ -80088,7 +80282,7 @@ lgf
 jGf
 pUB
 gVQ
-cxz
+dSd
 azu
 gIa
 rXP
@@ -80123,7 +80317,7 @@ qJW
 uOP
 pOt
 pOt
-qCV
+gnC
 ndL
 nuf
 sCZ
@@ -80139,7 +80333,7 @@ wWd
 wXS
 xqm
 ova
-aJq
+wLG
 nUy
 nUy
 dzF
@@ -80602,7 +80796,7 @@ pUB
 pUB
 xAV
 dDD
-cxz
+lJe
 eZw
 qzL
 euG
@@ -80844,12 +81038,12 @@ wps
 tqY
 umX
 egG
-rLb
-rLb
 pXC
-wlv
+pXC
+pXC
+kkE
 pSq
-wlv
+kkE
 bdG
 tSj
 lAH
@@ -80894,7 +81088,7 @@ vEl
 ndY
 xLG
 xLG
-gnC
+qCV
 xQa
 xQa
 tja
@@ -81094,29 +81288,29 @@ pZT
 mEz
 pxi
 bGg
-gUG
+vuv
 ceW
 vuv
 vuv
 vuv
 vuv
 qjJ
-xYQ
-rDV
+fMj
+wAB
 rDV
 aci
 lmc
-slV
+fMj
 gle
 wEd
-xRw
+uAI
 fhn
 xRw
 dyG
-slV
+fMj
 uKo
 tbm
-jxD
+dmm
 bON
 vzM
 rqV
@@ -81657,7 +81851,7 @@ gri
 eWw
 mTo
 viJ
-wRD
+ure
 mNn
 tzy
 bfv
@@ -82171,7 +82365,7 @@ eCl
 dWK
 qCx
 ure
-wRD
+ure
 jHR
 bfv
 aZS
@@ -82428,7 +82622,7 @@ eCl
 oWr
 whM
 hCi
-wRD
+hCi
 vBo
 bfv
 aZR
@@ -82661,14 +82855,14 @@ sYs
 auB
 apk
 anw
-anw
+vrJ
 anw
 anw
 fTu
 dPu
 awl
 azZ
-ayY
+azZ
 azZ
 azZ
 azZ
@@ -82685,12 +82879,12 @@ eCl
 dKW
 tZU
 nan
-wRD
+ure
 tBK
 bfv
 aZR
-aCN
-aCN
+bbm
+bbm
 bdh
 cEt
 bfv
@@ -82926,11 +83120,11 @@ fSc
 pno
 rUv
 rUv
-pQf
+xnj
 alk
-pQf
+xnj
 alk
-pQf
+xnj
 pQf
 rOo
 bBi
@@ -83182,12 +83376,12 @@ anA
 vIi
 pQf
 aAa
-ayZ
+aAa
 aAa
 vZM
 aAa
 aAa
-aAa
+ayZ
 aAa
 aHR
 aJt
@@ -83199,12 +83393,12 @@ eCl
 uzQ
 dAN
 pSK
-gai
+hCi
 fTU
 bfv
 aZR
-aCP
-aCP
+bbm
+bbm
 aEj
 vAG
 bfv
@@ -83456,7 +83650,7 @@ eCl
 uvo
 kJX
 ure
-gai
+ure
 ppK
 bfv
 krk
@@ -83713,7 +83907,7 @@ eCl
 nyY
 edt
 pmJ
-gai
+ure
 hwl
 bfv
 aZU
@@ -83964,13 +84158,13 @@ ahn
 aJn
 aJn
 aJq
-bBi
-aOE
+bjx
+gtI
 eCl
 eSD
 dNP
 dRf
-gai
+dRf
 qnw
 bfv
 bfv
@@ -84221,13 +84415,13 @@ hTM
 boP
 aJn
 aJq
-dRb
+oIS
 aOE
 eCl
 uTV
 oeJ
 uQe
-gai
+ure
 sIi
 lry
 bfv
@@ -84478,7 +84672,7 @@ hTM
 boP
 aJn
 aLY
-swA
+sBS
 oak
 rup
 rup
@@ -84706,8 +84900,8 @@ yhW
 yhW
 yhW
 aiQ
-pzi
-cdF
+nfO
+pwf
 pUB
 kCg
 uCu
@@ -84735,7 +84929,7 @@ hTM
 aJw
 aJw
 beX
-iEH
+ivV
 aOE
 aJn
 boP
@@ -84746,8 +84940,8 @@ mQG
 jsC
 qeI
 tuo
-kYB
-kYB
+jdv
+jdv
 mVa
 xHi
 fWQ
@@ -85003,9 +85197,9 @@ mzQ
 wBv
 olj
 gxp
+mau
 jdv
 jdv
-kYB
 joF
 cBu
 xpu
@@ -85249,7 +85443,7 @@ opq
 aJy
 aJy
 aMj
-iEH
+ivV
 oQH
 aJn
 boP
@@ -85262,7 +85456,7 @@ olj
 kyL
 tXA
 tXA
-rGu
+wKH
 qMp
 sar
 ncw
@@ -85478,7 +85672,7 @@ yhW
 yhW
 vtc
 nfO
-cdF
+pwf
 pUB
 akz
 lCe
@@ -85500,8 +85694,8 @@ xLu
 vaC
 vaC
 vaC
-vaC
-vaC
+tHv
+tHv
 nFv
 sSV
 aKo
@@ -85519,10 +85713,10 @@ olj
 cZv
 chw
 uhQ
-gdm
+wKH
 pIG
-kYB
-kYB
+jdv
+jdv
 kYB
 olj
 hnx
@@ -86034,7 +86228,7 @@ uvf
 jdv
 jdv
 jdv
-jdv
+eVO
 jdv
 jdv
 lcy
@@ -86249,7 +86443,7 @@ yhW
 yhW
 wHs
 nfO
-cdF
+pwf
 pUB
 eqC
 amr
@@ -87008,7 +87202,7 @@ hHL
 fYE
 fYE
 dFR
-bUr
+vKq
 jfz
 jfz
 jfz
@@ -87020,7 +87214,7 @@ jfz
 hSG
 jfz
 kXz
-xxF
+gMS
 jQg
 uAI
 flK
@@ -87266,19 +87460,19 @@ ozB
 mCJ
 fro
 ozB
-rdg
+fMj
 prx
 ozB
-rdg
+fMj
 cIi
 qCP
-lmc
-lmc
+yag
+wAB
 lTO
 mfy
 rvX
-ekC
-jjL
+dSd
+xAV
 yhW
 flK
 gMW
@@ -87550,7 +87744,7 @@ nnV
 hTM
 tVr
 pZn
-xBn
+vnc
 ydJ
 coc
 nlk
@@ -87810,9 +88004,9 @@ hmi
 xrF
 ihs
 eIL
+xsB
 cAU
-cAU
-xzP
+hax
 eIL
 evg
 smm
@@ -88089,7 +88283,7 @@ lor
 iBJ
 aYV
 iKz
-aYV
+usz
 bfF
 wDJ
 owD
@@ -88349,7 +88543,7 @@ iKz
 fva
 bfF
 acZ
-owD
+pDb
 bgP
 bfF
 bkL
@@ -88606,7 +88800,7 @@ iKz
 tuY
 bfF
 rDE
-owD
+tXI
 bjO
 bfF
 bfF
@@ -88863,7 +89057,7 @@ iKz
 aYV
 bfF
 tdC
-wrn
+tXI
 bjR
 kGA
 lTh
@@ -89371,8 +89565,8 @@ sSO
 egD
 eIO
 aYV
-qtw
-oOF
+aYV
+aYV
 iKz
 bet
 bfF
@@ -89629,7 +89823,7 @@ rvR
 eGr
 qtw
 qtw
-mju
+uiU
 wSp
 bet
 bfF
@@ -90400,7 +90594,7 @@ ppt
 wgL
 pXN
 bez
-bez
+mYx
 pEE
 bet
 bfF
@@ -90656,10 +90850,10 @@ std
 std
 std
 dmC
-aYV
-aDA
-iKz
-bet
+bcq
+bcq
+xrH
+mjQ
 xqe
 lyb
 wxF
@@ -91423,12 +91617,12 @@ usW
 ebS
 odG
 cLx
-nTS
+odG
 qmL
 liL
 liL
-bcq
-bcq
+aYV
+mju
 bPc
 oku
 oAn
@@ -91707,7 +91901,7 @@ ikw
 wvq
 bCN
 bEa
-pHl
+eLl
 ikw
 wXA
 utL
@@ -91963,7 +92157,7 @@ pva
 wdA
 wdA
 wdA
-wdA
+wmT
 wdA
 bLf
 ocb
@@ -92199,7 +92393,7 @@ rBv
 cMe
 ybZ
 aYV
-mju
+aYV
 oOF
 jxN
 bfK
@@ -92483,7 +92677,7 @@ bfG
 jqM
 yeI
 hQX
-dEq
+pJC
 giT
 kJc
 pOC
@@ -93725,7 +93919,7 @@ alP
 rmg
 vfu
 alP
-arI
+anf
 aIk
 alP
 lLT
@@ -93982,7 +94176,7 @@ atB
 wNN
 ykx
 alP
-arr
+anf
 aGH
 alP
 alP
@@ -96606,17 +96800,17 @@ jni
 nka
 xux
 nka
+bSq
+cIW
 nka
+bSq
+kft
 nka
-nka
-nka
-yhK
-nka
-nka
-nka
+bSq
+cIW
 ylY
-nka
-nka
+bSq
+cIW
 nka
 uyS
 boP
@@ -96861,19 +97055,19 @@ bRT
 bRT
 jni
 nka
+cIW
 nka
+bSq
+cIW
 nka
+bSq
+cIW
 nka
+bSq
+cIW
 nka
-nka
-nka
-nka
-nka
-nka
-nka
-nka
-nka
-nka
+bSq
+cIW
 nka
 uyS
 xrV
@@ -97118,19 +97312,19 @@ bRT
 bRT
 hdN
 yck
+hRu
 yck
 yck
+hRu
 yck
 yck
+hRu
 yck
 yck
+hRu
 yck
 yck
-yck
-yck
-yck
-yck
-yck
+hRu
 yck
 bIx
 xrV
@@ -97374,9 +97568,9 @@ owa
 owa
 owa
 wlC
-bRY
-bRY
-bRY
+bRT
+bRT
+bRT
 nOm
 sUX
 mdh
@@ -97387,7 +97581,7 @@ nOl
 vYW
 kFN
 lXq
-bRY
+bRT
 xII
 bDb
 xrV
@@ -97883,23 +98077,23 @@ jpF
 jpF
 kCw
 ubZ
-bQL
-bQL
-bQL
-bQL
+lvz
+lvz
+lvz
+lvz
 dMH
-dgQ
-dgQ
-dgQ
-dgQ
-dgQ
+fkM
+fkM
+fkM
+fkM
+eZk
 lpm
 lNo
 tkg
-dgQ
-dgQ
-dgQ
-dgQ
+eZk
+eZk
+eZk
+eZk
 dgQ
 efT
 iOI
@@ -98104,8 +98298,8 @@ siL
 siL
 siL
 siL
-siL
-csr
+oOj
+uGo
 aeq
 nhQ
 csr
@@ -98121,7 +98315,7 @@ cHO
 blG
 aJY
 cHV
-cIa
+aJY
 jtr
 box
 bpZ
@@ -98139,26 +98333,26 @@ mJV
 eHg
 jpF
 iLK
-ubZ
-lvz
+bMi
+bQL
 bQN
-dqL
-dqL
-dqL
+qlZ
+qlZ
+qlZ
 bVk
-wPv
+nIQ
 rUR
 bZb
 pnD
-kvq
-kvq
+dFp
+dFp
 nlQ
-ubZ
+bMi
 bQN
-dqL
+qlZ
 jPE
-jCV
-jCV
+qlZ
+qlZ
 fIU
 qyX
 xrV
@@ -98362,7 +98556,7 @@ sQM
 mek
 siL
 siL
-oOj
+siL
 aeq
 kuN
 mXU
@@ -98399,9 +98593,9 @@ bIv
 bIR
 bQL
 bLe
-bRY
-bRY
-bRY
+bRT
+bRT
+bRT
 joT
 gFU
 txJ
@@ -98412,10 +98606,10 @@ dDe
 rUB
 qlZ
 xCR
-bRY
-bRY
-bRY
-bRY
+bRT
+bRT
+bRT
+bRT
 lXc
 bDb
 ecj
@@ -98657,22 +98851,22 @@ mGc
 bQL
 nCf
 bSa
+vqb
 bSa
 bSa
+vqb
 bSa
 bSa
+vqb
 bSa
 bSa
+vqb
 bSa
 bSa
+vqb
 bSa
 bSa
-bSa
-bSa
-bSa
-bSa
-bSa
-bSa
+vqb
 bSa
 bIx
 xrV
@@ -98914,22 +99108,22 @@ mGc
 bQL
 pcf
 nka
+rEK
+wDZ
 nka
+cIW
+wDZ
 nka
+cIW
+wDZ
 nka
+cIW
+wDZ
 nka
+cIW
+wDZ
 nka
-nka
-nka
-nka
-nka
-nka
-nka
-nka
-nka
-nka
-nka
-nka
+cIW
 nka
 pCj
 xrV
@@ -99149,7 +99343,7 @@ blC
 bou
 cHT
 bou
-cId
+idl
 aPm
 uVq
 ybJ
@@ -99171,22 +99365,22 @@ uOW
 bQL
 pcf
 nBv
-nka
-nka
+rEK
+wDZ
 pBz
-nBv
+gKh
+wDZ
 nka
+cIW
+wDZ
 nka
+gKh
+wDZ
 nka
-nka
-nka
-nBv
-nka
-nka
-nka
+cIW
 fep
 nka
-nka
+cIW
 nka
 pCj
 boP
@@ -99920,8 +100114,8 @@ bjZ
 bvx
 boz
 boM
-bzE
-bzE
+btW
+btW
 btW
 dcG
 bxd
@@ -99932,19 +100126,19 @@ bWr
 gOm
 bzE
 qFn
-bvE
-bWr
-sjR
+fAO
 bWr
 bWr
 bWr
-bzE
+bWr
+bWr
+tMh
 dLY
 bvE
 bvE
-uvx
-dwp
 bvE
+bvE
+tXX
 ekm
 bPK
 bQO
@@ -100196,12 +100390,12 @@ xbx
 xbx
 xbx
 bJr
-bJr
-bJr
-bJr
-bJr
-bWr
-bWr
+bpW
+bpW
+bpW
+bpW
+bpW
+bpW
 bWo
 bJO
 foo
@@ -100719,8 +100913,8 @@ cas
 cas
 bQZ
 uOi
-cba
-gZY
+bYm
+khv
 nfe
 mtK
 nlW
@@ -100939,7 +101133,7 @@ mAw
 tVj
 eIf
 ykz
-aYV
+ooJ
 ycc
 bhN
 aLg
@@ -101196,8 +101390,8 @@ rZt
 tVj
 wYc
 ykz
-ooJ
-ooJ
+aYV
+aYV
 wVx
 vjP
 tcM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Many locations on icebox, such as the brig, had odd piping layouts that made no sense, and aren't conducive to knowing where to find the pipe you want. I also added a vent and scrubber to that one odd corner of central primary without one. In addition, there was one location in medbay with a vent under a disposal unit that I moved. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Hello yes I like my scrubber and distro lines on the same tile thanks.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Pipes, vents, scrubbers, and cables on icebox have been rearranged to be slightly more sane
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
