### PR TITLE
[MODULAR] Feign impairment ceiling increase 1 minute -> 10 hours

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human.dm
@@ -122,8 +122,8 @@
 	var/duration = input(src, "Enter how long you will feign [impairment]. (1 - 60 seconds)", "Duration in seconds", 25) as num|null
 	if(!isnum(duration))
 		return
-	if(duration > 60)
-		to_chat(src, "Please choose a duration in seconds between 1 to 60.")
+	if(duration > 3600) //A full hour.
+		to_chat(src, "Please choose a duration of up to 3600 seconds.")
 		return
 	switch(impairment)
 		if("Drunkenness")

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human.dm
@@ -119,7 +119,7 @@
 	if(!impairment)
 		return
 
-	var/duration = input(src, "Enter how long you will feign [impairment]. (1 - 60 seconds)", "Duration in seconds", 25) as num|null
+	var/duration = input(src, "Enter how long you will feign [impairment].", "Duration in seconds", 25) as num|null
 	if(!isnum(duration))
 		return
 	if(duration > 36000) // Ten hours.

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human.dm
@@ -110,7 +110,7 @@
 
 	var/list/choices = list("Drunkenness", "Stuttering", "Jittering")
 	if(slurring >= 10 || stuttering >= 10 || jitteriness >= 10) //Give the option to end the impairment if there's one ongoing.
-		var/disable = input(src, "Stop performing existing impairment?", "Impairments") as null|anything in choices
+		var/disable = tgui_input_list(src, "Stop performing existing impairment?", "Impairments", choices)
 		if(disable)
 			acting_expiry(disable)
 			return
@@ -119,12 +119,7 @@
 	if(!impairment)
 		return
 
-	var/duration = input(src, "Enter how long you will feign [impairment].", "Duration in seconds", 25) as num|null
-	if(!isnum(duration))
-		return
-	if(duration > 36000) // Ten hours.
-		to_chat(src, "Please choose a duration of up to 36000 seconds.")
-		return
+	var/duration = tgui_input_number(src, "How long would you like to feign [impairment] for?", "Duration in seconds", 25, 36000)
 	switch(impairment)
 		if("Drunkenness")
 			slurring = duration

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human.dm
@@ -115,7 +115,7 @@
 			acting_expiry(disable)
 			return
 
-	var/impairment = input(src, "Select an impairment to perform:", "Impairments") as null|anything in choices
+	var/impairment = tgui_input_list(src, "Select an impairment to perform:", "Impairments", choices)
 	if(!impairment)
 		return
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/human.dm
@@ -122,8 +122,8 @@
 	var/duration = input(src, "Enter how long you will feign [impairment]. (1 - 60 seconds)", "Duration in seconds", 25) as num|null
 	if(!isnum(duration))
 		return
-	if(duration > 3600) //A full hour.
-		to_chat(src, "Please choose a duration of up to 3600 seconds.")
+	if(duration > 36000) // Ten hours.
+		to_chat(src, "Please choose a duration of up to 36000 seconds.")
 		return
 	switch(impairment)
 		if("Drunkenness")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the amount of time feign impairment can last to up to 36000 seconds, being ten hours.

## How This Contributes To The Skyrat Roleplay Experience
The one minute limit seems arbitary, you can cancel the impairment whenever you want and keep extending it manually forever.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Feign impairment now has a time limit of 10 hours, instead of 1 minute
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
