### PR TITLE
[Modular] Fixes servelyn tails disappearing on *wag

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/tails.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/tails.dm
@@ -418,7 +418,7 @@
 	name = "Cat, Triple"
 	icon_state = "threecat"
 
-/datum/sprite_accessory/tails/mammal/wagging/tiger2
+/datum/sprite_accessory/tails/mammal/tiger2
 	name = "Servelyn Tails"
 	icon_state = "tiger2"
 	general_type = "feline"


### PR DESCRIPTION
## About The Pull Request

Because there is no wagging icon_state

## Changelog

:cl:
fix: Fixes servelyn tails disappearing on *wag
/:cl: