### PR TITLE
[MODULAR] Removes the link to paradise's wiki from spawning as a Nanotrasen Representative, and directs them to use the communications console to contact Central Command.

### DIFF
--- a/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
+++ b/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
@@ -42,9 +42,7 @@
 
 /datum/job/nanotrasen_consultant/after_spawn(mob/living/H, mob/M, latejoin)
 	. = ..()
-	to_chat(H, span_boldannounce("As the Nanotrasen Consultant, you are required to follow the following placeholder policy and SOP: https://paradisestation.org/wiki/index.php/Nanotrasen_Representative"))
-	//REMOVE THIS AFTER FAX MACHINES ARE ADDED!!!!
-	to_chat(H, span_boldannounce("If you require IC admin intervention, send an admin help until the fax machine is added."))
+	to_chat(H, span_boldannounce("If you require IC admin intervention, use the communications console to contact Central Command."))
 
 /datum/outfit/job/nanotrasen_consultant
 	name = "Nanotrasen Consultant"


### PR DESCRIPTION
## About The Pull Request

Removes the link to paradise's wiki from spawning as a Nanotrasen Representative, and directs them to use the communications console to contact Central Command.

## How This Contributes To The Skyrat Roleplay Experience

We shouldn't be sending players to off-site websites and telling them to do what those pages says. Paradise could edit the wiki to say the NT rep should rush armory for guns roundstart, and we can't do a damn thing about it.

That fax machine is never getting added because the Communications Console already has a "message CC" button on it, just use that, and if it hasn't been added yet then it's never getting added at this point.

## Changelog
:cl:
del: Removes the link to Paradise's wiki from spawning as a Nanotrasen Representative and directs them to use the communications console to contact Central Command instead of ahelping or using a non-existent fax machine when they want an IC intervention by Central Command.
/:cl: