### PR TITLE
[MODULAR] Fix greyscale colors on female versions of clothes

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_update_icons.dm
@@ -314,7 +314,7 @@
 		var/default_file = !isinhands ? (worn_icon ? worn_icon : default_icon_file) : default_icon_file
 		standing = wear_species_version(file_to_use, t_state, layer2use, species, default_file)
 	else if(femaleuniform)
-		standing = wear_female_version(t_state, file2use, layer2use, femaleuniform, greyscale_colors) //should layer2use be in sync with the adjusted value below? needs testing - shiz
+		standing = wear_female_version(t_state, file_to_use, layer2use, femaleuniform, greyscale_colors) //should layer2use be in sync with the adjusted value below? needs testing - shiz
 	if(!standing)
 		standing = mutable_appearance(file_to_use, t_state, -layer2use)
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human_update_icons.dm
@@ -314,7 +314,7 @@
 		var/default_file = !isinhands ? (worn_icon ? worn_icon : default_icon_file) : default_icon_file
 		standing = wear_species_version(file_to_use, t_state, layer2use, species, default_file)
 	else if(femaleuniform)
-		standing = wear_female_version(t_state,file_to_use,layer2use,femaleuniform) //should layer2use be in sync with the adjusted value below? needs testing - shiz
+		standing = wear_female_version(t_state, file2use, layer2use, femaleuniform, greyscale_colors) //should layer2use be in sync with the adjusted value below? needs testing - shiz
 	if(!standing)
 		standing = mutable_appearance(file_to_use, t_state, -layer2use)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cimika showed me this bug, where jumpskirts don't color properly:

![image](https://user-images.githubusercontent.com/35135081/152658535-3cdb5283-b061-4568-9cc1-e17aa98b0163.png)

This was because the Skyrat code for this was not properly updated to the tg one.

This updates the line to match what it is on tg:

https://github.com/tgstation/tgstation/blob/9dfba9bb7c715e8a416e3932137b708000d82598/code/modules/mob/living/carbon/human/human_update_icons.dm#L525

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed greyscale colors on female fitting versions of clothes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
