### PR TITLE
[Modular] Lifts blindness related job quirk bans

### DIFF
--- a/code/__DEFINES/~skyrat_defines/jobs.dm
+++ b/code/__DEFINES/~skyrat_defines/jobs.dm
@@ -4,8 +4,8 @@
 #define JOB_UNAVAILABLE_SPECIES JOB_UNAVAILABLE_QUIRK + 1
 #define JOB_UNAVAILABLE_LANGUAGE JOB_UNAVAILABLE_SPECIES + 1
 
-#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE
-#define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE
+#define SEC_RESTRICTED_QUIRKS "Brain Tumor" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE
+#define HEAD_RESTRICTED_QUIRKS "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE
 #define TECH_RESTRICTED_QUIRKS "Chunky Fingers" = TRUE
 
 #define FLAVOR_TEXT_CHAR_REQUIREMENT 150

--- a/code/__DEFINES/~skyrat_defines/jobs.dm
+++ b/code/__DEFINES/~skyrat_defines/jobs.dm
@@ -4,7 +4,7 @@
 #define JOB_UNAVAILABLE_SPECIES JOB_UNAVAILABLE_QUIRK + 1
 #define JOB_UNAVAILABLE_LANGUAGE JOB_UNAVAILABLE_SPECIES + 1
 
-#define SEC_RESTRICTED_QUIRKS "Brain Tumor" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE
+#define SEC_RESTRICTED_QUIRKS "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Chunky Fingers" = TRUE
 #define HEAD_RESTRICTED_QUIRKS "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Chunky Fingers" = TRUE
 #define TECH_RESTRICTED_QUIRKS "Chunky Fingers" = TRUE
 

--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -62,7 +62,7 @@
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)
 
 /datum/job/brigoff
-	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
+	banned_quirks = list(SEC_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)
 
 /datum/job/blueshield
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)

--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -61,7 +61,6 @@
 /datum/job/security_medic
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 
-
 /datum/job/blueshield
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 

--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -50,19 +50,22 @@
 
 //Security
 /datum/job/security_officer
-	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
+	banned_quirks = list(SEC_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)
 
 /datum/job/detective
-	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
+	banned_quirks = list(SEC_RESTRICTED_QUIRKS, "Blind" = TRUE)
 
 /datum/job/warden
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 
 /datum/job/security_medic
+	banned_quirks = list(SEC_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)
+
+/datum/job/brigoff
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 
 /datum/job/blueshield
-	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
+	banned_quirks = list(SEC_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)
 
 /datum/job/nanotrasen_representative
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)

--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -50,7 +50,7 @@
 
 //Security
 /datum/job/security_officer
-	banned_quirks = list(SEC_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)
+	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 
 /datum/job/detective
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS, "Blind" = TRUE)
@@ -59,13 +59,11 @@
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 
 /datum/job/security_medic
-	banned_quirks = list(SEC_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)
+	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 
-/datum/job/brigoff
-	banned_quirks = list(SEC_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)
 
 /datum/job/blueshield
-	banned_quirks = list(SEC_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)
+	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 
 /datum/job/nanotrasen_representative
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)


### PR DESCRIPTION
## About The Pull Request

Removes blindness from the job quirk ban-list, besides for detectives.

## How This Contributes To The Skyrat Roleplay Experience

Blindness has had a mechanics overhaul, it is also not very outlandish to have a command member with fading eyesight.

## Changelog

:cl:
balance: Command and security (besides detective) can have the blindness quirk
/:cl: