### PR TITLE
[NON-MODULAR] Removes Purge and Block Malf AI objectives

### DIFF
--- a/code/modules/antagonists/malf_ai/datum_malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/datum_malf_ai.dm
@@ -89,23 +89,21 @@
 
 /// Generates a special objective and adds it to the objective list.
 /datum/antagonist/malf_ai/proc/forge_special_objective()
-	// SKYRAT EDIT START
-	var/special_pick = rand(1,2)
+	var/special_pick = rand(3,4) // SKYRAT EDIT - REMOVING PURGE/BLOCK
 	switch(special_pick)
-		/*if(1)
+		if(1)
 			var/datum/objective/block/block_objective = new
 			block_objective.owner = owner
 			objectives += block_objective
 		if(2)
 			var/datum/objective/purge/purge_objective = new
 			purge_objective.owner = owner
-			objectives += purge_objective*/
-		if(1)
+			objectives += purge_objective
+		if(3)
 			var/datum/objective/robot_army/robot_objective = new
 			robot_objective.owner = owner
 			objectives += robot_objective
-		if(2) //Protect and strand a target
-	// SKYRAT EDIT END
+		if(4) //Protect and strand a target
 			var/datum/objective/protect/yandere_one = new
 			yandere_one.owner = owner
 			objectives += yandere_one

--- a/code/modules/antagonists/malf_ai/datum_malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/datum_malf_ai.dm
@@ -89,21 +89,23 @@
 
 /// Generates a special objective and adds it to the objective list.
 /datum/antagonist/malf_ai/proc/forge_special_objective()
-	var/special_pick = rand(1,4)
+	// SKYRAT EDIT START
+	var/special_pick = rand(1,2)
 	switch(special_pick)
-		if(1)
+		/*if(1)
 			var/datum/objective/block/block_objective = new
 			block_objective.owner = owner
 			objectives += block_objective
 		if(2)
 			var/datum/objective/purge/purge_objective = new
 			purge_objective.owner = owner
-			objectives += purge_objective
-		if(3)
+			objectives += purge_objective*/
+		if(1)
 			var/datum/objective/robot_army/robot_objective = new
 			robot_objective.owner = owner
 			objectives += robot_objective
-		if(4) //Protect and strand a target
+		if(2) //Protect and strand a target
+	// SKYRAT EDIT END
 			var/datum/objective/protect/yandere_one = new
 			yandere_one.owner = owner
 			objectives += yandere_one


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the following objectives:

- Do not allow any organic lifeforms with sapience to escape on the shuttle alive.
- Ensure no nonhuman humanoid species with sapience are present aboard the escape shuttle.

## How This Contributes To The Skyrat Roleplay Experience
AI, malf or not, shouldn't be murderboning and these objectives don't fit into what Skyrat is aiming for

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed Block and Purge Malf AI objectives
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
