### PR TITLE
[SEMI-MODULAR] Adds admin buttons for exploitable overrides, as well as an OPFOR service, letting admins easily give people exploitables. Also cleans up some code I made before.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -723,6 +723,7 @@
 					log_admin("[key_name(usr)] tried and failed to give [current] an uplink.")
 				else
 					log_admin("[key_name(usr)] gave [current] an uplink.")
+			//SKYRAT EDIT ADDITION BEGIN -- EXPLOITABLES
 			if("toggleexploitables")
 				if (has_exploitables_override)
 					has_exploitables_override = FALSE
@@ -739,6 +740,7 @@
 					add_verb(current, /mob/proc/view_exploitables_verb)
 				log_admin("[key_name(usr)] toggled [current]'s exploitable menu override to [has_exploitable_menu_override].")
 				message_admins("[key_name(usr)] toggled [current]'s exploitable menu override to [has_exploitable_menu_override].")
+			//SKYRAT EDIT ADDITION END
 
 
 	else if (href_list["obj_announce"])

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -95,6 +95,10 @@
 	// SKYRAT EDIT ADDITION -- EXPLOITABLE MENU
 	///Tracks if the target has the view_exploitables_verb verb. THIS MUST BE CHANGED IF THE VERB IS ADDED OR REMOVED OR ELSE STUFF BREAKS.
 	var/has_exploitable_menu = FALSE
+	/// While true, allows for unconditional access to examined exploitables.
+	var/has_exploitables_override = FALSE
+	/// Both a marker for having the exploitable menu verb, and the access key to certain alternate conditions in if statements to allow the user to use the exploitable menu.
+	var/has_exploitable_menu_override = FALSE
 
 /datum/mind/New(_key)
 	key = _key
@@ -320,9 +324,9 @@
 		var/datum/antagonist/A = a
 		A.on_removal()
 	//SKYRAT EDIT ADDITION BEGIN - EXPLOITABLE MENU
-	if (has_exploitable_menu)
-		remove_verb(current, /mob/proc/view_exploitables_verb)
-		has_exploitable_menu = FALSE
+		if (has_exploitable_menu)
+			remove_verb(current, /mob/proc/view_exploitables_verb)
+			has_exploitable_menu = FALSE
 	//SKYRAT EDIT ADDITION END
 
 /datum/mind/proc/has_antag_datum(datum_type, check_subtypes = TRUE)
@@ -719,6 +723,23 @@
 					log_admin("[key_name(usr)] tried and failed to give [current] an uplink.")
 				else
 					log_admin("[key_name(usr)] gave [current] an uplink.")
+			if("toggleexploitables")
+				if (has_exploitables_override)
+					has_exploitables_override = FALSE
+				else
+					has_exploitables_override = TRUE
+				log_admin("[key_name(usr)] toggled [current]'s exploitables override to [has_exploitables_override].")
+				message_admins("[key_name(usr)] toggled [current]'s exploitables override to [has_exploitables_override].")
+			if("toggleexploitablesmenu")
+				if (has_exploitable_menu_override)
+					has_exploitable_menu_override = FALSE
+					remove_verb(current, /mob/proc/view_exploitables_verb)
+				else
+					has_exploitable_menu_override = TRUE
+					add_verb(current, /mob/proc/view_exploitables_verb)
+				log_admin("[key_name(usr)] toggled [current]'s exploitable menu override to [has_exploitable_menu_override].")
+				message_admins("[key_name(usr)] toggled [current]'s exploitable menu override to [has_exploitable_menu_override].")
+
 
 	else if (href_list["obj_announce"])
 		announce_objectives()

--- a/code/modules/admin/antag_panel.dm
+++ b/code/modules/admin/antag_panel.dm
@@ -67,6 +67,9 @@ GLOBAL_VAR(antag_prototypes)
 				if (R.emagged)
 					common_commands += "<a href='?src=[REF(src)];silicon=unemagcyborgs'>Unemag slaved cyborgs</a>"
 					break
+	common_commands += "<a href='?src=[REF(src)];common=toggleexploitables'>Toggle exploitables access</a>"
+	common_commands += "<a href='?src=[REF(src)];common=toggleexploitablesmenu'>Toggle exploitables menu access</a>"
+
 	return common_commands
 
 /datum/mind/proc/get_special_statuses()

--- a/code/modules/admin/antag_panel.dm
+++ b/code/modules/admin/antag_panel.dm
@@ -67,8 +67,8 @@ GLOBAL_VAR(antag_prototypes)
 				if (R.emagged)
 					common_commands += "<a href='?src=[REF(src)];silicon=unemagcyborgs'>Unemag slaved cyborgs</a>"
 					break
-	common_commands += "<a href='?src=[REF(src)];common=toggleexploitables'>Toggle exploitables access</a>"
-	common_commands += "<a href='?src=[REF(src)];common=toggleexploitablesmenu'>Toggle exploitables menu access</a>"
+	common_commands += "<a href='?src=[REF(src)];common=toggleexploitables'>Toggle exploitables access</a>" //SKYRAT EDIT ADDITION BEGIN -- EXPLOITABLES
+	common_commands += "<a href='?src=[REF(src)];common=toggleexploitablesmenu'>Toggle exploitables menu access</a>" //SKYRAT EDIT ADDITION END
 
 	return common_commands
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -460,13 +460,17 @@
 		. += "<span class='info'><b>Traits:</b> [get_quirk_string(FALSE, CAT_QUIRK_ALL)]</span>"
 
 	//SKYRAT EDIT ADDITION BEGIN - EXAMINE RECORDS
-	if (is_special_character(user))
-		var/datum/data/record/is_in_world = find_record("name", perpname, GLOB.data_core.general) //apparantly golden is okay with offstation roles having no records, FYI
-		if (is_in_world && length(is_in_world.fields["exploitable_records"]) >= 2)
+	var/datum/data/record/target_record = find_record("name", perpname, GLOB.data_core.general)
+	if (target_record && length(target_record.fields["exploitable_records"]) >= 2)
+		if (is_special_character(user))
 			for(var/datum/antagonist/antag_datum in user.mind.antag_datums)
 				if (antag_datum.view_exploitables)
 					. += "<a href='?src=[REF(src)];exprecords=1'>\[View exploitable info\]</a>"
 					break
+
+		else if (user.mind.has_exploitables_override)
+			. += "<a href='?src=[REF(src)];exprecords=1'>\[View exploitable info\]</a>"
+
 	//SKYRAT EDIT END
 	//SKYRAT EDIT ADDITION BEGIN - GUNPOINT
 	if(gunpointing)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -392,7 +392,7 @@
 				return
 
 	//SKYRAT EDIT ADDITION BEGIN - VIEW RECORDS
-	if (is_special_character(usr))
+	if (is_special_character(usr) || usr.mind.has_exploitables_override)
 		var/perpname = get_face_name(get_id_name(""))
 		var/datum/data/record/EXP = find_record("name", perpname, GLOB.data_core.general)
 		if(href_list["exprecords"])

--- a/modular_skyrat/master_files/code/modules/antagonists/_common/antag_datum.dm
+++ b/modular_skyrat/master_files/code/modules/antagonists/_common/antag_datum.dm
@@ -1,5 +1,5 @@
 /datum/antagonist
-	//Should this antagonist be allowed to view exploitable information?
+	/// Should this antagonist be allowed to view exploitable information?
 	var/view_exploitables = FALSE
 
 /datum/antagonist/heretic

--- a/modular_skyrat/modules/opposing_force/code/equipment/services.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/services.dm
@@ -57,3 +57,22 @@
 /datum/opposing_force_equipment/service/market_crash/on_issue()
 	var/datum/round_event_control/event = locate(/datum/round_event_control/market_crash) in SSevents.control
 	event.runEvent()
+
+/datum/opposing_force_equipment/service/give_exploitables
+	name = "Exploitables Access"
+	description = "You will be given access to a network of exploitable information of certain crewmates, viewable on examine."
+	item_type = /obj/effect/gibspawner/generic
+	admin_note = "Gives them access to exploitables, which most antags get for existing."
+
+/datum/opposing_force_equipment/service/give_exploitables/on_issue(mob/living/target)
+	target.mind.has_exploitables_override = TRUE
+
+/datum/opposing_force_equipment/service/give_exploitables_menu
+	name = "Exploitables Menu Access"
+	description = "You will be given access to a network of exploitable information of certain crewmates, viewable using a OOC verb."
+	item_type = /obj/effect/gibspawner/generic
+	admin_note = "Gives them access to the exploitables menu, which lets them view the exploitables of anyone from anywhere."
+
+/datum/opposing_force_equipment/service/give_exploitables_menu/on_issue(mob/living/target)
+	target.mind.has_exploitable_menu_override = TRUE
+	add_verb(target, /mob/proc/view_exploitables_verb)

--- a/modular_skyrat/modules/records_on_examine/code/mind.dm
+++ b/modular_skyrat/modules/records_on_examine/code/mind.dm
@@ -1,4 +1,6 @@
 /datum/mind/proc/handle_exploitables_menu()
+	if (has_exploitable_menu_override)
+		return
 	//Only returns true if no datums are present in the mind. Without this, the for loop would end prematurely, as it would be null.
 	if (!antag_datums)
 		if (has_exploitable_menu)

--- a/modular_skyrat/modules/records_on_examine/code/view_exploitables.dm
+++ b/modular_skyrat/modules/records_on_examine/code/view_exploitables.dm
@@ -17,6 +17,12 @@
 
 				GLOB.record_manifest_tgui.ui_interact(src)
 				break
+
+	else if (src.mind.has_exploitable_menu_override)
+
+		if(!GLOB.record_manifest_tgui)
+			GLOB.record_manifest_tgui = new /datum/record_manifest(src)
+
 	else
 		to_chat(src, span_danger("You're not an antagonist that can view exploitables! This message should not appear!"))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes a bunch of edits in some core files, does what it says in the title. It also makes a few random changes to the code I made on this.

Won't lie, made this PR while tired off my ass, so don't be surprised if there's some fuckiness in the code.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Exploitables good.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: New OPFOR services for exploitables.
admin: Added new admin buttons in traitor panel for adding or removing exploitable access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
