### PR TITLE
pre-empts #11340 by modularizing the Wt550 crates.

### DIFF
--- a/modular_skyrat/modules/cargo/code/goodies.dm
+++ b/modular_skyrat/modules/cargo/code/goodies.dm
@@ -50,6 +50,20 @@
 //////////////////////////// Weapons or Ammo /////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
+/datum/supply_pack/goody/wt550_single
+	name = "WT-550 Auto Rifle Single-Pack"
+	desc = "Contains one high-powered, semiautomatic rifles chambered in 4.6x30mm." // "high-powered" lol yea right
+	cost = PAYCHECK_HARD * 20
+	access_view = ACCESS_ARMORY
+	contains = list(/obj/item/gun/ballistic/automatic/wt550)
+
+/datum/supply_pack/goody/wt550ammo_single
+	name = "WT-550 Auto Rifle Ammo Single-Pack"
+	desc = "Contains a 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads."
+	cost = PAYCHECK_HARD * 6
+	access_view = ACCESS_ARMORY
+	contains = list(/obj/item/ammo_box/magazine/wt550m9)
+
 /datum/supply_pack/goody/makarov
 	name = "Makarov Self Defense Pistol"
 	desc = "A small, slow firing and low capacity pistol, but hey, it's better then a crowbar, right? (Does not include a weapons permit.)"

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -118,6 +118,24 @@
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/mod/control/pre_equipped/security)
 	crate_name = "security MODsuit crate"
+	
+	
+/datum/supply_pack/security/armory/wt550
+	name = "WT-550 Auto Rifle Crate"
+	desc = "Contains two high-powered, semiautomatic rifles chambered in 4.6x30mm. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 7
+	contains = list(/obj/item/gun/ballistic/automatic/wt550,
+					/obj/item/gun/ballistic/automatic/wt550)
+	crate_name = "auto rifle crate"
+	
+/datum/supply_pack/security/armory/wt550ammo
+	name = "WT-550 Auto Rifle Ammo Crate"
+	desc = "Contains four 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 3.5
+	contains = list(/obj/item/ammo_box/magazine/wt550m9,
+					/obj/item/ammo_box/magazine/wt550m9,
+					/obj/item/ammo_box/magazine/wt550m9,
+					/obj/item/ammo_box/magazine/wt550m9)
 
 /datum/supply_pack/security/croonsurplus
 	name = "Croon Weapons Crate"


### PR DESCRIPTION
this is an addendum to pr  #11340, witness the branch this is PR'd towards

## About The Pull Request

what it says on the tin, the guns aren't a concern down here.

## How This Contributes To The Skyrat Roleplay Experience
variety, more pew-pew bang-bangs
## Changelog



:cl:
code: moved the wt-550 to the modular folder, thus preserving it in the cargo-crates.
/:cl:

