### PR TITLE
Removes stormtrooper outfit from PK vendor

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/misc/vending.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/vending.dm
@@ -71,11 +71,6 @@
 					/obj/item/clothing/head/beret/sec/peacekeeper = 5,
 					/obj/item/clothing/gloves/color/black/security = 10,
 					)
-	contraband = list(/obj/item/clothing/head/helmet/stormtrooper = 2,
-					/obj/item/clothing/suit/armor/stormtrooper = 2,
-					/obj/item/clothing/shoes/combat/stormtrooper = 2,
-					/obj/item/clothing/gloves/combat/peacekeeper/stormtrooper = 2,
-					)
 	premium = list( /obj/item/clothing/under/rank/security/officer/formal = 3,
 					/obj/item/clothing/suit/security/officer = 3,
 					/obj/item/clothing/head/beret/sec/navyofficer = 3)


### PR DESCRIPTION
# This is not an April fool's PR. Just poorly timed.

## About The Pull Request

Title

## How This Contributes To The Skyrat Roleplay Experience

The stormtrooper outfit actively detracts from a convincing atmosphere. Way too overt a reference.

## Changelog
:cl:
del: Security no longer gets the stormtrooper outfit in their vendors.
/:cl:
