### PR TITLE
[MODULAR] NRI ERT Redesign/Improvement

### DIFF
--- a/modular_skyrat/modules/novaya_ert/code/belt.dm
+++ b/modular_skyrat/modules/novaya_ert/code/belt.dm
@@ -30,3 +30,11 @@
 		/obj/item/grenade/smokebomb = 1,
 		/obj/item/grenade/frag = 1,
 	),src)
+
+/obj/item/storage/belt/military/nri/full_support/PopulateContents()
+	generate_items_inside(list(
+		/obj/item/ammo_box/magazine/plastikov9mm = 4,
+		/obj/item/knife/combat = 1,
+		/obj/item/grenade/smokebomb = 1,
+		/obj/item/grenade/frag = 1,
+	),src)

--- a/modular_skyrat/modules/novaya_ert/code/ert.dm
+++ b/modular_skyrat/modules/novaya_ert/code/ert.dm
@@ -3,7 +3,7 @@
 	leader_role = /datum/antagonist/ert/nri/commander
 	rename_team = "Novaya Rossiyskaya Imperiya Patrol"
 	code = "Red"
-	mission = "Subvert the station."
+	mission = "Cooperate with the station, protect NRI assets."
 	polldesc = "a squad of NRI border patrol"
 
 /datum/antagonist/ert/nri

--- a/modular_skyrat/modules/novaya_ert/code/ert.dm
+++ b/modular_skyrat/modules/novaya_ert/code/ert.dm
@@ -1,10 +1,10 @@
 /datum/ert/nri
-	roles = list(/datum/antagonist/ert/nri, /datum/antagonist/ert/nri/heavy)
+	roles = list(/datum/antagonist/ert/nri, /datum/antagonist/ert/nri/heavy, /datum/antagonist/ert/nri/medic, /datum/antagonist/ert/nri/engineer)
 	leader_role = /datum/antagonist/ert/nri/commander
-	rename_team = "Novaya Rossiyskaya Imperiya Platoon"
+	rename_team = "Novaya Rossiyskaya Imperiya Patrol"
 	code = "Red"
-	mission = "Assist the station."
-	polldesc = "a squad of specialized NRI soldiers"
+	mission = "Subvert the station."
+	polldesc = "a squad of NRI border patrol"
 
 /datum/antagonist/ert/nri
 	name = "Novaya Rossiyskaya Imperiya Soldier"
@@ -33,3 +33,13 @@
 	name = "Novaya Rossiyskaya Imperiya Heavy Soldier"
 	role = "Heavy Soldier"
 	outfit = /datum/outfit/centcom/ert/nri/heavy
+
+/datum/antagonist/ert/nri/medic
+	name = "Novaya Rossiyskaya Imperiya Corpsman"
+	role = "Corpsman"
+	outfit = /datum/outfit/centcom/ert/nri/medic
+
+/datum/antagonist/ert/nri/engineer
+	name = "Novaya Rossiyskaya Imperiya Combat Engineer"
+	role = "Combat Engineer"
+	outfit = /datum/outfit/centcom/ert/nri/engineer

--- a/modular_skyrat/modules/novaya_ert/code/outfit.dm
+++ b/modular_skyrat/modules/novaya_ert/code/outfit.dm
@@ -73,7 +73,7 @@
 	gloves = /obj/item/clothing/gloves/combat
 	belt = /obj/item/storage/belt/military/nri/full_support
 	back = /obj/item/storage/backpack/satchel/leather
-	backpack_contents = list(/obj/item/storage/box/nri_survival_pack, /obj/item/clothing/mask/gas/alt, /obj/item/storage/belt/utility/full/powertools, /obj/item/clothing/accessory/armband/engine, /obj/item/construction/rcd/combat)
+	backpack_contents = list(/obj/item/storage/box/nri_survival_pack, /obj/item/clothing/mask/gas/alt, /obj/item/storage/belt/utility/full/powertools, /obj/item/clothing/accessory/armband/engine, /obj/item/construction/rcd/combat, /obj/item/clothing/glasses/welding)
 	shoes = /obj/item/clothing/shoes/jackboots/black
 
 	id = /obj/item/card/id/advanced/centcom/ert/nri

--- a/modular_skyrat/modules/novaya_ert/code/outfit.dm
+++ b/modular_skyrat/modules/novaya_ert/code/outfit.dm
@@ -1,6 +1,5 @@
 /datum/outfit/centcom/ert/nri
 	name = "Novaya Rossiyskaya Imperiya Soldier"
-
 	head = /obj/item/clothing/head/helmet/rus_helmet/nri
 	glasses = /obj/item/clothing/glasses/night
 	ears = /obj/item/radio/headset/headset_cent/alt/with_key
@@ -11,7 +10,9 @@
 	gloves = /obj/item/clothing/gloves/combat
 	belt = /obj/item/storage/belt/military/nri/full
 	back = /obj/item/storage/backpack/satchel/leather
-	backpack_contents = list(/obj/item/storage/box/nri_survival_pack, /obj/item/clothing/mask/gas/alt)
+	backpack_contents = list(/obj/item/storage/box/nri_survival_pack, /obj/item/storage/firstaid/emergency, /obj/item/clothing/mask/gas/alt)
+	l_pocket = /obj/item/gun/ballistic/automatic/pistol
+	r_pocket = /obj/item/ammo_box/magazine/m9mm
 	shoes = /obj/item/clothing/shoes/jackboots/black
 
 	id = /obj/item/card/id/advanced/centcom/ert/nri
@@ -21,6 +22,7 @@
 	name = "Novaya Rossiyskaya Imperiya Heavy Soldier"
 	head = /obj/item/clothing/head/helmet/nri_heavy
 	suit = /obj/item/clothing/suit/armor/heavy/nri
+	glasses = /obj/item/clothing/glasses/hud/security/night
 	mask = /obj/item/clothing/mask/gas/alt
 	belt = /obj/item/storage/belt/military/nri/full_heavy
 	suit_store = /obj/item/gun/ballistic/automatic/pistol
@@ -33,10 +35,49 @@
 /datum/outfit/centcom/ert/nri/commander
 	name = "Novaya Rossiyskaya Imperiya Platoon Commander"
 	head = /obj/item/clothing/head/beret/sec/nri
+	glasses = /obj/item/clothing/glasses/thermal/eyepatch
 	belt = /obj/item/storage/belt/military/nri/full_commander
 	suit_store = /obj/item/gun/ballistic/automatic/submachine_gun/ppsh
+	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
+	backpack_contents = list(/obj/item/storage/box/nri_survival_pack, /obj/item/storage/firstaid/emergency, /obj/item/clothing/mask/gas/alt, /obj/item/clothing/accessory/armband, /obj/item/megaphone, /obj/item/binoculars)
 
 	id_trim = /datum/id_trim/nri/commander
+
+/datum/outfit/centcom/ert/nri/medic
+	name = "Novaya Rossiyskaya Imperiya Corpsman"
+	head = /obj/item/clothing/head/helmet/rus_helmet/nri
+	glasses = /obj/item/clothing/glasses/hud/health/night
+	ears = /obj/item/radio/headset/headset_cent/alt/with_key
+	mask = /obj/item/clothing/mask/balaclavaadjust
+	uniform = /obj/item/clothing/under/costume/nri
+	suit = /obj/item/clothing/suit/armor/vest/russian/nri
+	suit_store = /obj/item/gun/ballistic/automatic/plastikov
+	gloves = /obj/item/clothing/gloves/color/latex/nitrile
+	belt = /obj/item/storage/belt/military/nri/full_support
+	back = /obj/item/storage/backpack/satchel/leather
+	backpack_contents = list(/obj/item/storage/box/nri_survival_pack, /obj/item/clothing/mask/gas/alt, /obj/item/storage/firstaid/tactical, /obj/item/storage/firstaid/advanced, /obj/item/gun/medbeam, /obj/item/clothing/accessory/armband/med)
+	shoes = /obj/item/clothing/shoes/jackboots/black
+
+	id = /obj/item/card/id/advanced/centcom/ert/nri
+	id_trim = /datum/id_trim/nri
+
+/datum/outfit/centcom/ert/nri/engineer
+	name = "Novaya Rossiyskaya Imperiya Combat Engineer"
+	head = /obj/item/clothing/head/helmet/rus_helmet/nri
+	glasses = /obj/item/clothing/glasses/meson/night
+	ears = /obj/item/radio/headset/headset_cent/alt/with_key
+	mask = /obj/item/clothing/mask/balaclavaadjust
+	uniform = /obj/item/clothing/under/costume/nri
+	suit = /obj/item/clothing/suit/armor/vest/russian/nri
+	suit_store = /obj/item/gun/ballistic/automatic/plastikov
+	gloves = /obj/item/clothing/gloves/combat
+	belt = /obj/item/storage/belt/military/nri/full_support
+	back = /obj/item/storage/backpack/satchel/leather
+	backpack_contents = list(/obj/item/storage/box/nri_survival_pack, /obj/item/clothing/mask/gas/alt, /obj/item/storage/belt/utility/full/powertools, /obj/item/clothing/accessory/armband/engine, /obj/item/construction/rcd/combat)
+	shoes = /obj/item/clothing/shoes/jackboots/black
+
+	id = /obj/item/card/id/advanced/centcom/ert/nri
+	id_trim = /datum/id_trim/nri
 
 /datum/outfit/centcom/ert/nri/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
General improvement and specialization of a previously incredibly militarized ERT: added medic/corpsman and engineer/combat engineer roles, as well as improved loadouts of other roles for additional teamwork.

General look of new and old roles to give a small insight I guess?..
![image](https://user-images.githubusercontent.com/42087567/154840701-599ae9cd-c8c1-4881-affc-9baf663eee61.png)

Heavy weapons' guy's loadout is left almost the same, with an exception of NVG secHUD and an additional 9x25 mag:
![image](https://user-images.githubusercontent.com/42087567/154840855-227a09d5-eb4c-4a90-b89d-8829252e77d0.png)
Platoon commander was given a sidearm with a thermal eyepatch with guerilla (or was those gorilla?) gloves, as well as an emergency FAK, binoculars and megaphone:
![image](https://user-images.githubusercontent.com/42087567/154840975-f8e125cc-91c7-4ba0-88e4-b57ffbd9aa45.png)
Basic trooper was given a sidearm and emergency FAK:
![image](https://user-images.githubusercontent.com/42087567/154841037-4c1f1e1c-7973-4f6d-979a-8c34e6013445.png)
New medic/corpsman loadout features a weak'ish surplus SMG with 4 additional mags, a combat and advanced medkits, as well as a medbeam, NVG medhud and nitrile gloves:
![image](https://user-images.githubusercontent.com/42087567/154841098-9b583966-5afc-4171-87e7-f23856fea920.png)
New engineer/combat engineer loadout includes the same weak SMG with 4 reloads, as well as a set of advanced tools, NVG mesons and a combat RCD:
![image](https://user-images.githubusercontent.com/42087567/154841181-9e91c20b-fefb-4b4e-b517-8b5b3e0924c6.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
While I do fairly enjoy muh russian bias, it wasn't that thought out nor flexible enough to become a viable (and, tbh, purposeful) ERT. This should solve the issue of NRI ERT lacking any real purpose besides being a slightly weaker TGMC ERT.
This should also give admins/whoever's currently shitspawning an additional group of people to make station a problem, in case if there would be a need for some.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Stalkeros
qol: NRI ERT became more neutral in terms of their goals.
qol: NRI ERT loadout improvements: added engineer and medic roles, and generally improved existing ones.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
