### PR TITLE
Combat overhaul - Reloads

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -317,6 +317,7 @@
 /obj/item/gun/ballistic/can_shoot()
 	return chambered
 
+/* SKYRAT EDIT REMOVAL MOVED TO MODULAR BALLISTIC_MASTER.DM
 /obj/item/gun/ballistic/attackby(obj/item/A, mob/user, params)
 	. = ..()
 	if (.)
@@ -369,7 +370,7 @@
 			return
 
 	return FALSE
-
+*/ // SKYRAT EDIT END
 /obj/item/gun/ballistic/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 
 	if(magazine && chambered.loaded_projectile && can_misfire && misfire_probability > 0)

--- a/modular_skyrat/modules/gunsgalore/code/guns/ballistic_master.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/ballistic_master.dm
@@ -56,7 +56,7 @@
 /obj/item/gun/ballistic/insert_magazine(mob/user, obj/item/ammo_box/magazine/AM, display_message)
 	if(reload_time && !HAS_TRAIT(user, TRAIT_INSTANT_RELOAD) && magazine) //This only happens when you're attempting a tactical reload, e.g. there's a mag already inserted.
 		to_chat(user, span_notice("You start to insert the magazine into [src]!"))
-		if(!do_after(user, reload_time, src))
+		if(!do_after(user, reload_time, src, IGNORE_USER_LOC_CHANGE))
 			to_chat(user, span_danger("You fail to insert the magazine into [src]!"))
 			return
 	. = ..()

--- a/modular_skyrat/modules/gunsgalore/code/guns/ballistic_master.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/ballistic_master.dm
@@ -53,13 +53,63 @@
 				inhand_icon_state = "[initial(icon_state)]"
 				worn_icon_state = "[initial(icon_state)]"
 
-/obj/item/gun/ballistic/insert_magazine(mob/user, obj/item/ammo_box/magazine/AM, display_message)
-	if(reload_time && !HAS_TRAIT(user, TRAIT_INSTANT_RELOAD) && magazine) //This only happens when you're attempting a tactical reload, e.g. there's a mag already inserted.
-		to_chat(user, span_notice("You start to insert the magazine into [src]!"))
-		if(!do_after(user, reload_time, src, IGNORE_USER_LOC_CHANGE))
-			to_chat(user, span_danger("You fail to insert the magazine into [src]!"))
-			return
+/obj/item/gun/ballistic/attackby(obj/item/A, mob/user, params)
 	. = ..()
+	if (.)
+		return
+	if (!internal_magazine && istype(A, /obj/item/ammo_box/magazine))
+		var/obj/item/ammo_box/magazine/AM = A
+		handle_magazine(user, A)
+		return
+	if (istype(A, /obj/item/ammo_casing) || istype(A, /obj/item/ammo_box))
+		if (bolt_type == BOLT_TYPE_NO_BOLT || internal_magazine)
+			if (chambered && !chambered.loaded_projectile)
+				chambered.forceMove(drop_location())
+				chambered = null
+			var/num_loaded = magazine?.attackby(A, user, params, TRUE)
+			if (num_loaded)
+				to_chat(user, span_notice("You load [num_loaded] [cartridge_wording]\s into [src]."))
+				playsound(src, load_sound, load_sound_volume, load_sound_vary)
+				if (chambered == null && bolt_type == BOLT_TYPE_NO_BOLT)
+					chamber_round()
+				A.update_appearance()
+				update_appearance()
+			return
+	if(istype(A, /obj/item/suppressor))
+		var/obj/item/suppressor/S = A
+		if(!can_suppress)
+			to_chat(user, span_warning("You can't seem to figure out how to fit [S] on [src]!"))
+			return
+		if(!user.is_holding(src))
+			to_chat(user, span_warning("You need be holding [src] to fit [S] to it!"))
+			return
+		if(suppressed)
+			to_chat(user, span_warning("[src] already has a suppressor!"))
+			return
+		if(user.transferItemToLoc(A, src))
+			to_chat(user, span_notice("You screw [S] onto [src]."))
+			install_suppressor(A)
+			return
+	if (can_be_sawn_off)
+		if (sawoff(user, A))
+			return
+
+	if(can_misfire && istype(A, /obj/item/stack/sheet/cloth))
+		if(guncleaning(user, A))
+			return
+
+	return FALSE
+
+/obj/item/gun/ballistic/proc/handle_magazine(mob/user, obj/item/ammo_box/magazine/inserting_magazine)
+	if(magazine) // If we already have a magazine inserted, we're going to begin tactically reloading it.
+		if(reload_time && !HAS_TRAIT(user, TRAIT_INSTANT_RELOAD)) // Check if we have a reload time to tactical reloading, or if we have the instant reload trait.
+			to_chat(user, span_notice("You start to insert the magazine into [src]!"))
+			if(!do_after(user, reload_time, src, IGNORE_USER_LOC_CHANGE)) // We are allowed to move while reloading.
+				to_chat(user, span_danger("You fail to insert the magazine into [src]!"))
+				return
+		eject_magazine(user, FALSE, inserting_magazine) // We eject the magazine then insert the new one, while putting the old one in hands.
+	else
+		insert_magazine(user, inserting_magazine) // Otherwise, just insert it.
 
 /obj/item/gun/ballistic/proc/jam(unjam = FALSE, mob/living/user)
 	if(unjam && jammed != TRUE)

--- a/modular_skyrat/modules/gunsgalore/code/guns/ballistic_master.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/ballistic_master.dm
@@ -58,7 +58,6 @@
 	if (.)
 		return
 	if (!internal_magazine && istype(A, /obj/item/ammo_box/magazine))
-		var/obj/item/ammo_box/magazine/AM = A
 		handle_magazine(user, A)
 		return
 	if (istype(A, /obj/item/ammo_casing) || istype(A, /obj/item/ammo_box))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can now tactically reload a weapon while moving as specified in the combat overhaul.

Also fixes mags dropping during tac reloads.

## Changelog

:cl:
balance: You can now move while tactically reloading a weapon.
fix: Magazines will no longer drop onto the ground during tactical reloads.
/:cl:

