### PR TITLE
[MODULAR] Tarkon 1.5.1 update: 420 purge it, Xeno Weed Update compliance

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
@@ -287,13 +287,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/space/has_grav)
-"ck" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/sand,
-/obj/structure/alien/weeds,
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/port_tarkon/mining)
 "cn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/east,
@@ -301,7 +294,6 @@
 /area/ruin/space/has_grav/port_tarkon/starboardhall)
 "cq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -343,7 +335,6 @@
 "cz" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/alien/drone,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "cD" = (
@@ -425,7 +416,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/structure/alien/weeds,
+/obj/structure/alien/weeds/node,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "cZ" = (
@@ -788,6 +779,7 @@
 /obj/machinery/door/airlock/public,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
+/obj/structure/alien/weeds/node,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/observ)
 "eM" = (
@@ -935,7 +927,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "fK" = (
-/obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien/drone,
 /obj/item/stack/ore/uranium,
 /turf/open/floor/plating/asteroid,
@@ -1050,7 +1041,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/garden)
 "gt" = (
-/obj/structure/alien/weeds,
 /obj/item/stack/ore/uranium,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
@@ -1164,7 +1154,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/comms)
 "ha" = (
-/obj/structure/alien/weeds,
 /obj/structure/bed/nest,
 /obj/effect/mob_spawn/corpse/human/damaged,
 /turf/open/floor/plating/asteroid,
@@ -1393,7 +1382,6 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/alien/weeds,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -1404,7 +1392,6 @@
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "iu" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1472,14 +1459,12 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/starboardhall)
 "iU" = (
-/obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien/drone,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
 "iV" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/alien,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "iW" = (
@@ -1526,7 +1511,6 @@
 "jo" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/alien/weeds,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/brown,
@@ -1604,7 +1588,6 @@
 	dir = 1;
 	pixel_y = 23
 	},
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "jP" = (
@@ -1699,7 +1682,6 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 4
 	},
@@ -2060,7 +2042,6 @@
 "lZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/emcloset,
-/obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 4
 	},
@@ -2113,7 +2094,6 @@
 "mv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "mx" = (
@@ -2122,6 +2102,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/old,
+/obj/structure/alien/weeds/node,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "my" = (
@@ -2144,7 +2125,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon)
 "mD" = (
-/obj/structure/alien/weeds,
 /obj/item/stack/ore/bluespace_crystal,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
@@ -2173,7 +2153,6 @@
 "mI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "mK" = (
@@ -2341,7 +2320,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "oe" = (
-/obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien/sentinel,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
@@ -2388,7 +2366,6 @@
 "ot" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "ov" = (
@@ -2446,7 +2423,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/observ)
 "oK" = (
-/obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
@@ -2516,9 +2492,10 @@
 /area/ruin/space/has_grav/port_tarkon/porthall)
 "pk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/alien/weeds,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav)
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/alien/weeds/node,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/port_tarkon/forehall)
 "pl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -2610,7 +2587,6 @@
 /turf/open/floor/engine/vacuum,
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "pD" = (
-/obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien,
 /obj/item/stack/ore/uranium,
 /turf/open/floor/plating/asteroid,
@@ -2737,7 +2713,6 @@
 "qr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/alien/weeds,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -2762,7 +2737,6 @@
 "qF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand,
-/obj/structure/alien/weeds,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -2886,7 +2860,6 @@
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "rq" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 8
 	},
@@ -2967,7 +2940,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "rE" = (
-/obj/structure/alien/weeds,
 /obj/structure/alien/egg/burst,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
@@ -3306,7 +3278,6 @@
 "tV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -3333,10 +3304,10 @@
 /area/ruin/space/has_grav/port_tarkon/dorms)
 "tZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/alien/weeds,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/port_tarkon/mining)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/alien/weeds/node,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/port_tarkon/developement)
 "ub" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/structure/window/reinforced,
@@ -3347,7 +3318,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand,
 /obj/machinery/firealarm/directional/east,
-/obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 4
 	},
@@ -3389,7 +3359,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "un" = (
-/obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood,
 /obj/item/stack/ore/gold,
 /obj/item/stack/ore/gold,
@@ -3402,7 +3371,6 @@
 "up" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "ur" = (
@@ -3426,7 +3394,6 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/port_tarkon)
 "uw" = (
-/obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien,
 /obj/item/stack/ore/gold,
 /turf/open/floor/plating/asteroid,
@@ -3488,7 +3455,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "vd" = (
@@ -3680,7 +3646,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/north,
 /mob/living/simple_animal/hostile/alien/drone,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "vW" = (
@@ -4136,7 +4101,6 @@
 "zd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
@@ -4169,7 +4133,6 @@
 "zB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien/drone,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
@@ -4320,7 +4283,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand,
 /obj/machinery/light/small/directional/east,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "Bg" = (
@@ -4423,7 +4385,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/old,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "BS" = (
@@ -4433,7 +4394,6 @@
 /area/ruin/space/has_grav/port_tarkon/power1)
 "BU" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -4538,14 +4498,12 @@
 "Cq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery/blue,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "Cs" = (
 /obj/machinery/door/airlock/mining/glass,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand,
-/obj/structure/alien/weeds,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/closed{
@@ -4644,7 +4602,6 @@
 	opacity = 1
 	},
 /obj/machinery/door/airlock/mining/glass,
-/obj/structure/alien/weeds,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -4723,7 +4680,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/starboardhall)
 "Dc" = (
-/obj/structure/alien/weeds,
 /obj/structure/bed/nest,
 /obj/effect/mob_spawn/corpse/human/damaged,
 /obj/item/raw_anomaly_core/random,
@@ -4825,7 +4781,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/secoff)
 "DQ" = (
-/obj/structure/alien/weeds,
 /obj/item/stack/ore/iron,
 /obj/item/stack/ore/iron,
 /obj/item/stack/ore/iron,
@@ -4914,11 +4869,11 @@
 /area/ruin/space/has_grav/port_tarkon/afthall)
 "Er" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken/directional/north,
-/obj/effect/decal/cleanable/glass,
-/obj/structure/alien/weeds,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/port_tarkon/forehall)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/alien/weeds/node,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/port_tarkon/developement)
 "Es" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -5135,13 +5090,6 @@
 "FC" = (
 /turf/open/floor/mineral/titanium,
 /area/ruin/space/has_grav)
-"FD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/red,
-/obj/structure/alien/weeds,
-/obj/structure/alien/weeds,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/port_tarkon/forehall)
 "FE" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -5322,7 +5270,6 @@
 "GD" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "GF" = (
@@ -5452,12 +5399,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/porthall)
-"Hw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/obj/structure/alien/weeds,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/port_tarkon/forehall)
 "Hy" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/port_tarkon/mining)
@@ -5478,7 +5419,6 @@
 "HH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/alien/weeds,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -5608,11 +5548,6 @@
 /obj/effect/turf_decal/tile/brown/half,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/port_tarkon/storage)
-"Iu" = (
-/obj/structure/alien/resin/wall,
-/obj/structure/alien/weeds,
-/turf/open/floor/plating/asteroid,
-/area/ruin/space/has_grav)
 "Iw" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/port_tarkon/power1)
@@ -5826,7 +5761,6 @@
 "Jw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/ore_box,
-/obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 8
 	},
@@ -5838,7 +5772,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/afthall)
 "Jz" = (
-/obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/machine,
 /obj/item/circuitboard/machine/destructive_analyzer,
@@ -5849,7 +5782,6 @@
 /area/ruin/space/has_grav/port_tarkon/developement)
 "JB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/alien/weeds,
 /obj/structure/closet/crate/radiation,
 /obj/item/stack/sheet/mineral/uranium/five,
 /turf/open/floor/iron,
@@ -5965,7 +5897,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/comms)
 "Kf" = (
-/obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
@@ -6015,7 +5946,6 @@
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "Kr" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/alien/weeds,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/brown{
@@ -6028,7 +5958,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "Kw" = (
@@ -6047,7 +5976,7 @@
 	opacity = 1
 	},
 /obj/machinery/door/airlock/mining/glass,
-/obj/structure/alien/weeds,
+/obj/structure/alien/weeds/node,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "KD" = (
@@ -6110,7 +6039,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/alien/resin/wall,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "KS" = (
@@ -6124,7 +6052,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "KZ" = (
@@ -6152,7 +6079,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/cargo)
 "Lg" = (
-/obj/structure/alien/weeds,
 /obj/structure/bed/nest,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/mob_spawn/corpse/human/damaged,
@@ -6182,7 +6108,6 @@
 "Lp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/emcloset,
-/obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 1
 	},
@@ -6204,11 +6129,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/trauma)
-"Lx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/alien/weeds,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/port_tarkon/forehall)
 "Ly" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6272,7 +6192,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "LS" = (
-/obj/structure/alien/weeds,
 /obj/item/stack/ore/titanium,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
@@ -6423,7 +6342,6 @@
 "Ng" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/tank_dispenser,
-/obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 1
 	},
@@ -6734,8 +6652,8 @@
 	locked = 0;
 	start_charge = 0
 	},
-/obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien/sentinel,
+/obj/structure/alien/weeds/node,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "Pf" = (
@@ -6748,7 +6666,6 @@
 /area/ruin/space/has_grav/port_tarkon/developement)
 "Pp" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "Pq" = (
@@ -7110,7 +7027,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "RI" = (
-/obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/machine,
 /obj/item/circuitboard/machine/circuit_imprinter/offstation,
@@ -7145,7 +7061,6 @@
 "RP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken/directional/north,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "RT" = (
@@ -7241,7 +7156,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "Sp" = (
-/obj/structure/alien/weeds,
 /obj/structure/alien/resin/wall,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/built/directional/east,
@@ -7285,7 +7199,6 @@
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/light/broken/directional/north,
 /obj/effect/decal/cleanable/glass,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "SH" = (
@@ -7501,7 +7414,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/power1)
 "TM" = (
-/obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/item/stack/ore/diamond,
 /turf/open/floor/plating/asteroid,
@@ -7522,7 +7434,6 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/structure/alien/weeds,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 4
@@ -7650,7 +7561,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/observ)
 "Uz" = (
-/obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien/queen/large,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
@@ -7809,11 +7719,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
-"VK" = (
-/obj/structure/alien/weeds,
-/obj/structure/alien/weeds/node,
-/turf/open/floor/plating/asteroid,
-/area/ruin/space/has_grav)
 "VN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
@@ -7881,7 +7786,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand,
 /obj/structure/closet/emcloset,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "We" = (
@@ -7954,7 +7858,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "WJ" = (
-/obj/structure/alien/weeds,
 /obj/item/stack/ore/diamond,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
@@ -8010,7 +7913,6 @@
 "Xn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/ore_box,
-/obj/structure/alien/weeds,
 /obj/effect/turf_decal/tile/brown/anticorner,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
@@ -8080,7 +7982,6 @@
 /obj/effect/decal/cleanable/blood/gibs/up,
 /obj/item/clothing/suit/toggle/labcoat/medical,
 /obj/item/clothing/neck/stethoscope,
-/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "XS" = (
@@ -8125,7 +8026,6 @@
 /turf/open/floor/engine/co2,
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "Yl" = (
-/obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav)
@@ -8194,7 +8094,6 @@
 "YD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/dim/directional/west,
-/obj/structure/alien/weeds,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -8219,11 +8118,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
-"YJ" = (
-/obj/structure/alien/weeds,
-/obj/structure/alien/resin/wall,
-/turf/open/floor/plating/asteroid,
-/area/ruin/space/has_grav)
 "YK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8276,7 +8170,6 @@
 "Zl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand,
-/obj/structure/alien/weeds,
 /mob/living/simple_animal/hostile/alien/drone,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -8331,10 +8224,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
-"ZF" = (
-/obj/structure/alien/weeds,
-/turf/open/floor/plating/asteroid,
-/area/ruin/space/has_grav)
 "ZG" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/port_tarkon/storage)
@@ -9602,7 +9491,7 @@ qe
 nP
 Uf
 EH
-UV
+tZ
 EH
 EH
 Id
@@ -9678,7 +9567,7 @@ EH
 rt
 rt
 rt
-rt
+Er
 sr
 nd
 Uf
@@ -10108,7 +9997,7 @@ Wa
 Wa
 kf
 jN
-Lx
+yi
 wo
 nP
 RO
@@ -10181,8 +10070,8 @@ Wa
 Wa
 kf
 cz
-Lx
-cY
+yi
+FF
 db
 nS
 Nh
@@ -10253,9 +10142,9 @@ Wa
 Wa
 sv
 kf
-Er
-mI
-cY
+VO
+pk
+FF
 db
 FM
 WQ
@@ -10328,7 +10217,7 @@ Wa
 kf
 zK
 DG
-cY
+FF
 db
 wl
 pr
@@ -10401,7 +10290,7 @@ sv
 kf
 LH
 KW
-cY
+FF
 db
 QX
 kx
@@ -10473,7 +10362,7 @@ sv
 Wa
 kf
 aI
-Lx
+yi
 Tx
 db
 PM
@@ -10547,7 +10436,7 @@ Wa
 kf
 mI
 zK
-cY
+FF
 db
 DO
 wx
@@ -10618,8 +10507,8 @@ Wa
 Wa
 Wa
 kf
-Lx
-Lx
+yi
+yi
 Pc
 db
 QX
@@ -10693,7 +10582,7 @@ sv
 kf
 vq
 ja
-cY
+FF
 db
 Te
 Zi
@@ -10766,7 +10655,7 @@ Wa
 kf
 zK
 hB
-cY
+FF
 db
 HY
 Vl
@@ -10983,7 +10872,7 @@ Wa
 Wa
 sv
 kf
-FD
+sI
 zK
 Tx
 xa
@@ -11056,7 +10945,7 @@ Wa
 Wa
 Wa
 kf
-Lx
+aI
 eY
 sT
 Nj
@@ -11202,9 +11091,9 @@ sv
 sv
 sv
 kf
-Lx
-Hw
-cY
+yi
+UO
+FF
 kf
 nZ
 jZ
@@ -11277,7 +11166,7 @@ Wa
 kf
 aI
 cz
-cY
+FF
 kf
 jZ
 Fl
@@ -11350,7 +11239,7 @@ Wa
 kf
 cH
 up
-cY
+FF
 cV
 cV
 cV
@@ -11496,7 +11385,7 @@ sv
 kf
 JB
 KQ
-cY
+FF
 cV
 EV
 IW
@@ -11568,8 +11457,8 @@ Wa
 Wa
 kf
 vU
-Lx
-cY
+yi
+FF
 iA
 xi
 xi
@@ -11713,7 +11602,7 @@ Wa
 sv
 Wa
 kf
-Lx
+yi
 aI
 NL
 cV
@@ -11786,7 +11675,7 @@ Wa
 sv
 Wa
 kf
-Lx
+yi
 cH
 NL
 cV
@@ -11932,7 +11821,7 @@ sv
 sv
 Wa
 kf
-Lx
+yi
 GD
 vc
 Uj
@@ -12010,11 +11899,11 @@ PF
 Ks
 Uj
 Wa
-YJ
-YJ
-YJ
-YJ
-YJ
+ta
+ta
+ta
+ta
+ta
 Wa
 sv
 Wa
@@ -12079,16 +11968,16 @@ Wa
 sv
 Uj
 Bz
-pk
-pk
+Hq
+Hq
 Uj
 ta
-YJ
+ta
 iU
 rE
 Dc
-Iu
-YJ
+ta
+ta
 Wa
 sv
 vC
@@ -12149,19 +12038,19 @@ sv
 sv
 sv
 Wa
-YJ
-YJ
+ta
+ta
 DQ
-Iu
-YJ
-YJ
-YJ
+ta
+ta
+ta
+ta
 ha
 DK
 Uz
 iU
-VK
-YJ
+DK
+ta
 Wa
 Wa
 vC
@@ -12222,19 +12111,19 @@ sv
 sv
 sv
 Wa
-YJ
-ZF
-ZF
-ZF
+ta
+ed
+ed
+DK
 un
 uw
-YJ
-YJ
+ta
+ta
 rE
-ZF
+ed
 DK
 iU
-YJ
+ta
 Wa
 Wa
 vC
@@ -12295,19 +12184,19 @@ sv
 sv
 Wa
 Wa
-YJ
-YJ
+ta
+ta
 gt
 pD
-YJ
-YJ
-YJ
-YJ
+ta
+ta
+ta
+ta
 Dc
-ZF
+ed
 oe
-ZF
-YJ
+ed
+ta
 sv
 Wa
 vC
@@ -12369,18 +12258,18 @@ sv
 sv
 Wa
 Wa
-YJ
-YJ
-ZF
-ZF
+ta
+ta
+ed
+ed
 DK
 LS
-YJ
-YJ
-YJ
+ta
+ta
+ta
 rE
-ZF
-YJ
+ed
+ta
 Wa
 sv
 vC
@@ -12443,17 +12332,17 @@ sv
 Wa
 sv
 Wa
-YJ
-ZF
+ta
+ed
 LS
 oe
-ZF
+ed
 Kf
 oe
-YJ
-YJ
-ZF
-YJ
+ta
+ta
+ed
+ta
 sv
 sv
 vC
@@ -12516,17 +12405,17 @@ sv
 sv
 Wa
 Wa
-YJ
-YJ
-YJ
-YJ
-YJ
-ZF
+ta
+ta
+ta
+ta
+ta
+ed
 cs
 mD
-YJ
-ZF
-YJ
+ta
+DK
+ta
 Wa
 sv
 vC
@@ -12590,16 +12479,16 @@ Wa
 sv
 Wa
 sv
-YJ
+ta
 DK
-ZF
+ed
 LS
 oK
 gt
-YJ
-YJ
-ZF
-YJ
+ta
+ta
+ed
+ta
 Wa
 Wa
 vC
@@ -12622,7 +12511,7 @@ Hy
 Sa
 Fq
 LQ
-tZ
+LQ
 os
 LQ
 Xz
@@ -12663,16 +12552,16 @@ sv
 Wa
 sv
 Wa
-YJ
+ta
 LS
 iU
-YJ
-YJ
-YJ
-YJ
+ta
+ta
+ta
+ta
 fK
 TM
-YJ
+ta
 Wa
 sv
 vC
@@ -12736,16 +12625,16 @@ sv
 sv
 Wa
 Wa
-YJ
-YJ
-ZF
-ZF
-ZF
-YJ
+ta
+ta
+ed
+ed
+ed
+ta
 rE
 ow
 Lg
-YJ
+ta
 Wa
 sv
 vC
@@ -12810,15 +12699,15 @@ sv
 sv
 Wa
 Wa
-YJ
-YJ
+ta
+ta
 Kf
 DK
-YJ
-ZF
+ta
+ed
 WJ
 Yl
-YJ
+ta
 Wa
 sv
 vC
@@ -12846,7 +12735,7 @@ YD
 Jw
 Bq
 Wc
-ck
+Wc
 bH
 sv
 sv
@@ -12884,14 +12773,14 @@ sv
 sv
 Wa
 Wa
-YJ
-ZF
+ta
+ed
 mD
 oe
-ZF
-ZF
-YJ
-YJ
+ed
+ed
+ta
+ta
 Wa
 Wa
 sv
@@ -12957,13 +12846,13 @@ Wa
 sv
 Wa
 Wa
-YJ
-YJ
-ZF
+ta
+ta
+ed
 gt
 WJ
-YJ
-YJ
+ta
+ta
 Wa
 Wa
 Wa
@@ -13031,11 +12920,11 @@ Wa
 Wa
 sv
 sv
-YJ
-YJ
-YJ
-YJ
-YJ
+ta
+ta
+ta
+ta
+ta
 Wa
 Wa
 sv

--- a/_maps/skyrat/shuttles/ruin_tarkon_driver.dmm
+++ b/_maps/skyrat/shuttles/ruin_tarkon_driver.dmm
@@ -2,24 +2,20 @@
 "a" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "b" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/tarkon_driver,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "d" = (
 /obj/structure/window/reinforced/tinted,
 /obj/structure/table/reinforced,
 /obj/item/oxygen_candle,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "e" = (
 /obj/machinery/computer/shuttle/tarkon_driver,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "g" = (
@@ -29,18 +25,12 @@
 /obj/item/bedsheet{
 	dir = 1
 	},
-/obj/structure/alien/weeds,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/tarkon_driver)
-"k" = (
-/obj/structure/alien/weeds/node,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "l" = (
 /obj/machinery/light/dim/directional/west,
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/gas,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "p" = (
@@ -57,7 +47,6 @@
 	preferred_direction = 8;
 	width = 12
 	},
-/obj/structure/alien/weeds,
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
@@ -74,37 +63,32 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "u" = (
 /obj/machinery/light/dim/directional/east,
 /obj/structure/table/reinforced,
 /obj/item/flashlight/flare,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "v" = (
 /obj/structure/window/reinforced/tinted,
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/emergency,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "x" = (
 /obj/machinery/door/window/southright,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "A" = (
 /obj/machinery/door/window/southleft,
-/obj/structure/alien/weeds,
+/obj/structure/alien/weeds/node,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "B" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "C" = (
@@ -114,23 +98,19 @@
 /obj/item/oxygen_candle,
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "E" = (
 /mob/living/simple_animal/hostile/alien/sentinel,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "F" = (
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "G" = (
 /obj/machinery/door/window/eastright{
 	opacity = 1
 	},
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "H" = (
@@ -142,7 +122,6 @@
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/clothing/mask/breath,
 /obj/structure/closet/crate/internals,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "I" = (
@@ -150,7 +129,6 @@
 /area/template_noop)
 "K" = (
 /mob/living/simple_animal/hostile/alien,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "M" = (
@@ -162,7 +140,6 @@
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/clothing/mask/breath,
 /obj/structure/closet/crate/internals,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "Q" = (
@@ -172,12 +149,10 @@
 /obj/machinery/door/window/westleft{
 	opacity = 1
 	},
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "S" = (
 /obj/machinery/door/airlock/titanium,
-/obj/structure/alien/weeds,
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
@@ -185,11 +160,14 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
+"V" = (
+/obj/structure/alien/weeds/node,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/tarkon_driver)
 "W" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/emergency,
 /obj/machinery/light/warm/directional/south,
-/obj/structure/alien/weeds,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 
@@ -219,7 +197,7 @@ I
 r
 F
 F
-F
+V
 r
 U
 "}
@@ -249,7 +227,7 @@ b
 t
 x
 F
-k
+F
 F
 S
 "}
@@ -258,9 +236,9 @@ p
 e
 t
 A
-k
 F
 F
+V
 q
 "}
 (8,1,1) = {"
@@ -288,7 +266,7 @@ I
 I
 r
 F
-F
+V
 F
 r
 U


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes all cases of /obj/structure/alien/weeds, As so they'll function properly when the nodes are cleared out. Also creates compliance with #11171 so the changes aren't in vain.

Also adds more xeno weed nodes to compensate.

## How This Contributes To The Skyrat Roleplay Experience

We changed how xenoweeds behave, This is just a compliance issue

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Removes all xeno-weed instances from Tarkon so xenoweeds will auto-purge correctly. Adds more xeno weed nodes to compensate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
