### PR TITLE
Fixes Emergency Shuttles

### DIFF
--- a/modular_skyrat/modules/advanced_shuttles/code/shuttles.dm
+++ b/modular_skyrat/modules/advanced_shuttles/code/shuttles.dm
@@ -62,7 +62,7 @@
 	port_id = "escape_pod"
 	suffix = "default_skyrat"
 
-/datum/map_template/shuttle/emergency
+/datum/map_template/shuttle/emergency/default
 	prefix = "_maps/shuttles/skyrat/"
 	suffix = "skyrat"
 	name = "Standard Emergency Shuttle"

--- a/modular_skyrat/modules/mapping/code/shuttles.dm
+++ b/modular_skyrat/modules/mapping/code/shuttles.dm
@@ -4,6 +4,7 @@
 
 /datum/map_template/shuttle/emergency/outpost
 	suffix = "outpost"
+	prefix = "_maps/shuttles/skyrat/"
 	name = "Outpoststation Emergency Shuttle"
 	description = "The perfect shuttle for rectangle enthuasiasts, this long and slender shuttle has been known for it's incredible(Citation Needed) safety rating."
 	admin_notes = "Has airlocks on both sides of the shuttle and will probably ram deltastation's maint wing below medical. Oh well?"


### PR DESCRIPTION
## About The Pull Request

Currently the system loading the shuttles looks in the wrong folder for most shuttles as Skyrat Emergency Shuttle overrides the path for it. From what I've tested this fix still ends up having the default shuttle, but now the others are buyable again.

**To note: I have no idea if this was maybe intended? i.e. the correct way to enable the other shuttles would be to copy their map files to the Skyrat folder and edit them to fit the Skyrat theme better.**

## How This Contributes To The Skyrat Roleplay Experience

Allows more shuttles to exist again, as people seem to want them.

## Changelog

:cl:
fix: Fix pathing issue with Skyrat emergency shuttle causing other emergency shuttles to not be found
/:cl:
