### PR TITLE
[NON-MODULAR] Thieving gloves let you tie/untie shoes in half the time

### DIFF
--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -159,8 +159,12 @@
 			to_chat(user, span_warning("You're already interacting with [src]!"))
 			return
 		user.visible_message(span_notice("[user] begins [tied ? "unknotting" : "tying"] the laces of [user.p_their()] [src.name]."), span_notice("You begin [tied ? "unknotting" : "tying"] the laces of your [src.name]..."))
-
-		if(do_after(user, lace_time, target = our_guy, extra_checks = CALLBACK(src, .proc/still_shoed, our_guy)))
+		// SKYRAT EDIT START
+		var/tie_time = lace_time
+		if(HAS_TRAIT(user, TRAIT_STICKY_FINGERS))
+			tie_time *= 0.5
+		if(do_after(user, tie_time, target = our_guy, extra_checks = CALLBACK(src, .proc/still_shoed, our_guy)))
+		// SKYRET EDIT END
 			to_chat(user, span_notice("You [tied ? "unknot" : "tie"] the laces of your [src.name]."))
 			if(tied == SHOES_UNTIED)
 				adjust_laces(SHOES_TIED, user)
@@ -183,7 +187,10 @@
 		to_chat(user, span_notice("You quietly set to work [tied ? "untying" : "knotting"] [loc]'s [src.name]..."))
 		if(HAS_TRAIT(user, TRAIT_CLUMSY)) // based clowns trained their whole lives for this
 			mod_time *= 0.75
-
+		// SKYRAT EDIT START
+		if(HAS_TRAIT(user, TRAIT_STICKY_FINGERS)) // Clowns with thieving gloves will be a menace
+			mod_time *= 0.5
+		// SKYRAT EDIT END
 		if(do_after(user, mod_time, target = our_guy, extra_checks = CALLBACK(src, .proc/still_shoed, our_guy)))
 			to_chat(user, span_notice("You [tied ? "untie" : "knot"] the laces on [loc]'s [src.name]."))
 			if(tied == SHOES_UNTIED)
@@ -270,7 +277,11 @@
 		return
 
 	to_chat(user, span_notice("You begin [tied ? "untying" : "tying"] the laces on [src]..."))
-
-	if(do_after(user, lace_time, target = src,extra_checks = CALLBACK(src, .proc/still_shoed, user)))
+	// SKYRAT EDIT START
+	var/tie_time = lace_time
+	if(HAS_TRAIT(user, TRAIT_STICKY_FINGERS))
+		tie_time *= 0.5
+	if(do_after(user, tie_time, target = src,extra_checks = CALLBACK(src, .proc/still_shoed, user)))
+	// SKYRAT EDIT END
 		to_chat(user, span_notice("You [tied ? "untie" : "tie"] the laces on [src]."))
 		adjust_laces(tied ? SHOES_UNTIED : SHOES_TIED, user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Thieving gloves let you tie and untie anyone's shoes, even your own, 2x as fast.

## How This Contributes To The Skyrat Roleplay Experience
It's funny

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Thieving gloves now let you tie/untie shoe laces in half time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
