### PR TITLE
[MODULAR] Transfer Shuttles are low priority

### DIFF
--- a/modular_skyrat/modules/autotransfer/code/shuttle.dm
+++ b/modular_skyrat/modules/autotransfer/code/shuttle.dm
@@ -4,7 +4,7 @@
 /datum/controller/subsystem/shuttle/proc/autoEnd()
 	if(EMERGENCY_IDLE_OR_RECALLED)
 		SSshuttle.emergency.request(null, set_coefficient = 2, silent = TRUE)
-		priority_announce("The shift has come to an end and the shuttle called. Low-Priority shuttle dispatched. It will arrive in [emergency.timeLeft(600)] minutes.", null, ANNOUNCER_SHUTTLECALLED, "Priority")
+		priority_announce("The shift has come to an end and the shuttle called. Non-Emergency shuttle dispatched. It will arrive in [emergency.timeLeft(600)] minutes.", null, ANNOUNCER_SHUTTLECALLED, "Priority")
 		log_game("Round end vote passed. Shuttle has been auto-called.")
 		message_admins("Round end vote passed. Shuttle has been auto-called.")
 	emergency_no_recall = TRUE

--- a/modular_skyrat/modules/autotransfer/code/shuttle.dm
+++ b/modular_skyrat/modules/autotransfer/code/shuttle.dm
@@ -3,7 +3,7 @@
 
 /datum/controller/subsystem/shuttle/proc/autoEnd()
 	if(EMERGENCY_IDLE_OR_RECALLED)
-		SSshuttle.emergency.request(silent = TRUE)
+		SSshuttle.emergency.request(null, set_coefficient = 2, silent = TRUE)
 		priority_announce("The shift has come to an end and the shuttle called. [SSsecurity_level.current_level == SEC_LEVEL_RED ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [emergency.timeLeft(600)] minutes.", null, ANNOUNCER_SHUTTLECALLED, "Priority")
 		log_game("Round end vote passed. Shuttle has been auto-called.")
 		message_admins("Round end vote passed. Shuttle has been auto-called.")

--- a/modular_skyrat/modules/autotransfer/code/shuttle.dm
+++ b/modular_skyrat/modules/autotransfer/code/shuttle.dm
@@ -4,7 +4,7 @@
 /datum/controller/subsystem/shuttle/proc/autoEnd()
 	if(EMERGENCY_IDLE_OR_RECALLED)
 		SSshuttle.emergency.request(null, set_coefficient = 2, silent = TRUE)
-		priority_announce("The shift has come to an end and the shuttle called. [SSsecurity_level.current_level == SEC_LEVEL_RED ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [emergency.timeLeft(600)] minutes.", null, ANNOUNCER_SHUTTLECALLED, "Priority")
+		priority_announce("The shift has come to an end and the shuttle called. Low-Priority shuttle dispatched. It will arrive in [emergency.timeLeft(600)] minutes.", null, ANNOUNCER_SHUTTLECALLED, "Priority")
 		log_game("Round end vote passed. Shuttle has been auto-called.")
 		message_admins("Round end vote passed. Shuttle has been auto-called.")
 	emergency_no_recall = TRUE


### PR DESCRIPTION
## About The Pull Request
The Crew Transfer shuttle has been set to a static 20 minutes regardless of alert level.
![image](https://user-images.githubusercontent.com/10399117/151736118-bc9ff02b-5101-4543-8806-5f1a9963da72.png)


## How This Contributes To The Skyrat Roleplay Experience

Scrambling your highest priority shuttle to dispatch because reason given: "crew is tired and wants to go home" makes little sense. Regardless of alert level active, the modular shuttle timer should only apply for if the shuttle is actually dispatched as an emergency measure.
If you want a priority shuttle, the crew should actually be trying to call for one. Boredom is not an emergency.

This gives antagonists and other crew events time to wrap up when the transfer vote comes up out of the blue, and preempts un-immersive behavior from occurring such as changing the alert level during a vote to force a different timer.

## Changelog

:cl:
balance: To save on frivolous expenses, Nanotrasen is no longer dispatching priority shuttles just for simple crew transfers. An admiral cited "Boredom is not an emergency." to justify the change.
/:cl:
