### PR TITLE
[NON-MODULAR] Fixes crew being able to order combat boots and gloves via Renaissance Crate

### DIFF
--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -345,11 +345,12 @@
 	name = "Plate Gauntlets"
 	icon_state = "crusader"
 	desc = "They're like gloves, but made of metal."
-	siemens_coefficient = 0
+	siemens_coefficient = 1 // SKYRAT EDIT ORIGINAL: 0
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+	armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 5, BIO = 0, FIRE = 60, ACID = 60) // SKYRAT ADDITION
 
 /obj/item/clothing/gloves/plate/red
 	icon_state = "crusader-red"
@@ -362,8 +363,8 @@
 	desc = "Metal boots, they look heavy."
 	icon_state = "crusader"
 	w_class = WEIGHT_CLASS_NORMAL
-	armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 60, BIO = 0, FIRE = 60, ACID = 60) //does this even do anything on boots?
-	clothing_flags = NOSLIP
+	armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 5, BIO = 0, FIRE = 60, ACID = 60) // SKYRAT EDIT ORIGINAL: MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 60, BIO = 0, FIRE = 60, ACID = 60
+	// SKYRAT REMOVAL // clothing_flags = NOSLIP
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As the title says, this PR removes the NOSLIP flag of the plate boots, decreases its armor since it is no longer a holodeck only item. Removes the insulation from the plate gauntlets and also gives it armor to make more sense. Unfortunately its non modular.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Plate gauntlets being insulated but not armored does not make sense from an IC standpoint. Having it provide armor but be less resistant to electric is good for immersion. Having easy access to noslip combat shoes that are skinned as plates is bad for the balance of the server.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Plate Gauntlets are no longer immune to electricity but provide armor while Plate Boots are no longer better combat shoes as they have lost their NOSLIP flag as well as had their armor reduced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
