### PR TITLE
[PR PR][MODULAR] Fixes to make 11853 work

### DIFF
--- a/modular_skyrat/modules/aesthetics/airlock/code/airlock.dm
+++ b/modular_skyrat/modules/aesthetics/airlock/code/airlock.dm
@@ -150,7 +150,7 @@
 				. += get_airlock_overlay("sparks_open", overlays_file, em_block = FALSE)
 
 	if(note)
-		. += get_airlock_overlay(note_type(), note_overlay_file, em_block = TRUE)
+		. += get_airlock_overlay(get_note_state(frame_state), note_overlay_file, em_block = TRUE)
 
 	if(frame_state == AIRLOCK_FRAME_CLOSED && seal)
 		. += get_airlock_overlay("sealed", overlays_file, em_block = TRUE)
@@ -186,7 +186,6 @@
 /obj/machinery/door/airlock
 	icon = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/station/public.dmi'
 	overlays_file = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/station/overlays.dmi'
-	note_overlay_file = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/station/overlays.dmi'
 
 /obj/machinery/door/airlock/command
 	icon = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/station/command.dmi'
@@ -342,7 +341,6 @@
 /obj/machinery/door/airlock/external
 	icon = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/external/external.dmi'
 	overlays_file = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/external/overlays.dmi'
-	note_overlay_file = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/external/overlays.dmi'
 
 //CENTCOMM
 /obj/machinery/door/airlock/centcom
@@ -362,12 +360,10 @@
 /obj/machinery/door/airlock/hatch
 	icon = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/hatch/centcom.dmi'
 	overlays_file = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/hatch/overlays.dmi'
-	note_overlay_file = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/hatch/overlays.dmi'
 
 /obj/machinery/door/airlock/maintenance_hatch
 	icon = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/hatch/maintenance.dmi'
 	overlays_file = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/hatch/overlays.dmi'
-	note_overlay_file = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/hatch/overlays.dmi'
 
 //HIGH SEC
 /obj/machinery/door/airlock/highsecurity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes to #11853 so it works with our codebase.

Overriding `note_overlay_file` in every case on our codebase appeared to be unnecessary, and those files were missing major icon_states anyway. Removing those differences from upstream allows me to not have to update our dmi's.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

See original PR.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
