### PR TITLE
[MODULAR] Adds new Quartermaster title and tweaks already existing ones

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -64,7 +64,7 @@
 	alt_titles = list("Curator", "Librarian", "Journalist", "Archivist")
 
 /datum/job/customs_agent
-	alt_titles = list("Customs Agent", "Customs Guard", "Cargo Guard")
+	alt_titles = list("Customs Agent", "Customs Guard", "Supply Guard")
 
 /datum/job/cyborg
 	alt_titles = list("Cyborg", "Robot", "Android")
@@ -115,7 +115,7 @@
 	alt_titles = list("Psychologist", "Psychiatrist", "Therapist", "Counsellor")
 
 /datum/job/quartermaster
-	alt_titles = list("Quartermaster", "Deck Chief", "Cargo Foreman", "Head of Cargo", "Chief Requisition Officer")
+	alt_titles = list("Quartermaster", "Deck Chief", "Supply Foreman", "Head of Supply", "Chief Requisition Officer", "Logistics Officer")
 
 /datum/job/research_director
 	alt_titles = list("Research Director", "Silicon Administrator", "Lead Researcher", "Biorobotics Director", "Research Supervisor", "Chief Science Officer")


### PR DESCRIPTION
## About The Pull Request

This PR adds a new Quartermaster title, named "Logistics Officer" and switches out the use of "Cargo" in most titles with "Supply".

## How This Contributes To The Skyrat Roleplay Experience

Adds more title choices. Also makes the changed titles advertise themselves as the head or guard of the whole department and not just the cargo bay.

## Changelog

:cl:
add: "Logistics Officer" QM title.
tweak: Titles "Head of Cargo", "Cargo Foreman" and "Cargo Guard" switched out for "Head of Supply", "Supply Foreman" and "Supply Guard".
/:cl: