### PR TITLE
[MODULAR] Rodstopper now WARNS LOUDLY to EVACUATE the AREA when it is DEPLOYED

### DIFF
--- a/modular_skyrat/modules/rod-stopper/code/rodstopper.dm
+++ b/modular_skyrat/modules/rod-stopper/code/rodstopper.dm
@@ -27,4 +27,4 @@
 /obj/machinery/rodstopper/proc/warn_area()
 	playsound(src, 'sound/misc/bloblarm.ogg', 100)
 	say("Warning! Please clear the area! Failure to do so will result in your immediate annihilation!")
-	addtimer(CALLBACK(src, .proc/warn_area), 70, TIMER_OVERRIDE|TIMER_UNIQUE) // sound file length for looping
+	addtimer(CALLBACK(src, .proc/warn_area), 15 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE) // the sound is 7 seconds, however.

--- a/modular_skyrat/modules/rod-stopper/code/rodstopper.dm
+++ b/modular_skyrat/modules/rod-stopper/code/rodstopper.dm
@@ -19,3 +19,12 @@
 /obj/machinery/rodstopper/examine(mob/user)
 	. = ..()
 	. += span_warning("It will create a localized reality-collapse when stopping a rod, keep your distance!")
+
+/obj/machinery/rodstopper/Initialize(mapload)
+	. = ..()
+	warn_area()
+
+/obj/machinery/rodstopper/proc/warn_area()
+	playsound(src, 'sound/misc/bloblarm.ogg', 100)
+	say("Warning! Please clear the area! Failure to do so will result in your immediate annihilation!")
+	addtimer(CALLBACK(src, .proc/warn_area), 70, TIMER_OVERRIDE|TIMER_UNIQUE) // sound file length for looping


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The rodstopper is an undocumented mechanic that only servers to round remove players with no warning or thought behind it. People will tell you "Build the Rodstopper, CE!" - but there is no way to know what it does - you only know it somehow stops rods? Well, you'd be surprised and your round ruined when it just hard round removes you. It's one of the very few sources of that, and it's completely and utterly bullshit for its victims.

## How This Contributes To The Skyrat Roleplay Experience

Same as above.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

qol: Rodstopper now yells at you to RUN.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
