### PR TITLE
[Non-modular] Allows (Health-)scanners to be used by blind players

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -188,9 +188,9 @@ GENE SCANNER
 	if(user.incapacitated())
 		return
 
-	if(user.is_blind())
+/*	if(user.is_blind())	SKYRAT EDIT - Blindness overhaul
 		to_chat(user, span_warning("You realize that your scanner has no accessibility support for the blind!"))
-		return
+		return	SKYRAT EDIT END	*/
 
 	// the final list of strings to render
 	var/render_list = list()
@@ -463,9 +463,9 @@ GENE SCANNER
 	if(user.incapacitated())
 		return
 
-	if(user.is_blind())
+/*	if(user.is_blind())	SKYRAT EDIT - Blindness overhaul
 		to_chat(user, span_warning("You realize that your scanner has no accessibility support for the blind!"))
-		return
+		return	SKYRAT EDIT END	*/
 
 	if(istype(target) && target.reagents)
 		var/render_list = list()
@@ -541,9 +541,9 @@ GENE SCANNER
 	if(!istype(patient) || user.incapacitated())
 		return
 
-	if(user.is_blind())
+/*	if(user.is_blind())	SKYRAT EDIT - Blindness overhaul
 		to_chat(user, span_warning("You realize that your scanner has no accessibility support for the blind!"))
-		return
+		return	SKYRAT EDIT END	*/
 
 	var/render_list = ""
 	for(var/i in patient.get_wounded_bodyparts())


### PR DESCRIPTION
## About The Pull Request

Related to our blindness overhaul.

## How This Contributes To The Skyrat Roleplay Experience

Just squint your eyes really hard.

## Changelog

:cl:
qol: Allows (Health-)scanners to be used by blind players
/:cl:
