### PR TITLE
temporarily disable lone ops

### DIFF
--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -83,3 +83,12 @@
  */
 /datum/round_event_control/sentient_disease
 	max_occurrences = 0
+
+/**
+ * Lone Ops
+ *
+ * Removed:
+ * Does not have policy. Will re-add if/when policy is added
+ */
+/datum/round_event_control/operative
+	max_occurrences = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
disables lone op through the nuke disk.
essentially https://github.com/Skyrat-SS13/Skyrat-tg/pull/2854

**This is temporary, until we have policy for lone ops. We will only allow this to play during high pop as well, since we are not balanced for low pop.**
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
**This is temporary, until we have policy for lone ops. We will only allow this to play during high pop as well, since we are not balanced for low pop.**
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: lone ops will no longer receive weight from nuke disk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
