### PR TITLE
Fixes a bug with native inputs.

### DIFF
--- a/code/modules/tgui/tgui_input_list.dm
+++ b/code/modules/tgui/tgui_input_list.dm
@@ -23,7 +23,7 @@
 			return
 	/// Client does NOT have tgui_input on: Returns regular input
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
-		return input(user, message, title) as null|anything in items
+		return input(user, message, title, default) as null|anything in items // SKYRAT EDIT: Fixes ALL non-tgui prompts. (Character editor, colours, suit sensors, etc)
 	var/datum/tgui_list_input/input = new(user, message, title, items, default, timeout)
 	input.ui_interact(user)
 	input.wait()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This looks like one of these intentional bugs people leave lying around to get free GBP later, it's that silly. Anyways, this passes the default value back to input() which no longer presents NULL now. As a result, colour picking no longer gives you #000000, suit sensors no longer default to off, etc. Works as expected.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/pull/11290
and https://github.com/Skyrat-SS13/Skyrat-tg/pull/10355

from: https://github.com/tgstation/tgstation/pull/63354
## How This Contributes To The Skyrat Roleplay Experience

Not having bugs is nice. Especially ones that seem intentional. I don't like the bloated library monster known as TGUI, so the less I need to depend on it, the better. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: fixed native windows input boxes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
