### PR TITLE
GATEWAY OPTIMISATION - MOB SPAWNING

### DIFF
--- a/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa/mesa_mobs.dm
+++ b/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa/mesa_mobs.dm
@@ -549,6 +549,8 @@
 	desc = "A 5.56mm surplus bullet casing."
 	projectile_type = /obj/projectile/bullet/a556/weak
 
+#define MOB_PLACER_RANGE 12 // One more tile than the biggest viewrange we have.
+
 /obj/effect/random_mob_placer
 	name = "mob placer"
 	icon = 'icons/effects/mapping_helpers.dmi'
@@ -557,9 +559,22 @@
 
 /obj/effect/random_mob_placer/Initialize(mapload)
 	. = ..()
+	for(var/turf/iterating_turf in range(MOB_PLACER_RANGE, src))
+		RegisterSignal(iterating_turf, COMSIG_ATOM_ENTERED, .proc/trigger)
+
+/obj/effect/random_mob_placer/proc/trigger(datum/source, atom/movable/entered_atom)
+	if(!isliving(entered_atom))
+		return
+	var/mob/living/entered_mob = entered_atom
+
+	if(!entered_mob.client)
+		return
+
 	var/mob/picked_mob = pick(possible_mobs)
 	new picked_mob(loc)
-	return INITIALIZE_HINT_QDEL
+	qdel(src)
+
+#undef MOB_PLACER_RANGE
 
 /obj/effect/random_mob_placer/xen
 	possible_mobs = list(

--- a/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa/mesa_mobs.dm
+++ b/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa/mesa_mobs.dm
@@ -549,7 +549,7 @@
 	desc = "A 5.56mm surplus bullet casing."
 	projectile_type = /obj/projectile/bullet/a556/weak
 
-#define MOB_PLACER_RANGE CONFIG_GET(string/default_view) + 1 // One more tile than the biggest viewrange we have.
+#define MOB_PLACER_RANGE 16 // One more tile than the biggest viewrange we have.
 
 /obj/effect/random_mob_placer
 	name = "mob placer"
@@ -563,6 +563,7 @@
 		RegisterSignal(iterating_turf, COMSIG_ATOM_ENTERED, .proc/trigger)
 
 /obj/effect/random_mob_placer/proc/trigger(datum/source, atom/movable/entered_atom)
+	SIGNAL_HANDLER
 	if(!isliving(entered_atom))
 		return
 	var/mob/living/entered_mob = entered_atom

--- a/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa/mesa_mobs.dm
+++ b/modular_skyrat/master_files/code/modules/awaymission/mission_code/black_mesa/mesa_mobs.dm
@@ -549,7 +549,7 @@
 	desc = "A 5.56mm surplus bullet casing."
 	projectile_type = /obj/projectile/bullet/a556/weak
 
-#define MOB_PLACER_RANGE 12 // One more tile than the biggest viewrange we have.
+#define MOB_PLACER_RANGE CONFIG_GET(string/default_view) + 1 // One more tile than the biggest viewrange we have.
 
 /obj/effect/random_mob_placer
 	name = "mob placer"


### PR DESCRIPTION
## About The Pull Request

Mobs no longer instantly spawn on mob_spawn_initialise. They instead spawn when a mob WITH a client enters their trigger range.

This should help with performance a little.

## Changelog

:cl:
code: Some mob spawners have been optimised.
/:cl:
