### PR TITLE
[NON-MODULAR] Mime Vow Changes

### DIFF
--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -113,7 +113,7 @@
 	clothes_req = FALSE
 	human_req = TRUE
 	antimagic_allowed = TRUE
-	charge_max = 3000
+	charge_max = 50 // SKYRAT EDIT | ORIGINAL: charge_max = 3000
 	range = -1
 	include_user = TRUE
 
@@ -138,9 +138,9 @@
 		H.mind.miming=!H.mind.miming
 		if(H.mind.miming)
 			to_chat(H, span_notice("You make a vow of silence."))
-			SEND_SIGNAL(H, COMSIG_CLEAR_MOOD_EVENT, "vow")
+//			SEND_SIGNAL(H, COMSIG_CLEAR_MOOD_EVENT, "vow") // SKYRAT EDIT | Mimes are people, not freaks.
 		else
-			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "vow", /datum/mood_event/broken_vow)
+//			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "vow", /datum/mood_event/broken_vow) // SKYRAT EDIT | Mimes are people, not freaks.
 			to_chat(H, span_notice("You break your vow of silence."))
 
 // These spells can only be gotten from the "Guide for Advanced Mimery series" for Mime Traitors.

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -6,7 +6,7 @@
 	summon_type = list(/obj/effect/forcefield/mime)
 	invocation_type = INVOCATION_EMOTE
 	invocation_emote_self = "<span class='notice'>You form a wall in front of yourself.</span>"
-	summon_lifespan = 300
+	summon_lifespan = 100 // SKYRAT EDIT ORIGINAL: summon_lifespan = 300
 	charge_max = 300
 	clothes_req = FALSE
 	antimagic_allowed = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the cooldown for the mime's vow to five seconds, and removes the mood debuff.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

It's fucking dumb, mimes are actors, not aliens or whatever dumb shit /tg/ made them. For reference, the mime mood de-buff was -12, losing a limb was -8. The cooldown on vow breaking was insanely long for no real reason and is just generally dumb.

This solidifies that mimes are just, people, not weird aliens.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Mime's no longer suffer a mood debuff, and their vow cooldown has been changed from five minutes, to five seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
