### PR TITLE
Changes all Head of Staff airlocks on maps to be fancy versions

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -3924,7 +3924,7 @@
 /area/security/prison)
 "aBU" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/captain{
 	name = "Emergency Escape";
 	req_access_txt = "20"
 	},
@@ -5245,7 +5245,7 @@
 /area/engineering/supermatter/room)
 "aOw" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/rd{
 	name = "Research Director's Office";
 	req_access_txt = "30"
 	},
@@ -5882,7 +5882,7 @@
 /area/maintenance/starboard/aft)
 "aVP" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/captain{
 	name = "Captain's Quarters";
 	req_access_txt = "20"
 	},
@@ -9012,7 +9012,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "bzp" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/hos{
 	name = "Head of Security's Office";
 	req_access_txt = "58"
 	},
@@ -44962,7 +44962,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "gKX" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/cmo{
 	name = "Chief Medical Officer's Quarters";
 	req_access_txt = "40"
 	},
@@ -49801,7 +49801,7 @@
 /area/command/heads_quarters/rd)
 "ifv" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining{
+/obj/machinery/door/airlock/qm{
 	name = "Quartermaster's Quarters";
 	req_access_txt = "41"
 	},
@@ -60718,7 +60718,7 @@
 /area/engineering/gravity_generator)
 "leC" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/rd{
 	name = "Research Director's Quarters";
 	req_access_txt = "30"
 	},
@@ -66047,7 +66047,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "mve" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/hos{
 	name = "Head of Security's Quarters";
 	req_access_txt = "58"
 	},
@@ -74954,7 +74954,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "oIS" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/cmo{
 	name = "Chief Medical Officer's Office";
 	req_access_txt = "40"
 	},
@@ -76952,7 +76952,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/ce{
 	name = "Chief Engineer's Office";
 	req_access_txt = "56"
 	},
@@ -79844,7 +79844,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/ce{
 	name = "Chief Engineer's Quarters";
 	req_access_txt = "56"
 	},
@@ -80635,7 +80635,7 @@
 	id = "hopblast";
 	name = "HoP Blast door"
 	},
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/hop{
 	name = "Head of Personnel's Office";
 	req_access_txt = "57"
 	},
@@ -85792,7 +85792,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mining{
+/obj/machinery/door/airlock/qm{
 	name = "Quartermaster's Office";
 	req_access_txt = "41"
 	},
@@ -89753,7 +89753,7 @@
 /area/service/kitchen)
 "sEN" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/hop{
 	name = "Head of Personnel's Office";
 	req_access_txt = "57"
 	},
@@ -99149,7 +99149,7 @@
 /area/hallway/primary/central/fore)
 "vdY" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/captain{
 	name = "Captain's Office";
 	req_access_txt = "20"
 	},

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -6356,7 +6356,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "bmY" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/cmo{
 	name = "Chief Medical Officer";
 	req_access_txt = "40"
 	},
@@ -21256,7 +21256,7 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "gTw" = (
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/rd/glass{
 	name = "Research Director";
 	req_access_txt = "30"
 	},
@@ -23122,7 +23122,7 @@
 	},
 /area/service/kitchen/diner)
 "hUJ" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/hop{
 	name = "Head of Personnel";
 	req_access_txt = "57"
 	},
@@ -23423,7 +23423,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/door/airlock/mining/glass{
+/obj/machinery/door/airlock/qm/glass{
 	name = "Quartermaster";
 	req_access_txt = "41"
 	},
@@ -30951,7 +30951,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "mfz" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/hop{
 	name = "Head of Personnel";
 	req_access_txt = "57"
 	},
@@ -38514,7 +38514,7 @@
 /turf/closed/wall,
 /area/security/checkpoint/medical)
 "qeI" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/captain{
 	name = "Captain's Office";
 	req_access_txt = "20"
 	},
@@ -47907,7 +47907,7 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "uYi" = (
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/ce{
 	name = "Chief Engineer";
 	req_access_txt = "56"
 	},
@@ -48056,7 +48056,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/hos/glass{
 	name = "Head of Security";
 	req_access_txt = "58"
 	},
@@ -50808,7 +50808,7 @@
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
 "wzX" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/captain{
 	name = "Captain's Quarters";
 	req_access_txt = "20"
 	},

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -47907,7 +47907,7 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "uYi" = (
-/obj/machinery/door/airlock/ce{
+/obj/machinery/door/airlock/ce/glass{
 	name = "Chief Engineer";
 	req_access_txt = "56"
 	},

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -6265,7 +6265,7 @@
 /area/science/robotics/mechbay)
 "aur" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/hop{
 	name = "Head of Personnel's Office";
 	req_access_txt = "57"
 	},
@@ -8890,7 +8890,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/cmo{
 	name = "Chief Medical Officer's Office";
 	req_access_txt = "40"
 	},
@@ -38676,7 +38676,7 @@
 /area/engineering/gravity_generator)
 "dZU" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/ce{
 	name = "Chief Engineer's Office";
 	req_access_txt = "56"
 	},
@@ -41336,7 +41336,7 @@
 /area/hallway/primary/fore)
 "fhv" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/captain{
 	name = "Captain's Office";
 	req_access_txt = "20"
 	},
@@ -55592,7 +55592,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/hop{
 	name = "Head of Personnel's Office";
 	req_access_txt = "57"
 	},
@@ -63046,7 +63046,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/mining/glass{
+/obj/machinery/door/airlock/qm/glass{
 	name = "Quartermaster";
 	req_access_txt = "41"
 	},
@@ -66308,7 +66308,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/captain{
 	name = "Captain's Tactical Relocation";
 	req_access_txt = "20"
 	},
@@ -71500,7 +71500,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/captain{
 	name = "Captain's Office";
 	req_access_txt = "20"
 	},
@@ -75020,7 +75020,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/ce{
 	name = "Chief Engineer's Office";
 	req_access_txt = "56"
 	},
@@ -79495,7 +79495,7 @@
 /area/commons/fitness/recreation)
 "wtC" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/rd{
 	name = "Research Director's Office";
 	req_access_txt = "30"
 	},
@@ -79507,7 +79507,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/hos{
 	name = "Head of Security's Office";
 	req_access_txt = "58"
 	},
@@ -80747,7 +80747,7 @@
 /area/engineering/main)
 "xaV" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/hos{
 	name = "Head of Security's Office";
 	req_access_txt = "58"
 	},
@@ -81839,7 +81839,7 @@
 /area/security/warden)
 "xwf" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining/glass{
+/obj/machinery/door/airlock/qm/glass{
 	name = "Quartermaster";
 	req_access_txt = "41"
 	},
@@ -83125,7 +83125,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/rd{
 	name = "Research Director's Office";
 	req_access_txt = "30"
 	},

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -4130,7 +4130,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/rd{
 	name = "Research Director's Office";
 	req_access_txt = "30"
 	},
@@ -15723,7 +15723,7 @@
 /area/cargo/storage)
 "dpY" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/hop{
 	name = "Head of Personnel";
 	req_access_txt = "57"
 	},
@@ -19335,7 +19335,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/rd{
 	name = "Research Director's Office";
 	req_access_txt = "30"
 	},
@@ -22107,7 +22107,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "fwg" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/captain{
 	name = "Emergency Escape";
 	req_access_txt = "20"
 	},
@@ -26888,7 +26888,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "hpS" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/cmo{
 	name = "Chief Medical Officer's Office";
 	req_access_txt = "40"
 	},
@@ -27483,7 +27483,7 @@
 "hDb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/ce{
 	name = "Chief Engineer's Office";
 	req_access_txt = "56"
 	},
@@ -38233,7 +38233,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "lCS" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/hos{
 	name = "Head of Security's Office";
 	req_access_txt = "58"
 	},
@@ -39685,7 +39685,7 @@
 /area/engineering/supermatter)
 "mee" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/captain{
 	name = "Captain's Quarters";
 	req_access_txt = "20"
 	},
@@ -43889,7 +43889,7 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "nAm" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/captain{
 	name = "Captain's Quarters";
 	req_access_txt = "20"
 	},
@@ -48723,7 +48723,7 @@
 /area/command/heads_quarters/captain/private)
 "pmf" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/hop{
 	name = "Head of Personnel";
 	req_access_txt = "57"
 	},
@@ -63513,7 +63513,7 @@
 /area/security/brig)
 "uAx" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/captain{
 	name = "Captain's Quarters";
 	req_access_txt = "20"
 	},
@@ -64124,7 +64124,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "uMk" = (
-/obj/machinery/door/airlock/mining/glass{
+/obj/machinery/door/airlock/qm/glass{
 	name = "Quartermaster";
 	req_access_txt = "41"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You know those fancy airlocks heads of staff get on blueshift? Now they can have those everywhere.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Because now they can all show off their uniqueness from each other with unique colored doors? I dunno, I like the way they look and it's a waste to not use them more.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Head of Staff doors on Kilo, Ice box, Meta, and Delta are all now the same as on blueshift
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
