### PR TITLE
Fix Delta Station air mixer

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -4503,7 +4503,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aGU" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix,
+/obj/machinery/atmospherics/components/trinary/mixer/airmix{
+	node1_concentration = 0.21;
+	node2_concentration = 0.79
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -4503,10 +4503,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aGU" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix{
-	node1_concentration = 0.21;
-	node2_concentration = 0.79
-	},
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The default "airmix" subtype of the mixer seems to assume the inputs will be opposite, so I changed the "node concentration" values manually until it occured to me that there was another subtype, and now it's the "inverse" type. Basically, the mix was 79% oxygen before, and is 21% oxygen now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Things working as intended is good, clearly.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Delta Station Air mix is now set to the correct ratios
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
