### PR TITLE
[NON-MODULAR] reenables the set_sprite proc

### DIFF
--- a/code/modules/surgery/organs/external/_external_organs.dm
+++ b/code/modules/surgery/organs/external/_external_organs.dm
@@ -103,7 +103,8 @@
 
 ///Generate a unique key based on our sprites. So that if we've aleady drawn these sprites, they can be found in the cache and wont have to be drawn again (blessing and curse)
 /obj/item/organ/external/proc/generate_icon_cache()
-	return "[sprite_datum.icon_state]_[feature_key]"
+	if(!isnull(sprite_datum)) // SKYRAT ADDITION
+		return "[sprite_datum.icon_state]_[feature_key]"
 
 /**This exists so sprite accessories can still be per-layer without having to include that layer's
 *  number in their sprite name, which causes issues when those numbers change.
@@ -134,7 +135,7 @@
 ///Because all the preferences have names like "Beautiful Sharp Snout" we need to get the sprite datum with the actual important info
 /obj/item/organ/external/proc/get_sprite_datum(sprite)
 	var/list/feature_list = get_global_feature_list()
-	if(!isnull(feature_list[sprite]))
+	if(!isnull(feature_list[sprite])) // SKYRAT ADDITION
 		return feature_list[sprite]
 
 ///Return a dumb glob list for this specific feature (called from parse_sprite)

--- a/code/modules/surgery/organs/external/_external_organs.dm
+++ b/code/modules/surgery/organs/external/_external_organs.dm
@@ -99,12 +99,11 @@
 
 /obj/item/organ/external/proc/set_sprite(sprite_name)
 	sprite_datum = get_sprite_datum(sprite_name)
-	// cache_key = generate_icon_cache() - SKYRAT EDIT REMOVAL
+	cache_key = generate_icon_cache()
 
 ///Generate a unique key based on our sprites. So that if we've aleady drawn these sprites, they can be found in the cache and wont have to be drawn again (blessing and curse)
 /obj/item/organ/external/proc/generate_icon_cache()
-	return ""
-	//return "[sprite_datum.icon_state]_[feature_key]" SKYRAT EDIT REMOVAL
+	return "[sprite_datum.icon_state]_[feature_key]"
 
 /**This exists so sprite accessories can still be per-layer without having to include that layer's
 *  number in their sprite name, which causes issues when those numbers change.
@@ -135,7 +134,8 @@
 ///Because all the preferences have names like "Beautiful Sharp Snout" we need to get the sprite datum with the actual important info
 /obj/item/organ/external/proc/get_sprite_datum(sprite)
 	var/list/feature_list = get_global_feature_list()
-	return feature_list[sprite]
+	if(!isnull(feature_list[sprite]))
+		return feature_list[sprite]
 
 ///Return a dumb glob list for this specific feature (called from parse_sprite)
 /obj/item/organ/external/proc/get_global_feature_list()

--- a/code/modules/surgery/organs/external/_external_organs.dm
+++ b/code/modules/surgery/organs/external/_external_organs.dm
@@ -98,11 +98,8 @@
 	overlay_list += appearance
 
 /obj/item/organ/external/proc/set_sprite(sprite_name)
-	return
-	/* SKYRAT EDIT REMOVAL
 	sprite_datum = get_sprite_datum(sprite_name)
-	cache_key = generate_icon_cache()
-	*/
+	// cache_key = generate_icon_cache() - SKYRAT EDIT REMOVAL
 
 ///Generate a unique key based on our sprites. So that if we've aleady drawn these sprites, they can be found in the cache and wont have to be drawn again (blessing and curse)
 /obj/item/organ/external/proc/generate_icon_cache()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this proc was disabled with no clear reason in documentation, so readding it because #12235 utilizes it. 

## How This Contributes To The Skyrat Roleplay Experience

qol

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: reenables the set_sprite proc for all your sprite datum needs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
