### PR TITLE
Disables clown borg module

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -796,6 +796,7 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/*
 /datum/design/borg_transform_clown
 	name = "Cyborg Upgrade (Clown Model)"
 	id = "borg_transform_clown"
@@ -804,6 +805,7 @@
 	materials = list(/datum/material/iron = 15000, /datum/material/glass = 15000, /datum/material/bananium = 1000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
+*/
 
 /datum/design/borg_upgrade_selfrepair
 	name = "Cyborg Upgrade (Self-repair)"


### PR DESCRIPTION
## About The Pull Request

Disable the clown borg module design.

## How This Contributes To The Skyrat Roleplay Experience

Clown is vet-locked, but this isn't - and for a clown borg running around spamming pies and among us on synthesiser, you can't take their tools. The only option is death.

Staff as a collective have agreed on its removal.

## Changelog
:cl:
del: Clown cyborg module has been disabled.
/:cl: