### PR TITLE
Tarkon 1.6.1: Ordnance update

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
@@ -3934,6 +3934,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
+/obj/item/circuitboard/machine/anomaly_refinery,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "xC" = (
@@ -6638,6 +6639,7 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
+/obj/structure/frame/machine,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "Oo" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Just re-adds the ordnance machine as a circuitboard and an empty frame on the map, Where there used to be the explosive compressor before the update.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Continuity, IDFK. Makes it so people aren't just hallucinating previously having a machine there? 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: 
expansion: Re-adds the ordinance machine thingy, but this time its a circuitboard. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
