### PR TITLE
DeltaStation - Engi guard/NT office fix

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -8208,7 +8208,6 @@
 /area/security/brig)
 "bto" = (
 /obj/structure/cable,
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -8223,6 +8222,7 @@
 	name = "Engineering Cell";
 	pixel_y = 32
 	},
+/obj/structure/closet/secure_closet/security/engine,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "btt" = (
@@ -53660,6 +53660,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/engineering_guard,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "jtO" = (
@@ -110322,12 +110323,14 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "ycZ" = (
-/obj/machinery/button/curtain{
-	id = "ntconshutter";
-	pixel_x = -25;
-	pixel_y = 23
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "ntconshutter";
+	name = "Privacy Shutter";
+	pixel_x = -37;
+	pixel_y = 33;
+	specialfunctions = 4
+	},
 /turf/open/floor/wood/parquet,
 /area/command/heads_quarters/captain/private/nt_rep)
 "ydg" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes some minor issues on deltastation which are SR specific, such as:

The NT Consultants office now has a button with special function 4 (Rather than a curtain button) meaning you can now properly open and close the privacy shutters:
![image](https://user-images.githubusercontent.com/32248891/156935132-a03cd3eb-3039-4585-9487-aa5051f13de4.png)

The Engineering Guardpost had only 1 locker rather than the standard 2:
![image](https://user-images.githubusercontent.com/32248891/156935174-1e08b343-db10-4981-95f8-769a0d47eb56.png)


## How This Contributes To The Skyrat Roleplay Experience

Oversights bad, fix good.

## Changelog

:cl:
fix: Minor Delta station fixes (Engi guard post, NT Rep office)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
