### PR TITLE
Fixes latejoin heretic influence generation

### DIFF
--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -98,7 +98,10 @@
 	tracked_heretics |= heretic
 
 	// If our heretic's on station, generate some new influences
-	if(ishuman(heretic.current)) //&& !is_centcom_level(heretic.current.z)) //SKYRAT EDIT
+	//SKYRAT EDIT START
+	var/area/heretic_area = get_area(heretic.current)
+	if(ishuman(heretic.current) && (!(is_centcom_level(heretic.current.z)) || istype(heretic_area, /area/centcom/interlink)) || istype(heretic_area, /area/shuttle/arrival))
+	//SKYRAT EDIT END
 		generate_new_influences()
 
 	add_to_smashes(heretic)

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -98,7 +98,7 @@
 	tracked_heretics |= heretic
 
 	// If our heretic's on station, generate some new influences
-	if(ishuman(heretic.current) && !is_centcom_level(heretic.current.z))
+	if(ishuman(heretic.current)) //&& !is_centcom_level(heretic.current.z)) //SKYRAT EDIT
 		generate_new_influences()
 
 	add_to_smashes(heretic)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Latejoining heretics don't get added to the list of heretic minds, so no new influences are made. This will make admin-spawned heretics in the tdome or wherever spawn influences, however.
closes https://github.com/Skyrat-SS13/Skyrat-tg/issues/12377

## How This Contributes To The Skyrat Roleplay Experience
Latejoin heretics getting influences would be good

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Latejoining heretics now will generate influences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
