### PR TITLE
Adds three new cargo goody packs

### DIFF
--- a/modular_skyrat/modules/cargo/code/goodies.dm
+++ b/modular_skyrat/modules/cargo/code/goodies.dm
@@ -134,6 +134,29 @@
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/weaponcrafting/gunkit/temperature)
 
+/datum/supply_pack/goody/croon_single
+	name = "Croon Single-Pack"
+	desc = "Contains one Croon Sub Machine Gun chambered in .32, not exactly reliable... but it'll do you okay."
+	cost = PAYCHECK_HARD * 10
+	access_view = ACCESS_ARMORY
+	contains = list(/obj/item/gun/ballistic/automatic/croon)
+	contraband = TRUE
+
+/datum/supply_pack/goody/croonammo_single
+	name = "Croon Ammo Single-Pack"
+	desc = "Contains a 15-round magazine for the Croon SMG."
+	cost = PAYCHECK_HARD * 3
+	access_view = ACCESS_ARMORY
+	contains = list(/obj/item/ammo_box/magazine/multi_sprite/croon)
+	contraband = TRUE
+
+/datum/supply_pack/goody/lasergun_single
+	name = "Allstar SC-1 Single-Pack"
+	desc = "Contains one Allstar Lasers SC-1 laser gun."
+	cost = PAYCHECK_HARD * 10
+	access_view = ACCESS_ARMORY
+	contains = list(/obj/item/gun/energy/laser)
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Carpet Packs ////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds:

- Croon single-pack (contraband, 1250 credits)
- Croon ammo single-pack (contraband, 375 credits)
- SC-1 Laser gun single pack (1250 credits)

## How This Contributes To The Skyrat Roleplay Experience
Croon's a funny sidearm that i'd like to see more
Laser gun's for crafting temp guns or hell guns

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Croon and sc-1 laser gun can now be purchased as goodies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
