### PR TITLE
Resets Icebox Medbay Central to match upstream

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -3164,7 +3164,7 @@
 "aKK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "aKY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -5911,7 +5911,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/textured,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bkL" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/beakers{
@@ -5923,7 +5923,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bkT" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -6185,7 +6185,7 @@
 /area/medical/pharmacy)
 "bmK" = (
 /turf/open/openspace,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bmL" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
@@ -6210,7 +6210,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bmW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6220,7 +6220,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bmY" = (
 /obj/machinery/door/airlock/cmo{
 	name = "Chief Medical Officer";
@@ -6326,7 +6326,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "boh" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
@@ -6342,7 +6342,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "boi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6354,7 +6354,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bon" = (
 /turf/closed/wall/r_wall,
 /area/science/genetics)
@@ -6498,18 +6498,18 @@
 	dir = 4
 	},
 /turf/open/floor/iron/textured,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bpN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bpP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bpR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -6607,12 +6607,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/end,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/textured,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bqP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bqQ" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/yellow,
@@ -6640,13 +6640,13 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bqU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bqV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -6658,7 +6658,7 @@
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bqX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6668,7 +6668,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "brc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -6821,7 +6821,7 @@
 "bsy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bsF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -7091,7 +7091,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/area/medical/medbay)
+/area/medical/medbay/central)
 "buG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7428,7 +7428,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "bwB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -11540,7 +11540,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
-/area/medical/medbay)
+/area/medical/medbay/central)
 "cqK" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/two,
@@ -14615,7 +14615,7 @@
 	},
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "dFz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -15731,7 +15731,7 @@
 	color = "#52B4E9"
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "ejY" = (
 /obj/effect/decal/cleanable/insectguts,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -16983,7 +16983,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "eSa" = (
 /obj/machinery/computer/station_alert{
 	dir = 8
@@ -17390,7 +17390,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/area/medical/medbay)
+/area/medical/medbay/central)
 "fep" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Xenobiology Pens Observation - Starboard Aft";
@@ -18964,7 +18964,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "fVp" = (
 /obj/structure/table,
 /obj/item/inspector,
@@ -20471,7 +20471,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/area/medical/medbay)
+/area/medical/medbay/central)
 "gJM" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "EVA Motion Sensor"
@@ -21455,7 +21455,7 @@
 /area/command/heads_quarters/hos)
 "hjZ" = (
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "hkc" = (
 /obj/structure/table,
 /turf/open/floor/carpet,
@@ -22983,7 +22983,7 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "hZc" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -23598,7 +23598,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "iri" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 4
@@ -25492,7 +25492,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/area/medical/medbay)
+/area/medical/medbay/central)
 "jtr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26494,7 +26494,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "jUS" = (
 /obj/structure/table,
 /obj/item/circular_saw,
@@ -26560,7 +26560,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "jWj" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -29067,7 +29067,7 @@
 	},
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "lqX" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -30312,7 +30312,7 @@
 	},
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "lZG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32248,7 +32248,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "nbT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -32518,7 +32518,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "nja" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron/dark,
@@ -32720,7 +32720,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/textured,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "nlQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33342,7 +33342,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
-/area/medical/medbay)
+/area/medical/medbay/central)
 "nFI" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -33616,7 +33616,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "nPP" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -35093,7 +35093,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "oCz" = (
 /obj/machinery/atmospherics/components/tank/air,
 /obj/effect/turf_decal/delivery,
@@ -36646,7 +36646,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "ptT" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -36972,7 +36972,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
-/area/medical/medbay)
+/area/medical/medbay/central)
 "pBb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
@@ -37007,7 +37007,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "pCj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -37100,7 +37100,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "pEU" = (
 /obj/machinery/computer/prisoner/gulag_teleporter_computer{
 	dir = 8
@@ -37847,7 +37847,7 @@
 /area/security/brig)
 "pXJ" = (
 /turf/closed/wall,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "pXN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -38148,7 +38148,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "qgX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 8
@@ -38434,7 +38434,7 @@
 	},
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/textured,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "qos" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -38669,7 +38669,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "qus" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/wood,
@@ -39020,7 +39020,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "qGV" = (
 /obj/machinery/light/directional/south,
 /obj/structure/closet/firecloset,
@@ -39363,7 +39363,7 @@
 /obj/effect/landmark/start/paramedic,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "qRj" = (
 /obj/item/storage/backpack{
 	pixel_x = 4;
@@ -40275,7 +40275,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "rrr" = (
 /obj/structure/rack,
 /obj/item/stack/rods/fifty,
@@ -44680,7 +44680,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "tAD" = (
 /obj/structure/railing,
 /obj/structure/chair/plastic{
@@ -46074,7 +46074,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/textured,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "ujZ" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/siding/yellow{
@@ -47727,7 +47727,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "vbE" = (
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plating/snowed/icemoon,
@@ -48191,7 +48191,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "voy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 8
@@ -49603,7 +49603,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "wac" = (
 /obj/machinery/chem_master,
 /obj/structure/window/reinforced,
@@ -50458,7 +50458,7 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "wuN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53364,7 +53364,7 @@
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "xTr" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line{
 	dir = 8
@@ -53737,7 +53737,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
-/area/medical/medbay)
+/area/medical/medbay/central)
 "yef" = (
 /obj/structure/ladder,
 /obj/structure/sign/warning/coldtemp{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

On Icebox, the area that is `/area/medical/medbay/central` upstream was just `/area/medical/medbay` on ours. Not a huge deal except the Medbay ordering console's default delivery location is Medbay Central, so our fork forced medbay orders to be opened in the fallback location, Central Primary Hallway. Switching the Medbay area to Medbay Central resets us to upstream and makes medbay crates open in Medbay Central.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Upstream alignment, medbay orders working correctly.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: On Icebox: Medbay orders can now be opened in Medbay Central, the area between the lobby and the treatment center.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
