### PR TITLE
more drone buffs

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -3934,6 +3934,10 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
 /obj/effect/spawner/random/maintenance/three,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/greater)
 "aHx" = (
@@ -63307,10 +63311,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "uko" = (
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/machinery/drone_dispenser,
 /turf/open/floor/plating,
 /area/maintenance/starboard/greater)
 "ukw" = (

--- a/_maps/readme.md
+++ b/_maps/readme.md
@@ -19,8 +19,9 @@ The list of items that are modular requiring adding/modifying to /tg/ maps:
 - Central Command Ferry Hangar (inside Arrival area)
 - Update roundstart_template variable on mining/public/labour stationary docks: mining/x > mining/skyrat, mining_common/x > mining_common/skyrat, labour/x > labour/skyrat , mining/large > mining/large/skyrat
 - Replace the security outposts with their departmental guards
-- Xenoarch Lab (Lavaland)
+- Xenoarch Base (Lavaland)
 - Modular pets: E-N (Robotics), Poppy (Engineering), Bumbles (Hydroponics) and Markus (Cargo)
+- Drone Dispensers added to all maps
 
 ## Rules
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -87,7 +87,7 @@
 	/// Hacked state, see [/mob/living/simple_animal/drone/proc/update_drone_hack]
 	var/hacked = FALSE
 	/// If we have laws to minimize bothering others. Enables or disables drone laws enforcement components (use [/mob/living/simple_animal/drone/proc/set_shy] to set)
-	var/shy = FALSE //SKYRAT EDIT: Original: TRUE
+	var/shy = TRUE
 	/// Flavor text announced to drones on [/mob/proc/Login]
 	var/flavortext = \
 	"\n<big><span class='warning'>DO NOT INTERFERE WITH THE ROUND AS A DRONE OR YOU WILL BE DRONE BANNED</span></big>\n"+\

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
@@ -23,16 +23,6 @@ GLOBAL_VAR_INIT(successful_blood_chem, 0)
 			return check_content
 	return FALSE
 
-//this allows borers to slide under/through a door
-/obj/machinery/door/Bumped(atom/movable/movable_atom)
-	if(iscorticalborer(movable_atom) && density)
-		if(!do_after(movable_atom, 5 SECONDS, src))
-			return ..()
-		movable_atom.forceMove(get_turf(src))
-		to_chat(movable_atom, span_notice("You squeeze through [src]."))
-		return
-	return ..()
-
 //so if a person is debrained, the borer is removed
 /obj/item/organ/brain/Remove(mob/living/carbon/target, special = 0, no_id_transfer = FALSE)
 	. = ..()

--- a/modular_skyrat/modules/drone_adjustments/drone.dm
+++ b/modular_skyrat/modules/drone_adjustments/drone.dm
@@ -1,0 +1,61 @@
+/obj/machinery/drone_dispenser/Initialize(mapload)
+	//So that there are starting drone shells in the beginning of the shift
+	if(mapload)
+		starting_amount = 10000
+	return ..()
+
+/obj/item/card/id/advanced/simple_bot
+	//So that the drones can actually access everywhere and fix it
+	trim = /datum/id_trim/centcom
+
+//This is so we log all machinery interactions for drones
+/obj/machinery/attack_drone(mob/living/simple_animal/drone/user, list/modifiers)
+	. = ..()
+	user.log_message("[key_name(user)] interacted with [src] at [AREACOORD(src)]", LOG_GAME)
+
+/obj/machinery/door
+	///The types of things that can slide under from bumping
+	var/static/list/sliding_under_types = list(
+		/mob/living/simple_animal/drone,
+		/mob/living/simple_animal/cortical_borer,
+	)
+
+//This allows drones to slide under/through a door
+/obj/machinery/door/Bumped(atom/movable/movable_atom)
+	. = ..()
+	addtimer(CALLBACK(src, .proc/sliding_under, movable_atom), 5)
+
+/**
+ * Called for when a movable atom tries to slide under the door
+ */
+/obj/machinery/door/proc/sliding_under(atom/movable/movable_atom)
+	if(!is_type_in_list(movable_atom, sliding_under_types) || !density)
+		return
+	if(!do_after(movable_atom, 5 SECONDS, src))
+		return
+	movable_atom.forceMove(get_turf(src))
+	to_chat(movable_atom, span_notice("You squeeze through [src]."))
+
+/mob/living/simple_animal/drone
+	//So that drones can do things without worrying about stuff
+	shy = FALSE
+	//So drones aren't forced to carry around a nodrop toolbox essentially
+	default_storage = /obj/item/storage/backpack/drone_bag
+
+/mob/living/simple_animal/drone/Initialize(mapload)
+	. = ..()
+	name = "[initial(name)] ([rand(100,999)])" //So that we can identify drones from each other
+
+/obj/item/storage/backpack/drone_bag
+	name = "drone backpack"
+	desc = "For all your storing needs; it is possible to remove this."
+
+/obj/item/storage/backpack/drone_bag/PopulateContents()
+	. = ..()
+	new /obj/item/crowbar(src)
+	new /obj/item/wrench(src)
+	new /obj/item/screwdriver(src)
+	new /obj/item/weldingtool(src)
+	new /obj/item/wirecutters(src)
+	new /obj/item/multitool(src)
+	new /obj/item/stack/cable_coil(src)

--- a/modular_skyrat/modules/drone_adjustments/drone.dm
+++ b/modular_skyrat/modules/drone_adjustments/drone.dm
@@ -8,33 +8,14 @@
 	//So that the drones can actually access everywhere and fix it
 	trim = /datum/id_trim/centcom
 
+/obj/machinery/door/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/sliding_under)
+
 //This is so we log all machinery interactions for drones
 /obj/machinery/attack_drone(mob/living/simple_animal/drone/user, list/modifiers)
 	. = ..()
 	user.log_message("[key_name(user)] interacted with [src] at [AREACOORD(src)]", LOG_GAME)
-
-/obj/machinery/door
-	///The types of things that can slide under from bumping
-	var/static/list/sliding_under_types = list(
-		/mob/living/simple_animal/drone,
-		/mob/living/simple_animal/cortical_borer,
-	)
-
-//This allows drones to slide under/through a door
-/obj/machinery/door/Bumped(atom/movable/movable_atom)
-	. = ..()
-	addtimer(CALLBACK(src, .proc/sliding_under, movable_atom), 5)
-
-/**
- * Called for when a movable atom tries to slide under the door
- */
-/obj/machinery/door/proc/sliding_under(atom/movable/movable_atom)
-	if(!is_type_in_list(movable_atom, sliding_under_types) || !density)
-		return
-	if(!do_after(movable_atom, 5 SECONDS, src))
-		return
-	movable_atom.forceMove(get_turf(src))
-	to_chat(movable_atom, span_notice("You squeeze through [src]."))
 
 /mob/living/simple_animal/drone
 	//So that drones can do things without worrying about stuff
@@ -44,11 +25,10 @@
 
 /mob/living/simple_animal/drone/Initialize(mapload)
 	. = ..()
-	name = "[initial(name)] ([rand(100,999)])" //So that we can identify drones from each other
+	name = "[initial(name)] [rand(0,9)]-[rand(100,999)]" //So that we can identify drones from each other
 
 /obj/item/storage/backpack/drone_bag
 	name = "drone backpack"
-	desc = "For all your storing needs; it is possible to remove this."
 
 /obj/item/storage/backpack/drone_bag/PopulateContents()
 	. = ..()

--- a/modular_skyrat/modules/drone_adjustments/slide_component.dm
+++ b/modular_skyrat/modules/drone_adjustments/slide_component.dm
@@ -1,0 +1,44 @@
+/datum/component/sliding_under
+	///The atom that has this component
+	var/atom/atom_parent
+	///The list of allowed mobs to slide under
+	var/static/list/allowed_mobs = list(
+		/mob/living/simple_animal/cortical_borer,
+		/mob/living/simple_animal/drone,
+	)
+
+/datum/component/sliding_under/Initialize(allowed_mobs_override = null)
+	//needs to be an atom
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+	atom_parent = parent
+	//if we have an override, go ahead
+	if(allowed_mobs_override)
+		allowed_mobs = allowed_mobs_override
+	//either bumping or ctrl click
+	RegisterSignal(atom_parent, COMSIG_CLICK_CTRL, .proc/check_conditions)
+	//so that we can know how to do that (sliding under)
+	RegisterSignal(atom_parent, COMSIG_PARENT_EXAMINE, .proc/ExamineMessage)
+
+/datum/component/sliding_under/Destroy(force, silent)
+	UnregisterSignal(atom_parent, list(COMSIG_CLICK_CTRL, COMSIG_PARENT_EXAMINE))
+	return ..()
+
+/datum/component/sliding_under/proc/check_conditions(datum/source, mob/user)
+	//the parent needs to be dense in order to slide through
+	if(!atom_parent.density)
+		return
+	//you have to be in the list
+	if(!is_type_in_list(user, allowed_mobs))
+		return
+	//you need to have patience and can't move away
+	if(!do_after(user, 5 SECONDS, atom_parent))
+		return
+	user.forceMove(get_turf(atom_parent))
+	atom_parent.balloon_alert_to_viewers("something squeezes through!")
+
+/datum/component/sliding_under/proc/ExamineMessage(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+	if(!is_type_in_list(user, allowed_mobs))
+		return
+	examine_list += span_warning("Ctrl + Click [atom_parent] to slide under!")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4860,6 +4860,7 @@
 #include "modular_skyrat\modules\digi_bloodsole\code\_shoes.dm"
 #include "modular_skyrat\modules\dogfashion\code\head.dm"
 #include "modular_skyrat\modules\drone_adjustments\drone.dm"
+#include "modular_skyrat\modules\drone_adjustments\slide_component.dm"
 #include "modular_skyrat\modules\electric_welder\code\electric_welder.dm"
 #include "modular_skyrat\modules\emotes\code\dna_screams.dm"
 #include "modular_skyrat\modules\emotes\code\emotes.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4859,6 +4859,7 @@
 #include "modular_skyrat\modules\decay_subsystem\code\spawn_nest.dm"
 #include "modular_skyrat\modules\digi_bloodsole\code\_shoes.dm"
 #include "modular_skyrat\modules\dogfashion\code\head.dm"
+#include "modular_skyrat\modules\drone_adjustments\drone.dm"
 #include "modular_skyrat\modules\electric_welder\code\electric_welder.dm"
 #include "modular_skyrat\modules\emotes\code\dna_screams.dm"
 #include "modular_skyrat\modules\emotes\code\emotes.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds a drone dispenser to meta station
drones, when they bump against an airlock that won't open, will attempt to slip under/through it
drones have AA (centcom)
drone dispensers, on map initialization, will have some materials to start with
drones will have a random 100-999 number assigned to them
drones now have a removable back pack
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
drones are so abused... they really deserve some love.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: meta station: added a drone dispenser
add: drones will now slip through doors if they are unable to bump open them
qol: drone dispensers have materials roundstart
qol: drones are now assigned a number 100-999 in their name
qol: drones now have removable backpacks
qol: drones now have AA
admin: drones now have their machinery interactions logged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
