### PR TITLE
[NONMODULAR] adds sleeping after head smashes

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -175,6 +175,7 @@
 		extra_wound = 20
 	banged_limb?.receive_damage(30, wound_bonus = extra_wound)
 	pushed_mob.apply_damage(60, STAMINA)
+	pushed_mob.SetSleeping(300) // SKYRAT EDIT
 	take_damage(50)
 	if(user.mind?.martial_art.smashes_tables && user.mind?.martial_art.can_use(user))
 		deconstruct(FALSE)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -175,7 +175,7 @@
 		extra_wound = 20
 	banged_limb?.receive_damage(30, wound_bonus = extra_wound)
 	pushed_mob.apply_damage(60, STAMINA)
-	pushed_mob.SetSleeping(300) // SKYRAT EDIT
+	pushed_mob.SetSleeping(50) // SKYRAT EDIT
 	take_damage(50)
 	if(user.mind?.martial_art.smashes_tables && user.mind?.martial_art.can_use(user))
 		deconstruct(FALSE)

--- a/modular_skyrat/modules/medical/code/wounds/bones.dm
+++ b/modular_skyrat/modules/medical/code/wounds/bones.dm
@@ -202,7 +202,7 @@
 	examine_desc = "is awkwardly jammed out of place"
 	occur_text = "jerks violently and becomes unseated"
 	severity = WOUND_SEVERITY_MODERATE
-	viable_zones = list(BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+	viable_zones = list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 	interaction_efficiency_penalty = 1.5
 	limp_slowdown = 3
 	threshold_minimum = 35

--- a/modular_skyrat/modules/medical/code/wounds/bones.dm
+++ b/modular_skyrat/modules/medical/code/wounds/bones.dm
@@ -202,7 +202,7 @@
 	examine_desc = "is awkwardly jammed out of place"
 	occur_text = "jerks violently and becomes unseated"
 	severity = WOUND_SEVERITY_MODERATE
-	viable_zones = list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+	viable_zones = list(BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 	interaction_efficiency_penalty = 1.5
 	limp_slowdown = 3
 	threshold_minimum = 35


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

allows you to put someone in a sleeping period of 50 (5 seconds) after you get your head smashed against a table.

![unknown](https://user-images.githubusercontent.com/88991542/156949357-f1654e15-4e46-473f-9f34-49802e138811.png)

(LIUVIK'S SEAL OF APPROVAL)

## How This Contributes To The Skyrat Roleplay Experience

when you get your head slammed against a table loud enough to make a large banging sound, you tend to go sleepy night night for a few seconds.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Nanotrasen's Expert Combat Mechanics have finally realized you actually pass out for a few seconds after you get table slammed! Innovation, people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
