### PR TITLE
Delta station atmos door ID requirement undo

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -36069,7 +36069,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
-	req_one_access_txt = "10;24"
+	req_access_txt = "24"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -45011,7 +45011,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Upper Atmospherics";
-	req_one_access_txt = "10;24"
+	req_access_txt = "24"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -50994,7 +50994,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
-	req_one_access_txt = "10;24"
+	req_access_txt = "24"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -60969,7 +60969,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
-	req_one_access_txt = "10;24"
+	req_access_txt = "24"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -67399,7 +67399,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Turbine Generator Access";
-	req_one_access_txt = "10;24"
+	req_access_txt = "24"
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -70311,7 +70311,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Upper Atmospherics";
-	req_one_access_txt = "10;24"
+	req_access_txt = "24"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -72275,7 +72275,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
-	req_one_access_txt = "10;24"
+	req_access_txt = "24"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -94858,7 +94858,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Turbine Generator Access";
-	req_one_access_txt = "10;24"
+	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Delta station atmos is either atmos or engineering access, which allows heads of staff and the paramedic access to atmospherics, which is of course not necessary in the slightest. Engineers still have atmos access on skeleton crew and can get the HoP or captain to give them atmos access if they need it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: removed generic engineering access from delta station atmos doors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
