### PR TITLE
Fixes preference menu for NO_UNDERWEAR species (Teshari)

### DIFF
--- a/code/modules/client/preferences/clothing.dm
+++ b/code/modules/client/preferences/clothing.dm
@@ -1,5 +1,3 @@
-//THIS FILE HAS BEEN EDITED BY SKYRAT EDIT
-
 /proc/generate_values_for_underwear(list/accessory_list, list/icons, color, icon_offset) //SKYRAT EDIT CHANGE - Colorable Undershirt/Socks
 	var/icon/lower_half = icon('icons/blanks/32x32.dmi', "nothing")
 
@@ -83,19 +81,10 @@
 	should_generate_icons = TRUE
 
 /datum/preference/choiced/socks/init_possible_values()
-	return generate_values_for_underwear(GLOB.socks_list, list("human_r_leg", "human_l_leg"), COLOR_ALMOST_BLACK, 0) //SKYRAT EDIT CHANGE - Colorable Undershirt/Socks
+	return generate_values_for_underwear(GLOB.socks_list, list("human_r_leg", "human_l_leg"))
 
 /datum/preference/choiced/socks/apply_to_human(mob/living/carbon/human/target, value)
 	target.socks = value
-
-//SKYRAT EDIT CHANGE BEGIN - Colorable Undershirt/Socks
-/datum/preference/choiced/socks/compile_constant_data()
-	var/list/data = ..()
-
-	data[SUPPLEMENTAL_FEATURE_KEY] = "socks_color"
-
-	return data
-//SKYRAT EDIT CHANGE END - Colorable Undershirt/Socks
 
 /// Undershirt preference
 /datum/preference/choiced/undershirt
@@ -105,20 +94,32 @@
 	category = PREFERENCE_CATEGORY_CLOTHING
 	should_generate_icons = TRUE
 
-//SKYRAT EDIT CHANGE BEGIN - Colorable Undershirt/Socks
 /datum/preference/choiced/undershirt/init_possible_values()
-	return generate_values_for_underwear(GLOB.undershirt_list, list("human_chest_m", "human_r_arm", "human_l_arm", "human_r_leg", "human_l_leg", "human_r_hand", "human_l_hand"), COLOR_ALMOST_BLACK,10)
+	var/icon/body = icon('icons/mob/human_parts_greyscale.dmi', "human_r_leg")
+	body.Blend(icon('icons/mob/human_parts_greyscale.dmi', "human_l_leg"), ICON_OVERLAY)
+	body.Blend(icon('icons/mob/human_parts_greyscale.dmi', "human_r_arm"), ICON_OVERLAY)
+	body.Blend(icon('icons/mob/human_parts_greyscale.dmi', "human_l_arm"), ICON_OVERLAY)
+	body.Blend(icon('icons/mob/human_parts_greyscale.dmi', "human_r_hand"), ICON_OVERLAY)
+	body.Blend(icon('icons/mob/human_parts_greyscale.dmi', "human_l_hand"), ICON_OVERLAY)
+	body.Blend(icon('icons/mob/human_parts_greyscale.dmi', "human_chest_m"), ICON_OVERLAY)
+
+	var/list/values = list()
+
+	for (var/accessory_name in GLOB.undershirt_list)
+		var/icon/icon_with_undershirt = icon(body)
+
+		if (accessory_name != "Nude")
+			var/datum/sprite_accessory/accessory = GLOB.undershirt_list[accessory_name]
+			icon_with_undershirt.Blend(icon('icons/mob/clothing/underwear.dmi', accessory.icon_state), ICON_OVERLAY)
+
+		icon_with_undershirt.Crop(9, 9, 23, 23)
+		icon_with_undershirt.Scale(32, 32)
+		values[accessory_name] = icon_with_undershirt
+
+	return values
 
 /datum/preference/choiced/undershirt/apply_to_human(mob/living/carbon/human/target, value)
 	target.undershirt = value
-
-/datum/preference/choiced/undershirt/compile_constant_data()
-	var/list/data = ..()
-
-	data[SUPPLEMENTAL_FEATURE_KEY] = "undershirt_color"
-
-	return data
-//SKYRAT EDIT CHANGE END - Colorable Undershirt/Socks
 
 /// Underwear preference
 /datum/preference/choiced/underwear
@@ -129,7 +130,7 @@
 	should_generate_icons = TRUE
 
 /datum/preference/choiced/underwear/init_possible_values()
-	return generate_values_for_underwear(GLOB.underwear_list, list("human_chest_m", "human_r_leg", "human_l_leg"), COLOR_ALMOST_BLACK, 5) //SKYRAT EDIT CHANGE - Colorable Undershirt/Socks
+	return generate_values_for_underwear(GLOB.underwear_list, list("human_chest_m", "human_r_leg", "human_l_leg"), COLOR_ALMOST_BLACK)
 
 /datum/preference/choiced/underwear/apply_to_human(mob/living/carbon/human/target, value)
 	target.underwear = value
@@ -139,8 +140,8 @@
 		return FALSE
 
 	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
-	var/datum/species/species = species_type
-	return !(NO_UNDERWEAR in initial(species.species_traits))
+	var/datum/species/species = new species_type
+	return !(NO_UNDERWEAR in species.species_traits)
 
 /datum/preference/choiced/underwear/compile_constant_data()
 	var/list/data = ..()
@@ -148,4 +149,3 @@
 	data[SUPPLEMENTAL_FEATURE_KEY] = "underwear_color"
 
 	return data
-

--- a/modular_skyrat/master_files/code/modules/client/preferences/clothing.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/clothing.dm
@@ -1,0 +1,46 @@
+/datum/preference/choiced/socks/init_possible_values()
+	return generate_values_for_underwear(GLOB.socks_list, list("human_r_leg", "human_l_leg"), COLOR_ALMOST_BLACK, 0)
+
+/datum/preference/choiced/socks/compile_constant_data()
+	var/list/data = ..()
+
+	data[SUPPLEMENTAL_FEATURE_KEY] = "socks_color"
+
+	return data
+
+/datum/preference/choiced/socks/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species = new species_type
+	return !(NO_UNDERWEAR in species.species_traits)
+
+/datum/preference/choiced/undershirt/init_possible_values()
+	return generate_values_for_underwear(GLOB.undershirt_list, list("human_chest_m", "human_r_arm", "human_l_arm", "human_r_leg", "human_l_leg", "human_r_hand", "human_l_hand"), COLOR_ALMOST_BLACK,10)
+
+/datum/preference/choiced/undershirt/compile_constant_data()
+	var/list/data = ..()
+
+	data[SUPPLEMENTAL_FEATURE_KEY] = "undershirt_color"
+
+	return data
+
+/datum/preference/choiced/undershirt/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species = new species_type
+	return !(NO_UNDERWEAR in species.species_traits)
+
+/datum/preference/choiced/underwear/init_possible_values()
+	return generate_values_for_underwear(GLOB.underwear_list, list("human_chest_m", "human_r_leg", "human_l_leg"), COLOR_ALMOST_BLACK, 5)
+
+/datum/preference/choiced/underwear/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species = new species_type
+	return !(NO_UNDERWEAR in species.species_traits)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4364,6 +4364,7 @@
 #include "modular_skyrat\master_files\code\modules\client\preferences\auto_dementor.dm"
 #include "modular_skyrat\master_files\code\modules\client\preferences\be_antag.dm"
 #include "modular_skyrat\master_files\code\modules\client\preferences\body_type.dm"
+#include "modular_skyrat\master_files\code\modules\client\preferences\clothing.dm"
 #include "modular_skyrat\master_files\code\modules\client\preferences\cursed_shit.dm"
 #include "modular_skyrat\master_files\code\modules\client\preferences\delete_sparks.dm"
 #include "modular_skyrat\master_files\code\modules\client\preferences\emote_overlay.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I could've sworn this was a posted issue, but teshari had the underwear, undershirt, and socks buttons on character creation, but they were guaranteed to crash when interacted with.

The underwear, undershirt, and socks buttons were still showing up in Character Preferences for teshari, but crashing when interacted with, because there was no code to make them acknowledge the `NO_UNDERWEAR` flag, but the colors they were dependent on (eg `undershirt_color`) WERE using the flag, so they still showed up but just crashed, expecting the color to exist at the same time. They now indicate they're not available if there's the flag is set.

I also moved all of the changes in `code/modules/client/preferences/clothing.dm` that were for the underwear, socks, and undershirt preference datums to a new file in the modular_skyrat/master_files, as all the other preferences datums have their edits there. As a result, I largely reset that file. In my opinion, our handling of the client module is incredibly cursed, but we were changing these datums in 2 places, so I made it vaguely more consistent for these 3 pref datums.

![image](https://user-images.githubusercontent.com/1185434/152741804-2feaf6b0-d8b3-4595-9810-ed6ef10f14c7.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Fixes possibly the most trivial to reproduce tgui crash on our fork.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
fix: Teshari no longer have the underwear, undershirt, or socks buttons in the character editor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
