### PR TITLE
[NON-MODULAR] Small MODsuits remaster

### DIFF
--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -19,7 +19,7 @@
 	var/obj/item/part = locate(part_reference) in mod_parts
 	if(!istype(part) || user.incapacitated())
 		return
-	if((active && part != helmet) || activating) // SKYRAT EDIT - Let the hair flow - ORIGINAL: if(active || activating)
+	if(activating) // SKYRAT EDIT - RETRACTABLE EVERYTHING
 		balloon_alert(user, "deactivate the suit first!")
 		playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 		return
@@ -41,7 +41,7 @@
 
 /// Quickly deploys all parts (or retracts if all are on the wearer)
 /obj/item/mod/control/proc/quick_deploy(mob/user)
-	if(active || activating)
+	if(activating) // SKYRAT EDIT - RETRACTABLE EVERYTHING
 		balloon_alert(user, "deactivate the suit first!")
 		playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 		return FALSE
@@ -70,6 +70,16 @@
 	if(piece == boots && wearer.shoes)
 		boots.overslot = wearer.shoes
 		wearer.transferItemToLoc(boots.overslot, boots, force = TRUE)
+
+	// SKYRAT EDIT START - DEPLOYABLE EVERYTHING OVER EVERYTHING
+	if(piece == helmet && wearer.head)
+		helmet.overslot = wearer.head
+		wearer.transferItemToLoc(helmet.overslot, helmet, force = TRUE)
+	if(piece == chestplate && wearer.wear_suit)
+		chestplate.overslot = wearer.wear_suit
+		wearer.transferItemToLoc(chestplate.overslot, chestplate, force = TRUE)
+	// SKYRAT EDIT STOP
+
 	if(wearer.equip_to_slot_if_possible(piece, piece.slot_flags, qdel_on_fail = FALSE, disable_warning = TRUE))
 		ADD_TRAIT(piece, TRAIT_NODROP, MOD_TRAIT)
 		if(!user)
@@ -100,6 +110,16 @@
 		gauntlets.show_overslot()
 	if(piece == boots)
 		boots.show_overslot()
+	//SKYRAT EDIT START - DEPLOYABLE EVERYTHING OVER EVERYTHING
+	if(piece == helmet)
+		helmet.show_overslot()
+	if(piece == chestplate)
+		for(var/obj/item/mod/module/module as anything in modules)
+			if(!module.active)
+				continue
+			module.on_deactivation(display_message = FALSE)
+		chestplate.show_overslot()
+	//SKYRAT EDIT END
 	if(!user)
 		return
 	wearer.visible_message(span_notice("[wearer]'s [piece.name] retract[piece.p_s()] back into [src] with a mechanical hiss."),

--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -12,6 +12,7 @@
 	obj_flags = IMMUTABLE_SLOW
 	var/alternate_layer = NECK_LAYER
 	var/obj/item/mod/control/mod
+	var/obj/item/clothing/overslot //SKYRAT EDIT - DEPLOYABLE EVERYTHING OVER EVERYTHING
 
 /obj/item/clothing/head/mod/Destroy()
 	if(!QDELETED(mod))
@@ -23,6 +24,16 @@
 /obj/item/clothing/head/mod/atom_destruction(damage_flag)
 	return mod.atom_destruction(damage_flag)
 
+//SKYRAT EDIT START - DEPLOYABLE EVERYTHING OVER EVERYTHING
+
+/obj/item/clothing/head/mod/proc/show_overslot()
+	if(!overslot)
+		return
+	if(!mod.wearer.equip_to_slot_if_possible(overslot, overslot.slot_flags, qdel_on_fail = FALSE, disable_warning = TRUE))
+		mod.wearer.dropItemToGround(overslot, force = TRUE, silent = TRUE)
+	overslot = null
+
+//SKYRAT EDIT END
 /obj/item/clothing/suit/mod
 	name = "MOD chestplate"
 	desc = "A chestplate for a MODsuit."
@@ -36,6 +47,7 @@
 	cold_protection = CHEST|GROIN
 	obj_flags = IMMUTABLE_SLOW
 	var/obj/item/mod/control/mod
+	var/obj/item/clothing/overslot //SKYRAT EDIT - DEPLOYABLE EVERYTHING OVER EVERYTHING
 
 /obj/item/clothing/suit/mod/Destroy()
 	if(!QDELETED(mod))
@@ -46,6 +58,17 @@
 
 /obj/item/clothing/suit/mod/atom_destruction(damage_flag)
 	return mod.atom_destruction(damage_flag)
+
+//SKYRAT EDIT START - DEPLOYABLE EVERYTHING OVER EVERYTHING
+
+/obj/item/clothing/suit/mod/proc/show_overslot()
+	if(!overslot)
+		return
+	if(!mod.wearer.equip_to_slot_if_possible(overslot, overslot.slot_flags, qdel_on_fail = FALSE, disable_warning = TRUE))
+		mod.wearer.dropItemToGround(overslot, force = TRUE, silent = TRUE)
+	overslot = null
+
+//SKYRAT EDIT END
 
 /obj/item/clothing/gloves/mod
 	name = "MOD gauntlets"

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -598,6 +598,7 @@
 	slowdown_inactive = 1
 	slowdown_active = 0.5
 	allowed_suit_storage = list(
+		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -652,6 +653,7 @@
 	slowdown_inactive = 0.75
 	slowdown_active = 0.25
 	allowed_suit_storage = list(
+		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -708,6 +710,7 @@
 	slowdown_inactive = 0.75
 	slowdown_active = 0.25
 	allowed_suit_storage = list(
+		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -810,6 +813,7 @@
 	ui_theme = "syndicate"
 	inbuilt_modules = list(/obj/item/mod/module/armor_booster)
 	allowed_suit_storage = list(
+		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -887,6 +891,7 @@
 	ui_theme = "syndicate"
 	inbuilt_modules = list(/obj/item/mod/module/armor_booster)
 	allowed_suit_storage = list(
+		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -1043,6 +1048,7 @@
 	slowdown_inactive = 0.5
 	slowdown_active = 0
 	allowed_suit_storage = list(
+		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -1116,6 +1122,7 @@
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 10
 	allowed_suit_storage = list(
+		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -1169,6 +1176,7 @@
 	slowdown_inactive = 0.5
 	slowdown_active = 0
 	allowed_suit_storage = list(
+		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -94,9 +94,11 @@
 		if(mod.wearer)
 			balloon_alert(mod.wearer, "not active!")
 		return
+	// SKYRAT EDIT START - DEPLOYABLE EVERYTHING OVER EVERYTHING
 	if(mod.wearer.wear_suit != mod.chestplate)
 		balloon_alert(mod.wearer, "chestplate retracted!")
 		return
+	// SKYRAT EDIT END
 	if(module_type != MODULE_USABLE)
 		if(active)
 			on_deactivation()

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -94,6 +94,9 @@
 		if(mod.wearer)
 			balloon_alert(mod.wearer, "not active!")
 		return
+	if(mod.wearer.wear_suit != mod.chestplate)
+		balloon_alert(mod.wearer, "chestplate retracted!")
+		return
 	if(module_type != MODULE_USABLE)
 		if(active)
 			on_deactivation()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This changes a few things : 

- You can now equip guns in the exosluit of combat modsuits (Sec, Hos, cap, ERT, syndi, syndielite, DS)
- You can now deploy chestplate and helmet over a worn suit or headwear.
- You can now retract even when active. Retract deactivates your modules but keeps consuming power.

TODO : 

- [x] Make modules unusable when chestplate is not deployed.

## How This Contributes To The Skyrat Roleplay Experience

Just a lot of QoL changes to streamline modsuits usage. It'll remove a lot of the tedium that comes from putting a MODsuit on and off without a big balance implication - It just saves time, mostly.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: You can now equip guns in the exosluit of combat modsuits (Sec, Hos, cap, ERT, syndi, syndielite, DS)
expansion: You can now deploy chestplate and helmet over a worn suit or headwear.
expansion: You can now retract even when active. Retracting the chest deactivates your modules but keeps consuming power. You need at least the chest out to use modules.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
