### PR TITLE
Fixes the weird say description that gets applied when FIX SAY is called

### DIFF
--- a/modular_skyrat/modules/admin/code/fix_chat.dm
+++ b/modular_skyrat/modules/admin/code/fix_chat.dm
@@ -1,5 +1,5 @@
 /client/proc/fix_say()
-    set name = "Fix Say For Players"
+    set name = "Fix say for players"
     set category = "Admin"
     for(var/player in GLOB.player_list)
         if(isnull(player))

--- a/modular_skyrat/modules/admin/code/fix_chat.dm
+++ b/modular_skyrat/modules/admin/code/fix_chat.dm
@@ -1,7 +1,6 @@
 /client/proc/fix_say()
-    set name = "FIX SAY"
+    set name = "Fix Say For Players"
     set category = "Admin"
-    set desc = "fixes bug where people can't say shid"
     for(var/player in GLOB.player_list)
         if(isnull(player))
             GLOB.player_list -= player


### PR DESCRIPTION
## About The Pull Request
Does what it says on the tin. I also renamed it to `Fix Say For Players`, so it's less likely to get called by people on accident.

## How This Contributes To The Skyrat Roleplay Experience
No more will you see `"fixes bug where people can't say shid"` when you press T.

## Changelog

:cl: GoldenAlpharex
fix: Fixed the weird description when you hit the *say hotkey.
/:cl: