### PR TITLE
[NONMODULAR] Makes ghosts unable to see smugglers satchels.

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -313,7 +313,7 @@
 
 /obj/item/storage/backpack/satchel/flat/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE, INVISIBILITY_OBSERVER, use_anchor = TRUE)
+	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE, INVISIBILITY_MAXIMUM, use_anchor = TRUE) // SKYRAT EDIT - ORIGINAL: INVISIBILITY_OBSERVER
 
 /obj/item/storage/backpack/satchel/flat/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION


## About The Pull Request
You already know why, I don't even have to say it, everyone knows what everyone else did.

## How This Contributes To The Skyrat Roleplay Experience
Something you're supposed to look for, shouldn't be findable by ghosting pre-round and scouting them out, just to respawn and join at roundstart.

## Changelog



:cl:
golden should tell me what to put here i'm like a lost tourist at a Tesco
/:cl:

