### PR TITLE
[NON-MODULAR] Allow you to load your character at the magic mirror

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -150,8 +150,15 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 		return TRUE
 
 	var/mob/living/carbon/human/amazed_human = user
+// SKYRAT EDIT BEGIN - Magic Mirror Character Application
+	var/choice
+	var/ask = tgui_alert(user, "Would you like to apply your loaded character?","Confirm", list("Yes!", "No, I want to manually edit my character here."))
 
-	var/choice = tgui_input_list(user, "Something to change?", "Magical Grooming", list("name", "race", "gender", "hair", "eyes"))
+	if(ask == "Yes!")
+		user?.client?.prefs?.safe_transfer_prefs_to(amazed_human)
+	else
+		choice = tgui_input_list(user, "Something to change?", "Magical Grooming", list("name", "race", "gender", "hair", "eyes"))
+// SKYRAT EDIT END
 	if(isnull(choice))
 		return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As it says in the title. Critical alert: Non modular change detected!

https://user-images.githubusercontent.com/77420409/155597793-58529e9b-3e6f-4c20-a58b-18e2caa821cb.mp4




## How This Contributes To The Skyrat Roleplay Experience

If you rolled a thing with access to this, you can change your character to one you want for this role without admin intervention. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

qol: You can now load your character slot at the magic mirror. 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
