### PR TITLE
Fixes frame_canvas not returning TRUE/FALSE because of modular code

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
@@ -272,9 +272,9 @@
 
 /obj/structure/sign/painting/frame_canvas(mob/user,obj/item/canvas/new_canvas)
 	if(istype(new_canvas, /obj/item/canvas/drawingtablet)) // NO FINALIZING THIS BITCH.
-		return
+		return FALSE
 	else
-		..()
+		return ..()
 
 /obj/item/canvas/var/nooverlayupdates = FALSE
 


### PR DESCRIPTION
## About The Pull Request
See the title. Two lines changed.

## How This Contributes To The Skyrat Roleplay Experience
This will fix large frames sticking out of the wall when the canvas is framed.

## Changelog

:cl:
fix: Fixed some of the funkiness of large painting frames looking off when a painting is placed inside.
/:cl:
