### PR TITLE
[MODULAR] Traitor/OPFOR borer eggs now indicate that they were created in such a way to ghosts

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer_egg.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer_egg.dm
@@ -80,5 +80,11 @@
 			to yourself. The egg is extremely fragile, do not crush it in your hand nor throw it. \
 			The egg is required to sit out in the open in order to hatch. (Cannot be hidden in closets, etc.)"
 	progression_minimum = 20 MINUTES
-	item = /obj/effect/mob_spawn/ghost_role/borer_egg
+	item = /obj/effect/mob_spawn/ghost_role/borer_egg/traitor
 	cost = 20
+
+/obj/effect/mob_spawn/ghost_role/borer_egg/traitor
+	prompt_name = "cortical borer (traitor spawned)"
+
+/obj/effect/mob_spawn/ghost_role/borer_egg/opfor
+	prompt_name = "cortical borer (OPFOR spawned)"

--- a/modular_skyrat/modules/opposing_force/code/equipment/utility.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/utility.dm
@@ -103,7 +103,7 @@
 	admin_note = "Allows a ghost to take control of a Cortical Borer."
 
 /datum/opposing_force_equipment/gear/borer_egg/on_issue(mob/living/target)
-	new /obj/effect/mob_spawn/ghost_role/borer_egg(get_turf(src))
+	new /obj/effect/mob_spawn/ghost_role/borer_egg/opfor(get_turf(src))
 
 /datum/opposing_force_equipment/gear/ventcrawl_book
 	item_type = /obj/item/book/granter/traitsr/ventcrawl_book


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Appends (traitor spawned) or (OPFOR spawned) to the end of the ghost popup for their respective eggs.

## How This Contributes To The Skyrat Roleplay Experience
Hey, if you're going to write an OPFOR for it / spend 20 TC on an egg, may as well have a higher chance of getting a ghost.
Jake's approval:
![image](https://user-images.githubusercontent.com/41448081/156907983-9cf9cdfb-42bf-4d6f-aa87-1b9750d42e71.png)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Borer egg ghost popup now shows the source of the borer egg
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
