### PR TITLE
[NON-MODULAR][QoL] Sterile Masks no longer hide your identity.

### DIFF
--- a/code/modules/clothing/masks/surgical.dm
+++ b/code/modules/clothing/masks/surgical.dm
@@ -4,9 +4,9 @@
 	icon_state = "sterile"
 	inhand_icon_state = "sterile"
 	w_class = WEIGHT_CLASS_TINY
-	flags_inv = HIDEFACE|HIDESNOUT
+	flags_inv =  HIDESNOUT //SKYRAT EDIT - ORIGINAL HIDEFACE|HIDESNOUT
 	flags_cover = MASKCOVERSMOUTH
-	visor_flags_inv = HIDEFACE|HIDESNOUT
+	visor_flags_inv = HIDESNOUT //SKYRAT EDIT - ORIGINAL HIDEFACE|HIDESNOUT
 	visor_flags_cover = MASKCOVERSMOUTH
 	permeability_coefficient = 0.01
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 25, FIRE = 0, ACID = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes it so that the sterile masks don't hide your identity while worn. This has no appearance on how they look.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
![image](https://user-images.githubusercontent.com/68373373/156899032-c585f75e-9f12-4947-b5b8-5fd9ff5b22f5.png)
I am making this PR downstream here first, because it helps solve what is a Skyrat RP issue.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: sterile masks no longer hide your face.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
