### PR TITLE
Fixes Chili sin carne

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
@@ -484,4 +484,3 @@
 	)
 	result = /obj/item/food/soup/red_porridge
 	subcategory = CAT_MOTH
-

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
@@ -485,14 +485,3 @@
 	result = /obj/item/food/soup/red_porridge
 	subcategory = CAT_MOTH
 
-/datum/crafting_recipe/food/chili_sin_carne
-	name = "Chili sin carne (vegetarian chili)"
-	reqs = list(
-		/obj/item/reagent_containers/glass/bowl = 1,
-		/datum/reagent/water = 10,
-		/datum/reagent/consumable/salt = 1,
-		/obj/item/food/grown/chili = 1,
-		/obj/item/food/grown/tomato = 1
-	)
-	result = /obj/item/food/soup/vegetarian_chili
-	subcategory = CAT_MOTH

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
@@ -486,13 +486,13 @@
 	subcategory = CAT_MOTH
 
 /datum/crafting_recipe/food/chili_sin_carne
-   name = "Chili sin carne (vegetarian chili)"
-   reqs = list(
-       /obj/item/reagent_containers/glass/bowl = 1,
-       /datum/reagent/water = 10,
-       /datum/reagent/consumable/salt = 1,
-       /obj/item/food/grown/chili = 1,
-       /obj/item/food/grown/tomato = 1
+	name = "Chili sin carne (vegetarian chili)"
+	reqs = list(
+		/obj/item/reagent_containers/glass/bowl = 1,
+		/datum/reagent/water = 10,
+		/datum/reagent/consumable/salt = 1,
+		/obj/item/food/grown/chili = 1,
+		/obj/item/food/grown/tomato = 1
 	)
-   result = /obj/item/food/soup/vegetarian_chili
-   subcategory = CAT_MOTH
+	result = /obj/item/food/soup/vegetarian_chili
+	subcategory = CAT_MOTH

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
@@ -484,3 +484,15 @@
 	)
 	result = /obj/item/food/soup/red_porridge
 	subcategory = CAT_MOTH
+
+/datum/crafting_recipe/food/chili_sin_carne
+   name = "Chili sin carne (vegetarian chili)"
+   reqs = list(
+       /obj/item/reagent_containers/glass/bowl = 1,
+       /datum/reagent/water = 10,
+       /datum/reagent/consumable/salt = 1,
+       /obj/item/food/grown/chili = 1,
+       /obj/item/food/grown/tomato = 1
+   )
+   result = /obj/item/food/soup/vegetarian_chili
+   subcategory = CAT_MOTH

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
@@ -493,6 +493,6 @@
        /datum/reagent/consumable/salt = 1,
        /obj/item/food/grown/chili = 1,
        /obj/item/food/grown/tomato = 1
-   )
+	)
    result = /obj/item/food/soup/vegetarian_chili
    subcategory = CAT_MOTH

--- a/modular_skyrat/modules/customization/datums/components/crafting/recipes.dm
+++ b/modular_skyrat/modules/customization/datums/components/crafting/recipes.dm
@@ -51,3 +51,15 @@
 	)
 	result = /obj/item/food/canned/tuna
 	subcategory = CAT_SEAFOOD
+
+/datum/crafting_recipe/food/chili_sin_carne
+	name = "Chili sin carne (vegetarian chili)"
+	reqs = list(
+		/obj/item/reagent_containers/glass/bowl = 1,
+		/datum/reagent/water = 10,
+		/datum/reagent/consumable/salt = 1,
+		/obj/item/food/grown/chili = 1,
+		/obj/item/food/grown/tomato = 1
+	)
+	result = /obj/item/food/soup/vegetarian_chili
+	subcategory = CAT_MOTH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I added a missing crafting recipe for Chili sin carne so that this can be crafted (Getting this recipe to be craft-able will also make other items possible to craft again since they use Chili sin carne as an ingredient)

## How This Contributes To The Skyrat Roleplay Experience

It gives us more foods to eat!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
Fix: fixes Chili sin carne being un-craftable
/:cl: