### PR TITLE
[MODULAR] Adds stammer quirk

### DIFF
--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -135,3 +135,16 @@
 
 	var/obj/item/organ/tongue/dog/new_tongue = new(get_turf(human_holder))
 	new_tongue.Insert(human_holder)
+
+/datum/quirk/stammer
+	name = "Stammer"
+	desc = "You stammer (stutter) whenever you speak"
+	icon = "comment-slash"
+	value = 0
+	medical_record_text = "Patient has an uncurable stammer, causing pauses and repeating of letters in their speech"
+	processing_quirk = TRUE
+
+/datum/quirk/stammer/process()
+	var/mob/living/carbon/human/user = quirk_holder
+	if (user && istype(user))
+		user.stuttering = 20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Plain and simple, this adds a 0 neutral quirk which makes a person permanently stammer/stutter when they speak. The Social Anxiety perk has this built into it, but there is a few people who merely don't need the downsides SA comes with for a relatively straightforward character gimmick.

## How This Contributes To The Skyrat Roleplay Experience

Allows people whom's character stammers to-do so peacefully without the massive disadvantages SA has. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added Stammer (Stutter) Quirk 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
