### PR TITLE
Head of staff bowman headsets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -17,6 +17,8 @@
 	new /obj/item/clothing/head/soft(src) // Why does the QM spawn with a generic soft cap
 	*/
 	// new /obj/item/radio/headset/headset_cargo(src) //ORIGINAL
+	new	/obj/item/radio/headset/heads/qm(src) //SKYRAT EDIT ADDITION
+	new	/obj/item/radio/headset/heads/qm/alt(src) //SKYRAT EDIT ADDITION
 	new /obj/item/clothing/suit/fire/firefighter(src)
 	new /obj/item/megaphone/cargo(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -9,6 +9,7 @@
 	new /obj/item/storage/bag/garment/engineering_chief (src)
 	new /obj/item/cartridge/ce(src)
 	new /obj/item/radio/headset/heads/ce(src)
+	new /obj/item/radio/headset/heads/ce/alt(src) //SKYRAT EDIT ADDITION
 	new /obj/item/megaphone/command(src)
 	new /obj/item/areaeditor/blueprints(src)
 	new /obj/item/holosign_creator/atmos(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -79,6 +79,7 @@
 	new /obj/item/storage/bag/garment/chief_medical(src)
 	new /obj/item/cartridge/cmo(src)
 	new /obj/item/radio/headset/heads/cmo(src)
+	new /obj/item/radio/headset/heads/cmo/alt(src) //SKYRAT EDIT ADDITION
 	new /obj/item/megaphone/command(src)
 	new /obj/item/defibrillator/compact/loaded(src)
 	new /obj/item/healthanalyzer/advanced(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -11,6 +11,7 @@
 	new /obj/item/storage/bag/garment/research_director(src)
 	new /obj/item/cartridge/rd(src)
 	new /obj/item/radio/headset/heads/rd(src)
+	new /obj/item/radio/headset/heads/rd/alt(src) //SKYRAT EDIT ADDITION
 	new /obj/item/megaphone/command(src)
 	new /obj/item/storage/lockbox/medal/sci(src)
 	new /obj/item/clothing/suit/armor/reactive/teleport(src)

--- a/modular_skyrat/master_files/code/game/objects/items/devices/radio/headset.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/devices/radio/headset.dm
@@ -20,6 +20,6 @@
 	icon_state = "com_headset_alt"
 
 /obj/item/radio/headset/heads/qm/alt
-	name = "\proper the quartermaster's headset"
+	name = "\proper the quartermaster's bowman headset"
 	desc = "The headset of the king (or queen) of paperwork. Protects ears from flashbangs."
 	icon_state = "com_headset_alt"

--- a/modular_skyrat/master_files/code/game/objects/items/devices/radio/headset.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/devices/radio/headset.dm
@@ -3,3 +3,23 @@
 	desc = "The headset of the king (or queen) of paperwork."
 	icon_state = "com_headset"
 	keyslot = new /obj/item/encryptionkey/heads/qm
+
+/obj/item/radio/headset/heads/rd/alt
+	name = "\proper the research director's bowman headset"
+	desc = "Headset of the fellow who keeps society marching towards technological singularity. Protects ears from flashbangs."
+	icon_state = "com_headset_alt"
+
+/obj/item/radio/headset/heads/ce/alt
+	name = "\proper the chief engineer's bowman headset"
+	desc = "The headset of the guy in charge of keeping the station powered and undamaged. Protects ears from flashbangs."
+	icon_state = "com_headset_alt"
+
+/obj/item/radio/headset/heads/cmo/alt
+	name = "\proper the chief medical officer's bowman headset"
+	desc = "The headset of the highly trained medical chief. Protects ears from flashbangs."
+	icon_state = "com_headset_alt"
+
+/obj/item/radio/headset/heads/qm/alt
+	name = "\proper the quartermaster's headset"
+	desc = "The headset of the king (or queen) of paperwork. Protects ears from flashbangs."
+	icon_state = "com_headset_alt"

--- a/modular_skyrat/master_files/code/game/objects/items/devices/radio/headset.dm
+++ b/modular_skyrat/master_files/code/game/objects/items/devices/radio/headset.dm
@@ -9,17 +9,32 @@
 	desc = "Headset of the fellow who keeps society marching towards technological singularity. Protects ears from flashbangs."
 	icon_state = "com_headset_alt"
 
+/obj/item/radio/headset/heads/rd/alt/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
+
 /obj/item/radio/headset/heads/ce/alt
 	name = "\proper the chief engineer's bowman headset"
 	desc = "The headset of the guy in charge of keeping the station powered and undamaged. Protects ears from flashbangs."
 	icon_state = "com_headset_alt"
+
+/obj/item/radio/headset/heads/ce/alt/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
 
 /obj/item/radio/headset/heads/cmo/alt
 	name = "\proper the chief medical officer's bowman headset"
 	desc = "The headset of the highly trained medical chief. Protects ears from flashbangs."
 	icon_state = "com_headset_alt"
 
+/obj/item/radio/headset/heads/cmo/alt/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
 /obj/item/radio/headset/heads/qm/alt
 	name = "\proper the quartermaster's bowman headset"
 	desc = "The headset of the king (or queen) of paperwork. Protects ears from flashbangs."
 	icon_state = "com_headset_alt"
+
+/obj/item/radio/headset/heads/qm/alt/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives heads of staff bowman headsets in their lockers, like the HoP, cap, and HoS. Heads of staff can't be antags, except obsessed, which anyone at all can be including the captain. So you don't need to account for them needing to be chased by security, and and this doesn't necessarily increase the ease of getting a bowman, because checkpoint, and with command keys orderable through cargo, this doesn't make that any easier either. (basically I just want this)

Also I gave the QM a normal spare headset in their locker since they didn't have one. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Heads of staff with bowmans provides them a reliable defense against basic stuff, and means a blueshield might be able to reliably carry equipment like flashbangs, and most importantly, makes not being allowed to take the captain's bowman headset as acting captain less of an issue.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Heads of staff will now find bowman headsets in their lockers.
fix: The QM's locker now has a spare normal headset.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
