### PR TITLE
Feather tickling mood rebalance

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/feather.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/feather.dm
@@ -139,5 +139,5 @@
 //Mood boost
 /datum/mood_event/tickled
 	description = span_nicegreen("Wooh... I was tickled. It was... Funny!\n")
-	mood_change = 4
+	mood_change = 0
 	timeout = 2 MINUTES


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Feather tickling now is a +0 mood bonus, instead of a +4.

## How This Contributes To The Skyrat Roleplay Experience
Being able to give yourself or anyone else a +4 at the cost of a minor amount of stamina isn't a fair tradeoff, and this one doesn't match the other ERP mood bonuses, which were brought to 0.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Feather tickling is now a +0 mood bonus instead of a +4
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
