### PR TITLE
Fixes succumb still killing you if you cancel it.

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -430,7 +430,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 	var/mob/living/living_owner = owner
 	var/last_whisper = tgui_input_text(usr, "Do you have any last words?", "Final Words")
-	if (isnull(last_whisper) || !CAN_SUCCUMB(living_owner))
+	if (isnull(last_whisper) || !CAN_SUCCUMB(living_owner) || last_whisper == "") // SKYRAT EDIT: Fixes a bug with cancelling succumb.
 		return
 
 	if (length(last_whisper))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Due to the code never ever possibly being null for TGUI inputs since everything goes through a buggy TGUI wrapper now (TGUI cannot be null), the null check will never succeed. This adds an empty string check to determine if the user clicked cancel or gave a blank gasp. 

Bug introduced in: https://github.com/tgstation/tgstation/pull/63354

fixes https://github.com/tgstation/tgstation/issues/63802

## How This Contributes To The Skyrat Roleplay Experience

Sometimes I don't want to actually deathgasp, and change my mind. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: Deathgasps prompt now works properly. 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
