### PR TITLE
Species lock for ghost spawners

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -155,6 +155,7 @@
 	and eventually bring life to this desolate planet while waiting for contact from your creators. \
 	Estimated time of last contact: Deployment, 5000 millennia ago."
 	spawner_job_path = /datum/job/lifebringer
+	restricted_species = list(/datum/species/pod) //SKYRAT EDIT ADDITION
 
 /obj/effect/mob_spawn/ghost_role/human/seed_vault/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -264,7 +264,7 @@
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
 	mob_type = /mob/living/carbon/human
-	restricted_species = list(/datum/species/lizard/ashwalker)
+	restricted_species = list(/datum/species/lizard/ashwalker) //SKYRAT EDIT ADDITION
 
 /obj/effect/mob_spawn/corpse/human
 	icon_state = "corpsehuman"

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -138,7 +138,7 @@
 	var/loadout_enabled = FALSE
 	/// Can we use our quirks for this role?
 	var/quirks_enabled = FALSE
-	/// Are we limited to a certain species type?
+	/// Are we limited to a certain species type? LISTED TYPE
 	var/restricted_species
 	// SKYRAT EDIT END
 
@@ -159,7 +159,7 @@
 	if(!SSticker.HasRoundStarted() || !loc)
 		return
 	// SKYRAT EDIT ADDITION
-	if(restricted_species && user.client?.prefs?.read_preference(/datum/preference/choiced/species) != restricted_species)
+	if(restricted_species && !(user.client?.prefs?.read_preference(/datum/preference/choiced/species) in restricted_species))
 		to_chat(user, span_warning("You cannot use this role because you are not the correct species!"))
 		return
 	// SKYRAT EDIT END
@@ -264,6 +264,7 @@
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
 	mob_type = /mob/living/carbon/human
+	restricted_species = list(/datum/species/lizard/ashwalker)
 
 /obj/effect/mob_spawn/corpse/human
 	icon_state = "corpsehuman"

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -159,7 +159,7 @@
 	if(!SSticker.HasRoundStarted() || !loc)
 		return
 	// SKYRAT EDIT ADDITION
-	if(restricted_species && !istype(user.client?.prefs?.read_preference(/datum/preference/choiced/species), restricted_species))
+	if(restricted_species && user.client?.prefs?.read_preference(/datum/preference/choiced/species) != restricted_species)
 		to_chat(user, span_warning("You cannot use this role because you are not the correct species!"))
 		return
 	// SKYRAT EDIT END

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -138,6 +138,8 @@
 	var/loadout_enabled = FALSE
 	/// Can we use our quirks for this role?
 	var/quirks_enabled = FALSE
+	/// Are we limited to a certain species type?
+	var/restricted_species
 	// SKYRAT EDIT END
 
 /obj/effect/mob_spawn/ghost_role/Initialize(mapload)
@@ -156,6 +158,11 @@
 /obj/effect/mob_spawn/ghost_role/attack_ghost(mob/user)
 	if(!SSticker.HasRoundStarted() || !loc)
 		return
+	// SKYRAT EDIT ADDITION
+	if(restricted_species && !istype(user.client?.prefs?.read_preference(/datum/preference/choiced/species), restricted_species))
+		to_chat(user, span_warning("You cannot use this role because you are not the correct species!"))
+		return
+	// SKYRAT EDIT END
 	if(prompt_ghost)
 		var/ghost_role = tgui_alert(usr, "Become [prompt_name]? (Warning, You can no longer be revived!)",, list("Yes", "No"))
 		if(ghost_role != "Yes" || !loc || QDELETED(user))

--- a/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa.dm
+++ b/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa.dm
@@ -605,7 +605,7 @@
 	prompt_name = "a tactical squad member"
 	outfit = /datum/outfit/hecu
 	you_are_text = "You are an elite tactical squad deployed into the research facility to contain the infestation. DO NOT TRY TO EXPLORE THE LEVEL. STAY AROUND YOUR AREA."
-	restricted_species = /datum/species/human
+	restricted_species = list(/datum/species/human)
 
 /obj/item/clothing/under/rank/security/officer/hecu
 	name = "hecu jumpsuit"

--- a/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa.dm
+++ b/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa.dm
@@ -605,6 +605,7 @@
 	prompt_name = "a tactical squad member"
 	outfit = /datum/outfit/hecu
 	you_are_text = "You are an elite tactical squad deployed into the research facility to contain the infestation. DO NOT TRY TO EXPLORE THE LEVEL. STAY AROUND YOUR AREA."
+	restricted_species = /datum/species/human
 
 /obj/item/clothing/under/rank/security/officer/hecu
 	name = "hecu jumpsuit"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -303,10 +303,6 @@ GLOBAL_LIST_EMPTY(customizable_races)
 	default_mutant_bodyparts = list("tail" = "Cat", "ears" = "Cat")
 	learnable_languages = list(/datum/language/common, /datum/language/nekomimetic)
 
-/datum/species/human/monkey
-	mutant_bodyparts = list()
-	default_mutant_bodyparts = list("tail" = "Monkey")
-
 /datum/species/human
 	mutant_bodyparts = list()
 	default_mutant_bodyparts = list("ears" = "None", "tail" = "None", "wings" = "None")

--- a/modular_skyrat/modules/encounters/code/enclave_pirates.dm
+++ b/modular_skyrat/modules/encounters/code/enclave_pirates.dm
@@ -61,6 +61,7 @@
 	you_are_text = "You are an Imperial Enclave outfit."
 	flavour_text = "The station has refused to pay the fine for breaking Imperial regulations, you are here to recover the debt. Do so by ransoming crew and stealing credits."
 	spawner_job_path = /datum/job/space_pirate
+	restricted_species = /datum/species/human
 	spawn_oldpod = FALSE
 
 /datum/job/fugitive_hunter

--- a/modular_skyrat/modules/encounters/code/enclave_pirates.dm
+++ b/modular_skyrat/modules/encounters/code/enclave_pirates.dm
@@ -61,7 +61,7 @@
 	you_are_text = "You are an Imperial Enclave outfit."
 	flavour_text = "The station has refused to pay the fine for breaking Imperial regulations, you are here to recover the debt. Do so by ransoming crew and stealing credits."
 	spawner_job_path = /datum/job/space_pirate
-	restricted_species = /datum/species/human
+	restricted_species = list(/datum/species/human)
 	spawn_oldpod = FALSE
 
 /datum/job/fugitive_hunter


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can now species lock a ghost spawner.

Makes HECU and Enclave human only.

Ashwalker and pod person spawns are also locked to the native species.

## Changelog

:cl:
add: Some spawners now have species restrictions.
/:cl:

