### PR TITLE
Fixes Mechs (and all the other vehicles, and all of Megafauna) being considered as "stealthy" for the FoV

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -25,7 +25,7 @@
 	pull_force = MOVE_FORCE_OVERPOWERING
 	mob_size = MOB_SIZE_HUGE
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
-	plane = GAME_PLANE_UPPER_FOV_HIDDEN
+	plane = GAME_PLANE_UPPER_FOV
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
 	/// Crusher loot dropped when the megafauna is killed with a crusher

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -25,7 +25,7 @@
 	pull_force = MOVE_FORCE_OVERPOWERING
 	mob_size = MOB_SIZE_HUGE
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
-	plane = GAME_PLANE_UPPER_FOV
+	plane = GAME_PLANE_UPPER
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
 	/// Crusher loot dropped when the megafauna is killed with a crusher

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -25,7 +25,7 @@
 	pull_force = MOVE_FORCE_OVERPOWERING
 	mob_size = MOB_SIZE_HUGE
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
-	plane = GAME_PLANE_UPPER
+	plane = GAME_PLANE_UPPER // SKYRAT EDIT - ORIGINAL: plane = GAME_PLANE_UPPER_FOV_HIDDEN
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
 	/// Crusher loot dropped when the megafauna is killed with a crusher

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -6,7 +6,7 @@
 	max_integrity = 300
 	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 0, BOMB = 30, BIO = 0, FIRE = 60, ACID = 60)
 	layer = VEHICLE_LAYER
-	plane = GAME_PLANE_FOV_HIDDEN
+	plane = GAME_PLANE // SKYRAT EDIT - ORIGINAL: plane = GAME_PLANE_FOV_HIDDEN
 	density = TRUE
 	anchored = FALSE
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC


### PR DESCRIPTION
## About The Pull Request
Vehicles should not be hidden in the FoV. They are by no means stealthy. If you want a vehicle to be stealthy, change that vehicle particularly. But not literally every vehicle in existence. The same goes for Megafauna.

## How This Contributes To The Skyrat Roleplay Experience
No longer will mechs that LOUDLY stomp around the station, be able to be invisible when coming from behind yourself.

Megafauna also isn't known for being stealthy.

## Changelog

:cl: GoldenAlpharex
fix: Fixed vehicles being invisible outside of your field of view. Mechs are not stealthy, nor are skateboards. Deal with it.
fix: Fixed megafauna being invisible outside of your field of view. What a terribly idea that was.
/:cl: