### PR TITLE
[NON-MODULAR] Removes the bluespace launchpad from the uplink.

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -38,7 +38,7 @@
 		)))
 		if(KIT_RECON)
 			new /obj/item/clothing/glasses/thermal/xray(src) // ~8 tc?
-			new /obj/item/storage/briefcase/launchpad(src) //6 tc
+//			new /obj/item/storage/briefcase/launchpad(src) //6 tc // SKYRAT EDIT REMOVAL
 			new /obj/item/binoculars(src) // 2 tc?
 			new /obj/item/encryptionkey/syndicate(src) // 2 tc
 			new /obj/item/storage/box/syndie_kit/space(src) //4 tc

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -60,13 +60,13 @@
 	cost = 1
 	surplus = 20
 
-/datum/uplink_item/device_tools/briefcase_launchpad
+/* /datum/uplink_item/device_tools/briefcase_launchpad // SKYRAT EDIT REMOVAL
 	name = "Briefcase Launchpad"
 	desc = "A briefcase containing a launchpad, a device able to teleport items and people to and from targets up to eight tiles away from the briefcase. \
 			Also includes a remote control, disguised as an ordinary folder. Touch the briefcase with the remote to link it."
 	surplus = 0
 	item = /obj/item/storage/briefcase/launchpad
-	cost = 6
+	cost = 6 */
 
 /datum/uplink_item/device_tools/camera_bug
 	name = "Camera Bug"

--- a/modular_skyrat/modules/moretraitoritems/code/syndicate_loadout.dm
+++ b/modular_skyrat/modules/moretraitoritems/code/syndicate_loadout.dm
@@ -30,7 +30,7 @@
 	new /obj/item/clothing/glasses/thermal/syndi(src)
 	new /obj/item/knife/combat/survival(src)
 	new /obj/item/gun/energy/disabler(src)
-	new /obj/item/storage/briefcase/launchpad(src)
+// 	new /obj/item/storage/briefcase/launchpad(src) // Removed for now.
 	new /obj/item/binoculars(src)
 	new /obj/item/encryptionkey/syndicate(src)
 	new /obj/item/storage/box/syndie_kit/space(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does as it says in the title. Is a request.

## How This Contributes To The Skyrat Roleplay Experience

Hopefully less of this stealth antag nonsense, as it's a very controverisal item. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

del: Removed bluespace launchpad from uplink. 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
