### PR TITLE
lower required reagent for reagent forging

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/forge.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge.dm
@@ -38,7 +38,7 @@
 	///the fuel amount (in seconds) that the forge has (stronger than wood)
 	var/forge_fuel_strong = 0
 	///whether the forge is capable of allowing reagent forging of the forged item.
-	//normal forges are false; to turn into true, use 3 (active) legion cores.
+	//normal forges are false; to turn into true, use 6 (active) legion cores.
 	var/reagent_forging = FALSE
 	///counting how many cores used to turn forge into a reagent forging forge.
 	var/current_core = 0
@@ -79,7 +79,7 @@
 	if(forge_level < FORGE_LEVEL_THREE)
 		. += span_notice("[src] has [goliath_ore_improvement]/3 goliath hides.")
 		. += span_notice("[src] has [current_sinew]/10 watcher sinews.")
-		. += span_notice("[src] has [current_core]/3 regenerative cores.")
+		. += span_notice("[src] has [current_core]/6 regenerative cores.")
 	. += span_notice("<br>[src] is currently [forge_temperature] degrees hot, going towards [target_temperature] degrees.<br>")
 	if(reagent_forging)
 		. += span_warning("[src] has a red tinge, it is ready to imbue chemicals into reagent objects.")
@@ -185,7 +185,7 @@
 		current_sinew = 10
 		forge_level = FORGE_LEVEL_TWO
 	if(user_smithing_skill >= SKILL_LEVEL_MASTER)
-		current_core = 3
+		current_core = 6
 		forge_level = FORGE_LEVEL_THREE
 		create_reagent_forge()
 	if(forge_level == previous_level)
@@ -313,7 +313,7 @@
 		qdel(I)
 		current_core++
 		in_use = FALSE
-		if(current_core >= 3) //use three regenerative cores to get reagent forging capabilities on the forge
+		if(current_core >= 6) //use six regenerative cores to get reagent forging capabilities on the forge
 			create_reagent_forge()
 		return
 
@@ -446,7 +446,7 @@
 			fail_message(user, "You fail imbueing [attacking_item]!")
 			return
 		for(var/datum/reagent/weapon_reagent in attacking_item.reagents.reagent_list)
-			if(weapon_reagent.volume < 200)
+			if(weapon_reagent.volume < 100)
 				attacking_item.reagents.remove_all_type(weapon_reagent.type)
 				continue
 			weapon_component.imbued_reagent += weapon_reagent.type
@@ -481,7 +481,7 @@
 			fail_message(user, "You fail imbueing [attacking_item]!")
 			return
 		for(var/datum/reagent/clothing_reagent in attacking_item.reagents.reagent_list)
-			if(clothing_reagent.volume < 200)
+			if(clothing_reagent.volume < 100)
 				attacking_item.reagents.remove_all_type(clothing_reagent.type)
 				continue
 			clothing_component.imbued_reagent += clothing_reagent.type
@@ -588,7 +588,7 @@
 	return ..()
 
 /obj/structure/reagent_forge/ready
-	current_core = 3
+	current_core = 6
 	reagent_forging = TRUE
 	sinew_lower_chance = 100
 	forge_temperature = 1000

--- a/modular_skyrat/modules/reagent_forging/code/forge.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge.dm
@@ -184,14 +184,14 @@
 		to_chat(user, span_notice("[src] requires you to be more experienced!"))
 		return
 	if(user_smithing_skill >= SKILL_LEVEL_APPRENTICE)
-		goliath_ore_improvement = 3
+		goliath_ore_improvement = MAX_UPGRADE_GOLIATH
 		forge_level = FORGE_LEVEL_ONE
 	if(user_smithing_skill >= SKILL_LEVEL_EXPERT)
 		sinew_lower_chance = 100
-		current_sinew = 10
+		current_sinew = MAX_UPGRADE_SINEW
 		forge_level = FORGE_LEVEL_TWO
 	if(user_smithing_skill >= SKILL_LEVEL_MASTER)
-		current_core = 6
+		current_core = MAX_UPGRADE_REGEN
 		forge_level = FORGE_LEVEL_THREE
 		create_reagent_forge()
 	if(forge_level == previous_level)
@@ -594,7 +594,7 @@
 	return ..()
 
 /obj/structure/reagent_forge/ready
-	current_core = 6
+	current_core = MAX_UPGRADE_REGEN
 	reagent_forging = TRUE
 	sinew_lower_chance = 100
 	forge_temperature = 1000

--- a/modular_skyrat/modules/reagent_forging/code/forge.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge.dm
@@ -12,6 +12,12 @@
 #define FORGE_LEVEL_TWO 2
 #define FORGE_LEVEL_THREE 3
 
+#define MAX_UPGRADE_SINEW 10
+#define MAX_UPGRADE_GOLIATH 3
+#define MAX_UPGRADE_REGEN 6
+
+#define MIN_IMBUE_REQUIRED 100
+
 /obj/structure/reagent_forge
 	name = "forge"
 	desc = "A structure built out of bricks, with the intended purpose of heating up metal."
@@ -77,9 +83,9 @@
 		if(FORGE_LEVEL_THREE)
 			. += span_boldwarning("[src] has been touched by a master smithy; It is fully upgraded!<br>")
 	if(forge_level < FORGE_LEVEL_THREE)
-		. += span_notice("[src] has [goliath_ore_improvement]/3 goliath hides.")
-		. += span_notice("[src] has [current_sinew]/10 watcher sinews.")
-		. += span_notice("[src] has [current_core]/6 regenerative cores.")
+		. += span_notice("[src] has [goliath_ore_improvement]/[MAX_UPGRADE_GOLIATH] goliath hides.")
+		. += span_notice("[src] has [current_sinew]/[MAX_UPGRADE_SINEW] watcher sinews.")
+		. += span_notice("[src] has [current_core]/[MAX_UPGRADE_REGEN] regenerative cores.")
 	. += span_notice("<br>[src] is currently [forge_temperature] degrees hot, going towards [target_temperature] degrees.<br>")
 	if(reagent_forging)
 		. += span_warning("[src] has a red tinge, it is ready to imbue chemicals into reagent objects.")
@@ -274,7 +280,7 @@
 			to_chat(user, span_warning("You cannot do multiple things at the same time!"))
 			return
 		in_use = TRUE
-		if(sinew_lower_chance >= 100) //max is 100
+		if(sinew_lower_chance >= (MAX_UPGRADE_SINEW * 10)) //max is 100
 			fail_message(user, "You cannot insert any more of [I]!")
 			return
 		to_chat(user, span_warning("You start lining [src] with [I]..."))
@@ -313,7 +319,7 @@
 		qdel(I)
 		current_core++
 		in_use = FALSE
-		if(current_core >= 6) //use six regenerative cores to get reagent forging capabilities on the forge
+		if(current_core >= MAX_UPGRADE_REGEN) //use six regenerative cores to get reagent forging capabilities on the forge
 			create_reagent_forge()
 		return
 
@@ -323,7 +329,7 @@
 			to_chat(user, span_warning("You cannot do multiple things at the same time!"))
 			return
 		in_use = TRUE
-		if(goliath_ore_improvement >= 3)
+		if(goliath_ore_improvement >= MAX_UPGRADE_GOLIATH)
 			fail_message(user, "You have applied the max amount of [goliath_hide]!")
 			return
 		to_chat(user, span_warning("You start to improve [src] with [goliath_hide]..."))
@@ -446,7 +452,7 @@
 			fail_message(user, "You fail imbueing [attacking_item]!")
 			return
 		for(var/datum/reagent/weapon_reagent in attacking_item.reagents.reagent_list)
-			if(weapon_reagent.volume < 100)
+			if(weapon_reagent.volume < MIN_IMBUE_REQUIRED)
 				attacking_item.reagents.remove_all_type(weapon_reagent.type)
 				continue
 			weapon_component.imbued_reagent += weapon_reagent.type
@@ -481,7 +487,7 @@
 			fail_message(user, "You fail imbueing [attacking_item]!")
 			return
 		for(var/datum/reagent/clothing_reagent in attacking_item.reagents.reagent_list)
-			if(clothing_reagent.volume < 100)
+			if(clothing_reagent.volume < MIN_IMBUE_REQUIRED)
 				attacking_item.reagents.remove_all_type(clothing_reagent.type)
 				continue
 			clothing_component.imbued_reagent += clothing_reagent.type
@@ -606,3 +612,9 @@
 #undef FORGE_LEVEL_ONE
 #undef FORGE_LEVEL_TWO
 #undef FORGE_LEVEL_THREE
+
+#undef MAX_UPGRADE_SINEW
+#undef MAX_UPGRADE_GOLIATH
+#undef MAX_UPGRADE_REGEN
+
+#undef MIN_IMBUE_REQUIRED

--- a/modular_skyrat/modules/reagent_forging/code/forge.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge.dm
@@ -187,7 +187,7 @@
 		goliath_ore_improvement = MAX_UPGRADE_GOLIATH
 		forge_level = FORGE_LEVEL_ONE
 	if(user_smithing_skill >= SKILL_LEVEL_EXPERT)
-		sinew_lower_chance = 100
+		sinew_lower_chance = MAX_UPGRADE_SINEW * 10 //100, just written funny!
 		current_sinew = MAX_UPGRADE_SINEW
 		forge_level = FORGE_LEVEL_TWO
 	if(user_smithing_skill >= SKILL_LEVEL_MASTER)

--- a/modular_skyrat/modules/reagent_forging/code/reagent_component.dm
+++ b/modular_skyrat/modules/reagent_forging/code/reagent_component.dm
@@ -20,7 +20,7 @@
 	if(set_slot)
 		checking_slot = set_slot
 	parent_clothing = parent
-	parent_clothing.create_reagents(500, INJECTABLE | REFILLABLE)
+	parent_clothing.create_reagents(250, INJECTABLE | REFILLABLE)
 	applying_container = new /obj/item/reagent_containers(src)
 	RegisterSignal(parent_clothing, COMSIG_ITEM_EQUIPPED, .proc/set_wearer)
 	RegisterSignal(parent_clothing, COMSIG_ITEM_PRE_UNEQUIP, .proc/remove_wearer)
@@ -70,7 +70,7 @@
 	if(!istype(parent, /obj/item))
 		return COMPONENT_INCOMPATIBLE //they need to be weapons, I already said this
 	parent_weapon = parent
-	parent_weapon.create_reagents(500, INJECTABLE | REFILLABLE)
+	parent_weapon.create_reagents(250, INJECTABLE | REFILLABLE)
 	applying_container = new /obj/item/reagent_containers(src)
 	RegisterSignal(parent_weapon, COMSIG_ITEM_ATTACK, .proc/inject_attacked)
 

--- a/modular_skyrat/modules/reagent_forging/code/reagent_component.dm
+++ b/modular_skyrat/modules/reagent_forging/code/reagent_component.dm
@@ -1,3 +1,5 @@
+#define MAX_IMBUE_STORAGE 250
+
 //the component that is attached to clothes that allows them to be imbued
 //ONLY USE THIS FOR CLOTHING
 /datum/component/reagent_clothing
@@ -20,7 +22,7 @@
 	if(set_slot)
 		checking_slot = set_slot
 	parent_clothing = parent
-	parent_clothing.create_reagents(250, INJECTABLE | REFILLABLE)
+	parent_clothing.create_reagents(MAX_IMBUE_STORAGE, INJECTABLE | REFILLABLE)
 	applying_container = new /obj/item/reagent_containers(src)
 	RegisterSignal(parent_clothing, COMSIG_ITEM_EQUIPPED, .proc/set_wearer)
 	RegisterSignal(parent_clothing, COMSIG_ITEM_PRE_UNEQUIP, .proc/remove_wearer)
@@ -68,7 +70,7 @@
 	if(!istype(parent, /obj/item))
 		return COMPONENT_INCOMPATIBLE //they need to be weapons, I already said this
 	parent_weapon = parent
-	parent_weapon.create_reagents(250, INJECTABLE | REFILLABLE)
+	parent_weapon.create_reagents(MAX_IMBUE_STORAGE, INJECTABLE | REFILLABLE)
 	RegisterSignal(parent_weapon, COMSIG_ITEM_ATTACK, .proc/inject_attacked)
 
 /datum/component/reagent_weapon/Destroy(force, silent)
@@ -83,3 +85,5 @@
 	var/mob/living_target = target
 	for(var/create_reagent in imbued_reagent)
 		living_target.reagents.add_reagent(create_reagent, 1)
+
+#undef MAX_IMBUE_STORAGE

--- a/modular_skyrat/modules/reagent_forging/code/reagent_component.dm
+++ b/modular_skyrat/modules/reagent_forging/code/reagent_component.dm
@@ -61,8 +61,6 @@
 /datum/component/reagent_weapon
 	///the item that the component is attached to
 	var/obj/item/parent_weapon
-	///the container that will apply the chemicals
-	var/obj/item/reagent_containers/applying_container
 	///the list of imbued reagents that will given to the human owner
 	var/list/imbued_reagent = list()
 
@@ -71,13 +69,11 @@
 		return COMPONENT_INCOMPATIBLE //they need to be weapons, I already said this
 	parent_weapon = parent
 	parent_weapon.create_reagents(250, INJECTABLE | REFILLABLE)
-	applying_container = new /obj/item/reagent_containers(src)
 	RegisterSignal(parent_weapon, COMSIG_ITEM_ATTACK, .proc/inject_attacked)
 
 /datum/component/reagent_weapon/Destroy(force, silent)
 	UnregisterSignal(parent_weapon, COMSIG_ITEM_ATTACK)
 	parent_weapon = null
-	QDEL_NULL(applying_container)
 	return ..()
 
 /datum/component/reagent_weapon/proc/inject_attacked(datum/source, mob/living/target, mob/living/user, params)
@@ -86,5 +82,4 @@
 		return
 	var/mob/living_target = target
 	for(var/create_reagent in imbued_reagent)
-		applying_container.reagents.add_reagent(create_reagent, 1)
-		applying_container.reagents.trans_to(target = living_target, amount = 1, methods = INJECT)
+		living_target.reagents.add_reagent(create_reagent, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
lowers the required amount of reagents for reagent forging from 200 to 100.
increased the amount of legion cores required for reagent forging up from 3 to 6.
lowered the maximum amount of chems in reagent stuff from 500 to 250.
reagent weapons will now directly inject the chemicals without snowflake code.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Overall, I overlooked the possibility that, because the reagent things have 500u capacity, they could be used to create some insane stuff. Even though they could not have their reagents taken out, having access to a payload of 500 is pretty insane before bluespace beakers (and and they are still better than bluespace beakers). In order to compensate for that, I have to lower the required reagents; and because I did that, I increased the amount of legion cores required.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: lowered reagent cap in reagent forging items from 500 to 250
balance: lowered required reagents in reagent forging from 200 to 100
balance: increased the amount of cores required to start reagent forging from 3 to 6
balance: reagent weapons will now directly inject the chemicals without snowflake code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
