### PR TITLE
ARBORLINK vault + shuttle 8532 fixes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/shuttle8532.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/shuttle8532.dmm
@@ -585,6 +585,11 @@
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532researchbay)
+"lw" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/c38,
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav/shuttle8532crewquarters)
 "lD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/gibs/core,
@@ -817,6 +822,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/item/ammo_box/c38,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "ro" = (
@@ -918,7 +924,6 @@
 	dir = 8;
 	icon_state = "tube"
 	},
-/obj/item/ammo_box/c38,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "tA" = (
@@ -973,7 +978,8 @@
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "ul" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer4{
-	dir = 8
+	dir = 8;
+	on = 1
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -1659,6 +1665,11 @@
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532cargohall)
+"Gv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mob_spawn/corpse/human/syndicatecommando,
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav/shuttle8532bridge)
 "Gz" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -1886,8 +1897,8 @@
 	},
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/mob_spawn/corpse/human/syndicatecommando,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/mob_spawn/corpse/human,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "Lz" = (
@@ -3276,7 +3287,7 @@ qb
 (11,1,1) = {"
 HP
 eV
-ZU
+Gv
 Vi
 BS
 pu
@@ -3609,7 +3620,7 @@ uG
 yz
 Nx
 oh
-Zj
+lw
 TM
 Qx
 he

--- a/_maps/RandomRuins/SpaceRuins/skyrat/vaulttango.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/vaulttango.dmm
@@ -157,7 +157,7 @@
 	dir = 1
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/ruin/space/has_grav/vaulttango)
 "do" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2436,7 +2436,7 @@ PK
 PK
 PK
 PK
-nK
+pQ
 Su
 ai
 ai
@@ -2568,7 +2568,7 @@ PK
 PK
 PK
 PK
-nK
+pQ
 Su
 ai
 nm
@@ -3140,7 +3140,7 @@ PK
 PK
 PK
 PK
-nK
+pQ
 Su
 ai
 nn
@@ -3272,7 +3272,7 @@ PK
 PK
 PK
 PK
-nK
+pQ
 Su
 ai
 ai


### PR DESCRIPTION
## About The Pull Request

just a few balancing + map fixes.

## How This Contributes To The Skyrat Roleplay Experience

balance and QOL. (for me)

## Changelog
:cl:
balance: shuttle 8532's syndicate modsuit is now locked in the bridge, and an additional .38 speedloader is available.
fix: ARBORLINK vault's lattices now fully enter the exterior grilles.
/:cl: