### PR TITLE
Heretic Buffs, the Rebuffening

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -30,7 +30,7 @@
 	/// The path our heretic has chosen. Mostly used for flavor.
 	var/heretic_path = PATH_START
 	/// A list of how many knowledge points this heretic CURRENTLY has. Used to research.
-	var/knowledge_points = 1
+	var/knowledge_points = 2 //SKYRAT EDIT - ORIGINAL 1
 	/// The time between gaining influence passively. The heretic gain +1 knowledge points every this duration of time.
 	var/passive_gain_timer = 20 MINUTES
 	/// Assoc list of [typepath] = [knowledge instance]. A list of all knowledge this heretic's reserached.

--- a/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -12,7 +12,7 @@
 	flags_1 = CONDUCT_1
 	sharpness = SHARP_EDGED
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 27 //SKYRAT EDIT - ORIGINAL: 17
+	force = 25 //SKYRAT EDIT - ORIGINAL: 17
 	armour_penetration = 15 // SKYRAT EDIT - ADDITION
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -12,7 +12,8 @@
 	flags_1 = CONDUCT_1
 	sharpness = SHARP_EDGED
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 17
+	force = 27 //SKYRAT EDIT - ORIGINAL: 17
+	armour_penetration = 15 // SKYRAT EDIT - ADDITION
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")

--- a/code/modules/antagonists/heretic/items/madness_mask.dm
+++ b/code/modules/antagonists/heretic/items/madness_mask.dm
@@ -68,7 +68,7 @@
 
 		if(human_in_range.getStaminaLoss() >= 85 && DT_PROB(30, delta_time))
 			human_in_range.emote(pick("giggle", "laugh"))
-			human_in_range.adjustStaminaLoss(10)
+			human_in_range.adjustStaminaLoss(15) //SKYRAT EDIT - Original: 10
 
 		if(DT_PROB(25, delta_time))
 			human_in_range.Dizzy(5)

--- a/code/modules/antagonists/heretic/items/madness_mask.dm
+++ b/code/modules/antagonists/heretic/items/madness_mask.dm
@@ -68,7 +68,7 @@
 
 		if(human_in_range.getStaminaLoss() >= 85 && DT_PROB(30, delta_time))
 			human_in_range.emote(pick("giggle", "laugh"))
-			human_in_range.adjustStaminaLoss(15) //SKYRAT EDIT - Original: 10
+			human_in_range.adjustStaminaLoss(10)
 
 		if(DT_PROB(25, delta_time))
 			human_in_range.Dizzy(5)

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -44,7 +44,7 @@
 		/obj/item/match = 1,
 	)
 	result_atoms = list(/obj/item/melee/sickly_blade/ash)
-	limit = 20 //SKYRAT EDIT - ORIGINAL: 2
+	limit = 5 //SKYRAT EDIT - ORIGINAL: 2
 	cost = 1
 	route = PATH_ASH
 

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -44,7 +44,7 @@
 		/obj/item/match = 1,
 	)
 	result_atoms = list(/obj/item/melee/sickly_blade/ash)
-	limit = 2
+	limit = 20 //SKYRAT EDIT - ORIGINAL: 2
 	cost = 1
 	route = PATH_ASH
 

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -28,7 +28,7 @@
 	name = "Nightwatcher's Secret"
 	desc = "Opens up the Path of Ash to you. \
 		Allows you to transmute a match and a knife into an Ashen Blade. \
-		You can only create two at a time."
+		You can only create five at a time." //SKYRAT EDIT two to five
 	gain_text = "The City Guard know their watch. If you ask them at night, they may tell you about the ashy lantern."
 	next_knowledge = list(/datum/heretic_knowledge/ashen_grasp)
 	banned_knowledge = list(

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -49,7 +49,7 @@
 		/obj/effect/decal/cleanable/blood = 1,
 	)
 	result_atoms = list(/obj/item/melee/sickly_blade/flesh)
-	limit = 30 // Bumped up so they can arm up their ghouls too. //SKYRAT EDIT - ORIGINAL: 3
+	limit = 20 // Bumped up so they can arm up their ghouls too. //SKYRAT EDIT - ORIGINAL: 3
 	cost = 1
 	route = PATH_FLESH
 

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -33,7 +33,7 @@
 	name = "Principle of Hunger"
 	desc = "Opens up the Path of Flesh to you. \
 		Allows you to transmute a knife and a pool of blood into a Bloody Blade. \
-		You can only create three at a time."
+		You can only create twenty at a time." //SKYRAT EDIT three to twenty
 	gain_text = "Hundreds of us starved, but not me... I found strength in my greed."
 	next_knowledge = list(/datum/heretic_knowledge/limited_amount/flesh_grasp)
 	banned_knowledge = list(

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -49,7 +49,7 @@
 		/obj/effect/decal/cleanable/blood = 1,
 	)
 	result_atoms = list(/obj/item/melee/sickly_blade/flesh)
-	limit = 3 // Bumped up so they can arm up their ghouls too.
+	limit = 30 // Bumped up so they can arm up their ghouls too. //SKYRAT EDIT - ORIGINAL: 3
 	cost = 1
 	route = PATH_FLESH
 

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -44,7 +44,7 @@
 		/obj/item/trash = 1,
 	)
 	result_atoms = list(/obj/item/melee/sickly_blade/rust)
-	limit = 20 //SKYRAT EDIT - ORIGINAL: 2
+	limit = 5 //SKYRAT EDIT - ORIGINAL: 2
 	cost = 1
 	route = PATH_RUST
 

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -44,7 +44,7 @@
 		/obj/item/trash = 1,
 	)
 	result_atoms = list(/obj/item/melee/sickly_blade/rust)
-	limit = 2
+	limit = 20 //SKYRAT EDIT - ORIGINAL: 2
 	cost = 1
 	route = PATH_RUST
 

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -28,7 +28,7 @@
 	name = "Blacksmith's Tale"
 	desc = "Opens up the Path of Rust to you. \
 		Allows you to transmute a knife with any trash item into a Rusty Blade. \
-		You can only create two at a time."
+		You can only create five at a time." //SKYRAT EDIT two to five
 	gain_text = "\"Let me tell you a story\", said the Blacksmith, as he gazed deep into his rusty blade."
 	next_knowledge = list(/datum/heretic_knowledge/rust_fist)
 	banned_knowledge = list(

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -189,7 +189,7 @@
 		heretic_datum.high_value_sacrifices++
 
 	heretic_datum.total_sacrifices++
-	heretic_datum.knowledge_points += 3 //SKYRAT EDIT - ORIGINAL: 2
+	heretic_datum.knowledge_points += 4 //SKYRAT EDIT - ORIGINAL: 2
 
 	if(!begin_sacrifice(sacrifice))
 		disembowel_target(sacrifice)

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -189,7 +189,7 @@
 		heretic_datum.high_value_sacrifices++
 
 	heretic_datum.total_sacrifices++
-	heretic_datum.knowledge_points += 4 //SKYRAT EDIT - ORIGINAL: 2
+	heretic_datum.knowledge_points += 3 //SKYRAT EDIT - ORIGINAL: 2
 
 	if(!begin_sacrifice(sacrifice))
 		disembowel_target(sacrifice)

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -189,7 +189,7 @@
 		heretic_datum.high_value_sacrifices++
 
 	heretic_datum.total_sacrifices++
-	heretic_datum.knowledge_points += 2
+	heretic_datum.knowledge_points += 4 //SKYRAT EDIT - ORIGINAL: 2
 
 	if(!begin_sacrifice(sacrifice))
 		disembowel_target(sacrifice)

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -42,7 +42,7 @@
 	)
 	required_atoms = list(/obj/item/knife = 1)
 	result_atoms = list(/obj/item/melee/sickly_blade/void)
-	limit = 2
+	limit = 20 //SKYRAT EDIT - ORIGINAL: 2
 	cost = 1
 	route = PATH_VOID
 

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -28,7 +28,7 @@
 	name = "Glimmer of Winter"
 	desc = "Opens up the path of void to you. \
 		Allows you to transmute a knife in sub-zero temperatures into a Void Blade. \
-		You can only create two at a time."
+		You can only create five at a time." //SKYRAT EDIT two to five
 	gain_text = "I feel a shimmer in the air, the air around me gets colder. \
 		I start to realize the emptiness of existance. Something's watching me."
 	next_knowledge = list(/datum/heretic_knowledge/void_grasp)

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -42,7 +42,7 @@
 	)
 	required_atoms = list(/obj/item/knife = 1)
 	result_atoms = list(/obj/item/melee/sickly_blade/void)
-	limit = 20 //SKYRAT EDIT - ORIGINAL: 2
+	limit = 5 //SKYRAT EDIT - ORIGINAL: 2
 	cost = 1
 	route = PATH_VOID
 


### PR DESCRIPTION
## About The Pull Request

This PR gets Heretics back up to the same kind of level that all of our other main antags (Tators and Clings) have been pushed to in order to actually stand a chance in the current balance environment (Health changes, and security changes). Many of the changes in this PR had been made to them already, but were removed with the major rework of the code from upstream.

Buffs their heretic blade to no longer be way worse then basic bone tools, or the standard melee weapon of the other two antags, by giving it some extra damage and AP.
This also lets them make a couple extra copies if the weapon if they end up getting one-clicked disarmed into dropping it, because at that point you are already falling behind and not being able to create a new weapon makes it impossible to come back. I might lower the limit back down if it really becomes an issue, but the current one is very punishing for any mistakes.
Sacrifices now give more points, because of how much harder it is to pull off when we expect them to do more then just teleporting into the room and suddenly ganking people. Less punishing if you try to RP it out.
I have really only seen people pull off two of them per round, max. Most people are still doing less then that.
They also have one extra starting point, partly because I suspect a lot of people are going to want to buy the reroll ritual for the heart, because now you can't just make a second one if your target is busy in dorms.

Expect this thing to change as I get feedback on it, and it gets test-merged hopefully.

## How This Contributes To The Skyrat Roleplay Experience

Having the antag actually be playable, and not a total joke of a threat is good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Heretic sickle-sword now does 8 more damage, and has slight armor pen.
balance: Heretics are now able to have more of their weapons summoned at once.
balance: Heretics start with 1(one) extra free bonus point.
balance: The gift of Mansus becomes ever more temping, as those granted with the power of a Heretic now receive greater strength from sacrificing targets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
