### PR TITLE
you can emag the bluespace miner now

### DIFF
--- a/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
+++ b/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
@@ -6,7 +6,7 @@
 
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/bluespace_miner
-	idle_power_usage = 200
+	idle_power_usage = 300
 
 	///the temperature of the co2 produced per successful process (its really 100) KELVIN
 	var/gas_temp = 100
@@ -20,6 +20,7 @@
 		/obj/item/stack/sheet/mineral/silver = 8,
 		/obj/item/stack/sheet/mineral/titanium = 8,
 		/obj/item/stack/sheet/mineral/uranium = 3,
+		/obj/item/xenoarch/strange_rock = 3,
 		/obj/item/stack/sheet/mineral/gold = 3,
 		/obj/item/stack/sheet/mineral/diamond = 1,
 	)
@@ -47,6 +48,8 @@
 
 /obj/machinery/bluespace_miner/examine(mob/user)
 	. = ..()
+	if(obj_flags & EMAGGED)
+		. += span_warning("The safeties are turned off!")
 	var/turf/src_turf = get_turf(src)
 	var/datum/gas_mixture/environment = src_turf.return_air()
 	if(environment.temperature >= T20C)
@@ -91,6 +94,9 @@
 	var/datum/gas_mixture/merger = new
 	merger.assert_gas(/datum/gas/carbon_dioxide)
 	merger.gases[/datum/gas/carbon_dioxide][MOLES] = MOLES_CELLSTANDARD
+	if(obj_flags & EMAGGED)
+		merger.assert_gas(/datum/gas/tritium)
+		merger.gases[/datum/gas/tritium][MOLES] = MOLES_CELLSTANDARD
 	merger.temperature = (T20C + gas_temp)
 	src_turf.assume_air(merger)
 	return TRUE
@@ -118,6 +124,14 @@
 		update_appearance()
 		return
 	return FALSE
+
+/obj/machinery/bluespace_miner/emag_act(mob/user, obj/item/card/emag/emag_card)
+	if(obj_flags & EMAGGED)
+		balloon_alert(user, "already emagged!")
+		return
+	ore_chance += list(/obj/item/stack/sheet/mineral/bananium = 1)
+	obj_flags |= EMAGGED
+	balloon_alert_to_viewers("fizzles!")
 
 /obj/item/circuitboard/machine/bluespace_miner
 	name = "Bluespace Miner (Machine Board)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title! You can now emag the bluespace miner to have it produce bananium at the cost of it also producing tritium (which means more pressure and a bit more maintenance).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Adding more emag interactions is nice for traitors doing gimmicks and stuff.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: bluespace miners can now be emagged to produce bananium (will also produce tritium)
expansion: bluespace miners will now also default mine strange rocks
balance: idle power usage for bluespace miners is up from 200 to 300
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
