### PR TITLE
Replaces every use of the shuttle_bar subtype of wooden tables with normal ones in barber shops on both metastation and deltastaton, because for some reason mappers keep using this table type despite it not being meant to be used

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -54446,8 +54446,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/table/wood/shuttle_bar,
 /obj/item/lipstick/random,
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/salon)
 "jup" = (
@@ -83656,8 +83656,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/table/wood/shuttle_bar,
 /obj/item/book/fish_catalog,
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/salon)
 "qYD" = (

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -15662,8 +15662,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/table/wood/shuttle_bar,
 /obj/item/lipstick/random,
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/salon)
 "doO" = (
@@ -58122,8 +58122,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/table/wood/shuttle_bar,
 /obj/item/book/fish_catalog,
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/salon)
 "sHp" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the indestructible, unable to be deconstructed, and unable to be climbed upon wooden table types that are used in the barber's shops in meta and delta.
Mapping PSA: ***STOP USING THIS TABLE SUBTYPE ON MAPS ITS CALLED SHUTTLE_BAR FOR A REASON***

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
I keep having to ask admins to delete the tables on these maps because whoever mapped in these barber's shops is apparently incapable of reading.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: the wooden tables in the barber's shops on both meta and delta no longer have magic tables that cannot be touched in any way
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
