### PR TITLE
Fixes the shutter for the NT consultant on delta

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -29652,6 +29652,11 @@
 	},
 /obj/machinery/light_switch/directional/west,
 /obj/effect/landmark/start/nanotrasen_consultant,
+/obj/machinery/button/door/directional/west{
+	id = "ntconshutter";
+	name = "Shutter controls";
+	pixel_y = -9
+	},
 /turf/open/floor/carpet/green,
 /area/command/heads_quarters/captain/private/nt_rep)
 "erK" = (
@@ -41779,11 +41784,6 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "hYo" = (
-/obj/machinery/button/curtain{
-	id = "ntconshutter";
-	pixel_x = -25;
-	pixel_y = 23
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/parquet,
 /area/command/heads_quarters/captain/private/nt_rep)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Obviously, shutters aren't curtains. We all know that, right? Unfortunately, that subtlety was lost on whoever put a curtain button in the consultant's room and hoped it to control a shutter, as that simply won't work. (why is this an issue? Why don't all buttons control all things? This is silly beyond words)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
I once saw an NT consultant shooting their shutters because it didn't work. Now they'll have no excuse to fire off their gun into their own office.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The shutters on the delta station NT consultant's office can now be opened and closed as normal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
