### PR TITLE
Removes Rope Bunny quirk.

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -12,7 +12,6 @@
 #define TRAIT_SADISM		"sadism"
 #define TRAIT_NEVERBONER	"neverboner"
 #define TRAIT_RIGGER		"rigger"
-#define TRAIT_ROPEBUNNY		"rope bunny"
 
 #define APHRO_TRAIT			"aphro"				///traits gained by brain traumas, can be removed if the brain trauma is gone
 #define LEWDQUIRK_TRAIT		"lewdquirks"		///traits gained by quirks, cannot be removed unless the quirk itself is gone
@@ -591,26 +590,6 @@
 
 /datum/mood_event/subspace
 	description = span_purple("Everything is so woozy... Pain feels so... Awesome.\n")
-
-/datum/status_effect/ropebunny
-	id = "ropebunny"
-	tick_interval = 10
-	duration = INFINITE
-	alert_type = null
-
-/datum/status_effect/ropebunny/on_apply()
-	. = ..()
-	var/mob/living/carbon/human/target = owner
-	SEND_SIGNAL(target, COMSIG_ADD_MOOD_EVENT, "ropebunny", /datum/mood_event/ropebunny)
-
-/datum/status_effect/ropebunny/on_remove()
-	. = ..()
-	var/mob/living/carbon/human/target = owner
-	SEND_SIGNAL(target, COMSIG_CLEAR_MOOD_EVENT, "ropebunny", /datum/mood_event/ropebunny)
-
-/datum/mood_event/ropebunny
-	description = span_purple("I'm tied! Cannot move! These ropes... Ah!~")
-	mood_change = 0 //I don't want to doom the station to sonic-speed perverts, but still want to keep this as mood modifier.
 
 ///////////////////////
 ///AROUSAL INDICATOR///

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shibari_worn_hands.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shibari_worn_hands.dm
@@ -29,32 +29,9 @@
 /obj/item/clothing/gloves/shibari_hands/Destroy()
 	for(var/obj/item in contents)
 		item.forceMove(get_turf(src))
-	if(!ishuman(loc))
-		return ..()
-	var/mob/living/carbon/human/hooman = loc
-	if(HAS_TRAIT(hooman, TRAIT_ROPEBUNNY))
-		hooman.remove_status_effect(/datum/status_effect/ropebunny)
 	return ..()
 
 /obj/item/clothing/gloves/shibari_hands/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
-
-//stuff to apply mood event for perverts
-/obj/item/clothing/gloves/shibari_hands/equipped(mob/user, slot)
-	. = ..()
-	if(!ishuman(user))
-		return
-	var/mob/living/carbon/human/hooman = user
-	if(HAS_TRAIT(hooman, TRAIT_ROPEBUNNY))
-		hooman.apply_status_effect(/datum/status_effect/ropebunny)
-
-//same stuff as above but for dropping item
-/obj/item/clothing/gloves/shibari_hands/dropped(mob/user, slot)
-	if(!ishuman(user))
-		return ..()
-	var/mob/living/carbon/human/hooman = user
-	if(HAS_TRAIT(hooman, TRAIT_ROPEBUNNY))
-		hooman.remove_status_effect(/datum/status_effect/ropebunny)
-	return ..()
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shibari_worn_legs.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shibari_worn_legs.dm
@@ -33,12 +33,7 @@
 /obj/item/clothing/shoes/shibari_legs/Destroy()
 	for(var/obj/item in contents)
 		item.forceMove(get_turf(src))
-	if(!ishuman(loc))
-		return ..()
-	var/mob/living/carbon/human/hooman = loc
-	if(HAS_TRAIT(hooman, TRAIT_ROPEBUNNY))
-		hooman.remove_status_effect(/datum/status_effect/ropebunny)
-	return..()
+	return ..()
 
 /obj/item/clothing/shoes/shibari_legs/ComponentInitialize()
 	. = ..()
@@ -60,22 +55,4 @@
 	var/mob/living/carbon/human/hooman = user
 	if(do_after(hooman, HAS_TRAIT(hooman, TRAIT_RIGGER) ? 2 SECONDS : 10 SECONDS, target = src))
 		dropped(user)
-
-//stuff to apply mood event for perverts
-/obj/item/clothing/shoes/shibari_legs/equipped(mob/user, slot)
-	. = ..()
-	if(!ishuman(user))
-		return
-	var/mob/living/carbon/human/hooman = user
-	if(HAS_TRAIT(hooman, TRAIT_ROPEBUNNY))
-		hooman.apply_status_effect(/datum/status_effect/ropebunny)
-
-//same stuff as above but for dropping item
-/obj/item/clothing/shoes/shibari_legs/dropped(mob/user, slot)
-	if(!ishuman(user))
-		return ..()
-	var/mob/living/carbon/human/hooman = user
-	if(HAS_TRAIT(hooman, TRAIT_ROPEBUNNY))
-		hooman.remove_status_effect(/datum/status_effect/ropebunny)
-	return ..()
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shibari_worn_uniform.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shibari_worn_uniform.dm
@@ -33,11 +33,6 @@
 
 	for(var/obj/item in contents)
 		item.forceMove(get_turf(src))
-	if(!ishuman(loc))
-		return ..()
-	var/mob/living/carbon/human/hooman = loc
-	if(HAS_TRAIT(hooman, TRAIT_ROPEBUNNY))
-		hooman.remove_status_effect(/datum/status_effect/ropebunny)
 	return ..()
 
 /obj/item/clothing/under/shibari/equipped(mob/user, slot)
@@ -100,17 +95,6 @@
 	var/mob/living/carbon/human/hooman = user
 	if(src == hooman.w_uniform)
 		START_PROCESSING(SSobj, src)
-	if(HAS_TRAIT(hooman, TRAIT_ROPEBUNNY))
-		hooman.apply_status_effect(/datum/status_effect/ropebunny)
-
-//same stuff as above but for dropping item
-/obj/item/clothing/under/shibari/dropped(mob/user, slot)
-	if(!ishuman(user))
-		return ..()
-	var/mob/living/carbon/human/hooman = user
-	if(HAS_TRAIT(hooman, TRAIT_ROPEBUNNY))
-		hooman.remove_status_effect(/datum/status_effect/ropebunny)
-	return..()
 
 /obj/item/clothing/under/shibari/torso
 	name = "shibari ropes"

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/shibari_stand.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/shibari_stand.dm
@@ -155,8 +155,6 @@
 			current_mob.update_handcuffed()
 		current_mob.set_handcuffed(new /obj/item/restraints/handcuffs/milker/shibari(current_mob))
 		current_mob.handcuffed.parented_struct = src
-		if(HAS_TRAIT(current_mob, TRAIT_ROPEBUNNY))
-			current_mob.handcuffed.breakouttime = 4 MINUTES
 		current_mob.update_abstract_handcuffed()
 
 //Restore the position of the mob after unbuckling.

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -101,26 +101,7 @@
 			return TRUE
 	return FALSE
 
-//Shibari update quirks: Rope bunny and rigger. One have additional mood bonus (0) and exist for same reason as ananas affinity, other one can faster tie ropes on character because why not.
-//Rope bunny code
-/datum/quirk/ropebunny
-	name = "Rope bunny"
-	desc = "You love being tied up."
-	value = 0 //ERP Traits don't have price. They are priceless. Ba-dum-tss
-	mob_trait = TRAIT_ROPEBUNNY
-	gain_text = span_danger("You really want to be restrained for some reason.")
-	lose_text = span_notice("Being restrained doesn't arouse you anymore.")
-	icon = "link"
-
-/datum/quirk/ropebunny/post_add()
-	. = ..()
-	var/mob/living/carbon/human/H = quirk_holder
-	ADD_TRAIT(H,TRAIT_ROPEBUNNY, LEWDQUIRK_TRAIT)
-
-/datum/quirk/ropebunny/remove()
-	. = ..()
-	var/mob/living/carbon/human/H = quirk_holder
-	REMOVE_TRAIT(H,TRAIT_ROPEBUNNY, LEWDQUIRK_TRAIT)
+//Shibari update quirks: Rigger. One can faster tie ropes on character because why not.
 
 //Rigger code
 /datum/quirk/rigger


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR removes the Rope Bunny quirk, which gives you an extra +0 mood bonus when tied up with shibari gear, and makes the time to escape shibari 4 minutes from 45 seconds.

## How This Contributes To The Skyrat Roleplay Experience
There are several reasons behind this removal:

- If the focus of the quirk is on the mood bonus, why do you need the quirk at all? Can't you just have that be part of your character, instead of the game needing to tell you that you like it?
- If the focus of the quirk is the raised escape time, why? I don't see why you'd be escaping from it in the first place, considering that you __should not__ be using this for antaggery.
- I feel that, with the two points above, this quirk is bloat that doesn't really contribute much to the game.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed Rope Bunny quirk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
