### PR TITLE
[NONMODULAR] D-e-sword nerf option: 1: the revenge of the blockchance.

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -22,7 +22,7 @@
 	light_on = FALSE
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
-	block_chance = 75
+	block_chance = 45 //SKYRAT EDIT - Lowered ORIGINAL:75
 	max_integrity = 200
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 100, ACID = 70)
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION

## About The Pull Request
It was a long time coming, but for an item that's both easy to use, easier to pair with stuff, 75 blockchance is just too high functionally, leading to it being one of the strongest items in the game, with most of it's counters like 'slipping' having just as affordable ways around it, all while we're supposed to be trying to discourage wanton combat.

## How This Contributes To The Skyrat Roleplay Experience

Less people buying a D-E-Sword, and then casually walking around everyone, beating them down without effort while practically no one can reasonably fight back, unless by dumb-luck or sheer numbers.

## Changelog


:cl:
balance: Lowers block chance of double energy sword to 45, from 75.
/:cl:
