### PR TITLE
[NON-MODULAR] Exploitable Info fix

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -221,6 +221,10 @@ GLOBAL_LIST_EMPTY(antagonists)
 	for (var/datum/atom_hud/alternate_appearance/basic/has_antagonist/antag_hud as anything in GLOB.has_antagonist_huds)
 		if (!antag_hud.mobShouldSee(current))
 			antag_hud.remove_hud_from(current)
+	// SKYRAT EDIT START
+	if(owner.has_exploitable_menu)
+		remove_verb(owner.current?.client, /mob/proc/view_exploitables_verb)
+	// SKYRAT EDIT END
 
 	qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After getting my antag removed i still had the exploitable info verb, this fixes that.
![image](https://user-images.githubusercontent.com/41448081/158733110-1dbb1890-d8b1-48f6-bcca-78a0b09ec038.png)

## How This Contributes To The Skyrat Roleplay Experience
bugs bad.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Exploitable Information verb now gets properly removed when your antagonist status is.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
