### PR TITLE
[NON-MODULAR] Replaces the "no erotic paintings" warning in the AI portrait picker UI with something befitting for the server

### DIFF
--- a/tgui/packages/tgui/interfaces/PortraitPicker.js
+++ b/tgui/packages/tgui/interfaces/PortraitPicker.js
@@ -88,6 +88,8 @@ export const PortraitPicker = (props, context) => {
                 </Section>
               </Flex.Item>
             </Flex>
+//SKYRAT EDIT CHANGE BEGIN
+/*
             <Flex.Item mt={1}>
               <NoticeBox info>
                 Only the 23x23 or 24x24 canvas size art can be
@@ -104,6 +106,15 @@ export const PortraitPicker = (props, context) => {
                 you change your display portrait, for any reason.
               </NoticeBox>
             </Flex.Item>
+*/
+            <Flex.Item mt={1}>
+              <NoticeBox info>
+                Only the 23x23 or 24x24 canvas size art can be
+                displayed. Central Command reserves the right to request
+                you change your display portrait, for any reason.
+              </NoticeBox>
+            </Flex.Item>
+//SKYRAT EDIT CHANGE END
           </Flex.Item>
         </Flex>
       </Window.Content>


### PR DESCRIPTION
## About The Pull Request
See the title. I have commented out the original notice boxes in favor for something more neutral:
```
                Only the 23x23 or 24x24 canvas size art can be
                displayed. Central Command reserves the right to request
                you change your display portrait, for any reason.
```

## How This Contributes To The Skyrat Roleplay Experience
This warning doesn't blend in well with the actual rules of the server, primarily the lack of /tg/'s Rule 8, plus I doubt admins would actually enforce something like that for pixel art (otherwise I'd have found out the hard way).

## Changelog

:cl:
spellcheck: Removed a warning against smut paintings from the AI portrait picker UI.
/:cl:
