### PR TITLE
xenoarch engine lights, camera, and AREAction

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -2204,11 +2204,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "jy" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
 /obj/machinery/vending/tool{
 	onstation_override = 1
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/mine/xenoarch/engineering)
@@ -3367,7 +3367,7 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "nF" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
 	dir = 8
@@ -4682,12 +4682,8 @@
 /turf/open/floor/iron,
 /area/mine/xenoarch/science/cytology)
 "yh" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/mine/xenoarch/engineering)
+/turf/closed/wall/r_wall,
+/area/mine/xenoarch/living)
 "yl" = (
 /obj/effect/turf_decal/tile/yellow/anticorner,
 /turf/open/floor/iron,
@@ -4770,9 +4766,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
-"zr" = (
-/turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
 "zu" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
@@ -4834,6 +4827,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/mine/xenoarch/engineering/hfr)
+"zM" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/mine/xenoarch/engineering)
 "zO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -4875,7 +4875,7 @@
 	id = "xabc"
 	},
 /turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "zX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -4889,7 +4889,7 @@
 	id = "xaburn"
 	},
 /turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "Af" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5061,6 +5061,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"Bq" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/anticorner,
+/turf/open/floor/iron/dark,
+/area/mine/xenoarch/engineering)
 "Bt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -5289,7 +5294,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "DA" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
@@ -5345,6 +5350,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"Eh" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/mine/xenoarch/engineering)
 "Ek" = (
 /obj/structure/reagent_dispensers/fueltank/large,
 /obj/effect/turf_decal/bot,
@@ -5572,7 +5583,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/airless,
-/area/mine/xenoarch/engineering)
+/area/mine/xenoarch/engineering/hfr)
 "FO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/public/glass{
@@ -5885,7 +5896,7 @@
 "HJ" = (
 /obj/structure/cable,
 /turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "HK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6084,6 +6095,13 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/mine/xenoarch/maintenance/east)
+"Jt" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/mine/xenoarch/engineering)
 "Jy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6098,8 +6116,9 @@
 /turf/open/floor/iron,
 /area/mine/xenoarch/living)
 "JD" = (
-/turf/closed/wall/r_wall,
-/area/lavaland/surface/outdoors)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/mine/xenoarch/science)
 "JF" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -6136,6 +6155,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/mine/eva)
+"Ka" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Xenoarch Atmospherics East";
+	network = list("mine","rd")
+	},
+/turf/open/floor/iron,
+/area/mine/xenoarch/engineering)
 "Kb" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
@@ -6405,12 +6434,12 @@
 /area/mine/xenoarch/living)
 "Mi" = (
 /turf/open/floor/engine/airless,
-/area/mine/xenoarch/engineering)
+/area/mine/xenoarch/engineering/hfr)
 "Mj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark,
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/mine/xenoarch/engineering)
+/area/mine/xenoarch/engineering/hfr)
 "Ml" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/bot,
@@ -6593,6 +6622,13 @@
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron,
 /area/mine/xenoarch/science/cytology)
+"Oj" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/mine/xenoarch/engineering)
 "Ok" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -7306,12 +7342,12 @@
 /turf/open/floor/engine,
 /area/mine/xenoarch/engineering/hfr)
 "TF" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/mine/xenoarch/engineering)
 "TH" = (
@@ -7528,10 +7564,10 @@
 /turf/open/floor/iron,
 /area/mine/xenoarch/living)
 "UW" = (
-/obj/effect/turf_decal/tile/yellow/anticorner{
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
 	},
-/obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/mine/xenoarch/engineering)
 "UY" = (
@@ -7764,6 +7800,16 @@
 	},
 /turf/open/floor/iron,
 /area/mine/mechbay)
+"WA" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Xenoarch Atmospherics West";
+	network = list("mine","rd")
+	},
+/turf/open/floor/iron,
+/area/mine/xenoarch/engineering)
 "WB" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -7830,7 +7876,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "Xi" = (
 /obj/machinery/door/airlock{
 	id_tag = "xadorm1";
@@ -8049,7 +8095,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "Zg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/north,
@@ -8146,7 +8192,7 @@
 /obj/machinery/power/turbine,
 /obj/structure/cable,
 /turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "Zy" = (
 /obj/machinery/smartfridge/organ,
 /obj/structure/window/reinforced{
@@ -65234,13 +65280,13 @@ zn
 Cf
 lY
 Ru
+zM
 re
 re
+WA
 re
 re
-re
-re
-re
+zM
 re
 sT
 sF
@@ -67290,13 +67336,13 @@ mU
 tc
 mj
 ud
+Oj
 Yj
 Yj
+Ka
 Yj
 Yj
-Yj
-Yj
-Yj
+Oj
 Yj
 yl
 sF
@@ -67534,9 +67580,9 @@ Dg
 AK
 Dg
 ZA
-sF
-sF
-TU
+yh
+yh
+Dg
 sF
 iR
 Gd
@@ -67791,17 +67837,17 @@ rt
 Cp
 rt
 Qh
-TU
+Dg
 aj
 aj
 TU
 UW
-TF
-bO
-bO
-bO
-yh
-bO
+Gd
+vw
+vw
+vw
+Ri
+tc
 sF
 xW
 sF
@@ -68048,17 +68094,17 @@ As
 Rk
 As
 pG
-TU
+Dg
 aj
 aj
 TU
 jy
-Gd
-vw
-vw
-vw
-Ri
-Ri
+TF
+Eh
+Eh
+Eh
+Jt
+Bq
 sF
 Oo
 Oo
@@ -68305,7 +68351,7 @@ As
 uH
 US
 Xj
-sF
+yh
 aj
 aj
 Uf
@@ -68562,7 +68608,7 @@ As
 Kz
 As
 Jg
-TU
+Dg
 aj
 aj
 Uf
@@ -68819,7 +68865,7 @@ Ic
 xN
 Ic
 Nw
-TU
+Dg
 aj
 aj
 ew
@@ -69076,7 +69122,7 @@ HV
 zD
 HV
 Ex
-sF
+Ex
 aj
 aj
 Uf
@@ -69333,7 +69379,7 @@ ZT
 DA
 XL
 TS
-TU
+JD
 aj
 aj
 Uf
@@ -69590,7 +69636,7 @@ ZF
 dh
 KL
 VO
-sF
+Ex
 aj
 aj
 Uf
@@ -71139,11 +71185,11 @@ Va
 qO
 qO
 Va
-jJ
+Uf
 Mj
 Zf
 nC
-JD
+Uf
 aj
 aj
 aj
@@ -71396,12 +71442,12 @@ qO
 qO
 xF
 qO
-jJ
+Uf
 FG
 Xc
 HJ
-JD
-JD
+Uf
+Uf
 aj
 aj
 aj
@@ -71653,7 +71699,7 @@ EV
 pq
 EV
 jJ
-jJ
+Uf
 Mi
 zW
 HJ
@@ -71910,12 +71956,12 @@ vJ
 qO
 Ff
 jJ
-JD
-zr
-zr
-zr
-JD
-JD
+Uf
+Mi
+Mi
+Mi
+Uf
+Uf
 aj
 aj
 aj
@@ -72167,11 +72213,11 @@ KB
 rJ
 SU
 jJ
-JD
+Uf
 Ad
 Ad
 Ad
-JD
+Uf
 aj
 aj
 aj

--- a/_maps/skyrat/xenoarch_base.dmm
+++ b/_maps/skyrat/xenoarch_base.dmm
@@ -15,6 +15,16 @@
 "ak" = (
 /turf/closed/wall,
 /area/mine/xenoarch/maintenance/east)
+"an" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Xenoarch Atmospherics West";
+	network = list("mine","rd")
+	},
+/turf/open/floor/iron,
+/area/mine/xenoarch/engineering)
 "aw" = (
 /obj/machinery/button/door/directional/north{
 	id = "xadorm3";
@@ -186,7 +196,7 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "cD" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
@@ -371,9 +381,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/xenoarch/engineering/hfr)
-"fp" = (
-/turf/open/floor/engine/airless,
-/area/mine/xenoarch/engineering)
 "fz" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
@@ -469,11 +476,11 @@
 /turf/open/floor/iron,
 /area/mine/xenoarch/engineering/hfr)
 "gW" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
 /obj/machinery/vending/tool{
 	onstation_override = 1
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/mine/xenoarch/engineering)
@@ -602,6 +609,12 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/mine/xenoarch/maintenance/west)
+"jm" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/mine/xenoarch/engineering)
 "js" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/mineral/equipment_vendor,
@@ -914,7 +927,7 @@
 /area/mine/xenoarch/maintenance/east)
 "np" = (
 /turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "nz" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1352,6 +1365,11 @@
 	},
 /turf/open/floor/iron,
 /area/mine/xenoarch/living)
+"tA" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/anticorner,
+/turf/open/floor/iron/dark,
+/area/mine/xenoarch/engineering)
 "tC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -1395,6 +1413,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/mine/xenoarch/science/xenoarch)
+"uO" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/mine/xenoarch/engineering)
 "uR" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
@@ -1490,12 +1515,8 @@
 /turf/open/floor/iron,
 /area/mine/xenoarch/living)
 "wo" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/mine/xenoarch/engineering)
+/turf/closed/wall/r_wall,
+/area/mine/xenoarch/living)
 "ww" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1571,7 +1592,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "xS" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/brown/half{
@@ -1639,7 +1660,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "yS" = (
 /turf/closed/wall/r_wall,
 /area/mine/xenoarch/engineering)
@@ -1696,7 +1717,7 @@
 	id = "xaburn"
 	},
 /turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "zT" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
@@ -1774,7 +1795,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/airless,
-/area/mine/xenoarch/engineering)
+/area/mine/xenoarch/engineering/hfr)
 "AP" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron/dark,
@@ -1917,7 +1938,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark,
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/mine/xenoarch/engineering)
+/area/mine/xenoarch/engineering/hfr)
 "CN" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -2071,11 +2092,11 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "EI" = (
 /obj/structure/cable,
 /turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "EP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2159,7 +2180,7 @@
 	id = "xabc"
 	},
 /turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "Gd" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
@@ -2416,14 +2437,9 @@
 /turf/open/floor/plating,
 /area/mine/xenoarch/maintenance/west)
 "Kg" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/mine/xenoarch/engineering)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/mine/xenoarch/science)
 "Kt" = (
 /obj/machinery/door/airlock{
 	id_tag = "xadorm4";
@@ -2434,10 +2450,10 @@
 /turf/open/floor/carpet,
 /area/mine/xenoarch/living)
 "Kw" = (
-/obj/effect/turf_decal/tile/yellow/anticorner{
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
 	},
-/obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/mine/xenoarch/engineering)
 "Ky" = (
@@ -2615,8 +2631,14 @@
 /turf/open/floor/iron/dark,
 /area/mine/xenoarch/living)
 "NX" = (
-/turf/closed/wall/r_wall,
-/area/lavaland/surface/outdoors)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/mine/xenoarch/engineering)
 "NZ" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
@@ -2716,7 +2738,7 @@
 /obj/machinery/power/turbine,
 /obj/structure/cable,
 /turf/open/floor/engine/airless,
-/area/lavaland/surface/outdoors)
+/area/mine/xenoarch/engineering/hfr)
 "OP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -2757,6 +2779,16 @@
 	},
 /turf/open/floor/iron,
 /area/mine/xenoarch/living)
+"Pi" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Xenoarch Atmospherics East";
+	network = list("mine","rd")
+	},
+/turf/open/floor/iron,
+/area/mine/xenoarch/engineering)
 "Pq" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "xasafe";
@@ -2786,6 +2818,13 @@
 	dir = 8
 	},
 /turf/open/floor/engine/plasma,
+/area/mine/xenoarch/engineering)
+"PM" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
 /area/mine/xenoarch/engineering)
 "PP" = (
 /obj/structure/table,
@@ -3122,6 +3161,13 @@
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/engine,
 /area/mine/xenoarch/engineering/hfr)
+"Uj" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/mine/xenoarch/engineering)
 "Un" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -4884,13 +4930,13 @@ yA
 Dh
 Lf
 db
+PM
 ua
 ua
+an
 ua
 ua
-ua
-ua
-ua
+PM
 ua
 dA
 yS
@@ -5276,13 +5322,13 @@ VJ
 Yl
 nR
 vW
+uO
 MQ
 MQ
+Pi
 MQ
 MQ
-MQ
-MQ
-MQ
+uO
 MQ
 Qo
 yS
@@ -5312,9 +5358,9 @@ Un
 iz
 Un
 QW
-yS
-yS
-aS
+wo
+wo
+Un
 yS
 JE
 jT
@@ -5361,17 +5407,17 @@ QM
 lm
 QM
 TB
-aS
+Un
 Zc
 Zc
 aS
 Kw
-Kg
-UJ
-UJ
-UJ
-wo
-UJ
+jT
+IO
+IO
+IO
+wx
+Yl
 yS
 yq
 yS
@@ -5410,17 +5456,17 @@ eK
 GK
 eK
 yO
-aS
+Un
 Zc
 Zc
 aS
 gW
-jT
-IO
-IO
-IO
-wx
-wx
+NX
+jm
+jm
+jm
+Uj
+tA
 yS
 Xa
 Xa
@@ -5459,7 +5505,7 @@ eK
 Ts
 CO
 aA
-yS
+wo
 Zc
 Zc
 Zz
@@ -5508,7 +5554,7 @@ eK
 Ya
 eK
 Rk
-aS
+Un
 Zc
 Zc
 Zz
@@ -5557,7 +5603,7 @@ Zw
 Dx
 Zw
 Fw
-aS
+Un
 Zc
 Zc
 eM
@@ -5606,7 +5652,7 @@ dU
 pC
 dU
 Yt
-yS
+Yt
 Zc
 Zc
 Zz
@@ -5655,7 +5701,7 @@ Jb
 lq
 DY
 oa
-aS
+Kg
 Zc
 Zc
 Zz
@@ -5704,7 +5750,7 @@ qH
 gc
 So
 OE
-yS
+Yt
 Zc
 Zc
 Zz
@@ -6005,11 +6051,11 @@ st
 SY
 SY
 st
-Ns
+Zz
 CM
 xv
 cu
-NX
+Zz
 Zc
 Zc
 Zc
@@ -6054,12 +6100,12 @@ SY
 SY
 py
 SY
-Ns
+Zz
 AK
 yR
 EI
-NX
-NX
+Zz
+Zz
 Zc
 Zc
 Zc
@@ -6103,8 +6149,8 @@ ak
 lP
 ak
 Ns
-Ns
-fp
+Zz
+np
 FY
 EI
 EC
@@ -6152,12 +6198,12 @@ yC
 SY
 jL
 Ns
-NX
+Zz
 np
 np
 np
-NX
-NX
+Zz
+Zz
 Zc
 Zc
 Zc
@@ -6201,11 +6247,11 @@ VK
 dn
 AV
 Ns
-NX
+Zz
 zQ
 zQ
 zQ
-NX
+Zz
 Zc
 Zc
 Zc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
xenoarch atmos now has lights and cameras
xenoarch burn chamber now is the correct area
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
fixes...
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: xenoarch atmos now has lights and cameras
fix: xenoarch burn chamber is now the appropriate area
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
