### PR TITLE
[MODULAR] Pepperball ammo resupply kits can be ordered as a goodie from cargo.

### DIFF
--- a/modular_skyrat/modules/cargo/code/goodies.dm
+++ b/modular_skyrat/modules/cargo/code/goodies.dm
@@ -63,6 +63,14 @@
 	cost = PAYCHECK_MEDIUM * 17
 	contains = list(/obj/item/storage/box/gunset/pepperball)
 
+/datum/supply_pack/goody/pepperball_ammo
+	name = "PepperBall Ammo Resupply"
+	desc = "An ammobox and a few spare magazines for a PepperBall self defense weapon, in case you run out."
+	cost = PAYCHECK_MEDIUM * 6
+	contains = list(/obj/item/ammo_box/advanced/pepperballs,
+					/obj/item/ammo_box/magazine/pepperball,
+					/obj/item/ammo_box/magazine/pepperball)
+
 /datum/supply_pack/goody/gunmaint
 	name = "Gun Maintenance Kits"
 	desc = "Keep your pa's rifle in best condition, with two sets of cleaning supplies. Or your standard issue pistol if you're an itchy trigger, we're not here to judge."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds a new goody. pack to cargo, containing an ammo box (15 rounds) and two magazines for the PepperBall pistol, at a cost of 600 credits.

## How This Contributes To The Skyrat Roleplay Experience
To my knowledge, the only way to get more pepperball ammo is ordering a new gun, which is both expensive and unnecessary.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can now order PepperBall ammo kits under the "goodies" tab in cargo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
