### PR TITLE
[Modular] - Updates  golem_ship.dmm to unlink from station

### DIFF
--- a/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
+++ b/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
@@ -83,7 +83,9 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "p" = (
-/obj/machinery/mineral/ore_redemption,
+/obj/item/circuitboard/machine/ore_redemption,
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/five,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "q" = (
@@ -149,6 +151,14 @@
 	},
 /obj/item/storage/medkit/fire,
 /obj/item/storage/medkit/fire,
+/obj/item/stock_parts/matter_bin,
+/obj/item/assembly/igniter,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "B" = (


### PR DESCRIPTION
Related to issue

https://github.com/Skyrat-SS13/Skyrat-tg/issues/12096

Removes the prebuilt ORM to match how the sydicate base operates, requiring them to simply build it.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


## How This Contributes To The Skyrat Roleplay Experience
Currently the silo links to the station by default, meaning they either mine for the station accidentally or rob them blind accidentally. If the ORM Breaks then they lose everything.

## Changelog


🆑 
add: Fixed the Golem ship ORM linking to the station at round-start
/🆑