### PR TITLE
[NON-MODULAR] Soulshards now require a 5 second action bar

### DIFF
--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -172,6 +172,14 @@
 	if(HAS_TRAIT(M, TRAIT_NO_SOUL))
 		to_chat(user, span_warning("This body does not possess a soul to capture."))
 		return
+	// SKYRAT EDIT START
+	if(M.stat != DEAD)
+		to_chat(user, span_warning("Your target must be dead to capture their soul!"))
+		return
+	if(!do_after(user, 5 SECONDS, M))
+		to_chat(user, span_warning("You must stand still to capture their soul!"))
+		return
+	// SKYRAT EDIT END
 	log_combat(user, M, "captured [M.name]'s soul", src)
 	capture_soul(M, user)
 

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -173,9 +173,6 @@
 		to_chat(user, span_warning("This body does not possess a soul to capture."))
 		return
 	// SKYRAT EDIT START
-	if(M.stat != DEAD)
-		to_chat(user, span_warning("Your target must be dead to capture their soul!"))
-		return
 	if(!do_after(user, 5 SECONDS, M))
 		to_chat(user, span_warning("You must stand still to capture their soul!"))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.

## How This Contributes To The Skyrat Roleplay Experience
It seems prudent to make it harder to effectively round remove people than simply bonking them with a soul shard instantly.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Soulshards now require you to go through a five second actionbar to capture a sould
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
