### PR TITLE
[Semi-Modular] Allows ghost roles to use loadouts & quirks

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -14,6 +14,7 @@
 	the hostile creatures, and the ash drakes swooping down from the cloudless skies, all you can wish for is the feel of soft grass between your toes and \
 	the fresh air of Earth. These thoughts are dispelled by yet another recollection of how you got here... "
 	spawner_job_path = /datum/job/hermit
+	quirks_enabled = TRUE // SKYRAT EDIT ADDITION - ghost role loadouts
 
 /obj/effect/mob_spawn/ghost_role/human/hermit/Initialize(mapload)
 	. = ..()
@@ -79,6 +80,7 @@
 	flavour_text = "Ch'yea. You came here, like, on spring break, hopin' to pick up some bangin' hot chicks, y'knaw?"
 	spawner_job_path = /datum/job/beach_bum
 	outfit = /datum/outfit/beachbum
+	quirks_enabled = TRUE // SKYRAT EDIT ADDITION - ghost role loadouts
 
 /obj/effect/mob_spawn/ghost_role/human/beach/lifeguard
 	you_are_text = "You're a spunky lifeguard!"
@@ -271,6 +273,8 @@
 	important_text = "The base is rigged with explosives, DO NOT abandon it or let it fall into enemy hands!"
 	outfit = /datum/outfit/lavaland_syndicate
 	spawner_job_path = /datum/job/lavaland_syndicate
+	loadout_enabled = TRUE // SKYRAT EDIT ADDITION - ghost role loadouts
+	quirks_enabled = TRUE // SKYRAT EDIT ADDITION - ghost role loadouts
 
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/special(mob/living/new_spawn)
 	. = ..()

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -134,6 +134,10 @@
 	// SKYRAT EDIT ADDITION
 	/// Do we use a random appearance for this ghost role?
 	var/random_appearance = FALSE
+	/// Can we use our loadout for this role?
+	var/loadout_enabled = FALSE
+	/// Can we use our quirks for this role?
+	var/quirks_enabled = FALSE
 	// SKYRAT EDIT END
 
 /obj/effect/mob_spawn/ghost_role/Initialize(mapload)
@@ -181,8 +185,10 @@
 			var/mob/living/carbon/human/spawned_human = spawned_mob
 			mob_possessor?.client?.prefs?.safe_transfer_prefs_to(spawned_human)
 			spawned_human.dna.update_dna_identity()
-			SSquirks.AssignQuirks(spawned_human, mob_possessor.client)
-			spawned_human.equip_outfit_and_loadout(outfit, mob_possessor.client.prefs)
+			if(loadout_enabled)
+				SSquirks.AssignQuirks(spawned_human, mob_possessor.client)
+			if(quirks_enabled)
+				spawned_human.equip_outfit_and_loadout(outfit, mob_possessor.client.prefs)
 	// SKYRAT EDIT END
 	if(mob_possessor)
 		spawned_mob.ckey = mob_possessor.ckey

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -181,6 +181,7 @@
 			var/mob/living/carbon/human/spawned_human = spawned_mob
 			mob_possessor?.client?.prefs?.safe_transfer_prefs_to(spawned_human)
 			spawned_human.dna.update_dna_identity()
+			spawned_human.equip_outfit_and_loadout(outfit, mob_possessor.client.prefs)
 	// SKYRAT EDIT END
 	if(mob_possessor)
 		spawned_mob.ckey = mob_possessor.ckey

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -181,6 +181,7 @@
 			var/mob/living/carbon/human/spawned_human = spawned_mob
 			mob_possessor?.client?.prefs?.safe_transfer_prefs_to(spawned_human)
 			spawned_human.dna.update_dna_identity()
+			SSquirks.AssignQuirks(spawned_human, mob_possessor.client)
 			spawned_human.equip_outfit_and_loadout(outfit, mob_possessor.client.prefs)
 	// SKYRAT EDIT END
 	if(mob_possessor)

--- a/modular_skyrat/modules/mapping/code/mob_spawns.dm
+++ b/modular_skyrat/modules/mapping/code/mob_spawns.dm
@@ -21,6 +21,12 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	id = /obj/item/card/id/away/blackmarket
 
+/obj/effect/mob_spawn/ghost_role/human/ds2
+	name = "DS2 personnel"
+	prompt_name = "DS2 personnel"
+	you_are_text = "You are a syndicate operative, employed in a top secret research facility developing biological weapons."
+	flavour_text = "Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. Continue operating as best you can, and try to keep a low profile."
+
 /obj/effect/mob_spawn/ghost_role/human/ds2/prisoner
 	name = "Syndicate Prisoner"
 	prompt_name = "a Syndicate prisoner"
@@ -31,12 +37,6 @@
 	icon_state = "sleeper_s"
 	outfit = /datum/outfit/ds2/prisoner
 
-/obj/effect/mob_spawn/ghost_role/human/ds2
-	name = "DS2 personnel"
-	prompt_name = "DS2 personnel"
-	you_are_text = "You are a syndicate operative, employed in a top secret research facility developing biological weapons."
-	flavour_text = "Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. Continue operating as best you can, and try to keep a low profile."
-
 /obj/effect/mob_spawn/ghost_role/human/ds2/syndicate
 	name = "Syndicate Operative"
 	prompt_name = "a Syndicate operative"
@@ -46,6 +46,8 @@
 	flavour_text = "Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. Continue operating as best you can, and try to keep a low profile."
 	important_text = "You are not an antagonist."
 	outfit = /datum/outfit/ds2/syndicate
+	loadout_enabled = TRUE
+	quirks_enabled = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/special(mob/living/new_spawn)
 	. = ..()
@@ -260,6 +262,8 @@
 	flavour_text = "Something went wrong. Morality of experiments went awry, expansions were made before scans were fully done and now you have to deal with the aftermath of your past crews exodus. Bring P-T to the success it was ment to be, or die trying. (OOC note: This ghost role was not designed with Plasmamen or Vox in mind. While there are some accommodations so that they can survive, it should be noted that they were not the focal point whilst designing Port Tarkon. The closet in the middle of the room above contains the 'accommodations' for those species.)"
 	important_text = "DO NOT abandon the port, PERIOD, but using the ship to buy more items or get help is good, if not ideal. Do not trade special equipment to the station. Unwelcomed and uninvited guests are not obligated to your kindness."
 	outfit = /datum/outfit/tarkon
+	loadout_enabled = TRUE
+	quirks_enabled = TRUE
 
 /datum/outfit/tarkon
 	uniform = /obj/item/clothing/under/utility/cargo


### PR DESCRIPTION
## About The Pull Request

Ghost roles can now use loadouts and quirks.
Loadouts and quirks are enabled by `loadout_enabled` and `quirks_enabled` vars on the `mob_spawn` itself, both **disabled** by default.

Enabled in this PR are:
- Lavaland syndicates, quirks and loadouts
- Tarkon crew, quirks and loadouts
- DS2 Syndicates, quirks and loadouts
- Hermits, quirks only
- Beach workers, quirks only

Open to suggestions on who gets what.

I meant to do this like a month ago but I never got around to it.
![image](https://user-images.githubusercontent.com/8881105/151839987-fac5d881-ce80-4d28-92a1-29952ee1e20c.png)
![image](https://user-images.githubusercontent.com/8881105/151842463-c33f7483-bc85-4638-8506-0316114e4dcf.png)

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/10404

## Changelog
:cl:
fix: Ghost roles can now use loadouts and quirks as God intended.
/:cl: