### PR TITLE
[MODULAR] Mining MODsuit Armor Balance Alternative

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -46,7 +46,7 @@
 		new /datum/data/mining_equipment("Super Resonator", /obj/item/resonator/upgraded, 2500),
 		new /datum/data/mining_equipment("Jump Boots", /obj/item/clothing/shoes/bhop, 2500),
 		new /datum/data/mining_equipment("Ice Hiking Boots", /obj/item/clothing/shoes/winterboots/ice_boots, 2500),
-		new /datum/data/mining_equipment("Mining MODsuit", /obj/item/mod/control/pre_equipped/mining, 5000), //SKYRAT EDIT: 2500
+		new /datum/data/mining_equipment("Mining MODsuit", /obj/item/mod/control/pre_equipped/mining, 2500),
 		new /datum/data/mining_equipment("Luxury Shelter Capsule", /obj/item/survivalcapsule/luxury, 3000),
 		new /datum/data/mining_equipment("Luxury Bar Capsule", /obj/item/survivalcapsule/luxuryelite, 10000),
 		new /datum/data/mining_equipment("Nanotrasen Minebot", /mob/living/simple_animal/hostile/mining_drone, 800),

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -46,7 +46,7 @@
 		new /datum/data/mining_equipment("Super Resonator", /obj/item/resonator/upgraded, 2500),
 		new /datum/data/mining_equipment("Jump Boots", /obj/item/clothing/shoes/bhop, 2500),
 		new /datum/data/mining_equipment("Ice Hiking Boots", /obj/item/clothing/shoes/winterboots/ice_boots, 2500),
-		new /datum/data/mining_equipment("Mining MODsuit", /obj/item/mod/control/pre_equipped/mining, 2500),
+		new /datum/data/mining_equipment("Mining MODsuit", /obj/item/mod/control/pre_equipped/mining, 5000), //SKYRAT EDIT: 2500
 		new /datum/data/mining_equipment("Luxury Shelter Capsule", /obj/item/survivalcapsule/luxury, 3000),
 		new /datum/data/mining_equipment("Luxury Bar Capsule", /obj/item/survivalcapsule/luxuryelite, 10000),
 		new /datum/data/mining_equipment("Nanotrasen Minebot", /mob/living/simple_animal/hostile/mining_drone, 800),

--- a/modular_skyrat/modules/modsuit_armour/modsuit_armour.dm
+++ b/modular_skyrat/modules/modsuit_armour/modsuit_armour.dm
@@ -12,8 +12,8 @@
 /datum/mod_theme/loader // Cargo
 	armor = list(MELEE = 20, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 100, FIRE = 50, ACID = 25, WOUND = 10)
 
-/datum/mod_theme/mining // Shaft Miner
-	armor = list(MELEE = 5, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 100, FIRE = 100, ACID = 75, WOUND = 15)
+/datum/mod_theme/mining // Shaft Miner / Other half comes from the ashland booster
+	armor = list(MELEE = 5, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 25, BIO = 100, FIRE = 100, ACID = 75, WOUND = 15)
 
 /datum/mod_theme/medical // Paramedic / Medical Doctor
 	armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 60, ACID = 75, WOUND = 10)

--- a/modular_skyrat/modules/modsuit_armour/modsuit_armour.dm
+++ b/modular_skyrat/modules/modsuit_armour/modsuit_armour.dm
@@ -13,7 +13,7 @@
 	armor = list(MELEE = 20, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 100, FIRE = 50, ACID = 25, WOUND = 10)
 
 /datum/mod_theme/mining // Shaft Miner
-	armor = list(MELEE = 40, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 100, FIRE = 100, ACID = 75, WOUND = 15)
+	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 100, FIRE = 100, ACID = 75, WOUND = 15)
 
 /datum/mod_theme/medical // Paramedic / Medical Doctor
 	armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 60, ACID = 75, WOUND = 10)

--- a/modular_skyrat/modules/modsuit_armour/modsuit_armour.dm
+++ b/modular_skyrat/modules/modsuit_armour/modsuit_armour.dm
@@ -13,7 +13,7 @@
 	armor = list(MELEE = 20, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 100, FIRE = 50, ACID = 25, WOUND = 10)
 
 /datum/mod_theme/mining // Shaft Miner
-	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 100, FIRE = 100, ACID = 75, WOUND = 15)
+	armor = list(MELEE = 5, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 100, FIRE = 100, ACID = 75, WOUND = 15)
 
 /datum/mod_theme/medical // Paramedic / Medical Doctor
 	armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 60, ACID = 75, WOUND = 10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is an alternative to #11409

Makes the base melee armor of Mining MOD 5
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Mining Armor booster gives 50 Melee armor in ashlands. Currently this causes miners to have a whopping Melee 100 armor which should not be possible for players. This PR makes the mining MODsuits in line with civilian MOD's since miners are by design to not have weaponry and armor on station. Thus this makes Miniing MODsuit 55 Melee, while Drake Armor is 65, giving the miners choice between having the utility of a modsuit or the extra 10 armor of drake. 

After playing miner more, I can say while the modsuit has many nice gimmick modules, most are as named: gimmicks.
Most of the modules are already competing with already existing items. Therefor I decided not to touch its pricing to not make the modsuit redundant.

_`Also since our round times are the double of TG, doubling the point total of Kitted MODsuit to 5000 to make it achievable from a 20 minute to a 40 minute grind`_
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes the Melee Armor X (100) Mining MODsuits. Now they have a base Armor of I (5). They also have lower innate Laser, Bullet, Energy and Bomb Armor since they gain it from the ash module
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
