### PR TITLE
[HOST][TM-ONLY AT FIRST] Disables Progression Traitors

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -223,7 +223,7 @@ GLOBAL_LIST_INIT(ai_employers, list(
 // Progression traitor defines
 
 /// How many telecrystals a normal traitor starts with
-#define TELECRYSTALS_DEFAULT 35 //SKYRAT EDIT CHANGE
+#define TELECRYSTALS_DEFAULT 20
 /// How many telecrystals mapper/admin only "precharged" uplink implant
 #define TELECRYSTALS_PRELOADED_IMPLANT 10
 /// The normal cost of an uplink implant; used for calcuating how many

--- a/code/__DEFINES/~skyrat_defines/antagonists.dm
+++ b/code/__DEFINES/~skyrat_defines/antagonists.dm
@@ -1,0 +1,4 @@
+/// How many telecrystals a normal traitor starts with
+#define TELECRYSTALS_DEFAULT_SKYRAT 15
+/// How many telecrystals a traitor gets when they have an approved OPFOR
+#define TELECRYSTALS_OPFOR_SKYRAT 25

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -44,7 +44,7 @@
 	lockable = TRUE,
 	enabled = FALSE,
 	uplink_flag = UPLINK_TRAITORS,
-	starting_tc = TELECRYSTALS_DEFAULT,
+	starting_tc = TELECRYSTALS_DEFAULT_SKYRAT, //SKYRAT EDIT
 	has_progression = FALSE,
 	datum/uplink_handler/uplink_handler_override,
 )

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -205,7 +205,7 @@
 /datum/antagonist/traitor/proc/forge_traitor_objectives()
 	objectives.Cut()
 
-	//SKYRAT EDIT START - OBJECTIVE REMOVAL
+	//SKYRAT EDIT START - PROGTOT REVERT
 	/*
 	var/datum/objective/traitor_progression/final_objective = new /datum/objective/traitor_progression()
 	final_objective.owner = owner
@@ -214,7 +214,12 @@
 	var/datum/objective/traitor_objectives/objective_completion = new /datum/objective/traitor_objectives()
 	objective_completion.owner = owner
 	objectives += objective_completion
+
 	*/
+	var/objective_limit = CONFIG_GET(number/traitor_objectives_amount)
+
+	for(var/objective in objective_count to objective_limit - 1)
+		objectives += forge_single_generic_objective()
 	//SKYRAT EDIT END
 
 /datum/antagonist/traitor/apply_innate_effects(mob/living/mob_override)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -27,6 +27,10 @@
 
 	/// The uplink handler that this traitor belongs to.
 	var/datum/uplink_handler/uplink_handler
+	// SKYRAT EDIT START
+	///the final objective the traitor has to accomplish, be it escaping, hijacking, or just martyrdom.
+	var/datum/objective/ending_objective
+	// SKYRAT EDIT END
 
 	var/uplink_sale_count = 3
 
@@ -69,6 +73,7 @@
 
 	if(give_objectives)
 		forge_traitor_objectives()
+		forge_ending_objective() //SKYRAT EDIT
 
 	var/faction = prob(75) ? FACTION_SYNDICATE : FACTION_NANOTRASEN
 
@@ -217,9 +222,12 @@
 
 	*/
 	var/objective_limit = CONFIG_GET(number/traitor_objectives_amount)
+	var/objective_count = 0
 
 	for(var/objective in objective_count to objective_limit - 1)
 		objectives += forge_single_generic_objective()
+
+
 	//SKYRAT EDIT END
 
 /datum/antagonist/traitor/apply_innate_effects(mob/living/mob_override)

--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -11,7 +11,7 @@
 	/// The current uplink flag of this uplink
 	var/uplink_flag = NONE
 	/// This uplink has progression
-	var/has_progression = TRUE
+	var/has_progression = FALSE //SKYRAT EDIT
 	/// The amount of experience points this traitor has
 	var/progression_points = 0
 	/// The purchase log of this uplink handler

--- a/modular_skyrat/master_files/code/game/gamemodes/objective.dm
+++ b/modular_skyrat/master_files/code/game/gamemodes/objective.dm
@@ -7,3 +7,37 @@
 	SIGNAL_HANDLER
 	completed = TRUE
 	UnregisterSignal(dead_guy, COMSIG_LIVING_DEATH)
+
+/datum/objective/download
+	name = "download"
+
+/datum/objective/download/proc/gen_amount_goal()
+	target_amount = rand(20,40)
+	update_explanation_text()
+	return target_amount
+
+/datum/objective/download/update_explanation_text()
+	..()
+	explanation_text = "Download [target_amount] research node\s."
+
+/datum/objective/download/check_completion()
+	var/datum/techweb/checking = new
+	var/list/datum/mind/owners = get_owners()
+	for(var/datum/mind/owner in owners)
+		if(ismob(owner.current))
+			var/mob/mob_owner = owner.current //Yeah if you get morphed and you eat a quantum tech disk with the RD's latest backup good on you soldier.
+			if(ishuman(mob_owner))
+				var/mob/living/carbon/human/human_downloader = mob_owner
+				if(human_downloader && (human_downloader.stat != DEAD) && istype(human_downloader.wear_suit, /obj/item/clothing/suit/space/space_ninja))
+					var/obj/item/clothing/suit/space/space_ninja/ninja_suit = human_downloader.wear_suit
+					ninja_suit.stored_research.copy_research_to(checking)
+			var/list/otherwise = mob_owner.get_contents()
+			for(var/obj/item/disk/tech_disk/dat_fukken_disk in otherwise)
+				dat_fukken_disk.stored_research.copy_research_to(checking)
+	return checking.researched_nodes.len >= target_amount
+
+/datum/objective/download/admin_edit(mob/admin)
+	var/count = input(admin,"How many nodes ?","Nodes",target_amount) as num|null
+	if(count)
+		target_amount = count
+	update_explanation_text()

--- a/modular_skyrat/master_files/code/modules/antagonists/_common/antag_datum.dm
+++ b/modular_skyrat/master_files/code/modules/antagonists/_common/antag_datum.dm
@@ -64,7 +64,7 @@
 		objectives += kill_objective
 		return
 
-	if(prob(DOWNLOAD_PROB) && !(locate(/datum/objective/download) in objectives) && !(owner.assigned_role.departments & DEPARTMENT_SCIENCE))
+	if(prob(DOWNLOAD_PROB) && !(locate(/datum/objective/download) in objectives) && !(owner.assigned_role.departments_list.Find(/datum/job_department/science)))
 		var/datum/objective/download/download_objective = new
 		download_objective.owner = owner
 		download_objective.gen_amount_goal()
@@ -75,6 +75,29 @@
 	steal_objective.owner = owner
 	steal_objective.find_target()
 	objectives += steal_objective
+
+/datum/antagonist/traitor/proc/forge_ending_objective()
+	if(is_hijacker)
+		ending_objective = new /datum/objective/hijack
+		ending_objective.owner = owner
+		return
+
+	var/martyr_compatibility = TRUE
+
+	for(var/datum/objective/traitor_objective in objectives)
+		if(!traitor_objective.martyr_compatible)
+			martyr_compatibility = FALSE
+			break
+
+	if(martyr_compatibility && prob(MARTYR_PROB))
+		ending_objective = new /datum/objective/martyr
+		ending_objective.owner = owner
+		objectives += ending_objective
+		return
+
+	ending_objective = new /datum/objective/escape
+	ending_objective.owner = owner
+	objectives += ending_objective
 
 /datum/antagonist/traitor/greet()
 	..()

--- a/modular_skyrat/master_files/code/modules/antagonists/_common/antag_datum.dm
+++ b/modular_skyrat/master_files/code/modules/antagonists/_common/antag_datum.dm
@@ -1,3 +1,15 @@
+/// Chance the traitor gets a martyr objective instead of having to escape alive, as long as all the objectives are martyr compatible.
+#define MARTYR_PROB 20
+
+/// Chance the traitor gets a kill objective. If this prob fails, they will get a steal objective instead.
+#define KILL_PROB 50
+/// If a kill objective is rolled, chance that it is to destroy the AI.
+#define DESTROY_AI_PROB(denominator) (100 / denominator)
+/// If the destroy AI objective doesn't roll, chance that we'll get a maroon instead. If this prob fails, they will get a generic assassinate objective instead.
+#define MAROON_PROB 30
+/// If it's a steal objective, this is the chance that it'll be a download research notes objective. Science staff can't get this objective. It can only roll once. If any of these fail, they will get a generic steal objective instead.
+#define DOWNLOAD_PROB 15
+
 /datum/antagonist
 	//Should this antagonist be allowed to view exploitable information?
 	var/view_exploitables = FALSE
@@ -29,6 +41,41 @@
 /datum/antagonist/traitor
 	view_exploitables = TRUE
 
+/datum/antagonist/traitor/proc/forge_single_generic_objective()
+	if(prob(KILL_PROB))
+		var/list/active_ais = active_ais()
+		if(active_ais.len && prob(DESTROY_AI_PROB(GLOB.joined_player_list.len)))
+			var/datum/objective/destroy/destroy_objective = new
+			destroy_objective.owner = owner
+			destroy_objective.find_target()
+			objectives += destroy_objective
+			return
+
+		if(prob(MAROON_PROB))
+			var/datum/objective/maroon/maroon_objective = new
+			maroon_objective.owner = owner
+			maroon_objective.find_target()
+			objectives += maroon_objective
+			return
+
+		var/datum/objective/assassinate/kill_objective = new
+		kill_objective.owner = owner
+		kill_objective.find_target()
+		objectives += kill_objective
+		return
+
+	if(prob(DOWNLOAD_PROB) && !(locate(/datum/objective/download) in objectives) && !(owner.assigned_role.departments & DEPARTMENT_SCIENCE))
+		var/datum/objective/download/download_objective = new
+		download_objective.owner = owner
+		download_objective.gen_amount_goal()
+		objectives += download_objective
+		return
+
+	var/datum/objective/steal/steal_objective = new
+	steal_objective.owner = owner
+	steal_objective.find_target()
+	objectives += steal_objective
+
 /datum/antagonist/pirate
 	view_exploitables = TRUE //pirates are flexible antags, not strictly bound by their objective. i could see this working
 
@@ -43,3 +90,9 @@
 
 /*/datum/antagonist/abductor //maybe?
 	view_exploitables = TRUE */
+
+#undef MARTYR_PROB
+#undef KILL_PROB
+#undef DESTROY_AI_PROB
+#undef MAROON_PROB
+#undef DOWNLOAD_PROB

--- a/modular_skyrat/master_files/code/modules/antagonists/_common/antag_datum.dm
+++ b/modular_skyrat/master_files/code/modules/antagonists/_common/antag_datum.dm
@@ -76,6 +76,11 @@
 	steal_objective.find_target()
 	objectives += steal_objective
 
+/datum/antagonist/traitor/greet()
+	..()
+	if(!silent)
+		to_chat(owner.current, span_notice("Fill out an Opposing Force application to earn an extra [TELECRYSTALS_OPFOR_SKYRAT] TC on approval."))
+
 /datum/antagonist/pirate
 	view_exploitables = TRUE //pirates are flexible antags, not strictly bound by their objective. i could see this working
 

--- a/modular_skyrat/master_files/code/modules/antagonists/_common/antag_datum.dm
+++ b/modular_skyrat/master_files/code/modules/antagonists/_common/antag_datum.dm
@@ -64,7 +64,7 @@
 		objectives += kill_objective
 		return
 
-	if(prob(DOWNLOAD_PROB) && !(locate(/datum/objective/download) in objectives) && !(owner.assigned_role.departments_list.Find(/datum/job_department/science)))
+	if(prob(DOWNLOAD_PROB) && !(locate(/datum/objective/download) in objectives) && !(owner?.assigned_role?.departments_list.Find(/datum/job_department/science)))
 		var/datum/objective/download/download_objective = new
 		download_objective.owner = owner
 		download_objective.gen_amount_goal()

--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -545,6 +545,8 @@
 	send_system_message("[approver ? get_admin_ckey(approver) : "The OPFOR subsystem"] has approved the application")
 	send_admins_opfor_message("[span_green("APPROVED")]: [ADMIN_LOOKUPFLW(approver)] has approved [ckey]'s application")
 	ticket_counter_add_handled(approver.key, 1)
+	var/datum/component/uplink/uplink = mind_reference.find_syndicate_uplink(FALSE)
+	uplink.uplink_handler.telecrystals += TELECRYSTALS_OPFOR_SKYRAT
 
 /datum/opposing_force/proc/close_application(mob/user)
 	if(status == OPFOR_STATUS_NOT_SUBMITTED)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -257,6 +257,7 @@
 #include "code\__DEFINES\~skyrat_defines\_organ_defines.dm"
 #include "code\__DEFINES\~skyrat_defines\access.dm"
 #include "code\__DEFINES\~skyrat_defines\ammo_defines.dm"
+#include "code\__DEFINES\~skyrat_defines\antagonists.dm"
 #include "code\__DEFINES\~skyrat_defines\augment.dm"
 #include "code\__DEFINES\~skyrat_defines\banning.dm"
 #include "code\__DEFINES\~skyrat_defines\cells.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR disables prog traitors, reverting them to the regular 2 objectives + escape/die

In addition, makes traitors have 15 TC by default, earning an extra 25 on OPFOR approval.

## How This Contributes To The Skyrat Roleplay Experience
Host supported it, and it'll be interesting to see if this fixes any of the supposed issues that have been caused by progression traitors.

On the subject of the extra 5 TC: I think it won't be a massive amount of harm to give them an extra 5 TC *if* they fill out an OPFOR for an actual gimmick to do. Seeing as how you won't be able to earn large amounts of TC (as with prog traitors, without even needing to fill out an OPFOR), might as well see how this goes.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Progression Traitors are now gone
balance: Traitors get 15 TC by default and earn 25 more on filling and getting an OPFOR application approved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
