### PR TITLE
Adds stack spawners to Ghost Cafe

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -10129,6 +10129,12 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/centcom/interlink)
+"wQs" = (
+/obj/item/stackspawner,
+/obj/item/stackspawner,
+/obj/item/stackspawner,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "wUm" = (
 /obj/structure/toilet{
 	dir = 8
@@ -57951,7 +57957,7 @@ aqf
 vxh
 aXN
 aUo
-aUo
+wQs
 aQK
 aQK
 aqf


### PR DESCRIPTION


## About The Pull Request
Apparently there's an item right there in the code that lets you spawn stacks of whatever you want instead of trying to riffle through the cafe to find it or grow it or whatever

So I added a couple to the cafe

In leiu of this I'm adding stacks of bamboo upstream and putting them in the box with the wood and plastic if this gets denied for whatever stupid reason

## How This Contributes To The Skyrat Roleplay Experience
It really should have been there before. It's even in the same module.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Added some stack spawners to the cafe, which lets you dispense whatever material you want for building rooms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
