### PR TITLE
Deltastation Old Prison

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -3696,22 +3696,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
-"aDP" = (
-/obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "aDT" = (
 /obj/structure/chair/office,
 /turf/open/floor/wood,
@@ -9336,12 +9320,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"bLE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "bLF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22218,9 +22196,17 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 8
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/security/office)
 "dtv" = (
 /obj/structure/disposalpipe/segment,
@@ -29214,21 +29200,6 @@
 	dir = 1
 	},
 /area/security/prison)
-"ehe" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "ehq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
@@ -33693,9 +33664,17 @@
 /area/engineering/supermatter/room)
 "fxQ" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 8
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/security/office)
 "fxS" = (
 /obj/structure/window/reinforced{
@@ -35326,10 +35305,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/engineering/atmos/hfr_room)
-"fZB" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/security/office)
 "fZK" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -37374,6 +37349,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"gHf" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/office)
 "gHl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -39471,19 +39458,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
-"hsn" = (
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "hsx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39945,15 +39919,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hBn" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad/secure,
 /turf/open/floor/iron,
 /area/security/office)
 "hBy" = (
@@ -41786,8 +41759,19 @@
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "ibI" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/computer/crew{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "ibN" = (
@@ -44122,13 +44106,12 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "iHr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box{
+	pixel_x = -8;
+	pixel_y = -4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "iHs" = (
 /obj/structure/disposalpipe/segment{
@@ -47018,14 +47001,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/donkpockets{
-	pixel_x = -14;
-	pixel_y = 6
-	},
-/obj/item/storage/fancy/donut_box{
-	pixel_x = 4
-	},
 /turf/open/floor/iron,
 /area/security/office)
 "jCF" = (
@@ -47275,15 +47250,16 @@
 /turf/open/floor/iron/checker,
 /area/service/bar)
 "jGY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/obj/item/storage/secure/briefcase,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "jHc" = (
 /obj/structure/sign/warning/nosmoking,
@@ -47420,24 +47396,21 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "jJB" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/food/donut/jelly/choco,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 8
+	},
+/obj/effect/landmark/start/head_of_security,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/security/office)
 "jJG" = (
 /obj/structure/sign/directions/engineering{
@@ -48606,16 +48579,10 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/cmo)
 "kcu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "kcH" = (
 /obj/machinery/status_display/ai/directional/west,
@@ -51695,7 +51662,6 @@
 /area/service/kitchen)
 "kXD" = (
 /obj/vehicle/ridden/secway,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -52967,27 +52933,13 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/cmo)
 "loX" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box{
-	pixel_x = -8;
-	pixel_y = -4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/item/inspector,
 /obj/item/inspector{
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "loY" = (
 /obj/structure/cable,
@@ -55052,13 +55004,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "lTm" = (
 /obj/structure/disposalpipe/segment{
@@ -56298,6 +56245,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/service/theater/abandoned)
+"mjR" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/holobadge,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "mjU" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -56475,11 +56427,6 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /turf/open/floor/iron,
 /area/security/office)
 "mms" = (
@@ -57678,7 +57625,6 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "mFt" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -61805,17 +61751,12 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "nOL" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/blue/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
 /area/security/office)
 "nOM" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -61968,6 +61909,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/photocopier,
 /turf/open/floor/iron,
 /area/security/office)
 "nRV" = (
@@ -62832,19 +62774,15 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/cafeteria)
 "oel" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/taperecorder,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/landmark/start/security_medic,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/security/office)
 "oep" = (
 /obj/structure/disposalpipe/segment{
@@ -65671,24 +65609,14 @@
 	},
 /area/security/prison)
 "oQR" = (
-/obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "oQU" = (
 /obj/structure/disposalpipe/segment,
@@ -66068,11 +65996,15 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "oYc" = (
-/obj/machinery/holopad/secure,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/food/donut/jelly/choco,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "oYf" = (
 /obj/structure/table/reinforced,
@@ -66754,22 +66686,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/customs)
-"piu" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "piv" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/loading_area{
@@ -67007,9 +66923,6 @@
 /area/security/prison/mess)
 "pms" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -67034,8 +66947,6 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "pmP" = (
-/obj/machinery/recharger,
-/obj/structure/table/reinforced,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -72067,17 +71978,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/kitchen/coldroom)
-"qIw" = (
-/obj/machinery/photocopier,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "qIG" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
@@ -72418,22 +72318,22 @@
 /turf/open/floor/carpet/green,
 /area/service/bar/atrium)
 "qNC" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/flashlight/seclite,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/security/office)
 "qNK" = (
 /obj/item/radio/intercom/directional/north,
@@ -73028,16 +72928,23 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "qUt" = (
-/obj/machinery/computer/security{
+/obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "qUA" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -73895,11 +73802,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rgu" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
 /area/security/office)
 "rgz" = (
 /obj/machinery/keycard_auth/directional/south{
@@ -75804,13 +75715,8 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "rMx" = (
-/obj/structure/chair/office,
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/corner,
+/turf/open/floor/iron/dark/corner,
 /area/security/office)
 "rME" = (
 /obj/structure/disposalpipe/segment,
@@ -78128,11 +78034,6 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
-"stD" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/security/office)
 "stE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -79243,18 +79144,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/library)
-"sHJ" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/office)
 "sHM" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/engine{
@@ -80202,24 +80091,20 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "sWf" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/storage/secure/briefcase,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/security/office)
 "sWu" = (
 /obj/structure/cable,
@@ -81076,7 +80961,6 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "tkj" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -81087,6 +80971,11 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = 4;
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/security/office)
 "tku" = (
@@ -82643,6 +82532,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron,
 /area/security/office)
 "tHX" = (
@@ -83962,16 +83853,15 @@
 /turf/open/floor/wood,
 /area/security/prison/garden)
 "ucc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/obj/item/flashlight/seclite,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "ucd" = (
 /obj/machinery/holopad,
@@ -85561,9 +85451,13 @@
 "uAD" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/loading_area,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
 /area/security/office)
 "uAH" = (
 /obj/machinery/duct,
@@ -87871,14 +87765,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/salon)
-"vkk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/security/office)
 "vkA" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
@@ -90188,28 +90074,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/hfr_room)
 "vSA" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/folder/blue{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/lighter,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/landmark/start/warden,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/security/office)
 "vSC" = (
 /obj/structure/disposalpipe/segment,
@@ -91032,7 +90905,6 @@
 	pixel_y = -36;
 	req_access_txt = "63"
 	},
-/obj/effect/landmark/start/warden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -91422,6 +91294,12 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wnr" = (
+/obj/structure/chair/office,
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/blue/warning,
+/turf/open/floor/iron/dark/side,
+/area/security/office)
 "wnB" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/table/wood,
@@ -91983,17 +91861,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "wva" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/security/office)
 "wvg" = (
 /turf/closed/wall,
@@ -93407,7 +93284,17 @@
 /turf/open/floor/wood,
 /area/service/theater/abandoned)
 "wRJ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "wRK" = (
@@ -93513,17 +93400,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "wTr" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/security_officer,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/office)
 "wTy" = (
@@ -94549,10 +94432,17 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "xjg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/folder/red{
+	pixel_x = -2;
+	pixel_y = -2
 	},
-/turf/open/floor/iron,
+/obj/item/folder/blue{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/lighter,
+/turf/open/floor/iron/dark,
 /area/security/office)
 "xjn" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
@@ -94613,6 +94503,17 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/office)
+"xjM" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron,
+/area/security/office)
 "xjT" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -96204,10 +96105,6 @@
 /area/security/prison/mess)
 "xMc" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/security/office)
 "xMe" = (
@@ -96584,10 +96481,19 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos/office)
 "xRo" = (
-/obj/machinery/computer/secure_data{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/computer/security{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "xRK" = (
@@ -96837,6 +96743,7 @@
 	dir = 8
 	},
 /obj/structure/table,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "xVm" = (
@@ -97331,10 +97238,6 @@
 /turf/open/floor/wood,
 /area/service/library)
 "ycd" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -97342,6 +97245,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/machinery/computer/secure_data/laptop,
 /turf/open/floor/iron,
 /area/security/office)
 "ycm" = (
@@ -150213,13 +150118,13 @@ iyK
 ujk
 eMy
 tHW
-stD
-sHJ
-sHJ
+xMc
+xMc
+xMc
 xMc
 wTr
-ehe
-bLE
+sAv
+xBb
 kXD
 guL
 iLa
@@ -150471,8 +150376,8 @@ fCV
 tuZ
 mZx
 rMx
-piu
-aDP
+wva
+wva
 wva
 qNC
 sWf
@@ -150727,13 +150632,13 @@ xTl
 vbv
 tuZ
 uVx
-rMx
+wnr
 loX
 kcu
 jGY
 ucc
 oQR
-nOL
+gHf
 mmo
 guL
 kGH
@@ -150984,13 +150889,13 @@ fCV
 fCV
 tuZ
 mFt
-lVX
+wnr
 iHr
 xjg
 oYc
-lVX
+mjR
 lTi
-xjg
+gHf
 jCE
 guL
 iLa
@@ -151498,13 +151403,13 @@ fCV
 aad
 tuZ
 pmP
-fZB
-fZB
-qIw
+xBb
+xBb
+xBb
 hBn
-hsn
-vkk
-fZB
+xBb
+sAv
+xBb
 lVX
 swl
 gyk
@@ -151755,7 +151660,7 @@ fCV
 aaa
 tuZ
 ycd
-jvq
+xjM
 jvq
 jvq
 uBM

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -11590,7 +11590,7 @@
 	self_sustaining = 1
 	},
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/security/prison/garden)
 "ccK" = (
 /obj/effect/landmark/start/hangover/closet,
@@ -30617,6 +30617,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/service/chapel)
+"eDs" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet,
+/area/security/brig/upper)
 "eDz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40804,6 +40808,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"hME" = (
+/obj/machinery/camera{
+	c_tag = " Prison - (North-West) Blue Wing";
+	dir = 5;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "hML" = (
 /turf/closed/wall,
 /area/command/meeting_room/council)
@@ -42052,7 +42066,7 @@
 	plane = -7;
 	self_sustaining = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/security/prison/garden)
 "ifa" = (
 /obj/structure/disposalpipe/segment{
@@ -43727,7 +43741,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/small/red/directional/west,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/brown/side{
 	dir = 9
 	},
@@ -44438,6 +44452,7 @@
 /area/commons/dorms)
 "iMR" = (
 /obj/structure/bookcase/random/reference,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/wood,
 /area/security/prison)
 "iMT" = (
@@ -45935,16 +45950,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"jkv" = (
-/obj/machinery/camera{
-	c_tag = " Prison - (North-West) Blue Wing";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "jkx" = (
 /obj/structure/cable,
 /obj/machinery/power/smes,
@@ -53076,6 +53081,11 @@
 /obj/item/trash/chips,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = " Prison - (East) Brown Wing Upper";
+	dir = 8;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -54694,7 +54704,7 @@
 	pixel_x = 12;
 	pixel_y = -6
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/security/prison/garden)
 "lOi" = (
 /obj/structure/cable,
@@ -58433,6 +58443,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "mRz" = (
+/obj/machinery/light/directional/east,
 /turf/open/floor/carpet,
 /area/security/brig/upper)
 "mRF" = (
@@ -67237,6 +67248,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"pqL" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Security - Upper Brig";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "pre" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
@@ -69773,6 +69794,11 @@
 /area/commons/toilet/restrooms)
 "qbw" = (
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/camera{
+	c_tag = " Prison - (North-West) Blue Wing Upper";
+	dir = 4;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -73972,7 +73998,7 @@
 	plane = -7;
 	self_sustaining = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/security/prison/garden)
 "rhF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -77134,7 +77160,6 @@
 /area/engineering/atmos/project)
 "sgI" = (
 /obj/structure/bookcase/random/fiction,
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
 /area/security/prison)
 "sgL" = (
@@ -80034,11 +80059,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"sUa" = (
-/obj/structure/curtain/cloth/fancy,
-/obj/machinery/light/directional/west,
-/turf/open/floor/carpet,
-/area/security/brig/upper)
 "sUj" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -81161,7 +81181,11 @@
 	self_sustaining = 1
 	},
 /obj/item/food/grown/wheat,
-/turf/open/space/basic,
+/obj/machinery/camera{
+	c_tag = " Prison - Garden";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plating,
 /area/security/prison/garden)
 "tlp" = (
 /obj/structure/window/reinforced{
@@ -82381,7 +82405,7 @@
 	plane = -7;
 	self_sustaining = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/security/prison/garden)
 "tDX" = (
 /obj/structure/cable,
@@ -84725,7 +84749,7 @@
 /area/engineering/atmos/project)
 "upr" = (
 /obj/structure/bookcase/random/adult,
-/obj/machinery/light/small/red/directional/north,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
 /area/security/prison)
 "upw" = (
@@ -84983,7 +85007,7 @@
 /turf/open/floor/plating,
 /area/service/theater/abandoned)
 "utK" = (
-/obj/machinery/light/small/red/directional/east,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/wood,
 /area/security/prison)
 "utL" = (
@@ -88892,7 +88916,6 @@
 /area/engineering/atmos)
 "vzk" = (
 /obj/structure/curtain/cloth/fancy,
-/obj/machinery/light/directional/east,
 /turf/open/floor/carpet,
 /area/security/brig/upper)
 "vzm" = (
@@ -91049,7 +91072,7 @@
 	self_sustaining = 1
 	},
 /obj/item/seeds/tomato,
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/security/prison/garden)
 "wgF" = (
 /obj/structure/disposalpipe/segment{
@@ -148382,8 +148405,8 @@ amL
 aQY
 aSE
 fCV
-mRz
-sUa
+eDs
+vzk
 eHh
 nIX
 hTQ
@@ -148619,12 +148642,12 @@ aKV
 aKV
 kfk
 qbw
-jkv
+sxS
 sxS
 sat
 sxS
 hLX
-sxS
+hME
 vvb
 sxS
 sxS
@@ -152239,7 +152262,7 @@ aSH
 gCI
 ihm
 fCV
-wNS
+pqL
 hCy
 crM
 aFn

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -39501,10 +39501,7 @@
 /turf/open/floor/iron/dark,
 /area/commons/locker)
 "hsE" = (
-/obj/structure/table,
-/obj/item/clothing/suit/apron/chef,
-/obj/item/storage/bag/tray,
-/obj/item/kitchen/rollingpin,
+/obj/machinery/oven,
 /turf/open/floor/iron/dark,
 /area/security/prison/mess)
 "hsG" = (
@@ -44633,6 +44630,9 @@
 	},
 /obj/item/storage/box/drinkingglasses,
 /obj/item/storage/fancy/egg_box,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/storage/bag/tray,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/iron/dark,
 /area/security/prison/mess)
 "iPc" = (

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -488,16 +488,6 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"acI" = (
-/obj/machinery/flasher/directional/south{
-	id = "Cell 6"
-	},
-/obj/machinery/light/small/broken/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "acK" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -551,16 +541,20 @@
 /turf/open/floor/plating,
 /area/maintenance/space_hut/observatory)
 "acU" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK";
-	pixel_x = 32
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/structure/rack,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/mesh,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/reagent_containers/syringe/contraband/space_drugs,
+/obj/item/reagent_containers/syringe{
+	list_reagents = list(/datum/reagent/drug/aphrodisiac = 20);
+	name = "crocin syringe";
+	pixel_y = 6
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/turf/open/floor/plating,
+/area/security/prison)
 "acV" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -699,16 +693,10 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "adw" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/plant_analyzer,
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Garden";
-	network = list("ss13","prison")
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/iron/dark/side,
 /area/security/prison)
 "adx" = (
 /obj/structure/closet/toolcloset,
@@ -1667,17 +1655,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/customs)
-"alK" = (
-/obj/machinery/washing_machine,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "alL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1771,6 +1748,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/customs)
+"amH" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "amK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1778,6 +1762,12 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
+"amL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
 "amV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -3336,15 +3326,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
-"aAw" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "aAR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -3462,16 +3443,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"aBP" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -30
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Permabrig - Fitness";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "aBT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3600,13 +3571,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
-"aCX" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/spawner/random/contraband/prison,
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
 "aDa" = (
 /obj/effect/landmark/start/scientist,
 /obj/structure/disposalpipe/segment,
@@ -3749,10 +3713,8 @@
 /turf/open/floor/iron,
 /area/security/office)
 "aDT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/structure/chair/office,
+/turf/open/floor/wood,
 /area/security/prison)
 "aDU" = (
 /obj/structure/cable,
@@ -3790,27 +3752,6 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"aEn" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/item/seeds/onion,
-/obj/item/seeds/garlic,
-/obj/item/seeds/potato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/effect/spawner/random/contraband/prison,
-/obj/structure/window,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/seeds/tower,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "aEB" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -3932,7 +3873,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/security/brig/upper)
 "aFo" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -4512,16 +4453,22 @@
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
 "aLa" = (
-/obj/machinery/door/poddoor{
-	id = "justiceblast";
-	name = "Justice Blast door"
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/toilet{
+	pixel_y = 16
 	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 5
+	},
+/area/security/prison)
 "aLd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -4653,11 +4600,11 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "aNC" = (
-/obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "aNG" = (
 /obj/machinery/light/small/directional/east,
@@ -4720,6 +4667,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/checker,
 /area/engineering/supermatter/room)
+"aOr" = (
+/obj/machinery/processor,
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/light,
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "aOu" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -4817,29 +4770,37 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/science/xenobiology)
 "aPn" = (
-/obj/machinery/light/small/directional/west,
-/obj/item/clothing/suit/caution,
-/obj/structure/sign/poster/official/no_erp{
-	pixel_x = -30
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "aPo" = (
-/obj/machinery/shower{
+/obj/machinery/door/airlock/security{
+	name = "Permabrig Visitation"
+	},
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"aPu" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/item/soap/homemade,
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
-"aPu" = (
-/obj/structure/table,
-/obj/machinery/processor{
-	pixel_y = 8
+/turf/open/floor/iron/dark/brown/side{
+	dir = 5
 	},
-/turf/open/floor/plating,
 /area/security/prison)
 "aPx" = (
 /obj/structure/closet/secure_closet/atmospherics,
@@ -4983,34 +4944,11 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos)
-"aQX" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/item/reagent_containers/syringe,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "aQY" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/item/reagent_containers/syringe,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
 "aRm" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
@@ -5026,6 +4964,25 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
+"aRn" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 9
+	},
+/area/security/prison)
 "aRo" = (
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
@@ -5074,67 +5031,60 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "aSC" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/glasses/blindfold,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/plate_press{
+	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
-"aSD" = (
-/turf/open/floor/iron/white,
-/area/security/prison)
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
 "aSE" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/glasses/blindfold,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
-"aSG" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/cryopod,
-/turf/open/floor/iron,
+/obj/machinery/plate_press{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
+"aSG" = (
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/turnstile{
+	dir = 1;
+	req_one_access_txt = "2;63;81"
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aSH" = (
-/obj/item/radio/intercom/prison/directional/north,
+/obj/structure/table,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/security/prison)
 "aSM" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button/ignition{
-	id = "justicespark";
+/obj/item/reagent_containers/glass/bottle/morphine{
 	pixel_x = 7;
-	pixel_y = 24;
-	req_access_txt = "63"
+	pixel_y = 7
 	},
-/obj/machinery/button/flasher{
-	id = "justiceflash";
-	pixel_x = 6;
-	pixel_y = 34;
-	req_access_txt = "63"
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = -7;
+	pixel_y = 7
 	},
-/obj/item/folder/red{
-	pixel_x = 3
+/obj/item/reagent_containers/glass/bottle/chloralhydrate{
+	pixel_x = -7
 	},
-/obj/item/restraints/handcuffs,
-/obj/item/taperecorder,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/item/reagent_containers/glass/bottle/facid{
+	pixel_x = 7
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/item/storage/backpack/duffelbag/sec/surgery{
+	pixel_y = 5
 	},
 /obj/machinery/button/door/directional/north{
 	id = "justiceblast";
@@ -5149,7 +5099,22 @@
 	pixel_y = 34;
 	req_access_txt = "3"
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/button/ignition{
+	id = "justicespark";
+	pixel_x = 7;
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/obj/machinery/button/flasher{
+	id = "justiceflash";
+	pixel_x = 6;
+	pixel_y = 34;
+	req_access_txt = "63"
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark/red/side{
+	dir = 9
+	},
 /area/security/execution/education)
 "aSS" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -5177,7 +5142,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "aSZ" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -5240,26 +5205,22 @@
 /turf/open/floor/plating,
 /area/service/hydroponics/garden/abandoned)
 "aUD" = (
-/obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
-/obj/item/electropack,
-/obj/item/assembly/signaler,
-/obj/machinery/light/directional/west,
-/obj/item/clothing/head/helmet/sec,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/door/window/eastleft,
+/obj/structure/closet/crate,
+/obj/item/tank/internals/oxygen/red{
+	pixel_x = 3
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/item/tank/internals/oxygen/red{
+	pixel_x = -3
 	},
+/obj/item/wrench,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aUE" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Visitation"
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "aUH" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/plasma/spawner/west{
@@ -5321,6 +5282,17 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"aVy" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/hypospray/medipen/atropine,
+/obj/item/grenade/smokebomb,
+/obj/item/pda,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "aVB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -5379,24 +5351,17 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "aWf" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt1";
-	name = "Cell 1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut1"
-	},
-/obj/machinery/door/firedoor,
+/obj/structure/table,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "aWg" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -5407,17 +5372,13 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aWl" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light_switch/directional/south,
-/obj/item/flashlight/lamp,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/door/window/eastright,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aWq" = (
@@ -5444,12 +5405,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"aWH" = (
-/obj/structure/chair/stool/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/security/prison)
+"aWK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen,
+/area/security/prison/mess)
 "aWU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5524,18 +5485,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"aYG" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Sanitarium";
-	req_access_txt = "63"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/security/prison)
 "aYQ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -5556,21 +5505,27 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aZk" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/red,
+/area/security/brig/upper)
 "aZn" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/newscaster/security_unit/directional/north,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/red/side{
+	dir = 9
+	},
+/area/security/brig/upper)
 "aZo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "aZp" = (
 /obj/item/folder/yellow,
 /obj/item/multitool,
@@ -5592,27 +5547,42 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "aZt" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "aZu" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Prison"
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/button/door{
+	id = "permainner";
+	name = "Inner Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -6;
+	pixel_y = 25;
+	req_access_txt = "2";
+	specialfunctions = 4
+	},
+/obj/machinery/button/door{
+	id = "permaouter";
+	name = "Outer Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 6;
+	pixel_y = 25;
+	req_access_txt = "2";
+	specialfunctions = 4
+	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "aZC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "aZE" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -5635,7 +5605,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "aZL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5650,7 +5620,7 @@
 	luminosity = 2;
 	temperature = 2.7
 	},
-/area/security/prison)
+/area/security/brig/upper)
 "aZN" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red{
@@ -5724,6 +5694,17 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/science)
+"bbk" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "bbn" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/warning/pods{
@@ -5735,7 +5716,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "bbp" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/sign/warning/securearea{
@@ -5746,15 +5727,15 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "bbr" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/security/prison)
+/area/security/brig/upper)
 "bbt" = (
 /turf/open/floor/plating,
-/area/security/prison)
+/area/security/brig/upper)
 "bbu" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod 3";
@@ -5770,7 +5751,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "bbv" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod 3";
@@ -5786,7 +5767,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "bbw" = (
 /obj/structure/table/glass,
 /obj/effect/landmark/start/hangover,
@@ -5897,7 +5878,7 @@
 	cycle_id = "perma-entrance"
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "bcU" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -5911,7 +5892,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "bcV" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -5923,7 +5904,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "bcW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -5933,7 +5914,7 @@
 	luminosity = 2;
 	temperature = 2.7
 	},
-/area/security/prison)
+/area/security/brig/upper)
 "bde" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -6084,7 +6065,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "bes" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
@@ -6094,7 +6075,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "beK" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/bot/right,
@@ -6235,7 +6216,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "bfW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6333,9 +6314,16 @@
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bhs" = (
-/obj/structure/chair/stool/directional/south,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Prison - Visitation (Prisoner)";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
 /area/security/prison)
 "bhy" = (
 /obj/machinery/door/poddoor/preopen{
@@ -6503,6 +6491,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
+"bjf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/west,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "bjo" = (
 /obj/machinery/gibber,
 /turf/open/floor/iron/dark/textured,
@@ -6784,6 +6782,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"bmi" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "bmw" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -6824,6 +6829,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"bmN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/security/prison/mess)
 "bmP" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -6936,12 +6946,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"bnE" = (
+/turf/closed/wall/r_wall,
+/area/security/prison/work)
 "bnG" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
 "bnI" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/security/prison)
+/area/security/brig/upper)
 "bnS" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Holodeck - Fore 2";
@@ -7440,9 +7453,15 @@
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "bsB" = (
-/obj/effect/landmark/start/brigoff,
-/turf/open/floor/iron/dark,
-/area/brigofficer)
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "btb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
@@ -7640,6 +7659,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/execution/transfer)
+"buR" = (
+/obj/structure/bed/maint,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/prison)
 "bve" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Auxiliary Power";
@@ -7725,6 +7749,17 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"bvN" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell4";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "bvW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8163,12 +8198,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
-"bAZ" = (
-/obj/structure/window,
-/obj/machinery/seed_extractor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/security/prison)
 "bBs" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -8623,11 +8652,12 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/entry)
 "bFd" = (
-/obj/structure/cable,
-/obj/structure/table,
-/obj/machinery/computer/med_data/laptop,
-/turf/open/floor/iron/dark,
-/area/brigofficer)
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "bFf" = (
 /obj/effect/turf_decal/box/red/corners{
 	dir = 1
@@ -8735,20 +8765,12 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/engineering/gravity_generator)
-"bGi" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt3";
-	name = "Cell 3"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut3"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+"bGh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "bGk" = (
 /obj/structure/safe,
 /obj/item/clothing/neck/stethoscope,
@@ -8786,6 +8808,18 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/lockers)
+"bGs" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side,
+/area/security/prison)
 "bGK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -9000,21 +9034,6 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/primary/central/aft)
-"bIP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/security/prison)
-"bIS" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/computer/cryopod{
-	pixel_y = 30
-	},
-/obj/machinery/cryopod,
-/turf/open/floor/iron,
-/area/security/prison)
 "bIW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -9193,7 +9212,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "bKB" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -9923,6 +9942,17 @@
 /obj/structure/chair/office,
 /turf/open/floor/iron/grimy,
 /area/tcommsat/computer)
+"bQS" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "bRd" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/table/wood,
@@ -11281,6 +11311,11 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port/greater)
+"caJ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "caQ" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 4
@@ -11489,6 +11524,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"ccd" = (
+/obj/machinery/chem_master/condimaster,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "cck" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset,
@@ -11538,13 +11578,20 @@
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "ccu" = (
-/obj/structure/table,
-/obj/structure/cable,
-/obj/item/toy/cards/deck,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
+	},
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/turf/open/space/basic,
+/area/security/prison/garden)
 "ccK" = (
 /obj/effect/landmark/start/hangover/closet,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -11586,20 +11633,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "ccV" = (
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "Prisoner Telescreen";
-	network = list("prison");
-	pixel_x = 27
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/area/brigofficer)
 "ccZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -11837,15 +11874,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port/greater)
-"cer" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "ceG" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/two,
@@ -12056,6 +12084,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/medical/medbay/lobby)
+"cgA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/red,
+/area/security/brig/upper)
 "cgD" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -12247,6 +12281,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"chz" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "chG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12293,10 +12333,15 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "chQ" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/closet/secure_closet/brigoff,
-/turf/open/floor/iron/dark,
-/area/brigofficer)
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "chR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
@@ -12594,6 +12639,12 @@
 	dir = 8
 	},
 /area/service/hydroponics/garden)
+"cjA" = (
+/obj/structure/cable,
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/prison)
 "cjC" = (
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
@@ -12921,7 +12972,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/brig/upper)
 "cmO" = (
 /obj/item/beacon,
 /obj/effect/turf_decal/tile/neutral{
@@ -13378,6 +13429,12 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/maintenance/port/fore)
+"cpW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen,
+/area/security/prison/mess)
 "cpX" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral,
@@ -13457,6 +13514,11 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
+"cqq" = (
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "cqu" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/sofa/left{
@@ -13639,7 +13701,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/brig/upper)
 "crO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -13786,6 +13848,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"ctD" = (
+/obj/machinery/button/flasher{
+	id = "IsolationFlash";
+	pixel_x = 21;
+	pixel_y = 21
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "ctE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -13821,11 +13896,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port/greater)
-"ctK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
 "ctR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -14503,13 +14573,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cAe" = (
-/obj/machinery/door/airlock{
-	name = "Permabrig Showers"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
+/area/security/prison)
 "cAf" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14807,6 +14875,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
+"cCJ" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell5";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "cCO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -14909,6 +14988,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"cDJ" = (
+/obj/machinery/door/airlock/security/old{
+	name = "Jail Cell"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue,
+/area/security/prison)
 "cDN" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -15137,6 +15224,20 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/server)
+"cGH" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "cGJ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Chapel Maintenance";
@@ -15157,6 +15258,9 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"cGS" = (
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "cGY" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -15393,11 +15497,21 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cJG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/brigofficer)
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3;
+	pixel_y = 16
+	},
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "cJI" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -15546,14 +15660,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"cLF" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "cLH" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -16899,6 +17005,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"cTF" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell4";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
 "cTG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -18208,6 +18325,16 @@
 /obj/item/bot_assembly/medbot,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cZZ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Visitation";
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig/upper)
 "dac" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
@@ -19007,12 +19134,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ddq" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "ddu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
@@ -19656,6 +19777,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
+"dfC" = (
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
+	},
+/obj/machinery/door/window/southleft,
+/turf/open/floor/iron,
+/area/security/prison)
 "dfD" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
@@ -21250,6 +21380,11 @@
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
 /area/medical/surgery)
+"dnG" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "dnL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -22400,6 +22535,10 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
+"dvs" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/purple/side,
+/area/brigofficer)
 "dvF" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/brown{
@@ -23019,9 +23158,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
 "dzF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side,
 /area/security/prison)
 "dzG" = (
 /obj/item/paper_bin,
@@ -24279,6 +24420,13 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/department/engine/atmos)
+"dFW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/security/prison)
 "dFY" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -24389,10 +24537,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/detectives_office/private_investigators_office)
-"dGR" = (
-/obj/machinery/griddle,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "dGW" = (
 /turf/closed/wall/r_wall,
 /area/science/test_area)
@@ -24400,6 +24544,25 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/science/test_area)
+"dHc" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/camera{
+	c_tag = " Prison - Janitorial";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "dHh" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/ordnance,
@@ -24471,6 +24634,17 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"dHv" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/machinery/light/small/red/directional/south,
+/obj/item/restraints/handcuffs,
+/obj/item/toy/crayon/spraycan,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "dHw" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -25287,6 +25461,10 @@
 	heat_capacity = 1e+006
 	},
 /area/maintenance/starboard/aft)
+"dLr" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
 "dLw" = (
 /obj/structure/frame/computer,
 /obj/item/circuitboard/computer/secure_data,
@@ -26668,16 +26846,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"dSX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast door"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/brigofficer)
 "dSY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green{
@@ -26733,6 +26901,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dTC" = (
+/turf/closed/wall,
+/area/security/prison/work)
 "dTE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -26896,18 +27067,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"dVm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "dVt" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
@@ -27032,6 +27191,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"dVK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "dVM" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
@@ -27046,13 +27210,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dVR" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/open/floor/iron/dark/red/side{
+	dir = 9
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron/dark,
 /area/security/execution/education)
 "dVX" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -27687,12 +27847,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"eaI" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/security/prison)
 "eaL" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall/r_wall,
@@ -28093,6 +28247,16 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"eco" = (
+/obj/structure/bed/maint,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = 32
+	},
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/security/prison)
 "ecp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -28478,10 +28642,19 @@
 /turf/open/space/basic,
 /area/space)
 "eeg" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "eej" = (
@@ -28726,6 +28899,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
+"efa" = (
+/obj/effect/landmark/start/brigoff,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "efb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/closed/wall/r_wall,
@@ -29026,6 +29203,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/engineering/atmos/office)
+"egZ" = (
+/obj/structure/holohoop{
+	density = 0;
+	pixel_y = 18
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 1;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "ehe" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -29041,27 +29232,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"ehi" = (
-/obj/structure/cable,
-/obj/machinery/button/flasher{
-	id = "Cell 3";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/east{
-	id = "permashut3";
-	name = "Cell Lockdown Button";
-	pixel_y = -6;
-	req_access_txt = "2"
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "ehq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
@@ -29382,6 +29552,16 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
+"emb" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/work)
 "emc" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/grassybush,
@@ -29473,6 +29653,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"enz" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "enF" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -29531,26 +29719,13 @@
 /turf/open/floor/iron/dark,
 /area/service/library/abandoned)
 "eoZ" = (
+/obj/structure/table,
+/obj/machinery/computer/secure_data/laptop{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/machinery/button/flasher{
-	id = "Cell 2";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/east{
-	id = "permashut2";
-	name = "Cell Lockdown Button";
-	pixel_y = -6;
-	req_access_txt = "2"
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/iron/dark/purple/side,
+/area/brigofficer)
 "eph" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -29770,6 +29945,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"eso" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/brown/side,
+/area/security/prison)
 "esF" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -29975,13 +30159,9 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "evW" = (
-/obj/machinery/door/window/westleft,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Justice gas pump"
+/turf/open/floor/iron/dark/red/side{
+	dir = 10
 	},
-/turf/open/floor/iron/dark,
 /area/security/execution/education)
 "ewa" = (
 /obj/machinery/light/directional/north,
@@ -30450,6 +30630,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"eDB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/security/prison)
 "eDP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30563,6 +30750,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"eFR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen,
+/area/security/prison/mess)
 "eFX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -30607,13 +30799,12 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "eHh" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Prison Port"
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/red,
+/area/security/brig/upper)
 "eHv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30960,6 +31151,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"eLr" = (
+/obj/item/stack/sheet/cardboard{
+	amount = 10
+	},
+/obj/structure/loom,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
 "eLt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -30982,6 +31182,9 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"eLB" = (
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "eLJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31123,6 +31326,20 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/command/gateway)
+"eNq" = (
+/obj/machinery/button/door{
+	id = "isolationshutter";
+	name = "Isolation Shutter";
+	pixel_y = 23;
+	req_access_txt = "63"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "eNt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -31150,6 +31367,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"eNx" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "eNE" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
@@ -31157,11 +31385,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"eNQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "eNV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31508,15 +31731,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"eTj" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"eTq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
+/area/security/prison)
 "eTr" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -31582,12 +31804,6 @@
 	},
 /turf/open/floor/glass,
 /area/maintenance/space_hut/observatory)
-"eUh" = (
-/obj/structure/curtain,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
 "eUp" = (
 /obj/machinery/light/directional/west,
 /obj/effect/mapping_helpers/ianbirthday,
@@ -31605,12 +31821,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/science/lab)
-"eUv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "eUx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -31652,14 +31862,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
-"eVo" = (
-/obj/machinery/computer/crew{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron/dark,
-/area/brigofficer)
+"eVr" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/security/prison)
 "eVx" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -31743,6 +31949,31 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"eXF" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/computer/cryopod{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#00ff00";
+	name = "green"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"eXJ" = (
+/obj/item/toy/plush/beeplushie{
+	desc = "Maybe hugging this will make you feel better about yourself.";
+	name = "Therabee"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
+/area/security/prison)
 "eXK" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31917,19 +32148,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/entry)
-"fbc" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "fbe" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -32193,6 +32411,11 @@
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
+"ffj" = (
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/security/prison)
 "ffk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -32335,6 +32558,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"fhA" = (
+/obj/structure/curtain/bounty,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "fik" = (
 /obj/machinery/turretid{
 	icon_state = "control_stun";
@@ -32378,6 +32608,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"fiD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner,
+/area/security/prison)
 "fiE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -32773,6 +33009,17 @@
 "fot" = (
 /turf/closed/wall,
 /area/ai_monitored/command/storage/eva)
+"foC" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = -6;
+	reclaim_rate = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen,
+/area/security/prison/mess)
 "foG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -32878,18 +33125,19 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
 "fpP" = (
-/obj/structure/table,
-/obj/item/book/manual/chef_recipes,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 2
+/obj/item/trash/popcorn,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
+/turf/open/floor/iron/dark/brown/side{
+	dir = 9
 	},
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/storage/fancy/egg_box,
-/turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "fqj" = (
 /obj/machinery/light/directional/west,
@@ -33037,18 +33285,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"fsm" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast door"
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Visitation";
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/security/prison)
 "fsy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33094,10 +33330,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/service/theater)
-"fth" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "ftj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33375,8 +33607,11 @@
 /turf/open/floor/iron,
 /area/service/salon)
 "fxd" = (
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "fxe" = (
 /obj/structure/table,
@@ -33594,11 +33829,13 @@
 /turf/closed/wall,
 /area/commons/locker)
 "fBg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "fBo" = (
 /obj/structure/table,
@@ -33724,6 +33961,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
+"fCE" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison)
 "fCQ" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -33738,6 +33994,9 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library)
+"fCV" = (
+/turf/closed/wall/r_wall,
+/area/security/brig/upper)
 "fDa" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
@@ -33763,15 +34022,10 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "fDA" = (
-/obj/machinery/washing_machine,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
 /area/security/prison)
 "fEj" = (
 /obj/structure/cable,
@@ -33814,11 +34068,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"fEM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/oven,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "fEQ" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -33987,6 +34236,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/theater)
+"fGY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "fHd" = (
 /obj/effect/spawner/random/structure/chair_maintenance{
 	dir = 1
@@ -34135,6 +34391,17 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
+"fJo" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell8";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "fJD" = (
 /obj/structure/table/wood/poker,
 /obj/effect/decal/cleanable/dirt,
@@ -34316,14 +34583,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"fNW" = (
-/obj/machinery/door/airlock/security{
-	name = "Isolation Cell";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/security/prison)
 "fNX" = (
 /obj/structure/sign/departments/examroom,
 /turf/closed/wall,
@@ -34699,6 +34958,17 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"fTo" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell8";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "fTt" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -34915,6 +35185,15 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/command/gateway)
+"fWW" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/purple/side,
+/area/security/prison)
 "fXi" = (
 /obj/structure/table/wood,
 /obj/item/clothing/gloves/color/fyellow,
@@ -34959,16 +35238,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
-"fYr" = (
-/obj/structure/chair/stool/directional/south,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "fYJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -35128,6 +35397,14 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/medical/pharmacy)
+"gaW" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/lighter,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
+/area/security/prison)
 "gbm" = (
 /obj/machinery/porta_turret/ai,
 /obj/structure/sign/warning/electricshock{
@@ -35170,17 +35447,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"gcr" = (
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/effect/landmark/start/prisoner,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 6
+	},
+/area/security/prison)
 "gcs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
+/obj/structure/table,
 /obj/machinery/light/directional/south,
-/obj/item/radio/intercom/directional/south{
-	pixel_x = 26
-	},
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/dark,
-/area/brigofficer)
+/obj/item/storage/photo_album/prison,
+/obj/item/camera,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "gcu" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -35593,18 +35879,9 @@
 /turf/open/floor/iron/white,
 /area/science/lobby)
 "gkK" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 5";
-	req_access_txt = "2"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "gkR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -35745,17 +36022,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"gmX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/flasher/directional/south{
-	id = "Cell 5"
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "gna" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35876,11 +36142,6 @@
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/captain/private/nt_rep)
-"gos" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "goQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
@@ -36258,9 +36519,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "gsB" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/security/prison/garden)
 "gsC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36791,6 +37055,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"gBX" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell7";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/security/prison)
 "gBY" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet,
@@ -36831,6 +37106,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/engineering/supermatter/room)
+"gCI" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/iron,
+/area/security/prison)
 "gCK" = (
 /turf/closed/wall,
 /area/maintenance/department/science)
@@ -36869,17 +37151,11 @@
 /turf/open/floor/iron/dark,
 /area/science/server)
 "gDw" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/closet/secure_closet/injection,
+/obj/machinery/newscaster/security_unit/directional/north,
+/turf/open/floor/iron/dark/red/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
 /area/security/execution/education)
 "gDB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36920,15 +37196,6 @@
 	dir = 1
 	},
 /area/engineering/transit_tube)
-"gDS" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prisoner Workroom"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "gDT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -37123,6 +37390,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
+"gHq" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "gHK" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral,
@@ -37265,6 +37542,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/service/library)
+"gJM" = (
+/obj/structure/curtain/cloth,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "gJO" = (
 /obj/effect/landmark/start/hangover,
 /obj/item/kirbyplants/random,
@@ -37391,6 +37672,16 @@
 /obj/machinery/keycard_auth,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
+"gMv" = (
+/obj/machinery/deepfryer,
+/obj/machinery/light/directional/north,
+/obj/machinery/camera{
+	c_tag = " Prison - Kitchen";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "gMY" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -37482,6 +37773,9 @@
 /obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"gOM" = (
+/turf/closed/wall/r_wall,
+/area/space)
 "gOX" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37720,10 +38014,16 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "gSN" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light_switch/directional/north,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 5
+	},
+/area/brigofficer)
 "gSY" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral,
@@ -37910,15 +38210,11 @@
 /turf/open/floor/iron,
 /area/medical/surgery/fore)
 "gWq" = (
-/obj/structure/toilet/greyscale,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/turf/open/floor/iron/dark/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/area/brigofficer)
 "gWF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -37940,12 +38236,6 @@
 	icon_state = "wood-broken3"
 	},
 /area/service/library/abandoned)
-"gXd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "gXg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38079,6 +38369,16 @@
 	},
 /turf/open/floor/plating,
 /area/service/lawoffice)
+"gYG" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "gYQ" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
@@ -38611,6 +38911,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
+"hhV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/east{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/security/prison)
 "hij" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/purple{
@@ -38826,6 +39139,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
+"hmt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/rank/prisoner/classic,
+/obj/item/clothing/suit/jacket/leather/overcoat,
+/turf/open/floor/plating,
+/area/security/prison)
 "hmv" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -39098,6 +39417,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/space,
 /area/space/nearstation)
+"hri" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "hrn" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
@@ -39173,6 +39499,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/commons/locker)
+"hsE" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/storage/bag/tray,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "hsG" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -39284,6 +39617,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"hvN" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "hwm" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -39416,10 +39757,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "hxR" = (
-/obj/structure/chair/stool/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "hxZ" = (
 /obj/machinery/door/firedoor,
@@ -39471,6 +39812,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
+"hyE" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/brig/genpop,
+/turf/open/floor/iron/dark/red,
+/area/space)
 "hyF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39579,16 +39926,16 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "hAI" = (
-/obj/structure/window,
-/obj/structure/sink{
-	pixel_y = 30
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/security/old{
+	glass = 1;
+	name = "Garden"
 	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison/garden)
 "hBf" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
@@ -39694,6 +40041,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"hCy" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "hCG" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -39944,6 +40300,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
+"hFr" = (
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/wrench,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/security/prison)
 "hFt" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/small/directional/east,
@@ -40071,6 +40434,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
+"hGZ" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets/donkpocketberry,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "hHe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40091,7 +40465,15 @@
 /turf/open/floor/iron/cafeteria,
 /area/engineering/atmos)
 "hHu" = (
-/turf/open/floor/iron/cafeteria,
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell9";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison)
 "hHx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40115,6 +40497,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"hHM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = " Prison - Pool";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "hHR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/structure/lattice/catwalk,
@@ -40373,6 +40766,15 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"hLX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "hMg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -40618,15 +41020,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"hRW" = (
-/obj/structure/chair,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/toy/figure/prisoner,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "hSj" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/landmark/start/hangover,
@@ -40705,6 +41098,18 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"hSz" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown2";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "hSK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 8
@@ -40787,6 +41192,12 @@
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"hTQ" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/brig/genpop,
+/turf/open/floor/iron/dark/red,
+/area/security/brig/upper)
 "hTR" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -40998,6 +41409,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"hWc" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
+/area/security/prison)
 "hWo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -41620,11 +42035,28 @@
 	},
 /area/maintenance/disposal/incinerator)
 "ieL" = (
-/obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/flasher{
+	id = "transferflash";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"ieM" = (
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
+	},
+/turf/open/space/basic,
+/area/security/prison/garden)
 "ifa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41855,6 +42287,11 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"ihm" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "ihv" = (
 /obj/structure/table/wood,
 /obj/item/storage/crayons,
@@ -41885,6 +42322,18 @@
 /obj/item/bedsheet/ian,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hop)
+"ihO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 5
+	},
+/area/security/prison)
 "iil" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42381,16 +42830,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/engineering/main)
-"ipv" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "ipC" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder{
@@ -42412,12 +42851,15 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "ipK" = (
-/obj/structure/closet/secure_closet/evidence{
-	name = "Brig Officer's Locker";
-	req_one_access_txt = list(2)
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/brigofficer)
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "ipL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -42514,6 +42956,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"irp" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/security/old{
+	name = "Janitorial"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "iry" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -42667,12 +43119,13 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "isY" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Permabrig - Workroom";
-	network = list("ss13","prison")
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/item/radio/intercom/prison/directional/west,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/security/prison)
 "itf" = (
 /obj/machinery/door/firedoor,
@@ -42801,6 +43254,28 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
+"iuW" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/inflatable/door,
+/obj/item/clothing/suit/fire/atmos{
+	armor = list("melee" = 40, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 20, "bio" = 10, "rad" = 20, "fire" = 80, "acid" = 50);
+	desc = "An old, reinforced and obviously stolen firesuit. There's an expiry date for the thermal padding, safe to say it's well past the expiration date.";
+	name = "padded firesuit";
+	slowdown = 0.25
+	},
+/obj/item/stack/cable_coil,
+/obj/item/melee/chainofcommand{
+	damtype = "stamina";
+	desc = "Feels a lot softer than a real whip. Looks like it'll still sting and hurt, but it won't leave deep lacerations.";
+	force = 30;
+	name = "leather whip"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "ivf" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -42970,12 +43445,30 @@
 	},
 /turf/open/floor/iron/checker,
 /area/service/hydroponics/garden/abandoned)
-"iyK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/bombcloset/security,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+"iyB" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 9;
+	name = "blue line"
+	},
+/obj/machinery/camera{
+	c_tag = " Prison - (West) Purple Wing";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
 /area/security/prison)
+"iyK" = (
+/obj/structure/closet/bombcloset/security,
+/obj/effect/turf_decal/bot_blue,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/head/bomb_hood/security,
+/obj/item/clothing/head/bomb_hood/security,
+/turf/open/floor/iron/dark,
+/area/security/brig/upper)
 "iyU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43104,17 +43597,10 @@
 /turf/open/floor/iron,
 /area/service/chapel/office)
 "iAL" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 2";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/floor/iron/dark/purple,
+/area/brigofficer)
 "iAN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
@@ -43240,14 +43726,13 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "iCN" = (
-/obj/structure/table,
-/obj/structure/window{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/red/directional/west,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 9
 	},
-/obj/structure/reagent_dispensers/servingdish,
-/obj/structure/reagent_dispensers/servingdish,
-/obj/item/clothing/head/chefhat,
-/turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "iCO" = (
 /obj/item/kirbyplants/random,
@@ -43258,20 +43743,18 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/storage)
-"iCP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "iCQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
 "iDb" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/airalarm/directional/north,
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
+	},
+/obj/machinery/door/window/southright,
 /turf/open/floor/iron,
 /area/security/prison)
 "iDf" = (
@@ -43558,12 +44041,9 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "iGN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "iGQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43679,7 +44159,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/security/brig/upper)
 "iHZ" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -43743,12 +44223,25 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"iJY" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/obj/structure/cable,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
+/area/security/prison)
+"iJZ" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/security/prison/mess)
 "iKe" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/closet/secure_closet/brig/genpop,
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/brig/upper)
 "iKi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/north,
@@ -43946,14 +44439,8 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "iMR" = (
-/obj/structure/table,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/storage/crayons,
-/turf/open/floor/iron,
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
 /area/security/prison)
 "iMT" = (
 /obj/effect/turf_decal/stripes/line{
@@ -43984,13 +44471,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/security/range)
-"iNq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "iNs" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -44129,6 +44609,19 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating,
 /area/commons/toilet/restrooms)
+"iPa" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/fancy/egg_box,
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "iPc" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -44220,25 +44713,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "iQj" = (
-/obj/structure/cable,
-/obj/machinery/button/flasher{
-	id = "Cell 4";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	name = "blue line"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/east{
-	id = "permashut4";
-	name = "Cell Lockdown Button";
-	pixel_y = -6;
-	req_access_txt = "2"
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/blue/side,
 /area/security/prison)
 "iQu" = (
 /obj/structure/cable,
@@ -44302,7 +44781,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/brig/upper)
 "iQQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -44499,6 +44978,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
+"iVW" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass{
+	dir = 8
+	},
+/obj/structure/grille/broken,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "iWv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -44589,6 +45083,18 @@
 	heat_capacity = 1e+006
 	},
 /area/command/heads_quarters/cmo)
+"iXg" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown1";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "iXy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating{
@@ -44719,13 +45225,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"iZJ" = (
-/obj/structure/table,
-/obj/item/storage/photo_album/prison,
-/obj/item/camera,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "iZL" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/blue{
@@ -44777,6 +45276,19 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"jam" = (
+/obj/structure/table,
+/obj/item/soap,
+/obj/item/storage/bag/tray,
+/obj/item/storage/box/condimentbottles{
+	pixel_y = 10
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/kitchen,
+/area/security/prison/mess)
 "jaL" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Library";
@@ -44822,6 +45334,26 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
+"jbk" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = 32
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "jbp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/door/firedoor,
@@ -45145,14 +45677,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
-"jga" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/security/prison/safe)
 "jgb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -45413,6 +45937,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"jkv" = (
+/obj/machinery/camera{
+	c_tag = " Prison - (North-West) Blue Wing";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "jkx" = (
 /obj/structure/cable,
 /obj/machinery/power/smes,
@@ -45644,6 +46178,19 @@
 "jpf" = (
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"jpi" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permaouter";
+	name = "Permabrig Transfer";
+	req_access_txt = "2"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig/upper)
 "jpo" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow{
@@ -45782,6 +46329,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"jrs" = (
+/obj/machinery/seed_extractor,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood,
+/area/security/prison/garden)
 "jrt" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -45805,19 +46358,12 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "jrR" = (
-/obj/structure/sign/poster/ripped{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/obj/structure/cable,
+/turf/open/floor/iron/dark/purple,
+/area/brigofficer)
 "jrV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -46056,6 +46602,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/port/greater)
+"jvP" = (
+/obj/structure/cable,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
+/area/security/prison)
 "jwc" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -46078,8 +46629,15 @@
 /turf/open/floor/iron,
 /area/maintenance/port/greater)
 "jwH" = (
-/mob/living/simple_animal/mouse/brown/tom,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell11";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison)
 "jwO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46098,6 +46656,13 @@
 /obj/item/screwdriver,
 /turf/open/floor/iron,
 /area/engineering/main)
+"jwY" = (
+/obj/structure/table,
+/obj/item/toy/plush/borbplushie{
+	name = "Therapeep"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "jxd" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -46170,16 +46735,30 @@
 	},
 /area/service/chapel)
 "jxN" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron/dark,
+/obj/machinery/flasher/directional/north{
+	id = "justiceflash"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/red/side{
+	dir = 1
+	},
 /area/security/execution/education)
 "jxO" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"jyd" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 4;
+	name = "blue line"
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/security/prison)
 "jyi" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
@@ -46187,6 +46766,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/gateway)
+"jyz" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "jyF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -46357,6 +46942,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/service/theater)
+"jBq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "jBB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46500,6 +47094,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"jDP" = (
+/obj/structure/sign/warning/vacuum{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark/red/side{
+	dir = 5
+	},
+/area/security/execution/education)
 "jEq" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/seed_extractor,
@@ -46684,6 +47286,13 @@
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall,
 /area/commons/fitness/recreation)
+"jHx" = (
+/obj/machinery/camera{
+	c_tag = " Prison - East Hallway";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "jHA" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -46766,14 +47375,16 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jIP" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/camera/directional/north{
-	c_tag = "Permabrig - Isolation";
-	network = list("ss13","prison","solitary")
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell3";
+	name = "curtain"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/prison/safe)
+/area/security/prison)
 "jIV" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/closet/crate/silvercrate,
@@ -47109,7 +47720,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "jNR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47750,6 +48361,19 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
+"jZC" = (
+/obj/machinery/camera{
+	c_tag = "Prison Isolation Cell";
+	dir = 9;
+	network = list("ss13","prison","isolation")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 6
+	},
+/area/security/prison)
 "jZD" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -48121,6 +48745,23 @@
 	heat_capacity = 1e+006
 	},
 /area/commons/dorms)
+"kej" = (
+/obj/machinery/plate_press{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
+"kem" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell6";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "kep" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -48155,6 +48796,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"kfk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "kfz" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -48405,8 +49055,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/camera{
+	c_tag = "Security - Prison Port";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/red,
+/area/security/brig/upper)
 "kjh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
@@ -48764,6 +49418,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"kpg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	name = "Airmix Reserve to Distribution"
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/security/prison)
 "kpm" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -49032,13 +49694,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"ktd" = (
-/obj/structure/sign/poster/official/help_others{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "ktp" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
 /turf/open/floor/plating,
@@ -49322,6 +49977,18 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"kxr" = (
+/obj/structure/barricade/wooden{
+	opacity = 1
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "kxN" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
@@ -49366,18 +50033,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"kyu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"kyw" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "kyx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -49586,13 +50241,10 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "kAJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side,
 /area/security/prison)
 "kBl" = (
 /obj/machinery/light/directional/east,
@@ -49698,6 +50350,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
+"kDH" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell5";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
+	},
+/area/security/prison)
 "kDK" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/brown,
@@ -49715,11 +50378,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
-"kDY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/security/prison)
 "kEl" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -50052,14 +50710,14 @@
 /turf/open/floor/iron,
 /area/science/research)
 "kHZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast door"
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/turnstile{
+	dir = 1;
+	req_one_access_txt = "2;63;81"
 	},
-/turf/open/floor/plating,
-/area/security/prison)
+/turf/open/floor/iron/dark,
+/area/security/brig/upper)
 "kIc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50110,6 +50768,11 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"kJm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/security/prison)
 "kJo" = (
 /obj/item/food/pie/cream,
 /obj/structure/table,
@@ -50194,6 +50857,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"kLs" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "kLt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -50202,13 +50874,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"kLz" = (
+"kLC" = (
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "kLJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -50384,34 +51057,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"kPS" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/knife/plastic,
-/obj/item/knife/plastic,
-/obj/item/knife/plastic,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "kPY" = (
 /obj/item/storage/box/bodybags{
 	pixel_x = 3;
@@ -50911,6 +51556,19 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"kWq" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/east{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 6
+	},
+/area/security/prison)
 "kWr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden,
@@ -51203,18 +51861,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
-"kZW" = (
-/obj/structure/toilet/greyscale,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "kZX" = (
 /obj/structure/chair{
 	dir = 4
@@ -51435,6 +52081,13 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"ldX" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "ldZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -51573,14 +52226,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"lfr" = (
-/obj/machinery/door/window/southright,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "lft" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/end{
@@ -51628,6 +52273,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"lgi" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "lgs" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -51646,11 +52300,12 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "lgw" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/toy/figure/syndie,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating,
+/obj/machinery/camera{
+	c_tag = " Prison - Entrance";
+	network = list("ss13","prison")
+	},
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron,
 /area/security/prison)
 "lgz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -51672,7 +52327,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "lhi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -51705,31 +52360,11 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"lhs" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast door"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/security/prison)
 "lhy" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
-"lhB" = (
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "lhC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/airalarm/directional/north,
@@ -51863,11 +52498,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"ljE" = (
-/obj/structure/window,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/security/prison)
 "ljG" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -51937,9 +52567,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lkt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/machinery/light/directional/north,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "lkw" = (
 /obj/structure/table/glass,
@@ -52425,25 +53057,30 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "lpW" = (
-/obj/structure/closet/crate,
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/instrument/harmonica,
-/obj/item/storage/dice,
-/obj/item/toy/cards/deck/tarot,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/machinery/camera{
+	c_tag = " Prison - Library";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/wood,
 /area/security/prison)
+"lqh" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "lqq" = (
 /turf/open/floor/wood,
 /area/service/library/abandoned)
 "lqN" = (
+/obj/item/trash/chips,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/security/prison)
 "lqP" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -52786,7 +53423,7 @@
 	req_access_txt = "63"
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "lwL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -52852,13 +53489,14 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "lxf" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/shovel/spade,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/security/old{
+	glass = 1;
+	name = "Cafeteria"
 	},
-/area/security/prison)
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "lxk" = (
 /turf/open/floor/iron/dark,
 /area/service/library)
@@ -52889,11 +53527,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/kitchen)
-"lxx" = (
-/obj/machinery/door/window/southleft,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/security/prison)
 "lxA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -53056,6 +53689,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
+"lzv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen,
+/area/security/prison/mess)
 "lzx" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
@@ -53363,7 +54000,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "lCh" = (
 /obj/structure/statue/sandstone/venus{
 	name = "Justice"
@@ -53717,6 +54354,32 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"lJC" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/wirecutters,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/secateurs,
+/obj/item/secateurs,
+/obj/machinery/light/directional/north,
+/obj/item/plant_analyzer,
+/obj/item/plant_analyzer,
+/turf/open/floor/wood,
+/area/security/prison/garden)
 "lJI" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron{
@@ -53971,6 +54634,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"lNN" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 6;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/security/prison)
 "lNO" = (
 /obj/structure/table/wood,
 /obj/item/storage/crayons,
@@ -54009,18 +54682,22 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "lOb" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
 	},
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/water_source{
+	dir = 8;
+	name = "sink";
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/turf/open/space/basic,
+/area/security/prison/garden)
 "lOi" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -54440,12 +55117,13 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/security/brig/upper)
 "lUo" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
 /area/security/prison)
 "lUt" = (
@@ -54683,11 +55361,9 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/maintenance/port/greater)
-"lXm" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+"lXr" = (
+/obj/structure/curtain/bounty,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "lXF" = (
 /obj/machinery/light/directional/east,
@@ -54816,6 +55492,12 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"lYW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/security/prison)
 "lZd" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
@@ -54890,6 +55572,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lobby)
+"lZJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "lZN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/status_display/ai/directional/north,
@@ -54905,6 +55593,31 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"lZZ" = (
+/obj/structure/rack,
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = -6
+	},
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = -6
+	},
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "mal" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -55121,6 +55834,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/commons/locker)
+"mcQ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/purple/side,
+/area/security/prison)
 "mdd" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
@@ -55217,6 +55940,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"mex" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
+"meD" = (
+/turf/closed/wall,
+/area/security/brig/upper)
 "meG" = (
 /obj/structure/cable,
 /obj/structure/sink/kitchen{
@@ -55279,6 +56013,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"mfJ" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 6
+	},
+/area/security/prison)
 "mfK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55370,7 +56115,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "mhj" = (
 /turf/open/floor/iron{
 	dir = 8;
@@ -55392,11 +56137,15 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "mhE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/brigofficer)
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "mhI" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -55471,11 +56220,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "mit" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/side,
 /area/security/prison)
 "mix" = (
 /obj/structure/table_frame,
@@ -55532,20 +56278,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"mjo" = (
-/obj/machinery/button/flasher{
-	id = "visitorflash";
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/button/door/directional/north{
-	id = "visitation";
-	name = "Visitation Shutters";
-	pixel_x = 6;
-	req_access_txt = "2"
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "mjp" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
@@ -55558,12 +56290,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/service/theater/abandoned)
-"mjN" = (
-/obj/structure/window,
-/obj/machinery/biogenerator,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/security/prison)
 "mjU" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -55943,7 +56669,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/security/brig/upper)
 "mpA" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -56013,6 +56739,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/storage)
+"mqd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "mqj" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/newscaster/directional/east,
@@ -56021,33 +56754,11 @@
 	icon_state = "chapel"
 	},
 /area/service/chapel)
-"mqt" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "justicechamber";
-	name = "Justice Chamber Blast door"
-	},
-/obj/machinery/door/window/brigdoor/northright{
-	dir = 2;
-	name = "Justice Chamber";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/window/brigdoor/northright{
-	name = "Justice Chamber";
-	req_access_txt = "3"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+"mqw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/fedora,
+/turf/open/floor/plating,
+/area/security/prison)
 "mqA" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/railing,
@@ -56148,6 +56859,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/hallway/secondary/construction)
+"mrB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "mrD" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -56836,17 +57553,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"mCX" = (
-/obj/structure/closet/secure_closet/injection,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "mDk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -56981,6 +57687,14 @@
 "mFG" = (
 /turf/open/floor/iron/grimy,
 /area/service/library)
+"mGa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "mGk" = (
 /obj/machinery/power/emitter{
 	dir = 8
@@ -57087,6 +57801,18 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint)
+"mID" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permainner";
+	name = "Permabrig Transfer";
+	req_access_txt = "2"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "mIG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -57199,11 +57925,6 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"mKF" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/brown/tom,
-/turf/open/floor/iron,
-/area/security/prison)
 "mKM" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -57311,6 +58032,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"mMt" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "mMH" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/effect/turf_decal/stripes/line{
@@ -57493,6 +58225,16 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"mOQ" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 8;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 8
+	},
+/area/security/prison)
 "mOU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -57566,6 +58308,11 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"mPT" = (
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
+/area/security/prison)
 "mPZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -57688,16 +58435,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "mRz" = (
-/obj/structure/table/glass,
-/obj/item/storage/medkit/regular,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
+/turf/open/floor/carpet,
+/area/security/brig/upper)
 "mRF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
@@ -57761,6 +58500,14 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"mSQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
+/obj/machinery/meter,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "mTb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58094,11 +58841,18 @@
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "mXw" = (
-/obj/machinery/meter,
-/obj/machinery/door/window/westright,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/red/side{
+	dir = 8
+	},
 /area/security/execution/education)
 "mXx" = (
 /obj/structure/bed,
@@ -58499,6 +59253,17 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"ncr" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell5";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
 "ncv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/purple{
@@ -58578,6 +59343,28 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/crew_quarters/bar)
+"ncW" = (
+/obj/structure/closet/secure_closet/freezer/meat{
+	req_access = null
+	},
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/security/prison/mess)
 "ndb" = (
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/plating,
@@ -59458,16 +60245,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"npH" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "npO" = (
 /obj/machinery/camera/motion/directional/east{
 	c_tag = "E.V.A. Storage";
@@ -59484,11 +60261,11 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "npX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom/prison/directional/east,
-/obj/machinery/vending/cigarette,
+/obj/machinery/camera{
+	c_tag = " Prison - Central";
+	network = list("ss13","prison")
+	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "npZ" = (
@@ -59510,6 +60287,16 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"nqB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/west,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "nqJ" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/red{
@@ -59611,10 +60398,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "nsp" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/security/prison)
 "nsr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -59732,27 +60522,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science)
-"ntB" = (
-/obj/machinery/button/flasher{
-	id = "Cell 5";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/east{
-	id = "permashut5";
-	name = "Cell Lockdown Button";
-	pixel_y = -6;
-	req_access_txt = "2"
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "ntC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
@@ -59830,21 +60599,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
-"nuU" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast door"
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Perma Higher Officer";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/brigofficer)
 "nvf" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -59934,6 +60688,19 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"nwE" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/kitchen,
+/area/security/prison/mess)
 "nwG" = (
 /obj/item/beacon,
 /obj/structure/cable,
@@ -60352,6 +61119,10 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/service/library)
+"nEw" = (
+/obj/machinery/griddle,
+/turf/open/floor/iron/kitchen,
+/area/security/prison/mess)
 "nEK" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -60409,7 +61180,7 @@
 	cycle_id = "perma-entrance"
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "nFs" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/structure/cable,
@@ -60424,16 +61195,17 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "nFI" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/ambrosia_vulgaris{
-	pixel_x = -30
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/security/old{
+	glass = 1;
+	name = "Cafeteria"
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "nFS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -60596,22 +61368,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "nIA" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
 	},
-/obj/item/tank/internals/oxygen/red{
-	pixel_x = 3
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/item/tank/internals/oxygen/red{
-	pixel_x = -3
-	},
-/obj/item/wrench,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "nIF" = (
@@ -60660,6 +61426,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"nIX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/red,
+/area/security/brig/upper)
 "nJb" = (
 /obj/structure/sign/departments/chemistry{
 	pixel_x = -32
@@ -60789,6 +61565,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/medical/medbay/lobby)
+"nLA" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
+/area/security/prison)
 "nLH" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating,
@@ -60804,6 +61587,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"nMd" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 10;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/security/prison)
 "nMk" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -61154,6 +61947,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"nRR" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall/rust,
+/area/security/prison/mess)
 "nRT" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
@@ -61331,6 +62128,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/engineering/main)
+"nTf" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood,
+/area/security/prison)
 "nTx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61434,6 +62236,19 @@
 	},
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
+"nVP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 9
+	},
+/area/security/prison)
 "nVW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61463,20 +62278,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"nWJ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Cell 4";
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "nXc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/cloth/fancy/mechanical{
@@ -61546,15 +62347,14 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "nYb" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
+/obj/machinery/door/window/brigdoor/security/cell/northleft{
+	id = "isolation";
+	name = "Isolation Cell";
+	opacity = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "nYd" = (
 /obj/machinery/atmospherics/components/binary/valve,
@@ -61644,6 +62444,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"nZA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "nZB" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -61932,6 +62738,32 @@
 	},
 /turf/open/floor/iron,
 /area/medical/virology)
+"odA" = (
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/clothing/gloves/color/blue,
+/obj/item/clothing/suit/caution,
+/obj/item/clothing/suit/caution,
+/obj/item/clothing/suit/caution,
+/obj/item/clothing/suit/caution,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/mop,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/storage/bag/trash,
+/obj/structure/cable,
+/obj/item/pushbroom,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "odO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -62264,13 +63096,13 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "ohW" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/newscaster/security_unit/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/red/side{
+	dir = 6
+	},
 /area/security/execution/education)
 "oid" = (
 /obj/effect/landmark/event_spawn,
@@ -62447,12 +63279,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"okW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "ole" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -62512,18 +63338,20 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "olN" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown1";
+	name = "Lockdown"
 	},
-/obj/item/trash/sosjerky,
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = 32
+/obj/machinery/button/door{
+	id = "prisonlockdown1";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access_txt = "63"
 	},
-/obj/machinery/light/small/directional/north,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white,
-/area/security/prison/safe)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "olS" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
@@ -62594,10 +63422,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"omB" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/iron,
-/area/security/prison)
 "omG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -62934,6 +63758,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
+"oqO" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "orw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -63024,9 +63854,11 @@
 /turf/open/floor/carpet,
 /area/command/bridge)
 "osN" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "osV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -63082,6 +63914,20 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den/gaming)
+"otw" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "otC" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -63708,11 +64554,15 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/customs/auxiliary)
 "oCh" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark/red,
+/area/security/brig/upper)
 "oCs" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
@@ -64014,6 +64864,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/meeting_room/council)
+"oGk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/brigoff,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "oGz" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -64095,28 +64952,17 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "oHl" = (
-/obj/structure/sign/poster/official/work_for_a_future{
-	pixel_y = -32
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown3";
+	name = "Lockdown"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
-"oHn" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 1";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "oHv" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
@@ -64167,6 +65013,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"oHY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "oIf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -64328,6 +65187,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/half,
 /area/service/hydroponics)
+"oKf" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell4";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
+	},
+/area/security/prison)
 "oKo" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/bodybags{
@@ -64338,7 +65208,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/brig/upper)
 "oKp" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -64364,10 +65234,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"oKH" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "oKK" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -64419,7 +65285,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "oLh" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty,
@@ -64683,12 +65549,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/project)
 "oOT" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/obj/structure/barricade/wooden,
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/security/prison)
 "oPc" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/aft)
@@ -64783,6 +65647,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"oQF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/janitorialcart{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "oQR" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -64810,6 +65689,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"oRf" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "oRk" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -65080,11 +65965,17 @@
 	},
 /area/maintenance/port/aft)
 "oWs" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/computer/security{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/computer/security/telescreen/prison{
+	pixel_y = 32
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 9
+	},
+/area/brigofficer)
 "oWF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line{
@@ -65369,6 +66260,11 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"paz" = (
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "paE" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -65509,14 +66405,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/hfr_room)
-"pdi" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Permabrig - Central";
-	network = list("ss13","prison")
-	},
-/obj/item/radio/intercom/prison/directional/west,
-/turf/open/floor/iron,
-/area/security/prison)
 "pdo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65724,14 +66612,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"pgA" = (
-/obj/machinery/door/window/northleft,
-/obj/machinery/door/firedoor/border_only{
+"pgc" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell6";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "pgD" = (
 /obj/effect/landmark/start/hangover,
@@ -65753,14 +66643,15 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "phe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/turf/open/floor/iron/dark/brown/side{
+	dir = 6
+	},
+/area/security/prison)
 "phi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -65990,6 +66881,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint)
+"pkW" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "plo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66095,6 +66994,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"pmh" = (
+/turf/open/floor/iron/kitchen,
+/area/security/prison/mess)
 "pms" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -66103,7 +67005,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "pmy" = (
 /obj/structure/chair{
 	dir = 4
@@ -66114,6 +67016,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"pmE" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/security/prison/garden)
 "pmL" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/east,
@@ -66228,16 +67134,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"pow" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "pox" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/door/firedoor,
@@ -66250,11 +67146,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
-"poJ" = (
-/obj/machinery/light/directional/east,
-/mob/living/simple_animal/mouse/white,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "poQ" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
@@ -66298,6 +67189,11 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"pqe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/security/prison)
 "pqg" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/matches{
@@ -66439,6 +67335,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
+"psi" = (
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/turf/open/floor/plating,
+/area/security/prison)
 "psq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -66846,6 +67748,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"pym" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "pyF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -66863,18 +67774,15 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pyI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/brigofficer)
-"pyX" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/security/old{
+	glass = 1;
+	name = "Cafeteria"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/prison/mess)
 "pza" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -67113,6 +68021,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
+"pCW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "pDc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67146,6 +68061,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark/corner,
 /area/maintenance/department/electrical)
+"pDt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/security/prison)
 "pDz" = (
 /obj/machinery/newscaster/directional/north,
 /obj/structure/table/wood,
@@ -67244,6 +68167,29 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"pEB" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell9";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 1
+	},
+/area/security/prison)
+"pEL" = (
+/obj/structure/table,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
 "pES" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral,
@@ -67294,8 +68240,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "pFU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
 /area/security/prison)
 "pGb" = (
 /obj/structure/table/reinforced,
@@ -67341,28 +68291,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "pGM" = (
-/obj/structure/window{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
 	},
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null
-	},
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/onion,
-/obj/item/food/grown/onion,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/poster/ripped{
-	pixel_y = 32
-	},
-/obj/item/storage/box/ingredients/random,
-/obj/item/storage/box/ingredients/random,
-/obj/item/storage/box/ingredients/random,
-/turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "pGU" = (
 /obj/item/storage/pod{
@@ -67493,14 +68425,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "pIj" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/bookcase/random/religion,
+/obj/item/radio/intercom/directional/east{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/security/prison)
 "pIm" = (
 /obj/structure/window/reinforced{
@@ -67583,8 +68514,11 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "pJb" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "pJc" = (
 /obj/effect/landmark/start/hangover,
@@ -67635,6 +68569,13 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
+"pJQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/security/prison/mess)
 "pJR" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes,
@@ -67686,6 +68627,17 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
+"pKO" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "pKR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -67826,6 +68778,12 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"pNZ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "pOd" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -68127,6 +69085,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"pRT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating,
+/area/security/prison)
 "pRX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -68342,6 +69305,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"pVy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible/layer4,
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "pVS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -68526,6 +69496,12 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"pYx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen,
+/area/security/prison/mess)
 "pYz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/purple{
@@ -68645,12 +69621,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"qab" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron,
-/area/security/prison)
 "qak" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
@@ -68780,6 +69750,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"qbt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/security/prison)
 "qbv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit/old,
@@ -68797,6 +69774,12 @@
 	},
 /turf/open/floor/plating,
 /area/commons/toilet/restrooms)
+"qbw" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "qbE" = (
 /obj/machinery/door/window/northleft{
 	name = "Crate Return Access";
@@ -69181,6 +70164,22 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"qhN" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "qhQ" = (
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plating/airless,
@@ -69218,17 +70217,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"qiB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "qiG" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -69341,6 +70329,15 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"qkd" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "qkr" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
@@ -69390,6 +70387,19 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"qkR" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/item/reagent_containers/hypospray/medipen,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "qle" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L13"
@@ -69574,14 +70584,9 @@
 /turf/open/floor/iron,
 /area/service/kitchen/abandoned)
 "qnU" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "qnX" = (
@@ -69661,7 +70666,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/security/prison)
+/area/security/brig/upper)
 "qpi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69730,21 +70735,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/service/chapel)
-"qqG" = (
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "Prisoner Telescreen";
-	network = list("prison");
-	pixel_x = 27
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "qqU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
@@ -70028,14 +71018,19 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qtR" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table/reinforced,
+/obj/item/electropack,
+/obj/item/assembly/signaler,
+/obj/machinery/light/directional/west,
+/obj/item/clothing/head/helmet/sec,
+/turf/open/floor/iron/dark/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
 /area/security/execution/education)
+"qtV" = (
+/obj/structure/loom,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
 "qtW" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -70057,6 +71052,22 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"qup" = (
+/obj/structure/closet/crate/large,
+/obj/item/melee/chainofcommand{
+	damtype = "stamina";
+	desc = "Feels a lot softer than a real whip. Looks like it'll still sting and hurt, but it won't leave deep lacerations.";
+	force = 30;
+	name = "leather whip"
+	},
+/obj/item/grenade/smokebomb,
+/obj/item/screwdriver,
+/obj/item/toy/crayon/spraycan,
+/obj/item/pda,
+/obj/item/radio,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/prison)
 "quH" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -70072,6 +71083,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
+"qvw" = (
+/obj/structure/bed/maint,
+/obj/machinery/flasher{
+	id = "IsolationFlash";
+	pixel_y = 28
+	},
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 5
+	},
+/area/security/prison)
 "qvB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -70140,11 +71162,10 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "qwA" = (
-/obj/structure/sign/poster/official/here_for_your_safety{
-	pixel_x = 30
+/obj/structure/window/reinforced/tinted{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool,
 /turf/open/floor/iron,
 /area/security/prison)
 "qwF" = (
@@ -70235,6 +71256,17 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"qyc" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell7";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
 "qyg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -70494,14 +71526,13 @@
 /turf/open/floor/iron,
 /area/science/storage)
 "qBp" = (
-/obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/flasher/directional/south{
-	id = "Cell 3"
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "qBK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -70533,17 +71564,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/medical/medbay/lobby)
-"qBZ" = (
-/obj/machinery/computer/security{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen{
-	name = "Solitary Monitoring";
-	network = list("solitary");
-	pixel_x = -28
-	},
-/turf/open/floor/iron/dark,
-/area/brigofficer)
 "qCn" = (
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
@@ -70621,6 +71641,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"qDm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "qDD" = (
 /turf/open/floor/wood,
 /area/service/lawoffice)
@@ -70677,6 +71703,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"qDY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/security/prison)
+"qEt" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "qEv" = (
 /turf/open/floor/iron{
 	dir = 1;
@@ -70713,11 +71753,22 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "qEN" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/turf/open/floor/iron/dark,
+/obj/machinery/sparker/directional/south{
+	id = "justicespark"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/red/side,
 /area/security/execution/education)
+"qEP" = (
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 6
+	},
+/area/security/prison)
 "qFk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -70734,7 +71785,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "qFv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -70848,23 +71899,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "qGv" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"qGD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "justicechamber";
-	name = "Justice Chamber Blast door"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
 	},
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/execution/education)
+/turf/open/floor/iron/dark/red,
+/area/security/brig/upper)
 "qGH" = (
 /obj/structure/table/wood,
 /obj/item/storage/dice,
@@ -71101,6 +72140,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"qKo" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue/side,
+/area/security/prison)
 "qKp" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -71125,18 +72175,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/engineering/gravity_generator)
-"qKv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "qKx" = (
 /obj/machinery/power/energy_accumulator/tesla_coil,
 /obj/effect/turf_decal/bot,
@@ -71335,7 +72373,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/closet/secure_closet/brig/genpop,
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/brig/upper)
 "qMY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71387,6 +72425,11 @@
 	},
 /turf/open/floor/iron,
 /area/service/salon)
+"qNO" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "qNT" = (
 /turf/closed/wall,
 /area/maintenance/department/engine/atmos)
@@ -71558,6 +72601,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"qPJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "qPN" = (
 /obj/structure/rack,
 /obj/item/airlock_painter,
@@ -71645,6 +72696,18 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/library)
+"qQW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/security/prison)
 "qRk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -71662,7 +72725,16 @@
 	req_access_txt = "3"
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -71717,7 +72789,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/brig/upper)
 "qSI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -71759,12 +72831,8 @@
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
 "qSL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/side,
 /area/security/prison)
 "qSO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -71807,16 +72875,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/security/prison)
-"qSV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/flasher/directional/south{
-	id = "Cell 1"
-	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/brig/upper)
 "qSW" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
@@ -72180,6 +73239,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"qYh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
 "qYm" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -72319,15 +73388,6 @@
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"rav" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/east,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/security/prison)
 "ray" = (
 /obj/structure/closet/wardrobe/white,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -72532,6 +73592,18 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
+"rdv" = (
+/obj/structure/cable,
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "rdz" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -72676,13 +73748,25 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "reB" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "justicechamber";
+	name = "Justice Chamber Blast door"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/door/window/brigdoor/westleft{
+	req_access_txt = "3"
+	},
+/obj/machinery/door/window/brigdoor/eastleft{
+	req_access_txt = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
@@ -72717,18 +73801,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"rfz" = (
-/obj/structure/table,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "rfA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72894,19 +73966,16 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "rhs" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt3";
-	name = "Cell 4"
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut4"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/space/basic,
+/area/security/prison/garden)
 "rhF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -72917,12 +73986,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"rhH" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "rhJ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -73071,8 +74134,18 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "rjB" = (
-/turf/closed/wall/r_wall,
-/area/security/prison/safe)
+/obj/structure/cable,
+/obj/item/storage/toolbox/drone,
+/obj/structure/rack,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/machinery/camera{
+	c_tag = "Security - Prison Outpost";
+	network = list("ss13","Security","prison")
+	},
+/obj/machinery/newscaster/security_unit/directional/south,
+/turf/open/floor/iron/dark/purple/side,
+/area/brigofficer)
 "rjE" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
@@ -73090,16 +74163,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
-"rjJ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
-/area/security/prison)
 "rjU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73510,6 +74573,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"rrJ" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/sink{
+	pixel_y = 22
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "rrN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron{
@@ -73559,6 +74631,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"rsM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/brig/upper)
 "rsQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -73595,6 +74671,10 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"rtB" = (
+/obj/structure/chair/stool,
+/turf/open/floor/iron,
+/area/security/prison)
 "rtE" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -73714,6 +74794,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"rvq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/security/prison)
 "rvr" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/atmos/glass{
@@ -73730,6 +74814,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/atmos/office)
+"rvA" = (
+/obj/structure/bed/roller,
+/turf/open/floor/plating,
+/area/security/prison)
 "rvL" = (
 /obj/structure/cable,
 /obj/machinery/shower{
@@ -74285,6 +75373,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"rGJ" = (
+/obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
+/area/security/prison)
 "rGK" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -74307,6 +75403,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
+"rGV" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "rHt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -74318,15 +75421,17 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "rHx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/light/directional/south,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/iron/dark/red/side{
+	dir = 10
+	},
+/area/security/brig/upper)
 "rHy" = (
 /obj/structure/sign/directions/science{
 	pixel_y = -8
@@ -74361,6 +75466,19 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"rHM" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/landmark/start/brigoff,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "rHP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
@@ -74388,12 +75506,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"rIz" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
-/area/security/prison)
 "rID" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -74407,6 +75519,30 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/service/library)
+"rIK" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
+"rIN" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = " Prison - Cafeteria";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "rIW" = (
 /obj/machinery/shower{
 	dir = 8
@@ -74620,6 +75756,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"rMa" = (
+/obj/structure/table,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
+/area/security/prison)
 "rMk" = (
 /obj/machinery/portable_atmospherics/canister/bz,
 /obj/machinery/light/directional/south,
@@ -75070,6 +76213,19 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
+"rTM" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell10";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 1
+	},
+/area/security/prison)
 "rTN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -75370,20 +76526,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
-"rXt" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Cell 2";
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "rXA" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -75403,6 +76545,15 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/maintenance/department/crew_quarters/bar)
+"rXQ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/button/flasher{
+	id = "transferflash";
+	pixel_y = 24
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "rYg" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/iron/dark,
@@ -75450,6 +76601,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
+"rZb" = (
+/obj/item/chair/plastic{
+	pixel_y = 10
+	},
+/obj/item/chair/plastic{
+	pixel_y = 10
+	},
+/obj/item/chair/plastic{
+	pixel_y = 10
+	},
+/obj/item/chair/plastic{
+	pixel_y = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
 "rZh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -75524,6 +76691,13 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
+"sat" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "saw" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab/range)
@@ -75624,6 +76798,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
+"sbH" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "sbI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75657,8 +76841,12 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "scA" = (
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/flasher{
+	id = "visitorflash";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/security/prison)
 "scE" = (
 /obj/effect/turf_decal/stripes/line,
@@ -75728,8 +76916,12 @@
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/rd)
 "sdP" = (
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/security/prison)
 "sdU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -75937,8 +77129,9 @@
 /turf/open/floor/iron/textured_large,
 /area/engineering/atmos/project)
 "sgI" = (
-/obj/structure/easel,
-/turf/open/floor/iron,
+/obj/structure/bookcase/random/fiction,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/wood,
 /area/security/prison)
 "sgL" = (
 /obj/structure/table/glass,
@@ -76020,30 +77213,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
-"shJ" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast door"
-	},
-/obj/machinery/button/flasher{
-	id = "Cell 1";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/east{
-	id = "permashut1";
-	name = "Cell Lockdown Button";
-	pixel_y = -6;
-	req_access_txt = "2"
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "shN" = (
 /obj/machinery/griddle,
 /obj/machinery/duct,
@@ -76104,13 +77273,12 @@
 /area/service/abandoned_gambling_den)
 "siU" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/red,
+/area/security/brig/upper)
 "sjh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -76347,6 +77515,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"slS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/large,
+/obj/item/crowbar/red,
+/turf/open/floor/plating,
+/area/security/prison/work)
 "slU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -76388,6 +77562,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/tcommsat/server)
+"smo" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
 "sms" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77175,6 +78354,11 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
+"sxS" = (
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "sxV" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -77227,6 +78411,10 @@
 /obj/structure/flora/junglebush/c,
 /turf/open/misc/grass,
 /area/hallway/primary/fore)
+"syA" = (
+/obj/item/soap/nanotrasen,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "syL" = (
 /turf/open/floor/iron,
 /area/maintenance/port/greater)
@@ -77381,6 +78569,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"sAo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "isolationshutter"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "sAt" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -77893,6 +79089,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
+"sFM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
+	},
+/area/brigofficer)
 "sFN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -78247,12 +79450,10 @@
 	},
 /area/cargo/sorting)
 "sKL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/brigofficer)
 "sKN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
@@ -78394,13 +79595,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
-"sMR" = (
-/obj/item/kirbyplants/random,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -30
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "sMV" = (
 /obj/machinery/light/directional/north,
 /obj/item/kirbyplants/random,
@@ -78475,6 +79669,11 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/library)
+"sOy" = (
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/prison)
 "sOG" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -78522,20 +79721,20 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "sPv" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Cell 3";
-	network = list("ss13","prison")
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown3";
+	name = "Lockdown"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/button/door{
+	id = "prisonlockdown3";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "sPw" = (
 /turf/closed/wall,
 /area/engineering/storage/tech)
@@ -78580,6 +79779,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"sPZ" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "sQi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -78599,13 +79806,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "sQr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/flasher/directional/south{
-	id = "Cell 2"
+/obj/structure/chair{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 4
+	},
+/area/brigofficer)
 "sQK" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -78613,38 +79822,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"sQL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/status_display/evac/directional/north,
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/glass/bottle/chloralhydrate{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/glass/bottle/facid{
-	pixel_x = 7
-	},
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "sQV" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -78854,11 +80031,10 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "sUa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/medbay/alt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/structure/curtain/cloth/fancy,
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet,
+/area/security/brig/upper)
 "sUj" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -78981,6 +80157,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/service/library)
+"sVM" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plating,
+/area/security/prison)
 "sVT" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -79175,22 +80356,19 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
+"sYo" = (
+/turf/closed/wall,
+/area/security/prison/garden)
 "sYu" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt2";
-	name = "Cell 2"
+/obj/machinery/cryopod{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/effect/turf_decal/delivery/white{
+	color = "#00ff00";
+	name = "green"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "sYB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -79649,6 +80827,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"tfk" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "tfn" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -79704,6 +80888,18 @@
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/iron,
 /area/service/kitchen/abandoned)
+"tgn" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "tgr" = (
 /obj/structure/chair{
 	dir = 8;
@@ -79731,6 +80927,11 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
+"tgY" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
 "tgZ" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -79840,14 +81041,15 @@
 /turf/open/floor/wood,
 /area/service/theater)
 "tjY" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/effect/landmark/start/brigoff,
+/turf/open/floor/iron/dark/purple,
+/area/brigofficer)
 "tkb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79918,12 +81120,50 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "tll" = (
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/computer/secure_data{
-	dir = 4
+/turf/closed/wall,
+/area/security/prison/mess)
+"tlo" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/seeds/aloe,
+/obj/item/seeds/apple,
+/obj/item/seeds/cabbage,
+/obj/item/seeds/whitebeet,
+/obj/item/seeds/redbeet,
+/obj/item/seeds/sugarcane,
+/obj/item/seeds/sunflower,
+/obj/item/seeds/tea,
+/obj/item/seeds/tea/astra,
+/obj/item/seeds/tobacco,
+/obj/item/seeds/tomato/blood,
+/obj/item/seeds/cocoapod/vanillapod,
+/obj/item/seeds/cocoapod,
+/obj/item/seeds/coffee/robusta,
+/obj/item/seeds/coffee,
+/obj/item/seeds/corn,
+/obj/item/seeds/cotton,
+/obj/item/seeds/cotton/durathread,
+/obj/item/seeds/potato/sweet,
+/obj/item/grown/cotton,
+/obj/item/food/grown/poppy,
+/obj/item/food/grown/poppy/geranium,
+/obj/item/food/grown/poppy/lily,
+/obj/item/food/grown/harebell,
+/obj/item/food/grown/garlic,
+/obj/item/food/grown/onion,
+/obj/item/food/grown/peas,
+/obj/item/grown/log,
+/obj/item/food/grown/mushroom/chanterelle,
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
 	},
-/turf/open/floor/iron/dark,
-/area/brigofficer)
+/obj/item/food/grown/wheat,
+/turf/open/space/basic,
+/area/security/prison/garden)
 "tlp" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -80288,19 +81528,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "tqQ" = (
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "Prisoner Telescreen";
-	network = list("prison");
-	pixel_x = 27
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 1;
+	name = "blue line"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "tro" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80395,14 +81630,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"tsX" = (
-/obj/machinery/vending/sustenance,
-/obj/machinery/camera/directional/south{
-	c_tag = "Permabrig - Kitchen";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "tsY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80579,18 +81806,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/lobby)
-"tvL" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 3";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "tvO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -80838,7 +82053,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/security/brig/upper)
 "tzm" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -80964,6 +82179,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"tAZ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/security/prison)
 "tBg" = (
 /obj/machinery/air_sensor/atmos/nitrogen_tank,
 /turf/open/floor/engine/n2,
@@ -81010,6 +82233,14 @@
 	},
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
+"tBZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "tCh" = (
 /turf/closed/wall,
 /area/science/misc_lab)
@@ -81140,20 +82371,19 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "tDW" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt3";
-	name = "Cell 5"
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut5"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/space/basic,
+/area/security/prison/garden)
 "tDX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown{
@@ -81643,15 +82873,6 @@
 "tLe" = (
 /turf/closed/wall,
 /area/service/kitchen)
-"tLf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "tLg" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -82199,6 +83420,15 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
+"tTi" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "tTj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -82328,12 +83558,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/misc_lab)
-"tUQ" = (
-/obj/structure/table,
-/obj/machinery/computer/bookmanagement,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron,
-/area/security/prison)
 "tUR" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
@@ -82365,11 +83589,14 @@
 	dir = 1
 	},
 /area/service/kitchen)
-"tVr" = (
-/obj/structure/table,
-/obj/item/trash/popcorn,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/cafeteria,
+"tVh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/security/prison)
 "tVt" = (
 /obj/structure/chair/office{
@@ -82475,6 +83702,24 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
+"tWU" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown4";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "prisonlockdown4";
+	name = "Lockdown";
+	pixel_x = -24;
+	req_access_txt = "63"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "tXj" = (
 /obj/effect/landmark/start/chemist,
 /obj/effect/turf_decal/tile/yellow{
@@ -82669,6 +83914,30 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"ubY" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/seeds/banana,
+/obj/item/seeds/carrot,
+/obj/item/seeds/carrot/parsnip,
+/obj/item/seeds/chili,
+/obj/item/seeds/lemon,
+/obj/item/seeds/lime,
+/obj/item/seeds/orange,
+/obj/item/seeds/pineapple,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/wheat/oat,
+/obj/item/seeds/wheat/rice,
+/obj/item/seeds/eggplant,
+/obj/item/seeds/berry,
+/obj/item/seeds/cherry/blue,
+/obj/item/seeds/cherry,
+/obj/item/seeds/grape,
+/obj/item/seeds/grape/green,
+/obj/item/seeds/grass,
+/obj/item/seeds/pumpkin,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/wood,
+/area/security/prison/garden)
 "ucc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -82723,6 +83992,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
+"ucZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/red/directional/west,
+/turf/open/floor/plating,
+/area/security/prison)
 "uda" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -82891,18 +84165,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
-"ugH" = (
-/obj/machinery/sparker/directional/west{
-	id = "justicespark"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "uhr" = (
 /obj/machinery/photocopier,
 /obj/machinery/airalarm/directional/west,
@@ -82915,6 +84177,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/commons/dorms)
+"uhu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen,
+/area/security/prison/mess)
 "uhy" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -83010,11 +84278,17 @@
 /area/medical/medbay/central)
 "ujk" = (
 /obj/structure/closet/l3closet/security,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot_blue,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/head/bio_hood/security,
+/obj/item/clothing/head/bio_hood/security,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/brig/upper)
 "ujH" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -83238,15 +84512,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"ulZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/iron,
-/area/security/prison)
 "ums" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -83376,12 +84641,26 @@
 /turf/open/floor/plating,
 /area/cargo/sorting)
 "uoy" = (
-/obj/machinery/plate_press,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell10";
+	name = "curtain"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
+"uoH" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell7";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison)
 "uoR" = (
 /obj/structure/disposalpipe/segment,
@@ -83406,6 +84685,11 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/engineering/lobby)
+"upb" = (
+/obj/machinery/light/directional/south,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
+/area/security/prison)
 "upc" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -83441,10 +84725,9 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/project)
 "upr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/structure/bookcase/random/adult,
+/obj/machinery/light/small/red/directional/north,
+/turf/open/floor/wood,
 /area/security/prison)
 "upw" = (
 /obj/effect/turf_decal/tile/purple{
@@ -83572,11 +84855,11 @@
 	},
 /area/commons/fitness/recreation)
 "urA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/random/contraband/prison,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "urZ" = (
 /obj/structure/cable,
@@ -83625,6 +84908,19 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/dark,
 /area/commons/locker)
+"utf" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/security/prison)
 "uti" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -83688,11 +84984,8 @@
 /turf/open/floor/plating,
 /area/service/theater/abandoned)
 "utK" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Kitchen Entrance";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron,
+/obj/machinery/light/small/red/directional/east,
+/turf/open/floor/wood,
 /area/security/prison)
 "utL" = (
 /obj/structure/cable,
@@ -83715,6 +85008,12 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/engineering/main)
+"utT" = (
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/meter/atmos/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "uut" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -83739,6 +85038,19 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
+"uuv" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell11";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 1
+	},
+/area/security/prison)
 "uuA" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
@@ -83771,6 +85083,19 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
+"uuS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/cardboard,
+/obj/item/weldingtool/mini,
+/obj/item/grown/cotton/durathread,
+/obj/item/reagent_containers/hypospray/medipen/oxandrolone,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/stack/sheet/iron/twenty,
+/obj/item/radio,
+/turf/open/floor/plating,
+/area/security/prison)
 "uva" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -84188,12 +85513,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uAk" = (
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 11
-	},
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
 /area/security/prison)
 "uAo" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -84388,8 +85713,17 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hos)
 "uCx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/door_timer{
+	id = "isolation";
+	name = "Solitary Timer";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "uCK" = (
 /obj/structure/sign/warning/securearea{
@@ -84413,6 +85747,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/medical/surgery)
+"uCY" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "uDb" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
@@ -84670,15 +86014,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "uGw" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/red/side,
 /area/security/execution/education)
 "uGB" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -84713,15 +86053,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"uHz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "uHH" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple{
@@ -84763,7 +86094,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "uHZ" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -85073,6 +86404,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/engineering/main)
+"uMA" = (
+/turf/open/floor/iron/dark/red/side{
+	dir = 6
+	},
+/area/security/execution/education)
 "uML" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -85102,11 +86438,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"uNJ" = (
-/obj/structure/chair/stool/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "uNR" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -85145,13 +86476,25 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
-"uOU" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"uOG" = (
+/obj/structure/bed/maint,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
 	},
-/turf/open/floor/iron,
 /area/security/prison)
+"uOU" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
+/area/brigofficer)
 "uOW" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -85161,10 +86504,15 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "uPe" = (
-/obj/effect/decal/remains/human,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/old{
+	name = "Workshop"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison/work)
 "uPh" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -85377,23 +86725,13 @@
 	},
 /area/engineering/lobby)
 "uSB" = (
-/obj/machinery/flasher{
-	id = "justiceflash";
-	pixel_x = 26;
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/flasher/directional/east{
-	id = "justiceflash";
-	req_access_txt = "63"
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/obj/structure/rack,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/muzzle,
+/obj/item/restraints/handcuffs,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/security/prison)
 "uSJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -85579,6 +86917,19 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"uVV" = (
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
+"uWc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "uWl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/door/airlock/engineering/glass{
@@ -85672,6 +87023,34 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"uXF" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
+	},
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/italian,
+/obj/item/storage/box/ingredients/fruity,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/american,
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 600);
+	name = "Premium All-Purpose Flour (16KG)";
+	volume = 600
+	},
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	list_reagents = list(/datum/reagent/consumable/enzyme = 500);
+	name = "universe-sized universal enyzyme";
+	volume = 500
+	},
+/obj/item/reagent_containers/food/condiment/rice{
+	list_reagents = list(/datum/reagent/consumable/rice = 150);
+	name = "Basmati Rice Sack (4KG)";
+	volume = 150
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/security/prison/mess)
 "uXH" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -85856,6 +87235,21 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/science/research)
+"vaV" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown2";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "prisonlockdown1";
+	name = "Lockdown";
+	pixel_x = -24;
+	req_access_txt = "63"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "vaW" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -85866,7 +87260,12 @@
 "vbv" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood/tile,
-/area/security/prison)
+/area/security/brig/upper)
+"vbQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "vbX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85923,6 +87322,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
+"vcL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "vcW" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -86001,6 +87409,12 @@
 "vdR" = (
 /turf/closed/wall/r_wall,
 /area/engineering/transit_tube)
+"vdT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "vdU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -86108,6 +87522,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"vfk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/prison)
 "vfU" = (
 /obj/machinery/field/generator,
 /obj/effect/decal/cleanable/dirt,
@@ -86129,11 +87548,15 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "vgo" = (
-/obj/structure/chair/stool/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/machinery/button/curtain{
+	id = "prisonlibrarycurtain";
+	pixel_x = -24
+	},
+/obj/machinery/computer/bookmanagement{
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "vgy" = (
 /obj/structure/chair/office/light{
@@ -86231,6 +87654,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central/fore)
+"vhR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "vhT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -86336,13 +87765,16 @@
 	},
 /area/engineering/atmos)
 "vjn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/old{
+	name = "Kitchen"
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "vjp" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Auxiliary Port";
@@ -86389,6 +87821,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
+"vjD" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "vkc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -86599,6 +88039,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"vnc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "vnd" = (
 /obj/machinery/status_display/ai/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -86703,6 +88149,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"vnU" = (
+/turf/open/floor/wood,
+/area/security/prison)
 "vnW" = (
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
@@ -86728,6 +88177,15 @@
 	},
 /turf/open/floor/iron,
 /area/medical/cryo)
+"vpi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/security/glass{
+	name = "Perma Office";
+	req_access_txt = "2"
+	},
+/turf/open/floor/iron/dark/purple,
+/area/brigofficer)
 "vpk" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -86870,14 +88328,15 @@
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "vqY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/chair/office{
-	dir = 8
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/effect/landmark/start/brigoff,
-/turf/open/floor/iron/dark,
-/area/brigofficer)
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "vrc" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -87091,19 +88550,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/storage)
-"vuG" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/structure/sign/poster/official/obey{
-	pixel_x = 30
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Cell 5";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "vuI" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -87135,6 +88581,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"vvb" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown4";
+	name = "Lockdown"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "vvc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -87230,6 +88685,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"vwx" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark/red,
+/area/space)
 "vwy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -87325,6 +88784,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"vxV" = (
+/obj/structure/table,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
 "vyb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -87366,12 +88831,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "vyv" = (
-/obj/machinery/plate_press,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "vyz" = (
 /obj/machinery/camera/directional/south{
@@ -87427,6 +88891,11 @@
 "vyT" = (
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
+"vzk" = (
+/obj/structure/curtain/cloth/fancy,
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet,
+/area/security/brig/upper)
 "vzm" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -87748,6 +89217,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"vEW" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "vFa" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -87813,14 +89287,15 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "vFU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/flasher/directional/south{
-	id = "Cell 4"
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 4;
+	name = "blue line"
 	},
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/security/prison)
 "vGp" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -87913,13 +89388,18 @@
 /area/science/genetics)
 "vHF" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/red/side{
+	dir = 10
+	},
 /area/security/execution/education)
 "vHM" = (
 /obj/structure/table,
@@ -88061,6 +89541,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"vIM" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/security/prison)
 "vIV" = (
 /obj/machinery/holopad/secure,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -88211,6 +89695,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
+"vKP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/trashcart,
+/obj/item/seeds/tower/steel,
+/obj/item/grown/log/bamboo,
+/turf/open/floor/plating,
+/area/security/prison)
 "vKV" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
@@ -88482,6 +89973,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"vOR" = (
+/obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
+/area/security/prison)
 "vPe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
@@ -88547,6 +90046,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"vQi" = (
+/obj/machinery/door/airlock/security{
+	name = "Prison Library"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "vQm" = (
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
@@ -88584,6 +90093,15 @@
 "vRc" = (
 /turf/closed/wall,
 /area/cargo/sorting)
+"vRz" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "vRJ" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 4
@@ -88731,6 +90249,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"vTA" = (
+/turf/open/floor/iron/dark/red/side{
+	dir = 4
+	},
+/area/security/execution/education)
 "vTC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -89118,6 +90641,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/lockers)
+"wai" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "wao" = (
 /obj/structure/frame/computer{
 	dir = 1
@@ -89305,6 +90840,32 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
+"wdR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 9
+	},
+/area/security/prison)
+"wdT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/built,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/security/prison)
+"web" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell3";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
+	},
+/area/security/prison)
 "wew" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -89476,6 +91037,21 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
+"wgz" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
+	},
+/obj/item/seeds/tomato,
+/turf/open/space/basic,
+/area/security/prison/garden)
 "wgF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -89500,7 +91076,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "whm" = (
 /turf/closed/wall,
 /area/maintenance/port/lesser)
@@ -89516,6 +91092,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/salon)
+"whK" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "whP" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 8
@@ -89782,7 +91373,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "wmD" = (
 /obj/structure/cable,
 /obj/machinery/modular_computer/console/preset/id{
@@ -89979,10 +91570,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
-"wpt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "wpR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -90041,12 +91628,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos/hfr_room)
 "wqw" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/side,
 /area/security/prison)
 "wqK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -90057,15 +91644,11 @@
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "wqW" = (
-/obj/machinery/button/flasher{
-	id = "Cell 6";
-	name = "Prisoner Flash";
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/side,
 /area/security/prison)
 "wra" = (
 /obj/structure/cable,
@@ -90223,6 +91806,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/maintenance/department/crew_quarters/bar)
+"wsU" = (
+/obj/structure/table/reinforced,
+/obj/item/taperecorder,
+/obj/item/restraints/handcuffs,
+/obj/item/flashlight/lamp,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark/red/side{
+	dir = 1
+	},
+/area/security/execution/education)
 "wsX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -90252,14 +91845,14 @@
 /turf/open/floor/plating,
 /area/service/library/abandoned)
 "wtm" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 5;
+	name = "blue line"
 	},
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "wtr" = (
 /obj/effect/landmark/start/hangover,
@@ -90293,10 +91886,16 @@
 /turf/open/space,
 /area/ai_monitored/aisat/exterior)
 "wtx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = " Prison - (East) Brown Wing";
+	network = list("ss13","prison")
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
 /area/security/prison)
 "wub" = (
 /obj/structure/chair/office{
@@ -90308,11 +91907,18 @@
 /area/service/library/abandoned)
 "wui" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/red/side{
+	dir = 4
+	},
 /area/security/execution/education)
 "wuo" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -90478,19 +92084,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"wwA" = (
-/obj/structure/table/glass,
-/obj/item/folder/blue,
-/obj/item/healthanalyzer,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "wwH" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -90645,7 +92238,7 @@
 	req_access_txt = "63"
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "wyL" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -90654,21 +92247,6 @@
 "wzi" = (
 /turf/closed/wall,
 /area/cargo/warehouse)
-"wzs" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Cell 1";
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "wzw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
@@ -90769,10 +92347,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "wAy" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clipboard,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "wAL" = (
 /obj/machinery/rnd/server,
@@ -90908,9 +92486,12 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "wDi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/door/airlock/security/old{
+	name = "Jail Cell"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/brown,
 /area/security/prison)
 "wDk" = (
 /obj/structure/dresser,
@@ -90934,11 +92515,12 @@
 /turf/open/floor/iron,
 /area/service/abandoned_gambling_den/gaming)
 "wDB" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 7
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 4
 	},
-/turf/open/floor/plating,
 /area/security/prison)
 "wDH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -90950,15 +92532,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
-"wDP" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison)
 "wEb" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
 	dir = 4
@@ -91043,7 +92616,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "wFo" = (
 /obj/structure/table/reinforced,
 /obj/item/crowbar,
@@ -91053,6 +92626,10 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"wFu" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "wFx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -91189,10 +92766,11 @@
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "wHg" = (
-/obj/structure/chair/stool/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Prison - Visition (Visitor)";
+	network = list("ss13","prison")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "wHh" = (
@@ -91315,12 +92893,23 @@
 /turf/open/floor/iron/white,
 /area/security/medical)
 "wJo" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 8
+	},
+/area/brigofficer)
 "wJz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -91486,18 +93075,16 @@
 /obj/effect/landmark/start/engineering_guard,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"wMU" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 4";
-	req_access_txt = "2"
+"wNf" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison/mess)
 "wNi" = (
 /obj/structure/filingcabinet/medical,
 /obj/machinery/light/directional/north,
@@ -91538,11 +93125,8 @@
 "wNS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "wOf" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -91574,11 +93158,15 @@
 /turf/open/space,
 /area/space/nearstation)
 "wOH" = (
-/obj/structure/chair/stool/directional/west,
-/obj/machinery/flasher/directional/north{
-	id = "visitorflash"
+/obj/structure/table,
+/obj/structure/window/reinforced/tinted{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/security/prison)
 "wOU" = (
@@ -91587,16 +93175,10 @@
 	},
 /turf/closed/wall,
 /area/engineering/atmos/project)
-"wPe" = (
-/mob/living/simple_animal/mouse/gray,
-/turf/open/floor/iron,
-/area/security/prison)
 "wPg" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/dark/red/side,
 /area/security/execution/education)
 "wPu" = (
 /obj/structure/disposalpipe/trunk{
@@ -91708,10 +93290,17 @@
 	},
 /area/service/kitchen)
 "wQu" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
 /area/security/prison)
+"wQz" = (
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/poddoor{
+	id = "justiceblast";
+	name = "Justice Blast door"
+	},
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "wQC" = (
 /obj/machinery/door/airlock{
 	id_tag = "Arrivals_Toilet1";
@@ -91725,18 +93314,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
-"wQD" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "wQI" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/shoes/magboots{
@@ -92220,6 +93797,17 @@
 "wYm" = (
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"wYx" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell6";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
 "wYC" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -92257,14 +93845,7 @@
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den/gaming)
 "wYT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "visitation";
-	name = "Visitation Shutters"
-	},
-/obj/machinery/door/window/southright{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "wZb" = (
@@ -92303,20 +93884,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
-"wZG" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/contraband/prison,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/machinery/light/directional/south,
-/obj/item/radio/intercom/prison/directional/south,
-/turf/open/floor/iron,
-/area/security/prison)
 "wZU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -92447,6 +94014,12 @@
 "xbc" = (
 /turf/closed/wall,
 /area/service/abandoned_gambling_den/gaming)
+"xbf" = (
+/obj/structure/cable,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/prison)
 "xbm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -92483,6 +94056,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"xcm" = (
+/obj/structure/bed/maint,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/plating,
+/area/security/prison)
 "xcq" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -92826,6 +94405,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/cryo)
+"xhO" = (
+/obj/machinery/door/airlock/security/old{
+	name = "Jail Cell"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple,
+/area/security/prison)
 "xia" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/two,
@@ -92945,6 +94532,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"xjn" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "xjq" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue{
@@ -93044,17 +94640,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/maintenance/port/greater)
-"xlz" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/security/prison)
 "xlE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -93705,12 +95290,15 @@
 /turf/open/floor/iron,
 /area/maintenance/department/crew_quarters/bar)
 "xvZ" = (
-/obj/structure/bookcase/random,
-/obj/structure/sign/poster/ripped{
-	pixel_y = -32
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisonlibrarycurtain";
+	name = "curtain"
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/prison/garden)
 "xwc" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -93781,9 +95369,12 @@
 /turf/open/floor/plating,
 /area/service/library/abandoned)
 "xxj" = (
-/obj/structure/table,
-/obj/item/trash/raisins,
-/turf/open/floor/iron/cafeteria,
+/obj/item/trash/energybar,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "xxn" = (
 /obj/structure/chair/office{
@@ -94009,6 +95600,27 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
+"xAI" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = -4
+	},
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 4
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/security/prison)
 "xAW" = (
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/hfr_room)
@@ -94057,6 +95669,15 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
+"xBz" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
+/area/security/prison)
 "xBA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -94064,11 +95685,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"xCh" = (
-/obj/structure/chair/stool/directional/south,
-/obj/item/radio/intercom/prison/directional/west,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "xCi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -94351,6 +95967,11 @@
 "xHn" = (
 /turf/closed/wall,
 /area/commons/storage/tools)
+"xHJ" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "xHT" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
@@ -94379,19 +96000,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"xIN" = (
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 8
-	},
-/obj/machinery/status_display/evac/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Hall";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "xJd" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Central Hallway - Aft Port";
@@ -94566,6 +96174,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
+"xLB" = (
+/obj/machinery/door/airlock/freezer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison/mess)
 "xMc" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -94804,9 +96418,17 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xPp" = (
-/obj/structure/punching_bag,
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/security/prison/garden)
 "xPy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/purple{
@@ -94814,6 +96436,16 @@
 	},
 /turf/open/floor/glass,
 /area/maintenance/space_hut/observatory)
+"xPC" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/inflatable,
+/obj/item/inflatable/door,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "xPF" = (
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
@@ -95063,7 +96695,7 @@
 "xTl" = (
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/wood/tile,
-/area/security/prison)
+/area/security/brig/upper)
 "xTs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -95179,8 +96811,12 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "xVh" = (
-/turf/closed/wall,
-/area/security/prison/safe)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/security/prison)
 "xVm" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
@@ -95198,6 +96834,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"xVG" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell8";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
 "xVL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -95413,7 +97060,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "xZb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/pump,
@@ -95627,6 +97274,15 @@
 /obj/structure/closet/crate,
 /turf/open/space/basic,
 /area/space/nearstation)
+"ybJ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "ybK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -95652,13 +97308,6 @@
 "ybZ" = (
 /turf/open/floor/wood,
 /area/service/library)
-"ycc" = (
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "ycd" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -95766,7 +97415,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig/upper)
 "ydk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -95792,6 +97441,22 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/storage)
+"ydO" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 5
+	},
+/area/security/prison)
 "ydP" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -95864,14 +97529,19 @@
 	},
 /area/commons/fitness/recreation)
 "yeG" = (
-/obj/structure/chair/office{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/red/side{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
 /area/security/execution/education)
 "yeL" = (
 /turf/open/floor/plating{
@@ -95928,11 +97598,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den/gaming)
-"yfl" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/security/prison)
 "yfF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -95948,15 +97613,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"ygf" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Visitation";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "ygs" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -96147,6 +97803,16 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/cmo)
+"ykn" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/brigoff,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 6
+	},
+/area/brigofficer)
 "ykY" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
@@ -144904,11 +146570,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aad
 aaa
-aad
 aaa
+aaa
+aad
 aaa
 aaa
 aaa
@@ -145161,11 +146827,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aad
 aaa
-aad
 aaa
+aaa
+aad
 aaa
 aaa
 aaa
@@ -145409,31 +147075,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aac
-aaa
-aac
-aad
-aad
-aad
+aFm
+aFm
+xVG
+aFm
+aFm
+qyc
+aFm
+aFm
+wYx
+aFm
+aFm
+ncr
+aFm
+aFm
+cTF
+aFm
+aFm
+aFm
+bnE
+bnE
+bnE
+bnE
+bnE
+bnE
+bnE
 aad
 aad
 aad
@@ -145666,31 +147332,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aad
-aaa
-aaa
-aad
-aaa
-aad
-aaa
-aaa
-aac
-aaa
-aaa
-aaa
-aad
-aaa
-aad
-aaa
-aaa
-aad
+aFm
+fCE
+vOR
+aKV
+fCE
+vOR
+aKV
+fCE
+vOR
+aKV
+aRn
+xBz
+aKV
+aRn
+rGJ
+aKV
+aRn
+rMa
+dTC
+qtV
+rZb
+eLr
+emb
+slS
+bnE
 aaa
 aaa
 aaa
@@ -145919,40 +147585,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aad
-aaa
-aaa
-aad
-aad
-aac
-aac
-aad
-aad
-aaa
-aaa
-aaa
 aFm
 aFm
 aFm
 aFm
 aFm
-aFm
+fJo
+qKo
+aKV
+gBX
+qKo
+aKV
+pgc
+bGs
+aKV
+kDH
+mcQ
+aKV
+oKf
+mcQ
+aKV
+web
+fWW
+dTC
+pEL
+dLr
+vxV
+fCV
+fCV
+fCV
 aFn
 aFn
-aFm
-aFm
-aaa
+fCV
+fCV
+gOM
 vcw
 bWr
 bWr
@@ -146176,40 +147842,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
-aaa
-aaa
-abj
-aaa
-aad
-aaa
-aaa
-aad
-rjB
-rjB
-rjB
-rjB
-aQX
+aFm
+tfk
+tfk
+tfk
+aKV
+qQW
+iJY
+aKV
+qQW
+iJY
+aKV
+qQW
+iJY
+aKV
+ihO
+gcr
+aKV
+ihO
+gcr
+aKV
+ihO
+qEP
+dTC
+kej
+dLr
 aSC
-dVm
+fCV
 mRz
-aFn
+vzk
 aZk
 kiO
-pyX
-aFm
-aaa
+hTQ
+hTQ
+hyE
 vcw
 biz
 bkk
@@ -146431,42 +148097,42 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-qYo
-qYo
-qYo
-abj
-aaa
-aaa
-abj
-aad
-aad
-aad
-qYo
-qYo
-rjB
+tgY
+nOg
+aFm
+rrJ
+syA
+wFu
+aKV
+cDJ
+fTo
+aKV
+cDJ
+uoH
+aKV
+cDJ
+kem
+aKV
+xhO
+cCJ
+aKV
+xhO
+bvN
+aKV
+xhO
 jIP
-acI
-rjB
-wwA
-aSD
-eNQ
-eNQ
-aYG
+dTC
+qYh
+dLr
+vxV
+fCV
+fCV
+fCV
 oCh
 siU
 qGv
-aFm
-aaa
+cgA
+vwx
 vcw
 biA
 wJe
@@ -146686,44 +148352,44 @@ aaa
 aaa
 aaa
 aaa
+tgY
 aaa
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-aaa
-aaa
-aaa
-abj
-aaa
-aaa
-aad
-aaa
-aaa
-qYo
-aaa
-aaa
-rjB
+aFm
+jyz
+jyz
+jyz
+gJM
+fGY
+tBZ
+tBZ
+tBZ
+lUo
+nqB
+tBZ
+tBZ
+tWU
+tBZ
+tBZ
+bjf
+tVh
+tBZ
+vcL
+tBZ
 nsp
 uPe
-rjB
+amL
 aQY
 aSE
-pow
-aAw
+fCV
+mRz
 sUa
 eHh
-siU
-rKh
-aFm
-aaa
+nIX
+hTQ
+hTQ
+hyE
 vcw
 biB
 udO
@@ -146943,44 +148609,44 @@ aaa
 aaa
 aaa
 aaa
+tgY
+nOg
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-rSK
-qYo
-rSK
-aaa
-nKK
-nKK
-nKK
-nKK
-nKK
 aFm
-kHZ
-kHZ
-kHZ
-kHZ
-aFm
-aFm
-aFm
-fNW
-aFm
-aFm
-aFm
-aFm
-aFm
-aFm
+aKV
+aKV
+aKV
+aKV
+kfk
+qbw
+jkv
+sxS
+sat
+sxS
+hLX
+sxS
+vvb
+sxS
+sxS
+sxS
+qPJ
+sxS
+sxS
+uVV
+hri
+bnE
+bnE
+bnE
+bnE
+fCV
+fCV
+fCV
 aZn
 rHx
-aFm
-aFm
-aFm
+fCV
+fCV
+fCV
 vcw
 bWr
 njv
@@ -147200,41 +148866,41 @@ aaa
 aaa
 aaa
 aaa
+tgY
 aaa
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-rSK
-aaa
-rSK
-qYo
-pyI
-eVo
-qBZ
+aFm
+rJj
+aKV
+xPC
+aKV
+aKV
 tll
-dSX
-oWs
-tLf
-oWs
-npH
-oWs
+tll
+iJZ
+pyI
+iJZ
+tll
+tll
+aKV
+lNN
+mOQ
+mOQ
+mOQ
+mOQ
 wtm
-oWs
+paz
 wqW
-iNq
+nKK
 oWs
 wJo
 uOU
 sKL
-oWs
-lhs
+aaa
+rsM
 wNS
-siU
+hCy
 nFm
 lBT
 jNQ
@@ -147457,40 +149123,40 @@ aaa
 aaa
 aaa
 aaa
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-rSK
-aaa
-pwn
-aaa
-pyI
+tgY
+nOg
+aFm
+rJj
+ucZ
+rJj
+aVy
+aKV
+eNx
+rIN
+bFd
+pym
 bFd
 vqY
 mhE
-nuU
+aKV
 tqQ
-tjY
-ntB
-qqG
-tjY
+eLB
+eLB
+eLB
+eLB
 iQj
-ccV
-tjY
-ehi
+paz
+vhR
+sKL
 ccV
 tjY
 eoZ
-ccV
-sZD
-shJ
-ipv
+sKL
+aaa
+rsM
+wNS
 whb
 aFn
 beq
@@ -147714,39 +149380,39 @@ aaa
 aaa
 aaa
 aaa
+tgY
 aaa
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-rSK
-aaa
-rSK
-qYo
-pyI
+aFm
+rJj
+rJj
+rJj
+dHv
+aKV
+gHq
+cGH
+lqh
+pym
 bsB
 cJG
 gcs
-nKK
-rjB
+aKV
+egZ
 gkK
-rjB
-rjB
-wMU
-rjB
-rjB
-tvL
-rjB
-rjB
+efa
+eLB
+eLB
+iQj
+pCW
+vhR
+vpi
+sFM
 iAL
 rjB
-rjB
-oHn
-rjB
+nKK
+aaa
+fCV
 aZo
 whb
 bcN
@@ -147971,43 +149637,43 @@ aaa
 aaa
 aaa
 aaa
+tgY
+nOg
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-rSK
-qYo
-rSK
-aaa
-pyI
-ipK
+aFm
+rJj
+rJj
+rJj
+iuW
+aKV
+bQS
+chQ
+bFd
+pym
+pym
 ipK
 chQ
-nKK
-kZW
-wQD
-xVh
-gWq
-qKv
-xVh
-gWq
-qiB
-xVh
+aKV
+tqQ
+eLB
+eLB
+eLB
+eLB
+iQj
+paz
+vhR
+sKL
 gWq
 jrR
-xVh
-kZW
-iCP
-rjB
-rIz
+dvs
+sKL
+aaa
+rsM
+wNS
 whb
-aFm
-aFm
+fCV
+fCV
 bKv
 tuZ
 tuZ
@@ -148228,42 +149894,42 @@ aaa
 aaa
 aaa
 aaa
+tgY
 aaa
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-aaa
-nKK
-nKK
-nKK
-nKK
-rjB
-gSN
-gmX
-xVh
-okW
+aFm
+aKV
+aKV
+aKV
+aKV
+aKV
+enz
+bFd
+bFd
+bFd
+pym
+iJZ
+iJZ
+aKV
+nMd
 vFU
-xVh
-okW
+jyd
+vFU
+vFU
+iyB
+paz
 qBp
-xVh
+nKK
 gSN
 sQr
-xVh
-jga
-qSV
-rjB
-aZo
+ykn
+sKL
+aaa
+rsM
+wNS
 whb
-aFm
+fCV
 bes
 bfR
 tuZ
@@ -148487,40 +150153,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-aaa
-aaa
-aaa
-qYo
-aaa
-rjB
-vuG
-eTj
-xVh
-nWJ
-uHz
-xVh
+tgY
+nOg
+aFm
+pVy
+kpg
+utT
+tAZ
+aKV
+qEt
+hvN
+hvN
+hvN
+pym
+tTi
+wai
+sYo
+sYo
+pmE
+sYo
+pmE
+pmE
+sYo
 sPv
 oHl
-xVh
-rXt
-cer
-xVh
-wzs
-uHz
-rjB
+aFm
+aFm
+aFm
+aFm
+aFm
+aZL
+fCV
 aZr
 aSY
-aFm
+fCV
 iyK
 ujk
 eMy
@@ -148746,40 +150412,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-vVc
-vVc
-vVc
-qYo
-aaa
-rjB
-xVh
+aFm
+lZZ
+sVM
+vfk
+aKV
+aKV
+nRR
+ldX
+hGZ
+uCY
+mMt
+tTi
+whK
+sYo
+jrs
 tDW
-xVh
-xVh
+ieM
 rhs
-xVh
-xVh
-bGi
-xVh
-xVh
+rhs
+pmE
+paz
+vhR
 sYu
-xVh
+eXF
+sYu
+aKV
 xVh
 aWf
-rjB
-aZo
+fCV
+pNZ
 whb
-aFm
-aFm
-aFm
+fCV
+fCV
+fCV
 tuZ
 mZx
 rMx
@@ -149003,36 +150669,36 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-aaa
-aaa
-aaa
-qYo
 aFm
-aFm
+xAI
+pRT
+lZJ
+vEW
+vdT
+foC
+cpW
+pmh
+pkW
+hvN
+tTi
+pKO
+sYo
 xPp
-aJA
-pdi
-eaI
-uCx
-wPe
-qoZ
+wgz
+rhs
+rhs
+rhs
+pmE
+vnc
 pFU
 aNC
-kDY
 lUo
-bbt
-eUv
-aBP
-aFm
-aZo
+lUo
+mID
+sZD
+sZD
+jpi
+bmi
 whb
 cmM
 xTl
@@ -149260,40 +150926,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-qYo
 aFm
-aFm
-aFm
-aFm
+aKV
+aKV
+rdv
+aKV
+vjD
+eFR
+nwE
+pmh
+sbH
+hvN
+wNf
+vRz
 hAI
 gsB
-aJA
-lXm
-gXd
-lkt
-ulZ
+tDW
+rhs
+rhs
+tlo
+sYo
 lkt
 qnU
-xIN
-qab
+rKh
+sZD
 npX
-aWi
+aKV
 ieL
 aWg
-kHZ
+fCV
 aZu
 whb
 iQO
-aFm
-aFm
+fCV
+fCV
 tuZ
 mFt
 lVX
@@ -149517,37 +151183,37 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-rSK
-aaa
-kHZ
-xlz
+aFm
+vKP
+hmt
+eDB
+aKV
+rGV
+eFR
+jam
+aWK
+tll
+tll
 nFI
 lxf
-ljE
-oWs
-uNJ
-aWH
-rKh
-tUQ
-xVh
+sYo
+ubY
+tDW
+rhs
+rhs
+rhs
+pmE
 cAe
-xVh
-xVh
-xVh
-aKV
+fiD
+oRf
+kLC
+sxS
 aSG
-gXd
-cLF
+aJA
+rKh
 kHZ
-aZo
-siU
+wNS
+hCy
 qMI
 aFn
 aaa
@@ -149772,41 +151438,41 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-rSK
-qYo
-rSK
-aaa
-kHZ
-gos
+tgY
+nOg
+aFm
+uuS
+mqw
+qDm
+aKV
+gMv
+eFR
+nEw
+lzv
+aOr
+tll
 fBg
-lqN
-lfr
-lqN
+cGS
+sYo
+lJC
 ccu
 lOb
-rKh
-omB
-xVh
-ycc
-eUh
+rhs
+rhs
+pmE
+paz
+vhR
 iGN
 aPn
+eLB
 aKV
-bIS
-aWi
+oqO
 lgw
-aFm
-aZo
+fCV
+rXQ
 whb
 iKe
-aFm
+fCV
 aad
 tuZ
 pmP
@@ -150027,43 +151693,43 @@ aaa
 aaa
 aaa
 aaa
+tgY
 aaa
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-rSK
-aaa
-rSK
-aaa
-kHZ
+aFm
+aKV
+aKV
+rdv
+aKV
+hsE
+uhu
+uhu
+pYx
+bGh
 vjn
-rJj
+mex
 kAJ
-mjN
-rKh
-iZJ
-rhH
-kyu
+sYo
+sYo
 xvZ
-xVh
+sYo
+xvZ
+xvZ
+sYo
 olN
-xVh
-aCX
+iXg
+aKV
 aPo
 aKV
 aKV
-ygf
 aKV
-aFm
-aZo
-rjJ
-aFm
-aFm
+aKV
+fCV
+wNS
+whb
+fCV
+fCV
 aaa
 tuZ
 ycd
@@ -150284,43 +151950,43 @@ aaa
 aaa
 aaa
 aaa
+tgY
+nOg
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-pwn
-aaa
-qYo
-aaa
-kHZ
-kLz
-rJj
+aFm
+dVK
+qbt
+qDm
+aKV
+iPa
+vbQ
+ccd
+amH
+sPZ
+tll
+mex
 mit
-bAZ
+aKV
 wQu
 hxR
 vgo
-rKh
+chz
 lpW
-xVh
-xVh
-xVh
-xVh
-xVh
 aKV
-iDb
+paz
+vhR
+aKV
 aWi
-sMR
-aFm
-aZo
+rtB
+iDb
+dnG
+aWi
+cZZ
+bmi
 whb
 qSH
-aFm
+fCV
 aad
 tuZ
 qUt
@@ -150541,41 +152207,41 @@ aaa
 aaa
 aaa
 aaa
+tgY
 aaa
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-rSK
-aaa
-rSK
-aaa
-kHZ
-mKF
+smo
+uOG
+iVW
+eDB
+aKV
+tll
+xLB
+aKV
+aKV
+aKV
+aKV
 uCx
 qSL
-lxx
-upr
-pFU
-sZD
-rKh
-pJb
-fYr
-wAy
-xCh
-tVr
-bhs
 aKV
+upr
+pqe
+rvq
+nZA
+pJb
+aKV
+wAy
+vhR
+aKV
+bhs
+rIK
 aSH
-aWi
-rKh
-kHZ
-aZo
-siU
+gCI
+ihm
+fCV
+wNS
+hCy
 crM
 aFn
 aaa
@@ -150798,43 +152464,43 @@ aaa
 aaa
 aaa
 aaa
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-rSK
-qYo
-rSK
-aaa
-kHZ
-nYb
-rav
-adw
-ljE
-sgI
-bbt
-sZD
-aDT
-aWi
-pgA
-dzF
-dzF
-bbt
-scA
+tgY
+nOg
+aFm
 aKV
+aKV
+pDt
+aKV
+uXF
+bmN
+aKV
+wdR
+eXJ
+nYb
+mex
+adw
+aKV
+sgI
+pqe
+vnU
+aDT
+nTf
+aKV
+wAy
+dzF
+aKV
+scA
+qkd
 wOH
 qwA
 wHg
-wDP
-aZo
+fCV
+wNS
 whb
 oKo
-aFm
+fCV
 aad
 aad
 frV
@@ -151055,43 +152721,43 @@ aaa
 aaa
 aaa
 aaa
+tgY
 aaa
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-qYo
 aFm
-aFm
-aFm
-aFm
-aEn
+lYW
+qbt
+mqd
+aKV
+ncW
+pJQ
+aKV
+qvw
+jZC
+sAo
+ctD
+jHx
+aKV
 iMR
-yfl
+pqe
 pIj
 utK
 urA
-fYr
+aKV
 xxj
 wqw
-fth
-rfz
 aKV
+rKh
+rtB
+dfC
+qNO
 wYT
-aKV
-wYT
-aFm
+fCV
 qFn
 wFe
-aFm
-aFm
+fCV
+fCV
 aad
 aaa
 tKS
@@ -151312,41 +152978,41 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aad
-aaa
-aaa
-aaa
+tgY
+nOg
+tgY
 aaa
 aFm
-aFm
+buR
+xHJ
+dFW
 aKV
 aKV
-gDS
+aKV
+aKV
+aKV
+aKV
+aKV
+eNq
+cGS
+aKV
+aKV
+vQi
+aKV
 aKV
 aKV
 aKV
 fxd
-wpt
-hHu
-tsX
+hri
 aKV
-kyw
-rKh
-kyw
-aFm
+aKV
+aKV
+aKZ
+aKZ
+aKZ
+aKZ
 aZC
-siU
+hCy
 aFn
 aad
 aad
@@ -151569,39 +153235,39 @@ aaa
 aaa
 aaa
 aaa
+tgY
 aaa
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-vVc
-qYo
-rSK
-rSK
-rSK
-rSK
-qYo
-qYo
-kHZ
+aFm
+aKV
+aKV
+wdT
+aKV
+lgi
+lgi
+lgi
+hHM
+lXr
+mPT
+qDY
+ffj
+vaV
 fDA
 sdP
 lqN
 isY
 vyv
-aKV
+cqq
 pGM
-bIP
+vhR
 wDi
 iCN
-aKV
-mjo
+eTq
+aKZ
 aUE
 osN
-fsm
+aKZ
 pms
 whb
 aFn
@@ -151816,7 +153482,6 @@ aaa
 aaa
 aaa
 aaa
-agO
 aaa
 aaa
 aaa
@@ -151829,39 +153494,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-aaa
-aaa
-aaa
-kHZ
-ddq
-ctK
-lqN
-bbt
-wZG
-aKV
+tgY
+nOg
+aFm
+lYW
+qbt
+uWc
+kxr
+oGk
+mrB
+mrB
+mrB
+fhA
+hhV
+wDB
+jBq
+hSz
+kLs
+wDB
+kLs
+wDB
+wDB
+gYG
 wDB
 wtx
-hHu
+aKV
 aPu
+kWq
 aKZ
-aKZ
-aKZ
-aKZ
+caJ
+mSQ
 aKZ
 lwI
 bbn
-aFm
+fCV
 aad
 aad
 aad
@@ -152087,38 +153753,38 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-wTn
-aaa
-rSK
-aaa
-aaa
-aaa
-kHZ
-alK
+aFm
+eco
+xHJ
+mGa
+aKV
+bbk
+tgn
+xjn
+xjn
+aKV
+aKV
+irp
+aKV
+aKV
+wDi
 jwH
-lhB
-rKh
+aKV
+wDi
 uoy
 aKV
-fEM
+wDi
 hHu
-rJj
-dGR
+aKV
+aKV
+aFm
 aKZ
-sQL
 aUD
 aWl
 aKZ
 mhh
 aFn
-aFm
+fCV
 aad
 aaa
 aad
@@ -152344,30 +154010,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-rSK
-qYo
-rSK
-qYo
 aFm
 aFm
-kHZ
-kHZ
-kHZ
 aFm
 aFm
+aFm
+jvP
+hWc
+hWc
+hWc
+aKV
+oQF
+otw
+qhN
+aKV
+nVP
+gaW
+aKV
+nVP
+nLA
+aKV
 fpP
 uAk
-poJ
-kPS
+aKV
+rJj
 aKZ
 aSM
 yeG
@@ -152375,9 +154041,9 @@ vHF
 qRB
 uHV
 bbp
-aFm
-aFm
-aFm
+fCV
+fCV
+fCV
 aad
 aaa
 frV
@@ -152601,30 +154267,30 @@ aaa
 aaa
 aaa
 aaa
+nOg
+nOg
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-rSK
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aFm
-aKZ
-aKZ
-aKZ
-aKZ
+smo
+jvP
+hWc
+hWc
+upb
+aKV
+dHc
+rHM
+qkR
+aKV
+uuv
+eso
+aKV
+rTM
+eso
+aKV
+pEB
+eso
+aKV
+kJm
 aKZ
 qtR
 eeg
@@ -152857,41 +154523,41 @@ aaa
 aaa
 aaa
 aaa
+nOg
+nOg
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-rSK
-qYo
-vVc
-vVc
-vVc
-qYo
-qYo
-aaa
-aaa
+smo
+hWc
+hWc
+hWc
+hWc
+aKV
+utf
+jbk
+odA
+aKV
+ydO
+phe
+aKV
+aLa
+mfJ
+aKV
 aLa
 phe
-ugH
-oKH
-aWq
-qtR
-eeg
+aKV
+rJj
+aKZ
+wsU
+oHY
 wPg
 aKZ
 xYP
 aFn
-aFm
-aKV
-aFm
+fCV
+meD
+fCV
 aad
 aad
 frV
@@ -153113,33 +154779,33 @@ aaa
 aaa
 aaa
 aaa
+tgY
+nOg
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-aaa
-aaa
-aaa
-aaa
-aaa
-aad
-aaa
-aaa
-aLa
-oKH
-hRW
+nOg
+smo
+smo
+smo
+aFm
+aFm
+aFm
+smo
+aKV
+smo
+aKV
+aKV
+aKV
+aKV
+aKV
+aKV
+aKV
+aKV
+aKV
+aKV
 oOT
-mqt
+aKZ
 gDw
 wui
 ohW
@@ -153147,7 +154813,7 @@ aKZ
 qST
 bbr
 bcU
-aKV
+meD
 aaa
 aad
 aaa
@@ -153341,6 +155007,7 @@ aaa
 aaa
 aaa
 aaa
+agO
 aaa
 aaa
 aaa
@@ -153369,37 +155036,36 @@ aaa
 aaa
 aaa
 aaa
+tgY
+tgY
+aaa
+aaa
+nOg
+nOg
+nOg
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-rSK
-rSK
-rSK
-qYo
-aFo
-aad
-aad
-aad
-aLa
+nOg
+aFm
+cjA
+sOy
+xbf
+ybJ
+rJj
+rJj
+rJj
+rJj
+qup
+aKV
+vIM
 acU
 uSB
-ktd
-qGD
-mCX
+rJj
+aKZ
+aWq
 reB
-fbc
+aWq
 aKZ
 iHV
 lgV
@@ -153628,31 +155294,31 @@ aaa
 aaa
 aaa
 aaa
+tgY
+tgY
+nOg
+nOg
+nOg
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-pwn
-pwn
-pwn
-aaa
-aKZ
-aKZ
-aKZ
-aKZ
+nOg
+nOg
+aFm
+smo
+aFm
+smo
+aFm
+aFm
+aFm
+aFm
+aFm
+aFm
+aFm
+hFr
+rJj
+rJj
+eVr
 aKZ
 dVR
 mXw
@@ -153661,7 +155327,7 @@ aKZ
 aZK
 bbt
 qoZ
-aKV
+meD
 aaa
 aad
 aaa
@@ -153886,39 +155552,39 @@ aaa
 aaa
 aaa
 aaa
+tgY
+tgY
+nOg
 aaa
 aaa
 aaa
+nOg
+nOg
 aaa
 aaa
+nOg
+aaa
+nOg
 aaa
 aaa
+nOg
 aaa
+nOg
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-qYo
-qYo
-qYo
-qYo
-aaa
+aFm
+jwY
+rvA
+xcm
+psi
 aKZ
 jxN
 nIA
 qEN
 aKZ
-aZL
+rsM
 bbu
-aZL
-aKV
+rsM
+meD
 qYo
 pwn
 pwn
@@ -154144,38 +155810,38 @@ aaa
 aaa
 aaa
 aaa
+tgY
+tgY
 aaa
 aaa
+nOg
+nOg
 aaa
 aaa
+tgY
+tgY
+tgY
+tgY
+tgY
 aaa
+tgY
+tgY
+tgY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-vVc
-vVc
-jXB
-jXB
-pwn
-aaa
+aFm
+aFm
+aFm
+aFm
+aFm
 aKZ
-aKZ
-aKZ
-aKZ
+jDP
+vTA
+uMA
 aKZ
 aZM
 aZM
 bcW
-aKV
+meD
 aaa
 aaa
 aaa
@@ -154402,6 +156068,10 @@ aaa
 aaa
 aaa
 aaa
+tgY
+tgY
+nOg
+nOg
 aaa
 aaa
 aaa
@@ -154416,23 +156086,19 @@ aaa
 aaa
 aaa
 aaa
+nOg
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-vVc
-vVc
-vVc
-aaa
-pwn
-aad
-aKV
-aZL
+aKZ
+wQz
+wQz
+wQz
+meD
+rsM
 bbv
-aZL
-aKV
+rsM
+meD
 qYo
 qYo
 pwn
@@ -154660,6 +156326,8 @@ aaa
 aaa
 aaa
 aaa
+tgY
+tgY
 aaa
 aaa
 aaa
@@ -154675,21 +156343,19 @@ aaa
 aaa
 aaa
 aaa
+tgY
+tgY
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-pwn
-aad
-aKV
+meD
 aaa
 bXI
 aaa
-aKV
+meD
 aaa
 aaa
 aaa
@@ -154942,11 +156608,11 @@ aaa
 aaa
 aaa
 aaa
-aKV
+meD
 aaa
 aaa
 aaa
-aKV
+meD
 aaa
 aaa
 aaa
@@ -155705,7 +157371,7 @@ aaa
 aaa
 aaa
 aaa
-aab
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -5517,7 +5517,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/red/side{
-	dir = 9
+	dir = 8
 	},
 /area/security/brig/upper)
 "aZo" = (
@@ -22537,6 +22537,7 @@
 /area/engineering/supermatter/room)
 "dvs" = (
 /obj/structure/cable,
+/obj/effect/landmark/start/brigoff,
 /turf/open/floor/iron/dark/purple/side,
 /area/brigofficer)
 "dvF" = (
@@ -28899,10 +28900,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
-"efa" = (
-/obj/effect/landmark/start/brigoff,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "efb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/closed/wall/r_wall,
@@ -43599,6 +43596,7 @@
 "iAL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/brigoff,
 /turf/open/floor/iron/dark/purple,
 /area/brigofficer)
 "iAN" = (
@@ -48364,7 +48362,7 @@
 "jZC" = (
 /obj/machinery/camera{
 	c_tag = "Prison Isolation Cell";
-	dir = 9;
+	dir = 4;
 	network = list("ss13","prison","isolation")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -64868,7 +64866,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/brigoff,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "oGz" = (
@@ -70396,6 +70393,7 @@
 	},
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/item/reagent_containers/hypospray/medipen,
+/obj/item/toy/crayon/spraycan,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
@@ -75429,7 +75427,7 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/red/side{
-	dir = 10
+	dir = 8
 	},
 /area/security/brig/upper)
 "rHy" = (
@@ -75473,7 +75471,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/landmark/start/brigoff,
 /obj/structure/cable,
 /turf/open/floor/iron/kitchen{
 	dir = 1
@@ -75527,6 +75524,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
+/area/security/prison)
+"rIL" = (
+/obj/effect/spawner/random/structure/girder{
+	loot = list(/obj/structure/falsewall = 50, /turf/closed/wall = 50);
+	name = "fifty% falsewall, fifty% wall"
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "rIN" = (
 /obj/effect/turf_decal/tile/bar,
@@ -80927,11 +80931,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
-"tgY" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space,
-/area/space)
 "tgZ" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -148097,8 +148096,8 @@ aaa
 aaa
 aaa
 aaa
-tgY
-nOg
+aac
+aad
 aFm
 rrJ
 syA
@@ -148352,9 +148351,9 @@ aaa
 aaa
 aaa
 aaa
-tgY
+aac
 aaa
-tgY
+aac
 aaa
 aFm
 jyz
@@ -148609,12 +148608,12 @@ aaa
 aaa
 aaa
 aaa
-tgY
-nOg
-tgY
+aac
+aad
+aac
 aaa
 aFm
-aKV
+rIL
 aKV
 aKV
 aKV
@@ -148866,9 +148865,9 @@ aaa
 aaa
 aaa
 aaa
-tgY
+aac
 aaa
-tgY
+aac
 aaa
 aFm
 rJj
@@ -149123,10 +149122,10 @@ aaa
 aaa
 aaa
 aaa
-tgY
+aac
 aaa
-tgY
-nOg
+aac
+aad
 aFm
 rJj
 ucZ
@@ -149380,9 +149379,9 @@ aaa
 aaa
 aaa
 aaa
-tgY
+aac
 aaa
-tgY
+aac
 aaa
 aFm
 rJj
@@ -149400,7 +149399,7 @@ gcs
 aKV
 egZ
 gkK
-efa
+eLB
 eLB
 eLB
 iQj
@@ -149411,7 +149410,7 @@ sFM
 iAL
 rjB
 nKK
-aaa
+aad
 fCV
 aZo
 whb
@@ -149637,9 +149636,9 @@ aaa
 aaa
 aaa
 aaa
-tgY
-nOg
-tgY
+aac
+aad
+aac
 aaa
 aFm
 rJj
@@ -149894,9 +149893,9 @@ aaa
 aaa
 aaa
 aaa
-tgY
+aac
 aaa
-tgY
+aac
 aaa
 aFm
 aKV
@@ -150153,8 +150152,8 @@ aaa
 aaa
 aaa
 aaa
-tgY
-nOg
+aac
+aad
 aFm
 pVy
 kpg
@@ -151438,8 +151437,8 @@ aaa
 aaa
 aaa
 aaa
-tgY
-nOg
+aac
+aad
 aFm
 uuS
 mqw
@@ -151693,9 +151692,9 @@ aaa
 aaa
 aaa
 aaa
-tgY
+aac
 aaa
-tgY
+aac
 aaa
 aFm
 aKV
@@ -151950,9 +151949,9 @@ aaa
 aaa
 aaa
 aaa
-tgY
-nOg
-tgY
+aac
+aad
+aac
 aaa
 aFm
 dVK
@@ -152207,9 +152206,9 @@ aaa
 aaa
 aaa
 aaa
-tgY
+aac
 aaa
-tgY
+aac
 aaa
 smo
 uOG
@@ -152464,10 +152463,10 @@ aaa
 aaa
 aaa
 aaa
-tgY
+aac
 aaa
-tgY
-nOg
+aac
+aad
 aFm
 aKV
 aKV
@@ -152721,9 +152720,9 @@ aaa
 aaa
 aaa
 aaa
-tgY
+aac
 aaa
-tgY
+aac
 aaa
 aFm
 lYW
@@ -152978,9 +152977,9 @@ aaa
 aaa
 aaa
 aaa
-tgY
-nOg
-tgY
+aac
+aad
+aac
 aaa
 aFm
 buR
@@ -153235,9 +153234,9 @@ aaa
 aaa
 aaa
 aaa
-tgY
+aac
 aaa
-tgY
+aac
 aaa
 aFm
 aKV
@@ -153494,8 +153493,8 @@ aaa
 aaa
 aaa
 aaa
-tgY
-nOg
+aac
+aad
 aFm
 lYW
 qbt
@@ -153776,7 +153775,7 @@ aKV
 wDi
 hHu
 aKV
-aKV
+rIL
 aFm
 aKZ
 aUD
@@ -154267,8 +154266,8 @@ aaa
 aaa
 aaa
 aaa
-nOg
-nOg
+aad
+aad
 aaa
 aaa
 smo
@@ -154523,8 +154522,8 @@ aaa
 aaa
 aaa
 aaa
-nOg
-nOg
+aad
+aad
 aaa
 aaa
 aaa
@@ -154779,12 +154778,12 @@ aaa
 aaa
 aaa
 aaa
-tgY
-nOg
+aac
+aad
 aaa
 aaa
 aaa
-nOg
+aad
 smo
 smo
 smo
@@ -155036,17 +155035,17 @@ aaa
 aaa
 aaa
 aaa
-tgY
-tgY
+aac
+aac
 aaa
 aaa
-nOg
-nOg
-nOg
+aad
+aad
+aad
 aaa
 aaa
 aaa
-nOg
+aad
 aFm
 cjA
 sOy
@@ -155294,16 +155293,16 @@ aaa
 aaa
 aaa
 aaa
-tgY
-tgY
-nOg
-nOg
-nOg
+aac
+aac
+aad
+aad
+aad
 aaa
 aaa
 aaa
-nOg
-nOg
+aad
+aad
 aFm
 smo
 aFm
@@ -155552,24 +155551,24 @@ aaa
 aaa
 aaa
 aaa
-tgY
-tgY
-nOg
+aac
+aac
+aad
 aaa
 aaa
 aaa
-nOg
-nOg
+aad
+aad
 aaa
 aaa
-nOg
+aad
 aaa
-nOg
+aad
 aaa
 aaa
-nOg
+aad
 aaa
-nOg
+aad
 aaa
 aFm
 jwY
@@ -155810,23 +155809,23 @@ aaa
 aaa
 aaa
 aaa
-tgY
-tgY
+aac
+aac
 aaa
 aaa
-nOg
-nOg
+aad
+aad
 aaa
 aaa
-tgY
-tgY
-tgY
-tgY
-tgY
+aac
+aac
+aac
+aac
+aac
 aaa
-tgY
-tgY
-tgY
+aac
+aac
+aac
 aaa
 aFm
 aFm
@@ -156068,10 +156067,10 @@ aaa
 aaa
 aaa
 aaa
-tgY
-tgY
-nOg
-nOg
+aac
+aac
+aad
+aad
 aaa
 aaa
 aaa
@@ -156086,7 +156085,7 @@ aaa
 aaa
 aaa
 aaa
-nOg
+aad
 aaa
 aaa
 aaa
@@ -156326,8 +156325,8 @@ aaa
 aaa
 aaa
 aaa
-tgY
-tgY
+aac
+aac
 aaa
 aaa
 aaa
@@ -156343,8 +156342,8 @@ aaa
 aaa
 aaa
 aaa
-tgY
-tgY
+aac
+aac
 aaa
 aaa
 aaa

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -49059,7 +49059,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Prison Port";
+	c_tag = "Security - Genpop Lockers";
 	dir = 8
 	},
 /turf/open/floor/iron/dark/red,


### PR DESCRIPTION
## About The Pull Request
• Restores the old Delta prison.
• Some area re-jiggery to the sec prison hallway.
• Reinstalls the old security desk to the office, making the majority of security spawn around one desk.

## How This Contributes To The Skyrat Roleplay Experience
Host request, better bigger prison for highpop.

Bigger prisons with more content within for prisoners are much better suited to SR's usual high popcount. As Deltastation is specifically a high population map, there is no excuse for it to have the smallest prison out of all the maps we have in rotation. The inclusion of hidden areas (even if they aren't that hidden) gives opportunities for mischief. The prison is also divided into three distinct blocks, each of which has _some_ form of territorial control over adjacent parts of the prison. Gangs can be formed over who controls which rooms.

## Changelog
Tests Completed:
• APCs are functional.
• Lighting is functional.
• Cameras are functional and AI has visibility in all areas intended.

:cl:
add: Deltastation prison reverted to its old form, which is significantly better suited for high population counts.
add: Deltastation security office reverted to its old form, a big single desk instead of the weird whatever was.
/:cl:
