### PR TITLE
[SEMI-MODULAR] Removes the automatic gun safety toggling from Combat Mode for being clunky.

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -88,14 +88,6 @@
 	SEND_SIGNAL(src, COMSIG_LIVING_COMBAT_MODE_TOGGLE, new_mode) //SKYRAT EDIT ADDITION
 	if(hud_used?.action_intent)
 		hud_used.action_intent.update_appearance()
-	//SKYRAT EDIT ADDITION BEGIN
-	if(istype(get_active_held_item(), /obj/item/gun))
-		var/obj/item/gun/G = get_active_held_item()
-		if(G.has_gun_safety)
-			if(combat_mode)
-				G.toggle_safety(src, "off")
-			else
-				G.toggle_safety(src, "on")
 	if(!ishuman(src) && !ckey)
 		if(combat_mode)
 			set_combat_indicator(TRUE)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -88,6 +88,7 @@
 	SEND_SIGNAL(src, COMSIG_LIVING_COMBAT_MODE_TOGGLE, new_mode) //SKYRAT EDIT ADDITION
 	if(hud_used?.action_intent)
 		hud_used.action_intent.update_appearance()
+	//SKYRAT EDIT ADDITION BEGIN
 	if(!ishuman(src) && !ckey)
 		if(combat_mode)
 			set_combat_indicator(TRUE)


### PR DESCRIPTION
## About The Pull Request

Removes the automatic gun safety toggling from Combat Mode for being clunky.

## How This Contributes To The Skyrat Roleplay Experience

This shit throws me off all the time. I hate it.

## Changelog
:cl:
qol: Removes the automatic gun safety toggling from Combat Mode for being clunky.
/:cl:
