### PR TITLE
Reverts #9625

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -114,7 +114,7 @@
 /datum/station_trait/overflow_job_bureaucracy/proc/set_overflow_job_override(datum/source)
 	SIGNAL_HANDLER
 
-	var/datum/job/picked_job = pick(SSJob.joinable_occupations)
+	var/datum/job/picked_job = pick(SSjob.joinable_occupations)
 	//SKYRAT EDIT START
 	while(picked_job.veteran_only)
 		picked_job = pick(SSjob.joinable_occupations)

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -113,8 +113,12 @@
 
 /datum/station_trait/overflow_job_bureaucracy/proc/set_overflow_job_override(datum/source)
 	SIGNAL_HANDLER
-	
-	var/datum/job/picked_job = pick(SSjob.joinable_occupations)
+
+	var/datum/job/picked_job = pick(SSJob.joinable_occupations)
+	//SKYRAT EDIT START
+	while(picked_job.veteran_only)
+		picked_job = pick(SSjob.joinable_occupations)
+	//SKYRAT EDIT END
 	chosen_job_name = lowertext(picked_job.title) // like Chief Engineers vs like chief engineers
 	SSjob.set_overflow_role(picked_job.type)
 

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -113,21 +113,8 @@
 
 /datum/station_trait/overflow_job_bureaucracy/proc/set_overflow_job_override(datum/source)
 	SIGNAL_HANDLER
-	/* SKYRAT EDIT START - Nice try lol
+	
 	var/datum/job/picked_job = pick(SSjob.joinable_occupations)
-	*/ // ORIGINAL END
-	var/list/jobs_to_use = list(
-		/datum/job/clown,
-		/datum/job/bartender,
-		/datum/job/cook,
-		/datum/job/botanist,
-		/datum/job/cargo_technician,
-		/datum/job/mime,
-		/datum/job/janitor,
-		/datum/job/prisoner,
-		)
-	var/datum/job/picked_job = pick(jobs_to_use)
-	// SKYRAT EDIT END
 	chosen_job_name = lowertext(picked_job.title) // like Chief Engineers vs like chief engineers
 	SSjob.set_overflow_role(picked_job.type)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Now any* job can work for the overflow job station trait, instead of just a few.

*veteran crew jobs excluded so that the non-vet station doesn't get locked to 0 jobs if everything else gets taken

## How This Contributes To The Skyrat Roleplay Experience
![image](https://user-images.githubusercontent.com/41448081/159140537-5109ff1c-3f52-4c7d-bc94-94b8623b53f0.png)

On a slightly more serious note, I feel that it'll make some rounds feel less... samey by allowing for funny job situations to happen occasionally.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Overflow Job Bureaucracy station trait can now choose any job,
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
