### PR TITLE
[NONMOD] Locks tribal weapons to ashwalkers

### DIFF
--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_ash_walker1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_ash_walker1_skyrat.dmm
@@ -582,9 +582,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "tm" = (
-/mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch,
 /obj/structure/stone_tile/surrounding/cracked,
 /obj/structure/stone_tile/cracked,
+/mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "tH" = (
@@ -833,7 +833,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "Do" = (
-/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 8
 	},
@@ -843,6 +842,7 @@
 /obj/structure/stone_tile/cracked{
 	dir = 4
 	},
+/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "DJ" = (
@@ -1049,8 +1049,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "LM" = (
-/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
 /obj/structure/stone_tile/slab,
+/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "LO" = (
@@ -1410,8 +1410,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "RR" = (
-/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
 /obj/structure/stone_tile/slab/burnt,
+/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "St" = (
@@ -1441,6 +1441,9 @@
 	},
 /obj/item/knife/combat/bone{
 	pixel_x = -8
+	},
+/obj/item/claymore/bone{
+	pixel_x = 8
 	},
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -927,6 +927,7 @@
 	result = /obj/item/knife/combat/bone
 	time = 20
 	reqs = list(/obj/item/stack/sheet/bone = 2)
+	always_available = FALSE
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/bonespear
@@ -935,6 +936,7 @@
 	time = 30
 	reqs = list(/obj/item/stack/sheet/bone = 4,
 				/obj/item/stack/sheet/sinew = 1)
+	always_available = FALSE
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/boneaxe
@@ -943,6 +945,7 @@
 	time = 50
 	reqs = list(/obj/item/stack/sheet/bone = 6,
 				/obj/item/stack/sheet/sinew = 3)
+	always_available = FALSE
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/bonfire

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -927,7 +927,7 @@
 	result = /obj/item/knife/combat/bone
 	time = 20
 	reqs = list(/obj/item/stack/sheet/bone = 2)
-	always_available = FALSE
+	always_available = FALSE //SKYRAT EDIT
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/bonespear
@@ -936,7 +936,7 @@
 	time = 30
 	reqs = list(/obj/item/stack/sheet/bone = 4,
 				/obj/item/stack/sheet/sinew = 1)
-	always_available = FALSE
+	always_available = FALSE //SKYRAT EDIT
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/boneaxe
@@ -945,7 +945,7 @@
 	time = 50
 	reqs = list(/obj/item/stack/sheet/bone = 6,
 				/obj/item/stack/sheet/sinew = 3)
-	always_available = FALSE
+	always_available = FALSE //SKYRAT EDIT
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/bonfire

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -179,14 +179,14 @@
 	icon_prefix = "bone_spear"
 	name = "bone spear"
 	desc = "A haphazardly-constructed yet still deadly weapon. The pinnacle of modern technology."
-	force = 10 //SKYRAT EDIT
+	force = 8 //SKYRAT EDIT
 	throwforce = 22
 	reach = 2 // SKYRAT EDIT
 	armour_penetration = 15 //Enhanced armor piercing
 
 /obj/item/spear/bonespear/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded=10, force_wielded=16, icon_wielded="[icon_prefix]1") //SKYRAT EDIT
+	AddComponent(/datum/component/two_handed, force_unwielded=8, force_wielded=16, icon_wielded="[icon_prefix]1") //SKYRAT EDIT
 
 /*
  * Bamboo Spear

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -179,14 +179,14 @@
 	icon_prefix = "bone_spear"
 	name = "bone spear"
 	desc = "A haphazardly-constructed yet still deadly weapon. The pinnacle of modern technology."
-	force = 12
+	force = 10 //SKYRAT EDIT
 	throwforce = 22
 	reach = 2 // SKYRAT EDIT
 	armour_penetration = 15 //Enhanced armor piercing
 
 /obj/item/spear/bonespear/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded=12, force_wielded=20, icon_wielded="[icon_prefix]1")
+	AddComponent(/datum/component/two_handed, force_unwielded=10, force_wielded=16, icon_wielded="[icon_prefix]1") //SKYRAT EDIT
 
 /*
  * Bamboo Spear

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -33,6 +33,11 @@
 	RegisterSignal(owner.current, COMSIG_MOB_EXAMINATE, .proc/on_examinate)
 	owner.teach_crafting_recipe(/datum/crafting_recipe/skeleton_key)
 	owner.teach_crafting_recipe(/datum/crafting_recipe/ashnecklace) //SKYRAT EDIT DRACONIC NECKLACE//
+	owner.teach_crafting_recipe(/datum/crafting_recipe/bonesword)	//SKYRAT EDIT TRIBAL WEAPONS FOR TRIBALS//
+	owner.teach_crafting_recipe(/datum/crafting_recipe/macahuitl)	//SKYRAT EDIT
+	owner.teach_crafting_recipe(/datum/crafting_recipe/boneaxe)		//SKYRAT EDIT
+	owner.teach_crafting_recipe(/datum/crafting_recipe/bonespear)	//SKYRAT EDIT
+	owner.teach_crafting_recipe(/datum/crafting_recipe/bonedagger)	//SKYRAT EDIT
 
 /datum/antagonist/ashwalker/on_removal()
 	. = ..()

--- a/code/modules/cargo/bounties/mining.dm
+++ b/code/modules/cargo/bounties/mining.dm
@@ -18,11 +18,15 @@
 	required_count = 2
 	wanted_types = list(/obj/item/oar = TRUE)
 
+//SKYRAT EDIT REMOVAL
+/*
 /datum/bounty/item/mining/bone_axe
 	name = "Bone Axe"
 	description = "Station 12 has had their fire axes stolen by marauding clowns. Ship them a bone axe as a replacement."
 	reward = CARGO_CRATE_VALUE * 15
 	wanted_types = list(/obj/item/fireaxe/boneaxe = TRUE)
+*/
+//END SKYRAT EDIT REMOVAL
 
 /datum/bounty/item/mining/bone_armor
 	name = "Bone Armor"
@@ -42,13 +46,16 @@
 	reward = CARGO_CRATE_VALUE * 15
 	required_count = 3
 	wanted_types = list(/obj/item/clothing/accessory/talisman = TRUE)
-
+//SKYRAT EDIT REMOVAL
+/*
 /datum/bounty/item/mining/bone_dagger
 	name = "Bone Daggers"
 	description = "Central Command's canteen is undergoing budget cuts. Ship over some bone daggers so our Chef can keep working."
 	reward = CARGO_CRATE_VALUE * 10
 	required_count = 3
 	wanted_types = list(/obj/item/knife/combat/bone = TRUE)
+*/
+//END SKYRAT EDIT REMOVAL
 
 /datum/bounty/item/mining/polypore_mushroom
 	name = "Mushroom Bowl"

--- a/modular_skyrat/modules/ashwalker_shaman/code/ashwalker_shaman.dm
+++ b/modular_skyrat/modules/ashwalker_shaman/code/ashwalker_shaman.dm
@@ -76,7 +76,7 @@
 				/obj/item/stack/sheet/sinew = 2,
 				/obj/item/stack/sheet/animalhide/goliath_hide = 2)
 	time = 40
-	category = CAT_CLOTHING
+	category = CAT_PRIMAL
 
 /obj/item/clothing/head/ash_headdress/Initialize()
 	. = ..()
@@ -110,7 +110,7 @@
 				/obj/item/stack/sheet/sinew = 2,
 				/obj/item/stack/sheet/animalhide/goliath_hide = 2)
 	time = 40
-	category = CAT_CLOTHING
+	category = CAT_PRIMAL
 
 /obj/item/clothing/under/costume/gladiator/ash_walker/ash_robes/Initialize()
 	. = ..()
@@ -137,7 +137,7 @@
 				/obj/item/stack/sheet/sinew = 2,
 				/obj/item/stack/sheet/animalhide/goliath_hide = 2)
 	time = 40
-	category = CAT_CLOTHING
+	category = CAT_PRIMAL
 
 /obj/item/clothing/suit/ash_plates/Initialize()
 	. = ..()
@@ -154,7 +154,7 @@
 				/obj/item/stack/sheet/sinew = 2,
 				/obj/item/stack/sheet/animalhide/goliath_hide = 2)
 	time = 40
-	category = CAT_CLOTHING
+	category = CAT_PRIMAL
 
 //ASH WEAPON
 /obj/item/melee/macahuitl
@@ -182,8 +182,8 @@
 				/obj/item/stack/sheet/sinew = 2,
 				/obj/item/stack/sheet/animalhide/goliath_hide = 2)
 	time = 40
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	always_available = FALSE
+	category = CAT_PRIMAL
 
 /obj/item/cautery/ashwalker
 	name = "primitive cautery"

--- a/modular_skyrat/modules/tribal_extended/code/recipes.dm
+++ b/modular_skyrat/modules/tribal_extended/code/recipes.dm
@@ -64,6 +64,15 @@
 	time = 60
 	category = CAT_PRIMAL
 
+/datum/crafting_recipe/bonesword
+	name = "Bone Sword"
+	result = /obj/item/claymore/bone
+	reqs = list(/obj/item/stack/sheet/bone = 2,
+				/obj/item/stack/sheet/sinew = 2)
+	time = 40
+	always_available = FALSE
+	category = CAT_PRIMAL
+
 /datum/crafting_recipe/quiver
 	name = "Quiver"
 	result = /obj/item/storage/belt/quiver

--- a/modular_skyrat/modules/tribal_extended/code/recipes.dm
+++ b/modular_skyrat/modules/tribal_extended/code/recipes.dm
@@ -27,7 +27,7 @@
 	result = /obj/item/ammo_casing/caseless/arrow/wood
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 1,
 				/obj/item/stack/sheet/cloth= 1,
-				/obj/item/stack/rods = 1) 
+				/obj/item/stack/rods = 1)
 	time = 15
 	category = CAT_PRIMAL
 
@@ -62,14 +62,6 @@
 	reqs = list(/obj/item/stack/sheet/bone = 4,
 				/obj/item/stack/sheet/animalhide/goliath_hide = 3)
 	time = 60
-	category = CAT_PRIMAL
-
-/datum/crafting_recipe/bonesword
-	name = "Bone Sword"
-	result = /obj/item/claymore/bone
-	reqs = list(/obj/item/stack/sheet/bone = 2,
-				/obj/item/stack/sheet/sinew = 2)
-	time = 40
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/quiver


### PR DESCRIPTION
## About The Pull Request

~~removes the bone sword crafting recipe~~ Reverted
Removes all tribal weapons from normal crafting, enable only ashwalkers to use them
Rebalances the bone spear.
The ash village has a bone sword now in its map (I couldn't be bothered to remove it after redoing the PR)

## How This Contributes To The Skyrat Roleplay Experience

Frankly: It isn't balanced for the station.
~~The Bone Sword doesn't fit any design space for tribal weapons. It's too strong for a one-handed weapon, but there's already good 2-hand options for ashwalkers and the bone dagger is the best one handed option you should be able to make from just bones and stuff. It's also absurdly easy to craft for how powerful it is. Given public mining exists (miners themselves have decent weapon options already) it's way too easy to get these and bring them up.~~

I've gone the extra mile and just locked all tribal weapons to ashwalkers. They are insanely easy to craft for how insanely strong they are, and public mining makes it too easy to get the materials. I'm leaving tribal weapon balance to ashwalkers, they can fight over numbers themselves.

The spear was, however, extremely strong for how safe of a weapon option it is on Skyrat. Not only is it 20(!!) force when dual handed but it also has reach AND armour pen. You can't have everything and still have it mass-producible for the price of a watcher or two. It's been knocked down a peg.

Other weapon options the station AND ashwalkers can acquire are being filled design-wise by Forging, which I am rebalancing in another PR.

## Changelog

:cl:
balance: Tribal weapons are now ashwalker-only
balance: Bone spear was nerfed.
qol: adds a bone sword to the ash walker village.
/:cl:
