### PR TITLE
Map repair

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_upper.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_upper.dmm
@@ -34095,9 +34095,7 @@
 /area/ai_monitored/turret_protected/ai)
 "lOp" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/doppler_array{
-	dir = 8
-	},
+/obj/machinery/doppler_array,
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
 "lOq" = (
@@ -47560,8 +47558,22 @@
 /area/command/heads_quarters/rd)
 "qWV" = (
 /obj/structure/table/reinforced,
-/obj/item/relic,
 /obj/item/radio/intercom/directional/west,
+/obj/item/computer_hardware/hard_drive/portable{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/computer_hardware/hard_drive/portable{
+	pixel_x = -2
+	},
+/obj/item/computer_hardware/hard_drive/portable{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/computer_hardware/hard_drive/portable{
+	pixel_x = -8;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/dark,
 /area/science/misc_lab/range)
 "qWY" = (
@@ -47808,9 +47820,7 @@
 /area/commons/dorms)
 "rbT" = (
 /obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/components/binary/tank_compressor{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/binary/tank_compressor,
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
 "rcu" = (
@@ -56238,9 +56248,10 @@
 /area/maintenance/aft/upper)
 "ukP" = (
 /obj/structure/table/reinforced,
-/obj/item/binoculars,
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/light/directional/west,
+/obj/item/relic,
+/obj/item/binoculars,
 /turf/open/floor/iron/dark,
 /area/science/misc_lab/range)
 "ukW" = (

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -81622,11 +81622,17 @@
 /area/medical/virology)
 "tub" = (
 /obj/structure/dresser,
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/button/door/directional/south{
+	id = "chapelprivacy";
+	name = "Privacy Control";
+	req_access_txt = "27"
+	},
+/obj/structure/sign/nanotrasen{
+	pixel_x = -32;
+	pixel_y = -32
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "tui" = (
@@ -86649,10 +86655,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
 /area/security/prison)
-"uSJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/service/chapel/office)
 "uTc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -133009,7 +133011,7 @@ iGq
 xsm
 kKF
 bwT
-uSJ
+hCR
 aaa
 qYo
 aaa
@@ -133266,7 +133268,7 @@ xeL
 wlf
 tLg
 qjn
-uSJ
+hCR
 aaa
 qYo
 aaa
@@ -133523,7 +133525,7 @@ gDE
 aQK
 wbH
 qjn
-uSJ
+hCR
 qYo
 pwn
 aaa

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -32567,7 +32567,6 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/solars/port/aft)
 "cvt" = (
-/obj/machinery/firealarm/directional/south,
 /obj/structure/window/reinforced{
 	dir = 4
 	},

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -2627,6 +2627,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"awZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "axf" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -14900,7 +14906,9 @@
 /turf/open/floor/iron,
 /area/science/lab)
 "dki" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 5
+	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "dkn" = (
@@ -116789,7 +116797,7 @@ glb
 fbT
 mgs
 owP
-jMk
+awZ
 tvP
 irz
 wCh


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Corrected a few bugs I know in the maps.

**1. Removing the fire alarm in genetics on Kilo.** 
The monkeys in genetics are so dexterous and clever that they could push the alarm button through the glass, thereby constantly tormenting the scientists. 

Before:

<details>

![Снимок](https://user-images.githubusercontent.com/88540658/160373522-c2769f82-ae1c-4215-b160-7a2462af336c.jpg)

</details>

After:

<details>

![Снимок 2](https://user-images.githubusercontent.com/88540658/160373639-39d82f4a-473e-4efa-8ecc-c2749c2c7e35.PNG)

</details>

**2. Correction of sashes at the chaplain on Delta.** 
The chaplain was given a sash and any operative of the syndicate could peep at him slaughtering monkeys for the glory of his god. 

Before:

<details>

![Снимок3](https://user-images.githubusercontent.com/88540658/160375263-a5a81723-aa6e-492b-a942-9db0417678b9.jpg)

</details>

After:

<details>

![Снимок4](https://user-images.githubusercontent.com/88540658/160375333-28bbbd36-edd1-463f-a553-a9ab737de78e.PNG)

</details>


**3. Restoring the air supply to the Meta.** 
The designers of this station improperly installed an air supply pipe into the general life-support system, thus condemning her crew to death from lack of air. 

Before:

<details>

![Снимок5](https://user-images.githubusercontent.com/88540658/160376069-8449f7f2-d34c-46df-8e60-4c1e4216b8be.jpg)

</details>

After:

<details>

![Снимок6](https://user-images.githubusercontent.com/88540658/160376104-7b700cc0-57e3-42b9-bebd-89b1bc275fbe.PNG)

</details>

**4. Fixing the toxicology on BlueShift..** 
The cargoers, when manning the ship for the voyage, threw the explosion recorder in the wrong place. And because it was turned the wrong way, many scientists could not understand why it did not register explosions. And the floppy disks for recording were lost somewhere.  

Before:

<details>

![Снимок7](https://user-images.githubusercontent.com/88540658/160376789-006bba2f-c33c-4ff2-829d-a6fe7b410bc5.jpg)

</details>

After:

<details>

![Снимок8](https://user-images.githubusercontent.com/88540658/160376852-460fac4c-3237-4137-80a8-20a853e653c0.PNG)

</details>

## How This Contributes To The Skyrat Roleplay Experience

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixing a couple of things on Kilo, Delfa, Meta, and BlueShift.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
