### PR TITLE
malf can no longer doomsday

### DIFF
--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -109,7 +109,7 @@
 	else if(T.cooldown)
 		var/seconds_left = max(0, (T.cooldown_timer - world.time) / 10)
 		return "[round(seconds_left)]"
-
+/* SKYRAT EDIT: removed doomsday
 /obj/effect/countdown/doomsday
 	name = "doomsday countdown"
 
@@ -119,7 +119,7 @@
 		return
 	else if(DD.timing)
 		return "<div align='center' valign='middle' style='position:relative; top:0px; left:0px'>[DD.seconds_remaining()]</div>"
-
+SKYRAT EDIT: removed doomsday */
 /obj/effect/countdown/anomaly
 	name = "anomaly countdown"
 

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -171,7 +171,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /// Modules that are improving AI abilities and assets
 /datum/ai_module/upgrade
 	category = "Upgrade Modules"
-
+/* SKYRAT EDIT: No nuking the station
 /// Doomsday Device: Starts the self-destruct timer. It can only be stopped by killing the AI completely.
 /datum/ai_module/destructive/nuke_station
 	name = "Doomsday Device"
@@ -376,7 +376,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 		L.dust()
 	to_chat(world, "<B>The AI cleansed the station of life with the doomsday device!</B>")
 	SSticker.force_ending = 1
-
+SKYRAT EDIT: No nuking the station */
 /// Hostile Station Lockdown: Locks, bolts, and electrifies every airlock on the station. After 90 seconds, the doors reset.
 /datum/ai_module/destructive/lockdown
 	name = "Hostile Station Lockdown"

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -4,7 +4,7 @@
 GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		/obj/machinery/field/containment,
 		/obj/machinery/power/supermatter_crystal,
-		/obj/machinery/doomsday_device,
+		//obj/machinery/doomsday_device, //SKYRAT EDIT: no doomsday
 		/obj/machinery/nuclearbomb,
 		/obj/machinery/nuclearbomb/selfdestruct,
 		/obj/machinery/nuclearbomb/syndicate,

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -221,7 +221,7 @@
 	QDEL_NULL(eyeobj) // No AI, no Eye
 	QDEL_NULL(spark_system)
 	QDEL_NULL(malf_picker)
-	QDEL_NULL(doomsday_device)
+	//QDEL_NULL(doomsday_device) SKYRAT EDIT: No doomsday
 	QDEL_NULL(robot_control)
 	QDEL_NULL(aiMulti)
 	QDEL_NULL(alert_control)
@@ -775,7 +775,7 @@
 		if(!mind)
 			to_chat(user, span_warning("No intelligence patterns detected."))
 			return
-		ShutOffDoomsdayDevice()
+		//ShutOffDoomsdayDevice() SKYRAT EDIT: no more doomsday
 		var/obj/structure/ai_core/new_core = new /obj/structure/ai_core/deactivated(loc)//Spawns a deactivated terminal at AI location.
 		new_core.circuit.battery = battery
 		ai_restore_power()//So the AI initially has power.

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -32,7 +32,7 @@
 	GLOB.shuttle_caller_list -= src
 	SSshuttle.autoEvac()
 
-	ShutOffDoomsdayDevice()
+	//ShutOffDoomsdayDevice() SKYRAT EDIT: no more doomsday
 
 	if(explosive)
 		addtimer(CALLBACK(GLOBAL_PROC, .proc/explosion, loc, 3, 6, 12, null, 15), 1 SECONDS)
@@ -43,9 +43,10 @@
 		loc.icon_state = "aispook-404"
 	else if(istype(loc, /obj/item/aicard))
 		loc.icon_state = "aicard-404"
-
+/* SKYRAT EDIT: no more doomsday
 /mob/living/silicon/ai/proc/ShutOffDoomsdayDevice()
 	if(nuking)
 		nuking = FALSE
 	if(doomsday_device)
 		qdel(doomsday_device)
+SKYRAT EDIT: no more doomsday */

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -997,7 +997,7 @@
 	lamp_doom = FALSE
 	if(connected_ai)
 		connected_ai.connected_robots |= src
-		lamp_doom = connected_ai.doomsday_device ? TRUE : FALSE
+		//lamp_doom = connected_ai.doomsday_device ? TRUE : FALSE SKYRAT EDIT: no more doomsday
 	toggle_headlamp(FALSE, TRUE)
 
 /**

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1156,7 +1156,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, APC_PIXEL_OFFSET
 		return
 	if(!is_station_level(z))
 		return
-	malf.ShutOffDoomsdayDevice()
+	//malf.ShutOffDoomsdayDevice() SKYRAT EDIT: no more doomsday
 	occupier = new /mob/living/silicon/ai(src, malf.laws, malf) //DEAR GOD WHY? //IKR????
 	occupier.adjustOxyLoss(malf.getOxyLoss())
 	if(!findtext(occupier.name, "APC Copy"))

--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -14,7 +14,7 @@
 		//And another
 		/obj/item/slimecross/recurring,
 		//This should be obvious
-		/obj/machinery/doomsday_device,
+		//obj/machinery/doomsday_device, SKYRAT EDIT: no more doomsday
 		//Yet more templates
 		/obj/machinery/restaurant_portal,
 		//Template type


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
removes the doomsday ability, objective, and the doomsday device from malf ai. 

We will see about giving them a BSA instead.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
why do we want complete station-ending objectives...? 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: removed the doomsday ability and objective from malf ai
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
