### PR TITLE
Organic Interface Cleanup 4

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
@@ -127,13 +127,6 @@
 			if(side_double)
 				user.adjustArousal(6)
 				user.adjustPleasure(8)
-			user.visible_message(span_purple("[user] [message]!"))
-			playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang2.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang3.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang4.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang5.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang6.ogg'), 60, TRUE, ignore_walls = FALSE)
 
 		if(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_PRECISE_EYES) //Mouth only. Sorry, perverts. No eye/ear penetration for you today.
 			if(!target.is_mouth_covered())
@@ -144,13 +137,6 @@
 			target.adjustPleasure(1)
 			if(prob(70) && (target.stat != DEAD))
 				target.emote(pick("gasp","moan"))
-			user.visible_message(span_purple("[user] [message]!"))
-			playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang2.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang3.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang4.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang5.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang6.ogg'), 40, TRUE, ignore_walls = FALSE)
 
 
 		else
@@ -162,13 +148,14 @@
 			target.adjustPleasure(5)
 			if(prob(60) && (target.stat != DEAD))
 				target.emote(pick("twitch_s","moan","shiver"))
-			user.visible_message(span_purple("[user] [message]!"))
-			playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang2.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang3.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang4.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang5.ogg',
-								'modular_skyrat/modules/modular_items/lewd_items/sounds/bang6.ogg'), 100, TRUE, ignore_walls = FALSE)
+
+	user.visible_message(span_purple("[user] [message]!"))
+	playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
+						'modular_skyrat/modules/modular_items/lewd_items/sounds/bang2.ogg',
+						'modular_skyrat/modules/modular_items/lewd_items/sounds/bang3.ogg',
+						'modular_skyrat/modules/modular_items/lewd_items/sounds/bang4.ogg',
+						'modular_skyrat/modules/modular_items/lewd_items/sounds/bang5.ogg',
+						'modular_skyrat/modules/modular_items/lewd_items/sounds/bang6.ogg'), 100, TRUE, ignore_walls = FALSE)
 
 ///////////////////////
 ///POLYCHROMIC DILDO///

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/feather.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/feather.dm
@@ -8,63 +8,68 @@
 	righthand_file = 'modular_skyrat/modules/modular_items/lewd_items/icons/mob/lewd_inhands/lewd_inhand_right.dmi'
 	w_class = WEIGHT_CLASS_TINY
 
-/obj/item/tickle_feather/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
+/obj/item/tickle_feather/attack(mob/living/carbon/human/target, mob/living/carbon/human/user)
 	. = ..()
-	if(!istype(M))
+	if(!istype(target))
 		return
 
 	var/message = ""
-
+	var/targetedsomewhere = FALSE
 	switch(user.zone_selected) //to let code know what part of body we gonna tickle
 		if(BODY_ZONE_PRECISE_GROIN)
-			if(!(M.is_bottomless()))
-				to_chat(user, span_danger("[M]'s groin is covered!"))
+			targetedsomewhere = TRUE
+			if(!(target.is_bottomless()))
+				to_chat(user, span_danger("[target]'s groin is covered!"))
 				return
-			message = (user == M) ? pick("tickles [M.p_them()]self with [src]","gently teases [M.p_their()] belly with [src]") : pick("teases [M]'s belly with [src]", "uses [src] to tickle [M]'s belly","tickles [M] with [src]")
-			if(M.stat == DEAD)
+			message = (user == target) ? pick("tickles [target.p_them()]self with [src]","gently teases [target.p_their()] belly with [src]") : pick("teases [target]'s belly with [src]", "uses [src] to tickle [target]'s belly","tickles [target] with [src]")
+			if(target.stat == DEAD)
 				return
 			if(prob(70))
-				M.emote(pick("laugh","giggle","twitch","twitch_s"))
+				target.emote(pick("laugh","giggle","twitch","twitch_s"))
 
 		if(BODY_ZONE_CHEST)
-			var/obj/item/organ/genital/badonkers = M.getorganslot(ORGAN_SLOT_BREASTS)
-			if(!(M.is_topless() || badonkers.visibility_preference == GENITAL_ALWAYS_SHOW))
-				to_chat(user, span_danger("[M]'s chest is covered!"))
+			targetedsomewhere = TRUE
+			var/obj/item/organ/genital/badonkers = target.getorganslot(ORGAN_SLOT_BREASTS)
+			if(!(target.is_topless() || badonkers.visibility_preference == GENITAL_ALWAYS_SHOW))
+				to_chat(user, span_danger("[target]'s chest is covered!"))
 				return
-			message = (user == M) ? pick("tickles [M.p_them()]self with [src]","gently teases [M.p_their()] own nipples with [src]") : pick("teases [M]'s nipples with [src]", "uses [src] to tickle [M]'s left nipple", "uses [src] to tickle [M]'s right nipple")
-			if(M.stat == DEAD)
+			message = (user == target) ? pick("tickles [target.p_them()]self with [src]","gently teases [target.p_their()] own nipples with [src]") : pick("teases [target]'s nipples with [src]", "uses [src] to tickle [target]'s left nipple", "uses [src] to tickle [target]'s right nipple")
+			if(target.stat == DEAD)
 				return
 			if(prob(70))
-				M.emote(pick("laugh","giggle","twitch","twitch_s","moan",))
+				target.emote(pick("laugh","giggle","twitch","twitch_s","moan",))
 
 		if(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
-			if(!M.has_feet())
-				to_chat(user, span_danger("[M] doesn't have any feet!"))
+			targetedsomewhere = TRUE
+			if(!target.has_feet())
+				to_chat(user, span_danger("[target] doesn't have any feet!"))
 				return
 
-			if(!M.is_barefoot())
-				to_chat(user, span_danger("[M]'s feet are covered!"))
+			if(!target.is_barefoot())
+				to_chat(user, span_danger("[target]'s feet are covered!"))
 				return
-			message = (user == M) ? pick("tickles [M.p_them()]self with [src]","gently teases [M.p_their()] own feet with [src]") : pick("teases [M]'s feet with [src]", "uses [src] to tickle [M]'s [user.zone_selected == BODY_ZONE_L_LEG ? "left" : "right"] foot", "uses [src] to tickle [M]'s toes")
-			if(M.stat == DEAD)
+			message = (user == target) ? pick("tickles [target.p_them()]self with [src]","gently teases [target.p_their()] own feet with [src]") : pick("teases [target]'s feet with [src]", "uses [src] to tickle [target]'s [user.zone_selected == BODY_ZONE_L_LEG ? "left" : "right"] foot", "uses [src] to tickle [target]'s toes")
+			if(target.stat == DEAD)
 				return
 			if(prob(70))
-				M.emote(pick("laugh","giggle","twitch","twitch_s","moan",))
+				target.emote(pick("laugh","giggle","twitch","twitch_s","moan",))
 
 		if(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
-			if(!M.is_topless())
-				to_chat(user, span_danger("[M]'s armpits are covered!"))
+			targetedsomewhere = TRUE
+			if(!target.is_topless())
+				to_chat(user, span_danger("[target]'s armpits are covered!"))
 				return
-			message = (user == M) ? pick("tickles [M.p_them()]self with [src]","gently teases [M.p_their()] own armpit with [src]") : pick("teases [M]'s right armpit with [src]", "uses [src] to tickle [M]'s [user.zone_selected == BODY_ZONE_L_ARM ? "left" : "right"] armpit", "uses [src] to tickle [M]'s underarm")
-			if(M.stat == DEAD)
+			message = (user == target) ? pick("tickles [target.p_them()]self with [src]","gently teases [target.p_their()] own armpit with [src]") : pick("teases [target]'s right armpit with [src]", "uses [src] to tickle [target]'s [user.zone_selected == BODY_ZONE_L_ARM ? "left" : "right"] armpit", "uses [src] to tickle [target]'s underarm")
+			if(target.stat == DEAD)
 				return
 			if(prob(70))
-				M.emote(pick("laugh","giggle","twitch","twitch_s","moan",))
-
-	M.do_jitter_animation()
-	M.adjustStaminaLoss(4)
-	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "tickled", /datum/mood_event/tickled)
-	M.adjustArousal(3)
+				target.emote(pick("laugh","giggle","twitch","twitch_s","moan",))
+	if(!targetedsomewhere)
+		return
+	target.do_jitter_animation()
+	target.adjustStaminaLoss(4)
+	SEND_SIGNAL(target, COMSIG_ADD_MOOD_EVENT, "tickled", /datum/mood_event/tickled)
+	target.adjustArousal(3)
 	user.visible_message(span_purple("[user] [message]!"))
 	playsound(loc, pick('sound/items/handling/cloth_drop.ogg', 					//i duplicate this part of code because im useless shitcoder that can't make it work properly without tons of repeating code blocks
             			'sound/items/handling/cloth_pickup.ogg',				//if you can make it better - go ahead, modify it, please.

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/kinky_shocker.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/kinky_shocker.dm
@@ -112,6 +112,7 @@
 		to_chat(user, span_danger("[src] must be enabled before use!"))
 		return
 	var/message = ""
+	var/targetedsomewhere = FALSE
 	if(!target.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 		to_chat(user, span_danger("[target] doesn't want you to do that."))
 		return
@@ -119,6 +120,7 @@
 	playsound(loc, 'sound/weapons/taserhit.ogg', 70, 1, -1)
 	switch(user.zone_selected) //to let code know what part of body we gonna tickle
 		if(BODY_ZONE_PRECISE_GROIN)
+			targetedsomewhere = TRUE
 			var/obj/item/organ/genital/penis = target.getorganslot(ORGAN_SLOT_PENIS)
 			var/obj/item/organ/genital/vagina = target.getorganslot(ORGAN_SLOT_VAGINA)
 			if(vagina && penis)
@@ -178,6 +180,7 @@
 					return
 
 		if(BODY_ZONE_CHEST)
+			targetedsomewhere = TRUE
 			var/obj/item/organ/genital/breasts = target.getorganslot(ORGAN_SLOT_BREASTS)
 			if(breasts)
 				if(breasts.visibility_preference == GENITAL_ALWAYS_SHOW || target.is_topless())
@@ -200,6 +203,7 @@
 					return
 
 		if(BODY_ZONE_R_ARM)
+			targetedsomewhere = TRUE
 			if(target.has_arms())
 				if(target.is_hands_uncovered())
 					message = (user == target) ? pick("leans [src] against [target.p_their()] right arm, letting it shock it.",
@@ -214,6 +218,7 @@
 				return
 
 		if(BODY_ZONE_L_ARM)
+			targetedsomewhere = TRUE
 			if(target.has_arms())
 				if(target.is_hands_uncovered())
 					message = (user == target) ? pick("leans [src] against [target.p_their()] left arm, letting it shock it.",
@@ -228,6 +233,7 @@
 				return
 
 		if(BODY_ZONE_HEAD)
+			targetedsomewhere = TRUE
 			if(target.is_head_uncovered())
 				message = (user == target) ? pick("leans [src] against [target.p_their()] head, letting it shock it. Ouch! Why would they do that?!",
 											"shocks [target.p_their()] head with [src]") : pick("uses [src] to shock [target]'s head",
@@ -238,6 +244,7 @@
 				return
 
 		if(BODY_ZONE_L_LEG)
+			targetedsomewhere = TRUE
 			if(target.has_feet())
 				if(target.is_barefoot())
 					message = (user == target) ? pick("leans [src] against [target.p_their()] left leg, letting it shock it.",
@@ -252,6 +259,7 @@
 				return
 
 		if(BODY_ZONE_R_LEG)
+			targetedsomewhere = TRUE
 			if(target.has_feet())
 				if(target.is_barefoot())
 					message = (user == target) ? pick("leans [src] against [target.p_their()] right leg, letting it shock it.",
@@ -265,6 +273,8 @@
 			else
 				to_chat(user, span_danger("[target] doesn't have any legs!"))
 				return
+	if(!targetedsomewhere)
+		return
 	user.visible_message(span_purple("[user] [message]!"))
 	playsound(loc,'sound/weapons/taserhit.ogg')
 	if(target.stat == DEAD)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/leather_whip.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/leather_whip.dm
@@ -161,12 +161,14 @@
 		return
 
 	var/message = ""
+	var/targetedsomewhere = FALSE
 //and there is code for successful check, so we are whipping someone
 	if(!target.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 		to_chat(user, span_danger("[target] doesn't want you to do that."))
 		return
 	switch(user.zone_selected) //to let code know what part of body we gonna whip
 		if(BODY_ZONE_L_LEG)
+			targetedsomewhere = TRUE
 			if(!target.has_feet())
 				to_chat(user, span_danger("[target] is missing their left leg!"))
 				return
@@ -192,6 +194,7 @@
 				playsound(loc, 'sound/weapons/whip.ogg', 60)
 
 		if(BODY_ZONE_R_LEG)
+			targetedsomewhere = TRUE
 			if(!target.has_feet())
 				to_chat(user, span_danger("[target] is missing their right leg!"))
 				return
@@ -217,6 +220,7 @@
 				playsound(loc, 'sound/weapons/whip.ogg', 60)
 
 		if(BODY_ZONE_HEAD)
+			targetedsomewhere = TRUE
 			message = (user == target) ? pick("wraps [src] around [target.p_their()] neck, choking [target.p_them()]self", "chokes [target.p_them()]self with [src]") : pick("chokes [target] with [src]", "twines [src] around [target]'s neck!")
 			if(prob(70) && (target.stat != DEAD))
 				target.emote(pick("gasp","choke", "moan"))
@@ -225,6 +229,7 @@
 			playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 80)
 
 		if(BODY_ZONE_PRECISE_GROIN)
+			targetedsomewhere = TRUE
 			if(!target.is_bottomless())
 				to_chat(user, span_danger("[target]'s butt is covered!"))
 				return
@@ -278,6 +283,8 @@
 				target.adjustPain(4)
 				target.adjustArousal(5)
 				playsound(loc, 'sound/weapons/whip.ogg', 60)
+	if(!targetedsomewhere)
+		return
 	user.visible_message(span_purple("[user] [message]!"))
 
 //toggle low pain mode. Because sometimes screaming isn't good

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/serviette.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/serviette.dm
@@ -41,9 +41,9 @@
 			user.mind?.adjust_experience(/datum/skill/cleaning, max(round(cleanies.beauty/CLEAN_SKILL_BEAUTY_ADJUSTMENT),0)) //again, intentional that this does NOT round but mops do.
 			qdel(target)
 			qdel(src)
-			var/obj/item/serviette_used/W = new /obj/item/serviette_used
+			var/obj/item/serviette_used/used_serviette = new /obj/item/serviette_used
 			remove_item_from_storage(user)
-			user.put_in_hands(W)
+			user.put_in_hands(used_serviette)
 
 	else if(istype(target, /obj/structure/window))
 		user.visible_message(span_notice("[user] begins to clean \the [target.name] with [src]..."), span_notice("You begin to clean \the [target.name] with [src]..."))
@@ -53,9 +53,9 @@
 			target.set_opacity(initial(target.opacity))
 			user.mind?.adjust_experience(/datum/skill/cleaning, CLEAN_SKILL_GENERIC_WASH_XP)
 			qdel(src)
-			var/obj/item/serviette_used/W = new /obj/item/serviette_used
+			var/obj/item/serviette_used/used_serviette = new /obj/item/serviette_used
 			remove_item_from_storage(user)
-			user.put_in_hands(W)
+			user.put_in_hands(used_serviette)
 
 	else
 		user.visible_message(span_notice("[user] begins to clean \the [target.name] with [src]..."), span_notice("You begin to clean \the [target.name] with [src]..."))
@@ -68,9 +68,9 @@
 			target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 			user.mind?.adjust_experience(/datum/skill/cleaning, CLEAN_SKILL_GENERIC_WASH_XP)
 			qdel(src)
-			var/obj/item/serviette_used/W = new /obj/item/serviette_used
+			var/obj/item/serviette_used/used_serviette = new /obj/item/serviette_used
 			remove_item_from_storage(user)
-			user.put_in_hands(W)
+			user.put_in_hands(used_serviette)
 
 ///////////////////////////
 //CODE FOR SERVIETTE PACK//
@@ -98,8 +98,8 @@
 	if(!servleft)
 		to_chat(user, span_notice("You take a serviette from [src]."))
 		servleft--
-		var/obj/item/serviette/W = new /obj/item/serviette
-		user.put_in_hands(W)
+		var/obj/item/serviette/used_serviette = new /obj/item/serviette
+		user.put_in_hands(used_serviette)
 		update_icon()
 		update_icon_state()
 	else

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/shibari_stand.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/shibari_stand.dm
@@ -3,7 +3,6 @@
 	desc = "A stand for buckling people with ropes."
 	icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_structures/shibari_stand.dmi'
 	icon_state = "shibari_stand"
-	max_buckled_mobs = 1
 	max_integrity = 75
 	layer = 4
 	item_chair = null
@@ -65,8 +64,8 @@
 				span_hear("You hear loose ropes."))
 		add_fingerprint(user)
 		if(isliving(buckled.pulledby))
-			var/mob/living/L = buckled.pulledby
-			L.set_pull_offsets(buckled, L.grab_state)
+			var/mob/living/living_mob = buckled.pulledby
+			living_mob.set_pull_offsets(buckled, living_mob.grab_state)
 	unbuckle_mob(buckled_mob)
 	return buckled
 
@@ -188,7 +187,6 @@
 	name = "shibari stand construction kit"
 	desc = "Construction requires a wrench."
 	icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_structures/bdsm_furniture.dmi'
-	throwforce = 0
 	icon_state = "shibari_kit"
 	w_class = WEIGHT_CLASS_HUGE
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/torture_candle.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/torture_candle.dm
@@ -133,6 +133,7 @@
 		return
 
 	var/message = ""
+	var/targeted_somewhere
 	if(!lit)
 		to_chat(user, span_danger("[src] needs to be lit to produce wax!"))
 		return
@@ -141,10 +142,9 @@
 		return
 	switch(user.zone_selected) //to let code know what part of body we gonna wax
 		if(BODY_ZONE_PRECISE_GROIN)
+			targeted_somewhere = TRUE
 			var/obj/item/organ/genital/penis = attacked.getorganslot(ORGAN_SLOT_PENIS)
 			var/obj/item/organ/genital/vagina = attacked.getorganslot(ORGAN_SLOT_VAGINA)
-			if(attacked.gender != MALE)
-				return
 			if((vagina && penis) && (attacked.is_bottomless() || vagina.visibility_preference == GENITAL_ALWAYS_SHOW && penis.visibility_preference == GENITAL_ALWAYS_SHOW))
 				message = (user == attacked) ? pick("drips some wax on [attacked.p_their()] genitals, moaning in pleasure",
 											"drips some wax on [attacked.p_them()]self, moaning in pleasure as it reaches [attacked.p_their()] genitals") : pick(
@@ -175,6 +175,7 @@
 				return
 
 		if(BODY_ZONE_CHEST)
+			targeted_somewhere = TRUE
 			var/obj/item/organ/genital/breasts = attacked.getorganslot(ORGAN_SLOT_BREASTS)
 			if(attacked.is_topless() || breasts.visibility_preference == GENITAL_ALWAYS_SHOW)
 				message = (user == attacked) ? pick("drips some wax on [attacked.p_their()] [breasts ? "breasts" : "nipples"], releasing all [attacked.p_their()] lustness","drips some wax right on [attacked.p_their()] [breasts ? "tits" : "chest"], making [attacked.p_their()] feel faint.") : pick("pours the wax that is slowly dripping from [src] onto [attacked]'s [breasts ? "breasts" : "nipples"], [attacked.p_they()] shows pure enjoyment.","tilts the candle. Right in the moment when wax drips on [attacked]'s [breasts ? "breasts" : "nipples"], [attacked.p_they()] shivers","tilts the candle. Just when hot drops of wax fell on [attacked]'s [breasts ? "breasts" : "nipples"], [attacked.p_they()] quietly moans in pleasure")
@@ -184,7 +185,8 @@
 				to_chat(user, span_danger("Looks like [attacked]'s chest is covered!"))
 				return
 
-
+	if(!targeted_somewhere)
+		return
 	if(attacked.stat != DEAD)
 		attacked.do_jitter_animation()
 		if(prob(50))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/torture_candle.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/torture_candle.dm
@@ -1,4 +1,6 @@
-#define CANDLE_LUMINOSITY	2
+#define CANDLE_LUMINOSITY 2
+#define PAIN_DEFAULT 9
+
 /obj/item/bdsm_candle
 	name = "soy candle"
 	desc = "A candle with low melting temperature."
@@ -10,14 +12,20 @@
 	w_class = WEIGHT_CLASS_TINY
 	light_color = LIGHT_COLOR_FIRE
 	heat = 600
+	/// Current color of the candle, can be changed and affects sprite
 	var/current_color = "pink"
+	/// If the color has been changed before
 	var/color_changed = FALSE
+	/// If the candle is on
 	var/lit = FALSE
+	/// If the candle should spawn lit
 	var/start_lit = FALSE
+	/// Static list used for displaying colors in the radial selection menu
 	var/static/list/candle_designs
+	/// Static list of possible colors for the candle
 	var/static/list/candlelights = list(
                                 "pink" = LIGHT_COLOR_FIRE,
-                                "teal" = COLOR_CYAN)//list of colors to choose
+                                "teal" = COLOR_CYAN)
 
 //to change color of candle
 //create radial menu
@@ -51,8 +59,8 @@
 	icon_state = "[initial(icon_state)]_[current_color]_[lit ? "lit" : "off"]"
 	inhand_icon_state = "[initial(icon_state)]_[current_color]_[lit ? "lit" : "off"]"
 
-/obj/item/bdsm_candle/attackby(obj/item/W, mob/user, params)
-	var/msg = W.ignition_effect(src, user)
+/obj/item/bdsm_candle/attackby(obj/item/object, mob/user, params)
+	var/msg = object.ignition_effect(src, user)
 	update_brightness()
 	if(msg)
 		light(msg)
@@ -69,14 +77,15 @@
 	return lit * heat
 
 /obj/item/bdsm_candle/proc/light(show_message)
-	if(!lit)
-		lit = TRUE
-		if(show_message)
-			usr.visible_message(show_message)
-		set_light(CANDLE_LUMINOSITY)
-		START_PROCESSING(SSobj, src)
-		update_icon()
-		update_brightness()
+	if(lit)
+		return
+	lit = TRUE
+	if(show_message)
+		usr.visible_message(show_message)
+	set_light(CANDLE_LUMINOSITY)
+	START_PROCESSING(SSobj, src)
+	update_icon()
+	update_brightness()
 
 /obj/item/bdsm_candle/proc/put_out_candle()
 	if(!lit)
@@ -96,227 +105,93 @@
 	open_flame()
 	update_brightness()
 
-/obj/item/bdsm_candle/AltClick(mob/user, obj/item/I)
+/obj/item/bdsm_candle/AltClick(mob/user, obj/item/item)
 	. = ..()
-	if(lit == FALSE)
-		if(color_changed == FALSE)
-			var/choice = show_radial_menu(user,src, candle_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
-			if(!choice)
-				return FALSE
-			current_color = choice
-			light_color = candlelights[choice]
-			update_icon()
-			update_brightness()
-			color_changed = TRUE
-	if(lit == TRUE)
-		if(put_out_candle())
-			user.visible_message(span_notice("[user] snuffs [src]."))
+	if(!lit)
+		if(color_changed)
+			return
+		var/choice = show_radial_menu(user,src, candle_designs, custom_check = CALLBACK(src, .proc/check_menu, user, item), radius = 36, require_near = TRUE)
+		if(!choice)
+			return FALSE
+		current_color = choice
+		light_color = candlelights[choice]
+		update_icon()
+		update_brightness()
+		color_changed = TRUE
+	else
+		if(!put_out_candle())
+			return
+		user.visible_message(span_notice("[user] snuffs [src]."))
 
 ///////////////////////////////////////////////////
 //here goes things that required for wax dropping//
 ///////////////////////////////////////////////////
 
-/obj/item/bdsm_candle/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
+/obj/item/bdsm_candle/attack(mob/living/carbon/human/attacked, mob/living/carbon/human/user)
 	. = ..()
-	if(!istype(M, /mob/living/carbon/human))
+	if(!istype(attacked))
 		return
 
 	var/message = ""
-	if(lit == TRUE)
-		if(M.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
-			switch(user.zone_selected) //to let code know what part of body we gonna wax
-				if(BODY_ZONE_PRECISE_GROIN)
-					var/obj/item/organ/genital/penis = M.getorganslot(ORGAN_SLOT_PENIS)
-					var/obj/item/organ/genital/vagina = M.getorganslot(ORGAN_SLOT_VAGINA)
-					if(M.gender == MALE)
-						if(vagina && penis)
-							if(M.is_bottomless() || vagina.visibility_preference == GENITAL_ALWAYS_SHOW && penis.visibility_preference == GENITAL_ALWAYS_SHOW)
-								message = (user == M) ? pick("drips some wax on [M.p_their()] genitals, moaning in pleasure",
-															"drips some wax on [M.p_them()]self, moaning in pleasure as it reaches [M.p_their()] genitals") : pick(
-															"drips wax right on [M]'s genitalia. It slightly itches",
-															"drips hot wax from the [src] onto [M]'s genitalia, causing [M.p_them()] to shiver",
-															"tilts [src], dripping wax right onto [M]'s genitals, causing [M.p_them()] to moan",
-															"drips some wax onto [M]'s genitals, making [M.p_them()] moan in pleasure")
-								M.adjustPain(9)
-								if(M.stat != DEAD)
-									M.do_jitter_animation()
-									if(prob(50))
-										M.emote(pick("twitch_s" ,"gasp","shiver"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
-													'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)
-
-							else if(M.is_bottomless() || penis.visibility_preference == GENITAL_ALWAYS_SHOW)
-								message = (user == M) ? pick("drips some wax on [M.p_their()] penis, causing [M.p_them()] to moan in pleasure",
-															"drips some wax on themselves, letting it reach his penis. he moans in pleasure.") : pick(
-															"drips wax right on [M]'s penis. It slightly itches.",
-															"drips hot wax from the [src] on the [M]'s penis, he slightly shivers.",
-															"tilts the candle. Drops of wax, dripping right from [src] right on the [M]'s penis, made him moan.")
-								M.adjustPain(9)
-								if(M.stat != DEAD)
-									M.do_jitter_animation()
-									if(prob(50))
-										M.emote(pick("twitch_s" ,"gasp","shiver"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
-													'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)
-
-							else if(M.is_bottomless() || vagina.visibility_preference == GENITAL_ALWAYS_SHOW)
-								message = (user == M) ? pick("drips some wax on themselves, letting it reach his vagina. He moans in pleasure.","drips some wax on the [M]'s pussy, he moans in pleasure") : pick("drips some wax on the [M]'s vagina, he moans in pleasure","tilts the candle. Wax slowly goes down, reaching the [M]'s vagina.","tilts the candle. Drops of wax, dripping right from [src] right on the [M]'s pussy, made him moan.")
-								M.adjustPain(9)
-								if(M.stat != DEAD)
-									M.do_jitter_animation()
-									if(prob(50))
-										M.emote(pick("twitch_s" ,"gasp","shiver"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
-													'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)
-
-							else
-								to_chat(user, span_danger("Looks like [M]'s groin is covered!"))
-								return
-
-						else if(penis)
-							if(M.is_bottomless() || penis.visibility_preference == GENITAL_ALWAYS_SHOW)
-								message = (user == M) ? pick("drips some wax on the their penis, he moans in pleasure","drips some wax on themselves, letting it reach his penis. he moans in pleasure.") : pick("drips wax right on [M]'s penis. It slightly itches.","drips hot wax from the [src] on the [M]'s penis, he slightly shivers.","tilts the candle. Drops of wax, dripping right from [src] right on the [M]'s penis, made him moan.")
-								M.adjustPain(9)
-								if(M.stat != DEAD)
-									M.do_jitter_animation()
-									if(prob(50))
-										M.emote(pick("twitch_s" ,"gasp","shiver"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
-													'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)
-							else
-								to_chat(user, span_danger("Looks like [M]'s groin is covered!"))
-								return
-
-						else if(vagina)
-							if(M.is_bottomless() || vagina.visibility_preference == GENITAL_ALWAYS_SHOW)
-								message = (user == M) ? pick("drips some wax on themselves, letting it reach his vagina. He moans in pleasure.","drips some wax on the [M]'s pussy, he moans in pleasure") : pick("drips some wax on the [M]'s vagina, he moans in pleasure","tilts the candle. Wax slowly goes down, reaching the [M]'s vagina.","tilts the candle. Drops of wax, dripping right from [src] right on the [M]'s pussy, made him moan.")
-								M.adjustPain(9)
-								if(M.stat != DEAD)
-									M.do_jitter_animation()
-									if(prob(50))
-										M.emote(pick("twitch_s" ,"gasp","shiver"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
-													'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)
-							else
-								to_chat(user, span_danger("Looks like [M]'s groin is covered!"))
-								return
-
-						else
-							if(M.is_bottomless())
-								message = (user == M) ? pick("drips some wax on themselves, letting it reach his belly. He moans in pleasure.","drips some wax on the [M]'s tummy, he moans in pleasure") : pick("drips some wax on the [M]'s belly, he moans in pleasure","tilts the candle. Wax slowly goes down, reaching the [M]'s tummy.","tilts the candle. Drops of wax, dripping right from [src] right on the [M]'s groin, made him moan.")
-								M.adjustPain(9)
-								if(M.stat != DEAD)
-									M.do_jitter_animation()
-									if(prob(50))
-										M.emote(pick("twitch_s" ,"gasp","shiver"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
-													'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)
-							else
-								to_chat(user, span_danger("Looks like [M]'s groin is covered!"))
-								return
-
-				if(BODY_ZONE_CHEST)
-					var/obj/item/organ/genital/breasts = M.getorganslot(ORGAN_SLOT_BREASTS)
-					if(M.gender == MALE)
-						if(breasts)
-							if(M.is_topless() || breasts.visibility_preference == GENITAL_ALWAYS_SHOW)
-								message = (user == M) ? pick("drips some wax on his breasts, releasing all his lustness","drips some wax right on his tits, made him become faint.") : pick("pours the wax that is slowly dripping from the [src] on the [M]'s breasts, he shows pure enjoyment.","tilts the candle. Right in the moment when wax drips on [M]'s breasts, he shivers","tilts the candle. Just when hot drops of wax fell on the [M]'s breasts, he quietly moans in pleasure")
-								M.adjustPain(6)
-								if(M.stat != DEAD)
-									M.do_jitter_animation()
-									if(prob(50))
-										M.emote(pick("twitch_s" ,"gasp","shiver"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
-													'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)
-							else
-								to_chat(user, span_danger("Looks like [M]'s chest is covered!"))
-								return
-						else
-							if(M.is_topless())
-								message = (user == M) ? pick("drips some wax on his nipples, releasing all his lustness","drips some wax right on his chest, made him become faint.") : pick("drips wax from [src], that falls right on the [M]'s chest, he all shivers in pleasure.","tilts the candle. Right in the moment when wax drips on [M]'s nipples, he shivers","tilts the candle. Just when hot drops of wax fell on the [M]'s chest, he quietly moans in pleasure")
-								M.adjustPain(4)
-								if(M.stat != DEAD)
-									M.do_jitter_animation()
-									if(prob(50))
-										M.emote(pick("twitch_s" ,"gasp","shiver"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
-													'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)
-							else
-								to_chat(user, span_danger("Looks like [M]'s chest is covered!"))
-								return
-
-					if(M.gender == FEMALE)
-						if(breasts)
-							if(M.is_topless() || breasts.visibility_preference == GENITAL_ALWAYS_SHOW)
-								message = (user == M) ? pick("drips some wax on her breasts, releasing all her lustness","drips some wax right on her tits, made her become faint.") : pick("pours the wax that is slowly dripping from the [src] on the [M]'s breasts, she shows pure enjoyment.","tilts the candle. Right in the moment when wax drips on [M]'s breasts, she shivers","tilts the candle. Just when hot drops of wax fell on the [M]'s breasts, she quietly moans in pleasure")
-								M.adjustPain(6)
-								if(M.stat != DEAD)
-									M.do_jitter_animation()
-									if(prob(50))
-										M.emote(pick("twitch_s" ,"gasp","shiver"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
-													'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)
-							else
-								to_chat(user, span_danger("Looks like [M]'s chest is covered!"))
-								return
-						else
-							if(M.is_topless())
-								message = (user == M) ? pick("drips some wax on her nipples, releasing all her lustness","drips some wax right on her chest, made her become faint.") : pick("drips wax from [src], that falls right on the [M]'s chest, she all shivers in pleasure.","tilts the candle. Right in the moment when wax drips on [M]'s nipples, she shivers", "tilts the candle. Just when hot drops of wax fell on the [M]'s chest, she quietly moans in pleasure")
-								M.adjustPain(4)
-								if(M.stat != DEAD)
-									M.do_jitter_animation()
-									if(prob(50))
-										M.emote(pick("twitch_s" ,"gasp","shiver"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
-													'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)
-							else
-								to_chat(user, span_danger("Looks like [M]'s chest is covered!"))
-								return
-					else
-						if(breasts)
-							if(M.is_topless() || breasts.visibility_preference == GENITAL_ALWAYS_SHOW)
-								message = (user == M) ? pick("drips some wax on it's breasts, releasing all it's lustness","drips some wax right on it's tits, made it become faint.") : pick("pours the wax that is slowly dripping from the [src] on the [M]'s breasts, it shows pure enjoyment.","tilts the candle. Right in the moment when wax drips on [M]'s breasts, it shivers","tilts the candle. Just when hot drops of wax fell on the [M]'s breasts, it quietly moans in pleasure")
-								M.adjustPain(6)
-								if(M.stat != DEAD)
-									M.do_jitter_animation()
-									if(prob(50))
-										M.emote(pick("twitch_s" ,"gasp","shiver"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
-													'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)
-							else
-								to_chat(user, span_danger("Looks like [M]'s chest is covered!"))
-								return
-						else
-							if(M.is_topless())
-								message = (user == M) ? pick("drips some wax on it's nipples, releasing all it's lustness","drips some wax right on it's chest, made it become faint.") : pick("drips wax from [src], that falls right on the [M]'s chest, it all shivers in pleasure.","tilts the candle. Right in the moment when wax drips on [M]'s nipples, it shivers", "tilts the candle. Just when hot drops of wax fell on the [M]'s chest, it quietly moans in pleasure")
-								M.adjustPain(4)
-								if(M.stat != DEAD)
-									M.do_jitter_animation()
-									if(prob(50))
-										M.emote(pick("twitch_s" ,"gasp","shiver"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
-													'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)
-
-							else
-								to_chat(user, span_danger("Looks like [M]'s chest is covered!"))
-								return
-		else
-			to_chat(user, span_danger("Looks like [M] don't want you to do that."))
-			return
-	else
-		to_chat(user, span_danger("Candle should be lit to produce hot liquid wax!"))
+	if(!lit)
+		to_chat(user, span_danger("[src] needs to be lit to produce wax!"))
 		return
+	if(!attacked.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
+		to_chat(user, span_danger("It looks like [attacked] don't want you to do that."))
+		return
+	switch(user.zone_selected) //to let code know what part of body we gonna wax
+		if(BODY_ZONE_PRECISE_GROIN)
+			var/obj/item/organ/genital/penis = attacked.getorganslot(ORGAN_SLOT_PENIS)
+			var/obj/item/organ/genital/vagina = attacked.getorganslot(ORGAN_SLOT_VAGINA)
+			if(attacked.gender != MALE)
+				return
+			if((vagina && penis) && (attacked.is_bottomless() || vagina.visibility_preference == GENITAL_ALWAYS_SHOW && penis.visibility_preference == GENITAL_ALWAYS_SHOW))
+				message = (user == attacked) ? pick("drips some wax on [attacked.p_their()] genitals, moaning in pleasure",
+											"drips some wax on [attacked.p_them()]self, moaning in pleasure as it reaches [attacked.p_their()] genitals") : pick(
+											"drips wax right on [attacked]'s genitalia. It slightly itches",
+											"drips hot wax from the [src] onto [attacked]'s genitalia, causing [attacked.p_them()] to shiver",
+											"tilts [src], dripping wax right onto [attacked]'s genitals, causing [attacked.p_them()] to moan",
+											"drips some wax onto [attacked]'s genitals, making [attacked.p_them()] moan in pleasure")
+				attacked.adjustPain(PAIN_DEFAULT)
+
+			else if(penis && (attacked.is_bottomless() || penis.visibility_preference == GENITAL_ALWAYS_SHOW))
+				message = (user == attacked) ? pick("drips some wax on [attacked.p_their()] penis, causing [attacked.p_them()] to moan in pleasure",
+											"drips some wax on themselves, letting it reach his penis. he moans in pleasure.") : pick(
+											"drips wax right on [attacked]'s penis. It slightly itches.",
+											"drips hot wax from the [src] on the [attacked]'s penis, he slightly shivers.",
+											"tilts the candle. Drops of wax, dripping right from [src] right on the [attacked]'s penis, made him moan.")
+				attacked.adjustPain(PAIN_DEFAULT)
+
+			else if(vagina && (attacked.is_bottomless() || vagina.visibility_preference == GENITAL_ALWAYS_SHOW))
+				message = (user == attacked) ? pick("drips some wax on themselves, letting it reach his vagina. He moans in pleasure.","drips some wax on the [attacked]'s pussy, he moans in pleasure") : pick("drips some wax on the [attacked]'s vagina, he moans in pleasure","tilts the candle. Wax slowly goes down, reaching the [attacked]'s vagina.","tilts the candle. Drops of wax, dripping right from [src] right on the [attacked]'s pussy, made him moan.")
+				attacked.adjustPain(PAIN_DEFAULT)
+
+			else if(attacked.is_bottomless())
+				message = (user == attacked) ? pick("drips some wax on themselves, letting it reach his belly. He moans in pleasure.","drips some wax on the [attacked]'s tummy, he moans in pleasure") : pick("drips some wax on the [attacked]'s belly, he moans in pleasure","tilts the candle. Wax slowly goes down, reaching the [attacked]'s tummy.","tilts the candle. Drops of wax, dripping right from [src] right on the [attacked]'s groin, made him moan.")
+				attacked.adjustPain(PAIN_DEFAULT)
+
+			else
+				to_chat(user, span_danger("Looks like [attacked]'s groin is covered!"))
+				return
+
+		if(BODY_ZONE_CHEST)
+			var/obj/item/organ/genital/breasts = attacked.getorganslot(ORGAN_SLOT_BREASTS)
+			if(attacked.is_topless() || breasts.visibility_preference == GENITAL_ALWAYS_SHOW)
+				message = (user == attacked) ? pick("drips some wax on [attacked.p_their()] [breasts ? "breasts" : "nipples"], releasing all [attacked.p_their()] lustness","drips some wax right on [attacked.p_their()] [breasts ? "tits" : "chest"], making [attacked.p_their()] feel faint.") : pick("pours the wax that is slowly dripping from [src] onto [attacked]'s [breasts ? "breasts" : "nipples"], [attacked.p_they()] shows pure enjoyment.","tilts the candle. Right in the moment when wax drips on [attacked]'s [breasts ? "breasts" : "nipples"], [attacked.p_they()] shivers","tilts the candle. Just when hot drops of wax fell on [attacked]'s [breasts ? "breasts" : "nipples"], [attacked.p_they()] quietly moans in pleasure")
+				attacked.adjustPain(PAIN_DEFAULT * 0.66)
+
+			else
+				to_chat(user, span_danger("Looks like [attacked]'s chest is covered!"))
+				return
+
+
+	if(attacked.stat != DEAD)
+		attacked.do_jitter_animation()
+		if(prob(50))
+			attacked.emote(pick("twitch_s" ,"gasp","shiver"))
+	user.visible_message(span_purple("[user] [message]!"))
+	playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
+						'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)
 
 #undef CANDLE_LUMINOSITY
+#undef PAIN_DEFAULT

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibrator.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibrator.dm
@@ -1,3 +1,6 @@
+#define DEFAULT_AROUSAL_INCREASE 4
+#define DEAFAULT_PLEASURE_INCREASE 2
+
 //This code huge and blocky, but we're working on update for... my god, 4 months. If you can upgrade it - do it, but don't remove or break something, test carefully. This item is insertable.
 /obj/item/clothing/sextoy/vibrator
 	name = "vibrator"
@@ -7,16 +10,24 @@
 	icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_items.dmi'
 	lefthand_file = 'modular_skyrat/modules/modular_items/lewd_items/icons/mob/lewd_inhands/lewd_inhand_left.dmi'
 	righthand_file = 'modular_skyrat/modules/modular_items/lewd_items/icons/mob/lewd_inhands/lewd_inhand_right.dmi'
-	slot_flags = ITEM_SLOT_VAGINA|ITEM_SLOT_ANUS
+	slot_flags = ITEM_SLOT_VAGINA | ITEM_SLOT_ANUS
+	/// If the toy is on or not
 	var/toy_on = FALSE
+	/// Current color of the toy, can be changed and affects sprite
 	var/current_color = "pink"
+	/// If the color has been changed before
 	var/color_changed = FALSE
+	/// Current vibration mode of the toy
 	var/vibration_mode = "off"
+	/// Assoc list of modes and what they'll convert to
 	var/list/modes = list("low" = "medium", "medium" = "hard", "hard" = "off", "off" = "low")
+	/// Looping sound used for the toy's audible bit
 	var/datum/looping_sound/vibrator/low/soundloop1
+	/// Looping sound used for the toy's audible bit
 	var/datum/looping_sound/vibrator/medium/soundloop2
+	/// Looping sound used for the toy's audible bit
 	var/datum/looping_sound/vibrator/high/soundloop3
-	var/mode = "off"
+	/// Static list of designs of the toy, used for the color selection radial menu
 	var/static/list/vibrator_designs
 	w_class = WEIGHT_CLASS_TINY
 	moth_edible = FALSE
@@ -31,19 +42,18 @@
 		"green" = image(icon = src.icon, icon_state = "vibrator_green_low"))
 
 /obj/item/clothing/sextoy/vibrator/AltClick(mob/user, obj/item/object)
-	if(color_changed == FALSE)
-		. = ..()
-		if(.)
-			return
-		var/choice = show_radial_menu(user, src, vibrator_designs, custom_check = CALLBACK(src, .proc/check_menu, user, object), radius = 36, require_near = TRUE)
-		if(!choice)
-			return FALSE
-		current_color = choice
-		update_icon_state()
-		update_icon()
-		color_changed = TRUE
-	else
+	if(color_changed)
 		return
+	. = ..()
+	if(.)
+		return
+	var/choice = show_radial_menu(user, src, vibrator_designs, custom_check = CALLBACK(src, .proc/check_menu, user, object), radius = 36, require_near = TRUE)
+	if(!choice)
+		return FALSE
+	current_color = choice
+	update_icon_state()
+	update_icon()
+	color_changed = TRUE
 
 /obj/item/clothing/sextoy/vibrator/Initialize()
 	. = ..()
@@ -70,8 +80,8 @@
 
 /obj/item/clothing/sextoy/vibrator/equipped(mob/user, slot)
 	. = ..()
-	var/mob/living/carbon/human/H = user
-	if(src == H.anus || src == H.vagina)
+	var/mob/living/carbon/human/target = user
+	if(src == target.anus || src == target.vagina)
 		START_PROCESSING(SSobj, src)
 
 /obj/item/clothing/sextoy/vibrator/dropped(mob/user, slot)
@@ -79,328 +89,114 @@
 	STOP_PROCESSING(SSobj, src)
 
 /obj/item/clothing/sextoy/vibrator/process(delta_time)
-	var/mob/living/carbon/human/U = loc
-	if(toy_on == TRUE)
-		if(vibration_mode == "low" && U.arousal < 40) //prevent non-stop cumming from wearing this thing
-			U.adjustArousal(0.7 * delta_time)
-			U.adjustPleasure(0.7 * delta_time)
-		if(vibration_mode == "medium" && U.arousal < 70)
-			U.adjustArousal(1 * delta_time)
-			U.adjustPleasure(1 * delta_time)
+	var/mob/living/carbon/human/user = loc
+	if(!istype(user))
+		return
+	if(toy_on)
+		if(vibration_mode == "low" && user.arousal < 40) //prevent non-stop cumming from wearing this thing
+			user.adjustArousal(0.7 * delta_time)
+			user.adjustPleasure(0.7 * delta_time)
+		if(vibration_mode == "medium" && user.arousal < 70)
+			user.adjustArousal(1 * delta_time)
+			user.adjustPleasure(1 * delta_time)
 		if(vibration_mode == "hard") //no mercy
-			U.adjustArousal(1.5 * delta_time)
-			U.adjustPleasure(1.5 * delta_time)
-	if(toy_on == FALSE && U.arousal < 30)
-		U.adjustArousal(0.5 * delta_time)
-		U.adjustPleasure(0.5 * delta_time)
+			user.adjustArousal(1.5 * delta_time)
+			user.adjustPleasure(1.5 * delta_time)
+	else if(!toy_on && U.arousal < 30)
+		user.adjustArousal(0.5 * delta_time)
+		user.adjustPleasure(0.5 * delta_time)
 
 //SHITCODESHITCODESHITCODESHITCODESHITCODESHITCODESHITCODESHITCODESHITCODESHITCODESHITCODESHITCODESHITCODESHITCODESHITCODESHITCODE
-/obj/item/clothing/sextoy/vibrator/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
+/obj/item/clothing/sextoy/vibrator/attack(mob/living/carbon/human/target, mob/living/carbon/human/user)
 	. = ..()
-	if(!istype(M, /mob/living/carbon/human))
+	if(!istype(target))
 		return
 
 	var/message = ""
-	if(toy_on == TRUE)
-		if(M.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
-			switch(user.zone_selected) //to let code know what part of body we gonna vibe
-				if(BODY_ZONE_PRECISE_GROIN)
-					var/obj/item/organ/genital/penis = M.getorganslot(ORGAN_SLOT_PENIS)
-					var/obj/item/organ/genital/vagina = M.getorganslot(ORGAN_SLOT_VAGINA)
-					if(vibration_mode == "low")
-						if(vagina && penis)
-							if(vagina.visibility_preference == GENITAL_ALWAYS_SHOW && penis.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their vagina with the [src]","gently teases their pussy with [src]","massages their penis with the [src]","gently teases their penis with [src]") : pick("delicately massages [M]'s vagina with [src]", "uses [src] to gently massage [M]'s crotch","leans the massager against [M]'s pussy","delicately massages [M]'s penis with [src]", "uses [src] to gently massage [M]'s penis","leans the massager against [M]'s penis")
-								M.adjustArousal(4)
-								M.adjustPleasure(2)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan","blush"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE, ignore_walls = FALSE)
-
-							else if(vagina.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their vagina with the [src]","gently teases their pussy with [src]") : pick("delicately massages [M]'s vagina with [src]", "uses [src] to gently massage [M]'s crotch","leans the massager against [M]'s pussy")
-								M.adjustArousal(4)
-								M.adjustPleasure(2)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan","blush"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE, ignore_walls = FALSE)
-
-							else if(penis.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their penis with the [src]","gently teases their penis with [src]") : pick("delicately massages [M]'s penis with [src]", "uses [src] to gently massage [M]'s penis","leans the massager against [M]'s penis")
-								M.adjustArousal(4)
-								M.adjustPleasure(2)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan","blush"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE, ignore_walls = FALSE)
-							else
-								to_chat(user, span_danger("Looks like [M]'s groin is covered!"))
-								return
-
-						else if(penis)
-							if(penis.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their penis with the [src]","gently teases their penis with [src]") : pick("delicately massages [M]'s penis with [src]", "uses [src] to gently massage [M]'s penis","leans the massager against [M]'s penis")
-								M.adjustArousal(4)
-								M.adjustPleasure(2)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE, ignore_walls = FALSE)
-							else
-								to_chat(user, span_danger("Looks like [M]'s groin is covered!"))
-								return
-
-						else if(vagina)
-							if(vagina.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their vagina with the [src]","gently teases their pussy with [src]") : pick("delicately massages [M]'s vagina with [src]", "uses [src] to gently massage [M]'s crotch","leans the massager against [M]'s pussy")
-								M.adjustArousal(4)
-								M.adjustPleasure(2)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE, ignore_walls = FALSE)
-							else
-								user.visible_message(span_danger("Looks like [M]'s groin is covered!"))
-								return
-						else
-							user.visible_message(span_danger("Looks like [M] don't have suitable organs for that!"))
-							return
-
-					if(vibration_mode == "medium")
-						if(vagina && penis)
-							if(vagina.visibility_preference == GENITAL_ALWAYS_SHOW && penis.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their penis with the [src]","gently teases their penis with [src]","massages their vagina with the [src]","teases teases their pussy with [src]") : pick("massages [M]'s penis with [src]", "uses [src] to massage [M]'s penis","leans the massager against [M]'s penis","massages [M]'s vagina with [src]", "uses [src] to massage [M]'s crotch","leans the massager against [M]'s pussy")
-								M.adjustArousal(5)
-								M.adjustPleasure(5)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 20, TRUE, ignore_walls = FALSE)
-
-							else if(vagina.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their vagina with the [src]","gently teases their pussy with [src]") : pick("massages [M]'s vagina with [src]", "uses [src] to massage [M]'s crotch","leans the massager against [M]'s pussy")
-								M.adjustArousal(4)
-								M.adjustPleasure(2)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan","blush"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE, ignore_walls = FALSE)
-
-							else if(penis.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their penis with the [src]","gently teases their penis with [src]") : pick("massages [M]'s penis with [src]", "uses [src] to massage [M]'s penis","leans the massager against [M]'s penis")
-								M.adjustArousal(4)
-								M.adjustPleasure(2)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan","blush"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE, ignore_walls = FALSE)
-
-							else
-								to_chat(user, span_danger("Looks like [M]'s groin is covered!"))
-								return
-
-						else if(penis)
-							if(penis.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their penis with the [src]","gently teases their penis with [src]") : pick("massages [M]'s penis with [src]", "uses [src] to massage [M]'s penis","leans the massager against [M]'s penis")
-								M.adjustArousal(5)
-								M.adjustPleasure(5)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 20, TRUE, ignore_walls = FALSE)
-
-							else
-								to_chat(user, span_danger("Looks like [M]'s groin is covered!"))
-								return
-
-						else if(vagina)
-							if(vagina.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their vagina with the [src]","gently teases their pussy with [src]") : pick("massages [M]'s vagina with [src]", "uses [src] to massage [M]'s crotch","leans the massager against [M]'s pussy")
-								M.adjustArousal(5)
-								M.adjustPleasure(5)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 20, TRUE, ignore_walls = FALSE)
-
-							else
-								to_chat(user, span_danger("Looks like [M]'s groin is covered!"))
-								return
-
-						else
-							user.visible_message(span_danger("Looks like [M] don't have suitable organs for that!"))
-							return
-
-					if(vibration_mode == "hard")
-						if(vagina && penis)
-							if(vagina.visibility_preference == GENITAL_ALWAYS_SHOW && penis.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their penis with the [src]","hardly teases their penis with [src]","massages their vagina with the [src]","hardly teases their pussy with [src]") : pick("leans massager tight to [M]'s penis with [src]", "uses [src] to agressively massage [M]'s penis","leans the massager against [M]'s penis","leans massager tight to [M]'s vagina with [src]", "uses [src] to agressively massage [M]'s crotch","leans the massager against [M]'s pussy")
-								M.adjustArousal(8)
-								M.adjustPleasure(10)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 30, TRUE, ignore_walls = FALSE)
-
-							else if(vagina.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their vagina with the [src]","hardly teases their pussy with [src]") : pick("leans massager tight to [M]'s vagina with [src]", "uses [src] to agressively massage [M]'s crotch","leans the massager against [M]'s pussy")
-								M.adjustArousal(4)
-								M.adjustPleasure(2)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan","blush"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE, ignore_walls = FALSE)
-
-							else if(penis.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their penis with the [src]","hardly teases their penis with [src]") : pick("leans massager tight to [M]'s penis with [src]", "uses [src] to agressively massage [M]'s penis","leans the massager against [M]'s penis")
-								M.adjustArousal(4)
-								M.adjustPleasure(2)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan","blush"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE, ignore_walls = FALSE)
-
-							else
-								to_chat(user, span_danger("Looks like [M]'s groin is covered!"))
-								return
-
-						else if(penis)
-							if(penis.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their penis with the [src]","hardly teases their penis with [src]") : pick("leans massager tight to [M]'s penis with [src]", "uses [src] to agressively massage [M]'s penis","leans the massager against [M]'s penis")
-								M.adjustArousal(8)
-								M.adjustPleasure(10)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 30, TRUE, ignore_walls = FALSE)
-
-							else
-								to_chat(user, span_danger("Looks like [M]'s groin is covered!"))
-								return
-
-						else if(vagina)
-							if(vagina.visibility_preference == GENITAL_ALWAYS_SHOW || M.is_bottomless())
-								message = (user == M) ? pick("massages their vagina with the [src]","hardly teases their pussy with [src]") : pick("leans massager tight to [M]'s vagina with [src]", "uses [src] to agressively massage [M]'s crotch","leans the massager against [M]'s pussy")
-								M.adjustArousal(8)
-								M.adjustPleasure(10)
-								if(prob(50) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 30, TRUE, ignore_walls = FALSE)
-
-							else
-								to_chat(user, span_danger("Looks like [M]'s groin is covered!"))
-								return
-
-						else
-							user.visible_message(span_danger("Looks like [M] don't have suitable organs for that!"))
-							return
-
-				if(BODY_ZONE_CHEST)
-					var/obj/item/organ/genital/breasts = M.getorganslot(ORGAN_SLOT_BREASTS)
-					if(M.is_topless() || breasts.visibility_preference == GENITAL_ALWAYS_SHOW)
-						if(vibration_mode == "low")
-							if(breasts)
-								message = (user == M) ? pick("massages their breasts with the [src]","gently teases their tits with [src]") : pick("delicately teases [M]'s breasts with [src]", "uses [src] to slowly massage [M]'s tits", "uses [src] to tease [M]'s boobs", "rubs [M]'s tits with [src]")
-								M.adjustArousal(4)
-								M.adjustPleasure(1)
-								if(prob(30) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE, ignore_walls = FALSE)
-							else
-								message = (user == M) ? pick("massages their nipples with the [src]","gently teases their nipples with [src]") : pick("delicately teases [M]'s nipples with [src]", "uses [src] to slowly massage [M]'s nipples", "uses [src] to tease [M]'s nipples")
-								M.adjustArousal(2)
-								M.adjustPleasure(1)
-								if(prob(30) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE, ignore_walls = FALSE)
-
-
-						if(vibration_mode == "medium")
-							if(breasts)
-								message = (user == M) ? pick("massages their breasts with the [src]","gently teases their nipples with [src]") : pick("teases [M]'s nipples with [src]", "uses [src] to massage [M]'s tits", "uses [src] to tease [M]'s nipples")
-								M.adjustArousal(5)
-								M.adjustPleasure(4)
-								if(prob(30) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 20, TRUE, ignore_walls = FALSE)
-							else
-								message = (user == M) ? pick("massages their nipples with the [src]","gently teases their nipples with [src]") : pick("teases [M]'s nipples with [src]", "uses [src] to massage [M]'s nipples", "uses [src] to tease [M]'s nipples")
-								M.adjustArousal(3)
-								M.adjustPleasure(1)
-								if(prob(30) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 20, TRUE, ignore_walls = FALSE)
-
-						if(vibration_mode == "hard")
-							if(breasts)
-								message = (user == M) ? pick("massages their breasts with the [src]","hardly teases their nipples with [src]") : pick("leans massager tight against [M]'s nipples with [src]", "uses [src] to massage [M]'s tits", "uses [src] to tease [M]'s nipples")
-								M.adjustArousal(7)
-								M.adjustPleasure(9)
-								if(prob(30) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 30, TRUE, ignore_walls = FALSE)
-							else
-								message = (user == M) ? pick("massages their nipples with the [src]","hardly teases their nipples with [src]") : pick("leans massager tight against [M]'s nipples with [src]", "uses [src] to massage [M]'s nipples", "uses [src] to tease [M]'s nipples")
-								M.adjustArousal(4)
-								M.adjustPleasure(2)
-								if(prob(30) && (M.stat != DEAD))
-									M.emote(pick("twitch_s","moan"))
-								user.visible_message(span_purple("[user] [message]!"))
-								playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 30, TRUE, ignore_walls = FALSE)
-
-					else
-						to_chat(user, span_danger("Looks like [M]'s chest is covered!"))
-						return
-		else
-			to_chat(user, span_danger("Looks like [M] don't want you to do that."))
-			return
-	else
-		to_chat(user, span_notice("You must turn on the toy, to use it!"))
+	if(!toy_on)
+		to_chat(user, span_notice("[src] must be on to use it!"))
+		return
+	if(!target.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
+		to_chat(user, span_danger("Looks like [target] don't want you to do that."))
 		return
 
-/obj/item/clothing/sextoy/vibrator/attack_self(mob/user, obj/item/I)
+	switch(user.zone_selected) //to let code know what part of body we gonna vibe
+		if(BODY_ZONE_PRECISE_GROIN)
+			var/obj/item/organ/genital/penis = target.getorganslot(ORGAN_SLOT_PENIS)
+			var/obj/item/organ/genital/vagina = target.getorganslot(ORGAN_SLOT_VAGINA)
+			if((vagina && penis) && (vagina.visibility_preference == GENITAL_ALWAYS_SHOW && penis.visibility_preference == GENITAL_ALWAYS_SHOW || target.is_bottomless()))
+				message = (user == target) ? pick("massages their vagina with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their pussy with [src]","massages their penis with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their penis with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s vagina with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s crotch","leans the massager against [target]'s pussy","[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s penis with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s penis","leans the massager against [target]'s penis")
+				target.adjustArousal(DEFAULT_AROUSAL_INCREASE)
+				target.adjustPleasure(DEFAULT_PLEASURE_INCREASE)
+
+			else if(vagina && (vagina.visibility_preference == GENITAL_ALWAYS_SHOW || target.is_bottomless()))
+				message = (user == target) ? pick("massages their vagina with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their pussy with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s vagina with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s crotch","leans the massager against [target]'s pussy")
+				target.adjustArousal(DEFAULT_AROUSAL_INCREASE)
+				target.adjustPleasure(DEFAULT_PLEASURE_INCREASE)
+
+			else if(penis && (penis.visibility_preference == GENITAL_ALWAYS_SHOW || target.is_bottomless()))
+				message = (user == target) ? pick("massages their penis with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their penis with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s penis with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s penis","leans the massager against [target]'s penis")
+				target.adjustArousal(DEFAULT_AROUSAL_INCREASE)
+				target.adjustPleasure(DEFAULT_PLEASURE_INCREASE)
+
+			else
+				to_chat(user, span_danger("Looks like [target]'s groin is covered!"))
+				return
+
+			if(prob(50) && (target.stat != DEAD))
+				target.emote(pick("twitch_s","moan","blush"))
+
+		if(BODY_ZONE_CHEST)
+			var/obj/item/organ/genital/breasts = target.getorganslot(ORGAN_SLOT_BREASTS)
+			if(target.is_topless() || breasts.visibility_preference == GENITAL_ALWAYS_SHOW)
+				message = (user == target) ? pick("massages their [breasts ? "breasts" : "nipples"] with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their tits with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] teases [target]'s [breasts ? "breasts" : "nipples"] with [src]", "uses [src] to[vibration_mode == "low" ? " slowly" : ""] massage [target]'s [breasts ? "tits" : "nipples"]", "uses [src] to tease [target]'s [breasts ? "boobs" : "nipples"]", "rubs [target]'s [breasts ? "tits" : "nipples"] with [src]")
+				target.adjustArousal(DEFAULT_AROUSAL_INCREASE)
+				target.adjustPleasure(DEFAULT_PLEASURE_INCREASE * 0.5)
+				if(prob(30) && (target.stat != DEAD))
+					target.emote(pick("twitch_s","moan"))
+
+			else
+				to_chat(user, span_danger("Looks like [target]'s chest is covered!"))
+				return
+
+	user.visible_message(span_purple("[user] [message]!"))
+	playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE, ignore_walls = FALSE)
+
+/obj/item/clothing/sextoy/vibrator/attack_self(mob/user, obj/item/attack_item)
 	toggle_mode()
-	if(vibration_mode == "low")
-		to_chat(user, span_notice("Vibration mode now is low. Bzzz..."))
-	if(vibration_mode == "medium")
-		to_chat(user, span_notice("Vibration mode now is medium. Bzzzz!"))
-	if(vibration_mode == "hard")
-		to_chat(user, span_notice("Vibration mode now is hard. Careful with that thing."))
-	if(vibration_mode == "off")
-		to_chat(user, span_notice("Vibrator turned off. Fun is over?"))
+	switch(vibration_mode)
+		if("low")
+			to_chat(user, span_notice("Vibration mode now is low. Bzzz..."))
+		if("medium")
+			to_chat(user, span_notice("Vibration mode now is medium. Bzzzz!"))
+		if("hard")
+			to_chat(user, span_notice("Vibration mode now is hard. Careful with that thing."))
+		if("off")
+			to_chat(user, span_notice("Vibrator turned off. Fun's over?"))
 	update_icon()
 	update_icon_state()
 
 /obj/item/clothing/sextoy/vibrator/proc/toggle_mode()
-	mode = modes[mode]
-	switch(mode)
+	vibration_mode = modes[vibration_mode]
+	switch(vibration_mode)
 		if("low")
 			toy_on = TRUE
-			vibration_mode = "low"
 			playsound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 			soundloop1.start()
 		if("medium")
 			toy_on = TRUE
-			vibration_mode = "medium"
 			playsound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 			soundloop1.stop()
 			soundloop2.start()
 		if("hard")
 			toy_on = TRUE
-			vibration_mode = "hard"
 			playsound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
 			soundloop2.stop()
 			soundloop3.start()
 		if("off")
 			toy_on = FALSE
-			vibration_mode = "off"
 			playsound(loc, 'sound/weapons/magout.ogg', 20, TRUE)
 			soundloop3.stop()
+
+#undef DEFAULT_AROUSAL_INCREASE
+#undef DEFAULT_PLEASURE_INCREASE

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibrator.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibrator.dm
@@ -113,6 +113,7 @@
 		return
 
 	var/message = ""
+	var/targetedsomewhere = FALSE
 	if(!toy_on)
 		to_chat(user, span_notice("[src] must be on to use it!"))
 		return
@@ -122,6 +123,7 @@
 
 	switch(user.zone_selected) //to let code know what part of body we gonna vibe
 		if(BODY_ZONE_PRECISE_GROIN)
+			targetedsomewhere = TRUE
 			var/obj/item/organ/genital/penis = target.getorganslot(ORGAN_SLOT_PENIS)
 			var/obj/item/organ/genital/vagina = target.getorganslot(ORGAN_SLOT_VAGINA)
 			if((vagina && penis) && (vagina.visibility_preference == GENITAL_ALWAYS_SHOW && penis.visibility_preference == GENITAL_ALWAYS_SHOW || target.is_bottomless()))
@@ -147,6 +149,7 @@
 				target.emote(pick("twitch_s","moan","blush"))
 
 		if(BODY_ZONE_CHEST)
+			targetedsomewhere = TRUE
 			var/obj/item/organ/genital/breasts = target.getorganslot(ORGAN_SLOT_BREASTS)
 			if(target.is_topless() || breasts.visibility_preference == GENITAL_ALWAYS_SHOW)
 				message = (user == target) ? pick("massages their [breasts ? "breasts" : "nipples"] with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their tits with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] teases [target]'s [breasts ? "breasts" : "nipples"] with [src]", "uses [src] to[vibration_mode == "low" ? " slowly" : ""] massage [target]'s [breasts ? "tits" : "nipples"]", "uses [src] to tease [target]'s [breasts ? "boobs" : "nipples"]", "rubs [target]'s [breasts ? "tits" : "nipples"] with [src]")
@@ -158,7 +161,8 @@
 			else
 				to_chat(user, span_danger("Looks like [target]'s chest is covered!"))
 				return
-
+	if(!targetedsomewhere)
+		return
 	user.visible_message(span_purple("[user] [message]!"))
 	playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', 10, TRUE, ignore_walls = FALSE)
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibrator.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibrator.dm
@@ -1,5 +1,5 @@
 #define DEFAULT_AROUSAL_INCREASE 4
-#define DEAFAULT_PLEASURE_INCREASE 2
+#define DEFAULT_PLEASURE_INCREASE 2
 
 //This code huge and blocky, but we're working on update for... my god, 4 months. If you can upgrade it - do it, but don't remove or break something, test carefully. This item is insertable.
 /obj/item/clothing/sextoy/vibrator
@@ -102,7 +102,7 @@
 		if(vibration_mode == "hard") //no mercy
 			user.adjustArousal(1.5 * delta_time)
 			user.adjustPleasure(1.5 * delta_time)
-	else if(!toy_on && U.arousal < 30)
+	else if(!toy_on && user.arousal < 30)
 		user.adjustArousal(0.5 * delta_time)
 		user.adjustPleasure(0.5 * delta_time)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This refactors the BDSM candle and vibrators. In other words,

**I've done it, all sex2 items have been refactored.**

Also, goes over and fixes a bug that would allow you to create blank lewd messages with some items, and just overall refactors some already-refactored items.
TODO:

- [x] Actually see if this works?

## How This Contributes To The Skyrat Roleplay Experience
I needn't explain.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: Fixed a pile of spelling errors with organic interface items
refactor: Refactored yet more organic interface update code
fix: You can no longer create blank messages with some organic interface items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
