### PR TITLE
Since Opfor has it's own ban category, it no longer blocks people with an antag ban.

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/mind.dm
+++ b/modular_skyrat/modules/opposing_force/code/mind.dm
@@ -17,10 +17,6 @@
 		to_chat(src, span_warning(fail_message))
 		return
 
-	if(is_banned_from(ckey, BAN_ANTAGONIST))
-		to_chat(src, span_warning("You are antagonist banned!"))
-		return
-
 	if(is_banned_from(ckey, BAN_OPFOR))
 		to_chat(src, span_warning("You are OPFOR banned!"))
 		return


### PR DESCRIPTION
This seems like an oversight from before we added BAN_OPFOR.