### PR TITLE
[MODULAR] Adds a span to remind contract targets they are amnestic

### DIFF
--- a/modular_skyrat/modules/contractor/code/datums/contract.dm
+++ b/modular_skyrat/modules/contractor/code/datums/contract.dm
@@ -205,7 +205,8 @@
 	target.Dizzy(15)
 	target.add_confusion(20)
 	to_chat(target, span_doyourjobidiot(span_reallybig("You do not remember anything that happened this shift except being stuffed to a suspicious pod. \
-				Do not metagame your OOC knowledge and roleplay accordingly.")))
+				Do not metagame your OOC knowledge and roleplay accordingly. This applies even if you have \
+				entered the pod willingly.")))
 
 /// We're returning the victim
 /datum/syndicate_contract/proc/return_victim(mob/living/target)

--- a/modular_skyrat/modules/contractor/code/datums/contract.dm
+++ b/modular_skyrat/modules/contractor/code/datums/contract.dm
@@ -205,8 +205,8 @@
 	target.Dizzy(15)
 	target.add_confusion(20)
 	to_chat(target, span_doyourjobidiot(span_reallybig("You do not remember anything that happened this shift except being stuffed to a suspicious pod. \
-				Do not metagame your OOC knowledge and roleplay accordingly. This applies even if you have \
-				entered the pod willingly.")))
+				Do not metagame your OOC knowledge and roleplay accordingly. \
+				This applies even if you have entered the pod willingly.")))
 
 /// We're returning the victim
 /datum/syndicate_contract/proc/return_victim(mob/living/target)

--- a/modular_skyrat/modules/contractor/code/datums/contract.dm
+++ b/modular_skyrat/modules/contractor/code/datums/contract.dm
@@ -204,6 +204,8 @@
 	target.blur_eyes(10)
 	target.Dizzy(15)
 	target.add_confusion(20)
+	to_chat(target, span_doyourjobidiot(span_reallybig("You do not remember anything that happened this shift except being stuffed to a suspicious pod. \
+				Do not metagame your OOC knowledge and roleplay accordingly.")))
 
 /// We're returning the victim
 /datum/syndicate_contract/proc/return_victim(mob/living/target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
TG had removed the span that tells contracted targets they lose memories of how they got there. This PR re-adds it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Solves people accidentally using metaknowledge when they shouldn't.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Contractor Interrogation has been given amnestic drugs. Contracted people will no longer remember their demise to protect the identity of contractors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
