### PR TITLE
[HOST] [MODULAR] Disables barnyard curse in OPFOR

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/equipment/spells.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/spells.dm
@@ -36,12 +36,12 @@
 	name = "Knock"
 	item_type = /obj/item/book/granter/spell/knock
 	description = "This spell opens nearby doors and closets."
-
+/* //Requested to be removed by host for being too LRP
 /datum/opposing_force_equipment/spell/barnyard
 	name = "Barnyard Curse"
 	item_type = /obj/item/book/granter/spell/barnyard
 	description = "This spell dooms an unlucky soul to possess the speech and facial attributes of a barnyard animal."
-
+*/
 /datum/opposing_force_equipment/spell/charge
 	name = "Charge"
 	item_type = /obj/item/book/granter/spell/charge

--- a/modular_skyrat/modules/opposing_force/code/equipment/spells.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/spells.dm
@@ -36,12 +36,7 @@
 	name = "Knock"
 	item_type = /obj/item/book/granter/spell/knock
 	description = "This spell opens nearby doors and closets."
-/* //Requested to be removed by host for being too LRP
-/datum/opposing_force_equipment/spell/barnyard
-	name = "Barnyard Curse"
-	item_type = /obj/item/book/granter/spell/barnyard
-	description = "This spell dooms an unlucky soul to possess the speech and facial attributes of a barnyard animal."
-*/
+
 /datum/opposing_force_equipment/spell/charge
 	name = "Charge"
 	item_type = /obj/item/book/granter/spell/charge


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title

## How This Contributes To The Skyrat Roleplay Experience
Xyel wants it gone for being non-conductive to what they want skyrat to be.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Barnyard curse is no longer an OPFOR item
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
