### PR TITLE
[Modular] Removes Undercharger from the MCR

### DIFF
--- a/modular_skyrat/modules/microfusion/code/microfusion_techweb.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_techweb.dm
@@ -5,7 +5,7 @@
 	description = "Basic microfusion technology allowing for basic microfusion designs."
 	design_ids = list(
 		"basic_microfusion_cell",
-		"microfusion_phase_emitter_undercharger",
+		//"microfusion_phase_emitter_undercharger",
 	)
 
 //Enhanced microfusion


### PR DESCRIPTION
## About The Pull Request

Time to open up this controversial can of worms, debate time go. SO, this pr removes the MCR non-lethal attachment from the MCR. One simple line of code to make it not printable by the sec autolathe.

Now, why do I feel like this is a good change to make? As someone who's been playing warden more often since the MCRs came out, I started to witness a trend. A lot of officers will demand a MCR to have for 'non lethal use' then try to fully mod it for lethals, and keep it on their person. This, in my opinion, violates one of the fundamentals of good sportsmanship sec v antag play. **Do not prepare for a threat that you don't know about.** It's metagaming, to say the least. Most officers shouldn't expect anything to happen to our backwater station, but I am seeing a trend where it is used to be ready-to-go amber-- or even before then, on a moment's notice.

This is allowing officers to carry lethals on blue and green codes, and I think that this is a discussion that needs to be had. Some people may say they haven't seen it be abused; it can be abused and that's enough for me to want to make a change. They have access to disablers (More efficient then the undercharger,) the pepperball gun, bolas, grapplers they can order. There's many more non-lethal options they should be considering before packing a lethal gun with an undercharger.

I totally expect to get set on fire for this.

## How This Contributes To The Skyrat Roleplay Experience

Prevents sec from amber/red-prepping with MCRs on the technicality that they can be outfitted for non-lethals on blue/green.

## Changelog

:cl:
code: edited out the early undercharger tech availability.
/:cl:
