### PR TITLE
Forge weapon balance pass

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
@@ -16,7 +16,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	throwforce = 10
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	resistance_flags = FIRE_PROOF
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
@@ -32,7 +32,7 @@
 	righthand_file = 'modular_skyrat/modules/reagent_forging/icons/mob/forge_weapon_r.dmi'
 	throwforce = 0
 	slot_flags = ITEM_SLOT_BACK
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	resistance_flags = FIRE_PROOF
 	attack_verb_continuous = list("bonks", "bashes", "whacks", "pokes", "prods")
 	attack_verb_simple = list("bonk", "bash", "whack", "poke", "prod")
@@ -46,9 +46,9 @@
 	inhand_icon_state = "spear"
 	lefthand_file = 'modular_skyrat/modules/reagent_forging/icons/mob/forge_weapon_l.dmi'
 	righthand_file = 'modular_skyrat/modules/reagent_forging/icons/mob/forge_weapon_r.dmi'
-	throwforce = 0
+	throwforce = 10
 	slot_flags = ITEM_SLOT_BACK
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	resistance_flags = FIRE_PROOF
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "pokes", "jabs", "tears", "lacerates", "gores")
@@ -71,9 +71,9 @@
 	inhand_icon_state = "axe"
 	lefthand_file = 'modular_skyrat/modules/reagent_forging/icons/mob/forge_weapon_l.dmi'
 	righthand_file = 'modular_skyrat/modules/reagent_forging/icons/mob/forge_weapon_r.dmi'
-	throwforce = 0
+	throwforce = 20
 	slot_flags = ITEM_SLOT_BACK
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	resistance_flags = FIRE_PROOF
 	attack_verb_continuous = list("slashes", "bashes")
 	attack_verb_simple = list("slash", "bash")
@@ -87,9 +87,9 @@
 	inhand_icon_state = "crush_hammer"
 	lefthand_file = 'modular_skyrat/modules/reagent_forging/icons/mob/forge_weapon_l.dmi'
 	righthand_file = 'modular_skyrat/modules/reagent_forging/icons/mob/forge_weapon_r.dmi'
-	throwforce = 0
+	throwforce = 10
 	slot_flags = ITEM_SLOT_BACK
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	resistance_flags = FIRE_PROOF
 	attack_verb_continuous = list("bashes", "whacks")
 	attack_verb_simple = list("bash", "whack")
@@ -104,9 +104,9 @@
 	righthand_file = 'modular_skyrat/modules/reagent_forging/icons/mob/forge_weapon_r.dmi'
 	custom_materials = list(/datum/material/iron=1000)
 	resistance_flags = FIRE_PROOF
-	block_chance = 50
+	block_chance = 30
 	transparent = FALSE
-	max_integrity = 150
+	max_integrity = 110 //Double that of a wooden one
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/shield/riot/buckler/reagent_weapon/Initialize()


### PR DESCRIPTION
## About The Pull Request

Makes all the weapons bulky
Add throwforce to most of the weapons (why didn't they have any?)
Axes are now more suited to throwing since they didn't have much of a niche compared to spears (which has reach)
Nerfed the buckler's block and integrity.

## How This Contributes To The Skyrat Roleplay Experience
All the weapons being Normal class made no sense (especially polearm weapons), it basically let you fill your bag with weapons. Given weapons tend to be contraband, you should have a little more risk for lugging them around since you can make them very easily (and they tend to be better than any other station-found weapon)

The bucklers were quite frankly over-statted since they had better stats than every other non-energy shield in the game. They are now a more durable wooden buckler stat-wise.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Forge weapons are now bulkier, and hurt when thrown.
balance: forge shields are more durable bucklers instead of being the best shields in the game.
/:cl: