### PR TITLE
Fixes contractor kit OPFOR

### DIFF
--- a/modular_skyrat/modules/contractor/code/items/modsuit.dm
+++ b/modular_skyrat/modules/contractor/code/items/modsuit.dm
@@ -231,6 +231,15 @@
 	armor_values = list(MELEE = 20, BULLET = 20, LASER = 20, ENERGY = 20)
 	added_slowdown = 0.5 //Bulky as shit
 
+/obj/item/mod/control/update_appearance(updates)
+	var/obj/item/mod/module/chameleon/chameleon_module = modules.Find(/obj/item/mod/module/chameleon)
+	if(!chameleon_module)
+		return ..()
+	if(chameleon_module.on)
+		return
+
+	return ..()
+
 // I absolutely fuckin hate having to do this
 /obj/item/clothing/head/mod/contractor
 	worn_icon = 'modular_skyrat/modules/contractor/icons/worn_modsuit.dmi'

--- a/modular_skyrat/modules/opposing_force/code/equipment/loadouts.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/loadouts.dm
@@ -46,6 +46,6 @@
 
 /datum/opposing_force_equipment/loadout/contractor
 	name = "Contractor bundle"
-	item_type = /obj/item/storage/box/syndicate/contractor_loadout
+	item_type = /obj/item/storage/box/syndicate/contract_kit
 	description = "A box containing everything you need to take contracts from the Syndicate. Kidnap people and drop them off at specified locations for rewards in the form of Telecrystals (Usable in the provided uplink) and Contractor Points."
 	admin_note = "WARNING: This bundle is a pretty large change-up of how a person plays a round, giving them access to a swathe of new gear, in addition to a contractor tablet. This contractor tablet lets them take on objectives to non-lethally kidnap people in exhange for telecrystals, usable in the provided uplink."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Well this is a bit embarassing, it spawns the wrong item!
Also fixes a modsuit sprite bug

## How This Contributes To The Skyrat Roleplay Experience
Bugs are bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Contractor kit opfor item now spawns the correct item
fix: Contractor MODSuit now looks correct
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
