### PR TITLE
Makes the black market chevvy shuttle not a titanium rectangle

### DIFF
--- a/_maps/shuttles/skyrat/ruin_blackmarket_chevvy.dmm
+++ b/_maps/shuttles/skyrat/ruin_blackmarket_chevvy.dmm
@@ -332,9 +332,9 @@ Ov
 "}
 (11,1,1) = {"
 Ov
-fp
-eu
 YX
+eu
+fp
 Ov
 Ov
 Ov

--- a/_maps/shuttles/skyrat/ruin_blackmarket_chevvy.dmm
+++ b/_maps/shuttles/skyrat/ruin_blackmarket_chevvy.dmm
@@ -1,193 +1,341 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"bY" = (
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/mineral/titanium,
+"bu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/shuttle/cargo,
+/area/shuttle/blackmarket_chevvy)
+"cL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/blackmarket_chevvy)
+"en" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/cargo,
 /area/shuttle/blackmarket_chevvy)
 "eu" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/shuttle/blackmarket_chevvy)
-"fh" = (
-/turf/open/floor/mineral/titanium,
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
 /area/shuttle/blackmarket_chevvy)
 "fp" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/blackmarket_chevvy)
-"iG" = (
+"gt" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/bot_white,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/blackmarket_chevvy)
-"kT" = (
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/blackmarket_chevvy)
-"qx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/shuttle/blackmarket_chevvy)
-"rw" = (
-/obj/machinery/door/window{
-	req_access_txt = "208"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/shuttle/blackmarket_chevvy)
-"sU" = (
+"jD" = (
+/obj/effect/turf_decal/bot_white,
 /obj/structure/chair/comfy/shuttle{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/blackmarket_chevvy)
-"ts" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium,
+"nB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron/shuttle/cargo,
 /area/shuttle/blackmarket_chevvy)
 "uW" = (
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/blackmarket_chevvy)
-"vD" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 4
-	},
-/turf/closed/wall/mineral/titanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/blackmarket_chevvy)
 "vK" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/blackmarket_chevvy)
-"wV" = (
-/obj/docking_port/mobile{
-	callTime = 50;
-	dir = 4;
-	dwidth = 4;
-	height = 5;
-	id = "blackmarket_chevvy";
-	ignitionTime = 25;
-	name = "Chevvy";
-	port_direction = 2;
-	preferred_direction = 4;
-	width = 9
-	},
-/obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
-/area/shuttle/blackmarket_chevvy)
-"Dx" = (
-/turf/open/floor/plating,
-/area/shuttle/blackmarket_chevvy)
-"GO" = (
-/obj/structure/window/reinforced/spawner,
-/obj/machinery/computer/shuttle/caravan/blackmarket_chevvy{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/blackmarket_chevvy)
-"Jv" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 8
 	},
-/turf/closed/wall/mineral/titanium,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/blackmarket_chevvy)
+"wE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/blackmarket_chevvy)
+"zH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/cargo,
+/area/shuttle/blackmarket_chevvy)
+"Dx" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/blackmarket_chevvy)
+"Fr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/blackmarket_chevvy)
+"Fu" = (
+/obj/machinery/computer/shuttle/caravan/blackmarket_chevvy,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/smooth_large,
+/area/shuttle/blackmarket_chevvy)
+"GO" = (
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
+/area/shuttle/blackmarket_chevvy)
+"Ii" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/button/door/directional/west{
+	id = "skiffext";
+	name = "External Airlock Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/obj/machinery/light/cold/directional/south,
+/obj/structure/tank_holder/oxygen/yellow,
+/turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/blackmarket_chevvy)
 "Ov" = (
-/obj/structure/chair/comfy/shuttle{
+/turf/template_noop,
+/area/template_noop)
+"OR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/window/reinforced/spawner,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/shuttle/blackmarket_chevvy)
-"OR" = (
-/obj/structure/chair/comfy/shuttle{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/blackmarket_chevvy)
+"PY" = (
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/blackmarket_chevvy)
 "Tk" = (
-/obj/machinery/computer/camera_advanced/shuttle_docker/blackmarket_chevvy{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/structure/rack/shelf,
+/obj/item/storage/firstaid/emergency,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/blackmarket_chevvy)
 "Vy" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/blackmarket_chevvy)
+"VX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/blackmarket_chevvy)
+"Yg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/shuttle/cargo,
 /area/shuttle/blackmarket_chevvy)
 "YP" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/smooth_large,
 /area/shuttle/blackmarket_chevvy)
 "YX" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/turf/open/floor/plating,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/blackmarket_chevvy)
+"ZC" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/smooth_large,
+/area/shuttle/blackmarket_chevvy)
+"ZE" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/blackmarket_chevvy,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/smooth_large,
+/area/shuttle/blackmarket_chevvy)
+"ZW" = (
+/obj/docking_port/mobile{
+	dwidth = 6;
+	height = 7;
+	id = "blackmarket_chevvy";
+	launch_status = 0;
+	name = "Chevvy";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 12
+	},
+/obj/machinery/door/airlock/external{
+	id_tag = "skiffext"
+	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/textured_large,
 /area/shuttle/blackmarket_chevvy)
 
 (1,1,1) = {"
-Jv
-fp
-fp
-YX
-wV
-YX
-fp
-fp
-Jv
+Ov
+GO
+Ov
+Ov
+Ov
+GO
+Ov
 "}
 (2,1,1) = {"
-fp
-YP
-rw
+Ov
 uW
-fh
-iG
 vK
-sU
-fp
+vK
+vK
+uW
+Ov
 "}
 (3,1,1) = {"
-YX
-eu
 Ov
-kT
-qx
-bY
+uW
 Dx
-ts
-YX
+Dx
+Dx
+uW
+Ov
 "}
 (4,1,1) = {"
 fp
-Tk
-GO
-uW
+YX
 Vy
 OR
-OR
-OR
+Fr
+YX
 fp
 "}
 (5,1,1) = {"
-vD
+YX
+Tk
+wE
+cL
+VX
+Ii
+YX
+"}
+(6,1,1) = {"
+YX
+YP
+Yg
+Yg
+Yg
+zH
+ZW
+"}
+(7,1,1) = {"
 YX
 YX
+nB
+ZC
+gt
+jD
+YX
+"}
+(8,1,1) = {"
+eu
+ZE
+bu
+YX
+YX
+YX
+YX
+"}
+(9,1,1) = {"
+eu
+Fu
+en
+eu
+Ov
 YX
 fp
+"}
+(10,1,1) = {"
+fp
 YX
+PY
+eu
+Ov
+Ov
+Ov
+"}
+(11,1,1) = {"
+Ov
+fp
+eu
 YX
-YX
-vD
+Ov
+Ov
+Ov
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I saw that we had a shuttle that was literally just a rectangle made of titanium, and this is sin which cannot be allowed.

Old, sad, weak chevvy in the past:
![image](https://user-images.githubusercontent.com/82386923/154826356-d39f11d3-0f87-4c28-9544-326d6f9dc98e.png)

New, strong, not a rectangle chevvy:
![image](https://user-images.githubusercontent.com/82386923/154826408-c870c2f9-11af-42b9-b80f-ef97fcfe3fdd.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

We can have shuttles look a little nicer than being an actual box with engines.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: The blackmarket chevvy shuttle that's been seen near the station occasionally has been refit to look a bit less like a rectangle
/:cl: