### PR TITLE
Revert "[NONMOD] Locks tribal weapons to ashwalkers"

### DIFF
--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_ash_walker1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_ash_walker1_skyrat.dmm
@@ -582,9 +582,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "tm" = (
+/mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch,
 /obj/structure/stone_tile/surrounding/cracked,
 /obj/structure/stone_tile/cracked,
-/mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "tH" = (
@@ -833,6 +833,7 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "Do" = (
+/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 8
 	},
@@ -842,7 +843,6 @@
 /obj/structure/stone_tile/cracked{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "DJ" = (
@@ -1049,8 +1049,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "LM" = (
-/obj/structure/stone_tile/slab,
 /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
+/obj/structure/stone_tile/slab,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "LO" = (
@@ -1410,8 +1410,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "RR" = (
-/obj/structure/stone_tile/slab/burnt,
 /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
+/obj/structure/stone_tile/slab/burnt,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "St" = (
@@ -1441,9 +1441,6 @@
 	},
 /obj/item/knife/combat/bone{
 	pixel_x = -8
-	},
-/obj/item/claymore/bone{
-	pixel_x = 8
 	},
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -927,7 +927,6 @@
 	result = /obj/item/knife/combat/bone
 	time = 20
 	reqs = list(/obj/item/stack/sheet/bone = 2)
-	always_available = FALSE //SKYRAT EDIT
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/bonespear
@@ -936,7 +935,6 @@
 	time = 30
 	reqs = list(/obj/item/stack/sheet/bone = 4,
 				/obj/item/stack/sheet/sinew = 1)
-	always_available = FALSE //SKYRAT EDIT
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/boneaxe
@@ -945,7 +943,6 @@
 	time = 50
 	reqs = list(/obj/item/stack/sheet/bone = 6,
 				/obj/item/stack/sheet/sinew = 3)
-	always_available = FALSE //SKYRAT EDIT
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/bonfire

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -179,14 +179,14 @@
 	icon_prefix = "bone_spear"
 	name = "bone spear"
 	desc = "A haphazardly-constructed yet still deadly weapon. The pinnacle of modern technology."
-	force = 8 //SKYRAT EDIT
+	force = 12
 	throwforce = 22
 	reach = 2 // SKYRAT EDIT
 	armour_penetration = 15 //Enhanced armor piercing
 
 /obj/item/spear/bonespear/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded=8, force_wielded=16, icon_wielded="[icon_prefix]1") //SKYRAT EDIT
+	AddComponent(/datum/component/two_handed, force_unwielded=12, force_wielded=20, icon_wielded="[icon_prefix]1")
 
 /*
  * Bamboo Spear

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -33,11 +33,6 @@
 	RegisterSignal(owner.current, COMSIG_MOB_EXAMINATE, .proc/on_examinate)
 	owner.teach_crafting_recipe(/datum/crafting_recipe/skeleton_key)
 	owner.teach_crafting_recipe(/datum/crafting_recipe/ashnecklace) //SKYRAT EDIT DRACONIC NECKLACE//
-	owner.teach_crafting_recipe(/datum/crafting_recipe/bonesword)	//SKYRAT EDIT TRIBAL WEAPONS FOR TRIBALS//
-	owner.teach_crafting_recipe(/datum/crafting_recipe/macahuitl)	//SKYRAT EDIT
-	owner.teach_crafting_recipe(/datum/crafting_recipe/boneaxe)		//SKYRAT EDIT
-	owner.teach_crafting_recipe(/datum/crafting_recipe/bonespear)	//SKYRAT EDIT
-	owner.teach_crafting_recipe(/datum/crafting_recipe/bonedagger)	//SKYRAT EDIT
 
 /datum/antagonist/ashwalker/on_removal()
 	. = ..()

--- a/code/modules/cargo/bounties/mining.dm
+++ b/code/modules/cargo/bounties/mining.dm
@@ -18,15 +18,11 @@
 	required_count = 2
 	wanted_types = list(/obj/item/oar = TRUE)
 
-//SKYRAT EDIT REMOVAL
-/*
 /datum/bounty/item/mining/bone_axe
 	name = "Bone Axe"
 	description = "Station 12 has had their fire axes stolen by marauding clowns. Ship them a bone axe as a replacement."
 	reward = CARGO_CRATE_VALUE * 15
 	wanted_types = list(/obj/item/fireaxe/boneaxe = TRUE)
-*/
-//END SKYRAT EDIT REMOVAL
 
 /datum/bounty/item/mining/bone_armor
 	name = "Bone Armor"
@@ -46,16 +42,13 @@
 	reward = CARGO_CRATE_VALUE * 15
 	required_count = 3
 	wanted_types = list(/obj/item/clothing/accessory/talisman = TRUE)
-//SKYRAT EDIT REMOVAL
-/*
+
 /datum/bounty/item/mining/bone_dagger
 	name = "Bone Daggers"
 	description = "Central Command's canteen is undergoing budget cuts. Ship over some bone daggers so our Chef can keep working."
 	reward = CARGO_CRATE_VALUE * 10
 	required_count = 3
 	wanted_types = list(/obj/item/knife/combat/bone = TRUE)
-*/
-//END SKYRAT EDIT REMOVAL
 
 /datum/bounty/item/mining/polypore_mushroom
 	name = "Mushroom Bowl"

--- a/modular_skyrat/modules/ashwalker_shaman/code/ashwalker_shaman.dm
+++ b/modular_skyrat/modules/ashwalker_shaman/code/ashwalker_shaman.dm
@@ -76,7 +76,7 @@
 				/obj/item/stack/sheet/sinew = 2,
 				/obj/item/stack/sheet/animalhide/goliath_hide = 2)
 	time = 40
-	category = CAT_PRIMAL
+	category = CAT_CLOTHING
 
 /obj/item/clothing/head/ash_headdress/Initialize()
 	. = ..()
@@ -110,7 +110,7 @@
 				/obj/item/stack/sheet/sinew = 2,
 				/obj/item/stack/sheet/animalhide/goliath_hide = 2)
 	time = 40
-	category = CAT_PRIMAL
+	category = CAT_CLOTHING
 
 /obj/item/clothing/under/costume/gladiator/ash_walker/ash_robes/Initialize()
 	. = ..()
@@ -137,7 +137,7 @@
 				/obj/item/stack/sheet/sinew = 2,
 				/obj/item/stack/sheet/animalhide/goliath_hide = 2)
 	time = 40
-	category = CAT_PRIMAL
+	category = CAT_CLOTHING
 
 /obj/item/clothing/suit/ash_plates/Initialize()
 	. = ..()
@@ -154,7 +154,7 @@
 				/obj/item/stack/sheet/sinew = 2,
 				/obj/item/stack/sheet/animalhide/goliath_hide = 2)
 	time = 40
-	category = CAT_PRIMAL
+	category = CAT_CLOTHING
 
 //ASH WEAPON
 /obj/item/melee/macahuitl
@@ -182,8 +182,8 @@
 				/obj/item/stack/sheet/sinew = 2,
 				/obj/item/stack/sheet/animalhide/goliath_hide = 2)
 	time = 40
-	always_available = FALSE
-	category = CAT_PRIMAL
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
 
 /obj/item/cautery/ashwalker
 	name = "primitive cautery"

--- a/modular_skyrat/modules/tribal_extended/code/recipes.dm
+++ b/modular_skyrat/modules/tribal_extended/code/recipes.dm
@@ -27,7 +27,7 @@
 	result = /obj/item/ammo_casing/caseless/arrow/wood
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 1,
 				/obj/item/stack/sheet/cloth= 1,
-				/obj/item/stack/rods = 1)
+				/obj/item/stack/rods = 1) 
 	time = 15
 	category = CAT_PRIMAL
 
@@ -70,7 +70,6 @@
 	reqs = list(/obj/item/stack/sheet/bone = 2,
 				/obj/item/stack/sheet/sinew = 2)
 	time = 40
-	always_available = FALSE
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/quiver


### PR DESCRIPTION
Reverts Skyrat-SS13/Skyrat-tg#11505

The original PR was a bit kneejerk reaction without thinking of the other things that do rely on the tribal weapons to function correctly.

(IE other ghost roles like Interdyne, Hermit. Station people going down to lavaland/icemoon to hunt stuff)

While i'm not opposed to nerfing the bonespear damage and nerfing the bone sword to make it bulky and only fit on the belt/back, making tribal stuff Ashwalker only only brings up multiple other problems.