### PR TITLE
Fixed the book management console on all of our maps

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -7765,7 +7765,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
 "AF" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/skyrat/interdynefob/service/library)
 "AG" = (
@@ -9920,7 +9920,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/service/diner)
 "If" = (
 /obj/structure/table,
-/obj/machinery/computer/bookmanagement{
+/obj/machinery/computer/libraryconsole/bookmanagement{
 	pixel_y = 8
 	},
 /turf/open/floor/wood,

--- a/_maps/map_files/Blueshift/BlueShift_lower.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_lower.dmm
@@ -7996,7 +7996,7 @@
 /area/hallway/secondary/entry)
 "eTc" = (
 /obj/structure/table,
-/obj/machinery/computer/bookmanagement{
+/obj/machinery/computer/libraryconsole/bookmanagement{
 	pixel_y = 8
 	},
 /obj/machinery/button/curtain{

--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -59272,7 +59272,7 @@
 /area/service/janitor)
 "wWy" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/structure/window{
 	dir = 1
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -54160,7 +54160,7 @@
 /area/maintenance/port/greater)
 "lKp" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/grimy,
 /area/service/library)
@@ -87338,7 +87338,7 @@
 	id = "prisonlibrarycurtain";
 	pixel_x = -24
 	},
-/obj/machinery/computer/bookmanagement{
+/obj/machinery/computer/libraryconsole/bookmanagement{
 	pixel_y = 8
 	},
 /turf/open/floor/wood,

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -36874,7 +36874,7 @@
 /area/medical/medbay/lobby)
 "pxt" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/wood,

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
@@ -1587,7 +1587,7 @@
 /area/icemoon/underground/explored)
 "eb" = (
 /obj/structure/table,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
@@ -9256,7 +9256,7 @@
 /area/service/hydroponics)
 "xe" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement{
+/obj/machinery/computer/libraryconsole/bookmanagement{
 	pixel_y = 7
 	},
 /turf/open/floor/wood,

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -41286,7 +41286,7 @@
 	dir = 1
 	},
 /obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement{
+/obj/machinery/computer/libraryconsole/bookmanagement{
 	pixel_y = 5
 	},
 /obj/machinery/light/directional/east,
@@ -46354,7 +46354,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "hTQ" = (
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
@@ -53199,7 +53199,7 @@
 /area/engineering/break_room)
 "kLe" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement{
+/obj/machinery/computer/libraryconsole/bookmanagement{
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/tile/neutral,

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -383,7 +383,7 @@
 /turf/open/space/basic,
 /area/space)
 "adG" = (
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -66782,7 +66782,7 @@
 /area/commons/toilet/auxiliary)
 "vYw" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/structure/noticeboard/directional/east,
 /turf/open/floor/wood,
 /area/service/library)

--- a/_maps/map_files/Mining/Icemoon.dmm
+++ b/_maps/map_files/Mining/Icemoon.dmm
@@ -51,7 +51,7 @@
 /area/mine/laborcamp)
 "au" = (
 /obj/structure/table,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/mine/laborcamp)

--- a/_maps/map_files/Mining/Rockplanet.dmm
+++ b/_maps/map_files/Mining/Rockplanet.dmm
@@ -2785,7 +2785,7 @@
 /area/mine/mechbay)
 "zn" = (
 /obj/structure/table,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/item/pen,
 /turf/open/floor/wood,
 /area/mine/laborcamp)

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -10378,7 +10378,7 @@
 /area/service/library)
 "aTd" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood,
 /area/service/library)
@@ -54222,7 +54222,7 @@
 /turf/open/floor/plating,
 /area/brigofficer)
 "uNf" = (
-/obj/machinery/computer/bookmanagement{
+/obj/machinery/computer/libraryconsole/bookmanagement{
 	pixel_y = 8
 	},
 /obj/structure/table/wood,

--- a/_maps/map_files/generic/CentCom_skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat.dmm
@@ -8833,7 +8833,7 @@
 /area/centcom/holding)
 "Bs" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Bu" = (

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -5539,7 +5539,7 @@
 /area/centcom/interlink)
 "aXa" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafepark)
 "aXd" = (

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -2863,7 +2863,7 @@
 /area/hallway/primary/tram/right)
 "ast" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -67454,7 +67454,7 @@
 /area/science/mixing)
 "wAn" = (
 /obj/structure/table,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/sign/poster/official/here_for_your_safety{
 	pixel_y = -32

--- a/_maps/shuttles/skyrat/goldeneye_cruiser.dmm
+++ b/_maps/shuttles/skyrat/goldeneye_cruiser.dmm
@@ -540,7 +540,7 @@
 "lp" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/table,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/iron,
 /area/shuttle/syndicate/cruiser/brig)
 "lV" = (


### PR DESCRIPTION
## About The Pull Request
They changed the typepath for the book management console to make it a subtype of `/libraryconsole` (disgusting typepath btw), so it became just some standard computers instead, which is obviously incredibly underwhelming for curators.

## How This Contributes To The Skyrat Roleplay Experience
Curators already don't get *too* much to do, this gives them back the proper tools to actually make some sort of library roleplay possible.

## Changelog

:cl: GoldenAlpharex
fix: Nanotrasen reviewed their computer stocks and noticed how those stocked in libraries were mislabeled, swiftly correcting this error to ensure their Curators are able to work once again.
/:cl: