### PR TITLE
[MODULAR] Adds a temperature gunkit orderable from the goodies tab

### DIFF
--- a/modular_skyrat/modules/cargo/code/goodies.dm
+++ b/modular_skyrat/modules/cargo/code/goodies.dm
@@ -92,6 +92,13 @@
 	contains = list(/obj/item/gun_maintenance_supplies,
 					/obj/item/gun_maintenance_supplies)
 
+/datum/supply_pack/goody/temp_single
+	name = "Temperature Gun Kit Single-Pack"
+	desc = "Contains a gunkit for a temperature gun, usable on an Allstar SC-2 Laser Carbine to convert it into firing temperature-affecting shots instead of lasers."
+	cost = PAYCHECK_MEDIUM * 2
+	access_view = ACCESS_ARMORY
+	contains = list(/obj/item/weaponcrafting/gunkit/temperature)
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Carpet Packs ////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can now buy a temperature gunkit from cargo for 560 credits (on-par with the hellfire gunkit in price), like other gunkits it does require a laser rifle as a sacrifice to make a temperature gun.

## How This Contributes To The Skyrat Roleplay Experience
The temperature gun's not great without synergizing with other weaponry (or on lizards), so we may as well give more options to the goodies section while maybe giving an underused gun more time to shine.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added Temperature gunkit to the goodies tab in cargo for 560 credits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
