### PR TITLE
[SEMI-MODULAR] Non-Trivializing Thermals and X-Ray Implants

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -192,6 +192,24 @@
 	see_in_dark = 8
 	sight_flags = SEE_MOBS | SEE_OBJS | SEE_TURFS
 
+/obj/item/organ/eyes/robotic/xray/emp_act(severity) //SKYRAT EDIT START:X-RAY EYE NERF
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	if(owner && (damage < maxHealth) && prob(150/severity))
+		applyOrganDamage(30/severity)
+		owner.flash_act(intensity = 2/severity, override_blindness_check = 1)
+		owner.adjust_blurriness(30)
+		owner.visible_message(span_warning("[owner]'s eyes flash with a sickly blue light!"))
+		to_chat(owner, span_warning("Your vision swims with frantic, flashing images of the inside of your head!"))
+		owner.add_confusion(min(owner.get_confusion() + 10, 30))
+		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 30)
+		radiation_pulse(owner, max_range = 0, threshold = RAD_FULL_INSULATION, chance = 100)
+		do_sparks(2, TRUE, owner)
+		owner.emote("scream")
+		if(severity == 1)
+			owner.Knockdown(1 SECONDS)//SKYRAT EDIT END: X-RAY EYE NERF
+
 /obj/item/organ/eyes/robotic/thermals
 	name = "thermal eyes"
 	desc = "These cybernetic eye implants will give you thermal vision. Vertical slit pupil included."
@@ -200,6 +218,27 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	flash_protect = FLASH_PROTECTION_SENSITIVE
 	see_in_dark = 8
+
+/obj/item/organ/eyes/robotic/thermals/emp_act(severity) //SKYRAT EDIT START: THERMAL EYE NERF
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	if(owner && (damage < maxHealth) && prob(150/severity))
+		applyOrganDamage(30/severity)
+		owner.flash_act(intensity = 2/severity, override_blindness_check = 1)
+		owner.adjust_blurriness(30)
+		owner.visible_message(span_warning("[owner]'s eyes hiss smoke and burst into flame!"))
+		to_chat(owner, span_warning("Your eyes burn with a scorching, white heat!"))
+		owner.add_confusion(min(owner.get_confusion() + 10, 30))
+		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 30)
+		var/obj/item/bodypart/affecting = owner.get_bodypart(BODY_ZONE_HEAD)
+		owner.apply_damage(25, BURN, affecting)
+		owner.adjust_fire_stacks(10/severity)
+		owner.IgniteMob()
+		do_sparks(2, TRUE, owner)
+		owner.emote("scream")
+		if(severity == 1)
+			owner.Knockdown(1 SECONDS)//SKYRAT EDIT END: THERMAL EYE NERF
 
 /obj/item/organ/eyes/robotic/flashlight
 	name = "flashlight eyes"

--- a/modular_skyrat/modules/implants/code/medical_nodes.dm
+++ b/modular_skyrat/modules/implants/code/medical_nodes.dm
@@ -6,6 +6,18 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 
 /datum/techweb_node/combat_cyber_implants
-	design_ids = list("ci-xray", "ci-thermals", "ci-nv", "ci-antidrop", "ci-antistun", "ci-antisleep", "ci-thrusters", "ci-mantis", "ci-flash")
+	design_ids = list("ci-nv", "ci-antidrop", "ci-antistun", "ci-antisleep", "ci-thrusters", "ci-mantis", "ci-flash")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12000)
 
+/datum/techweb_node/combat_optics
+	id = "combat_optics"
+	display_name = "Advanced Optical Combat Implants"
+	description = "Game-changing replacements for the human eye. WARNING: Unadapted brains are highly vulnerable to electromagnetic feedback."
+	prereq_ids = list("adv_cyber_implants","weaponry","NVGtech","high_efficiency", "combat_cyber_implants")
+	design_ids = list("ci-xray", "ci-thermals")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 63000) //requires a solid ~20 minutes of uninterrupted passive research point gain plus experiments
+	required_experiments = list(/datum/experiment/explosion/maxcap,
+		/datum/experiment/scanning/points/machinery_tiered_scan/tier2_lathes,
+		/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_capacitors,
+		/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser,
+		)


### PR DESCRIPTION
## About The Pull Request

Alternative to #11179 

Moves thermal and X-ray implants to their own very-expensive techweb node behind the other combat implants and several experiments.

Makes much more severe EMP downsides to thermals/xray implants.

## How This Contributes To The Skyrat Roleplay Experience

The readdition of thermals and x-ray implants has come under fire for being a very early in to a lot of information and shutdown ability for security against antagonists. They also don't have particular downsides after being acquired. 

The compromise solution was to move them to alien tech (something that only shows up through mining or space explorers happenstancing loot/corpses back to the station, and very rarely at that.) This is highly-rare as-is, but even assuming people do start to go after the sources for alien tech every round, this really doesn't do much for people on the station. It doesn't add any good reason to get out and move around with other departments. It could still practically be done by one person without much coordination across the science department. For one dedicated individual without much concern about the opportunity cost, you could still get to a point of being able to beeline thermals/x-rays pretty well. 

This PR instead vastly raises the cost of thermals and X-rays in their own tech node; puts them behind several experiments requiring that science be doing toxins and performing experiments on machines around the station; and adds significant extra downsides to getting hit with EMP after getting them installed. It should encourage more interaction from science, give other people in the round more of a reason to allow science to move around and do things, push the implant acquisition later into the round. It readds an alibi to doing toxins since most of the MCR stuff was switched to discounts. It should also make the implants themselves more of an interesting choice and less of a flat tradeoff for people to try to get given that they're exposing themselves to a lot of hurt from EMP. It should also make it much more obvious how and when science is getting to the point that implants might be unlocked (other research stops, or continues - this also makes it much easier to slow down the acquisition by, say, blowing up the R&D server.) 

I'm not entirely happy with all the tradeoffs being loaded on EMPs, and I do think there's an argument for using alien tech for more things as a reason to get people out exploring more (also an alibi for going into space for antagonism.) However, I think I'm happier with this solution (one that requires a lot more coordination in the research team, keeps the implants, and introduces some stiffer mechanical drawbacks to using them) than I am with the PR now up to get rid of them again. Being able to pursue more information in-game is a good thing. Letting people progress and get meaningful benefits over the course of a round is a good thing. 

There are better ways to do that, and I think this is one.

## Changelog

:cl:
balance: Moves thermals/x-ray implants to their own much more expensive technode requiring several experiments to be completed. 
balance: Makes the penalties for getting EMP'd while having thermals/X-ray implants much more severe.
/:cl:
