### PR TITLE
[SEMI-MODULAR] Adds a "view OPFORs" admin verb and lets you get to it via the tickets tab

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -81,6 +81,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/admin_open_event_spawners_menu, //SKYRAT EDIT ADDITION - EVENTS
 	/datum/admins/proc/toggleaooc,		//SKYRAT EDIT ADDITION - ADMIN
 	/datum/admins/proc/togglesooc,		//SKYRAT EDIT ADDITION - ADMIN
+	/client/proc/view_opfors,			//SKYRAT EDIT
 	/datum/admins/proc/open_borgopanel,
 	/datum/admins/proc/view_all_circuits,
 	/datum/admins/proc/view_all_sdql_spells,

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -115,7 +115,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	//SKYRAT EDIT ADDITION
 	if(LAZYLEN(SSopposing_force.submitted_applications))
 		for(var/datum/opposing_force/opposing_force as anything in SSopposing_force.submitted_applications)
-			L[++L.len] = list("[opposing_force.handling_admin ? "H-[opposing_force.handling_admin]. " : ""]OPFOR: [opposing_force.ckey]", null, REF(opposing_force))
+			L[++L.len] = list("[opposing_force.handling_admin ? "H-[opposing_force.handling_admin]. " : ""]OPFOR:", "[opposing_force.stat_button.update(" [opposing_force.ckey] ")]", null, REF(opposing_force.stat_button))
 	//SKYRAT EDIT END
 	return L
 

--- a/modular_skyrat/modules/opposing_force/code/admin_procs.dm
+++ b/modular_skyrat/modules/opposing_force/code/admin_procs.dm
@@ -10,3 +10,14 @@
 			asked++
 	message_admins("[ADMIN_LOOKUP(usr)] has requested more OPFOR players! (Asked: [asked] players)")
 
+
+/client/proc/view_opfors()
+	set name = "View OPFORs"
+	set category = "Admin.Game"
+	if(holder)
+		var/list/dat = list("<html>")
+		dat += SSopposing_force.get_check_antag_listing()
+		dat += "</html>"
+		usr << browse(dat.Join(), "window=roundstatus;size=500x500")
+		log_admin("[key_name(usr)] viewed OPFORs.")
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "View OPFORs")

--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -73,6 +73,8 @@
 	var/admin_requested_changes = ""
 	/// The ckey of the person that made this application
 	var/ckey
+	/// Corresponding stat() click button
+	var/obj/effect/statclick/opfor_specific/stat_button
 
 	COOLDOWN_DECLARE(static/request_update_cooldown)
 	COOLDOWN_DECLARE(static/ping_cooldown)
@@ -81,6 +83,8 @@
 	src.mind_reference = mind_reference
 	ckey = ckey(mind_reference.key)
 	send_system_message("[ckey] created the application")
+	stat_button = new()
+	stat_button.opfor = src
 
 /datum/opposing_force/Destroy(force)
 	mind_reference.opposing_force = null
@@ -89,6 +93,7 @@
 	QDEL_LIST(objectives)
 	QDEL_LIST(admin_chat)
 	QDEL_LIST(modification_log)
+	QDEL_NULL(stat_button)
 	return ..()
 
 /datum/opposing_force/Topic(href, list/href_list)
@@ -868,3 +873,21 @@
 	if(!.)
 		return
 	return TRUE
+
+/obj/effect/statclick/opfor_specific
+	var/datum/opposing_force/opfor
+
+/obj/effect/statclick/opfor_specific/Destroy()
+	opfor = null
+	. = ..()
+
+/obj/effect/statclick/opfor_specific/Click()
+	if (!usr.client?.holder)
+		message_admins("[key_name_admin(usr)] non-holder clicked on an OPFOR statclick! ([src])")
+		log_game("[key_name(usr)] non-holder clicked on an OPFOR statclick! ([src])")
+		return
+
+	opfor.ui_interact(usr)
+
+/obj/effect/statclick/opfor_specific/proc/Action()
+	Click()

--- a/modular_skyrat/modules/ticket_counter/code/counter.dm
+++ b/modular_skyrat/modules/ticket_counter/code/counter.dm
@@ -7,6 +7,9 @@ GLOBAL_LIST_INIT(ticket_counter, list())
 	GLOB.ticket_counter[ckey]+= number
 	sortTim(GLOB.ticket_counter, cmp=/proc/cmp_numeric_dsc, associative = TRUE)
 
+/datum/admin_help_tickets
+	var/obj/effect/statclick/opfor_list/opforstat = new()
+
 /datum/admin_help_tickets/stat_entry()
 	var/list/L = ..()
 	L[++L.len] = list(null, null, null, null)
@@ -17,7 +20,7 @@ GLOBAL_LIST_INIT(ticket_counter, list())
 		//assumption, that there's no keys with empty values
 		L[++L.len] = list("[ckey]", "[GLOB.ticket_counter[ckey]]", null, null)
 
-	L[++L.len] = list("OPFOR:", "UNSUB: [LAZYLEN(SSopposing_force.unsubmitted_applications)] | SUB: [LAZYLEN(SSopposing_force.submitted_applications)] | APPR: [LAZYLEN(SSopposing_force.approved_applications)]", null, null)
+	L[++L.len] = list("[opforstat.update("OPFOR:")]", "UNSUB: [LAZYLEN(SSopposing_force.unsubmitted_applications)] | SUB: [LAZYLEN(SSopposing_force.submitted_applications)] | APPR: [LAZYLEN(SSopposing_force.approved_applications)]", null, REF(opforstat))
 
 	return L
 
@@ -47,3 +50,17 @@ GLOBAL_LIST_INIT(ticket_counter, list())
 	if(!previously_closed)
 		ticket_counter_add_handled(usr.key, 1)
 		previously_closed = TRUE
+
+/obj/effect/statclick/opfor_list
+
+/obj/effect/statclick/opfor_list/Click()
+	if (!usr.client?.holder)
+		message_admins("[key_name_admin(usr)] non-holder clicked on an OPFOR list statclick! ([src])")
+		log_game("[key_name(usr)] non-holder clicked on an OPFOR list statclick! ([src])")
+		return
+
+	usr.client.view_opfors()
+
+//called by admin topic
+/obj/effect/statclick/opfor_list/proc/Action()
+	Click()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a "view OPFORs" verb to admin.game verb tab and adds a button to the tickets tab

## How This Contributes To The Skyrat Roleplay Experience
Repeatedly requested by multiple staff, it's unintuitive to have to check opfors by going through the check-antagonists verb

## TODO

- [x] Test this[^1]

[^1]: I coded this on a laptop in five minutes that can't run spessgame, okay
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: New admin verb, View-OPFORs. Equivalent to the OPFOR section of check-antagonists without the bloat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
