### PR TITLE
Adding a fighting pit to Ghost Cafe. For containment following a ruling.

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -5948,6 +5948,10 @@
 /obj/structure/window/spawner/east,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"bbW" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/misc/grass/planet,
+/area/centcom/holding/cafepark)
 "bee" = (
 /obj/machinery/cryopod{
 	dir = 1
@@ -6075,10 +6079,6 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/cruiser_dock)
-"bBe" = (
-/obj/effect/gibspawner/robot,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "bDJ" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorm23";
@@ -6267,6 +6267,16 @@
 /obj/structure/alien/weeds,
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
+"cCL" = (
+/obj/machinery/door/airlock{
+	id_tag = "CCD2";
+	name = "Fight Club"
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/wooden/crude,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafewar)
 "cEt" = (
 /obj/machinery/vending/games,
 /turf/open/floor/iron,
@@ -6380,6 +6390,9 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/holding/cafe)
+"dmM" = (
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "doz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -6389,6 +6402,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"drj" = (
+/obj/item/paper{
+	name = "notice";
+	info = "Dear Valued Patrons. Due to events outside of our control, we will have to be shutting down our beloved arena. Please do not break in and fight. No one will be here to see it."
+	},
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "dty" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -6411,16 +6431,6 @@
 	},
 /turf/open/floor/carpet/executive,
 /area/centcom/interlink)
-"dxY" = (
-/obj/machinery/door/airlock{
-	id_tag = "CCD2";
-	name = "Fight Club"
-	},
-/obj/structure/fans/tiny/invisible,
-/obj/effect/decal/cleanable/blood,
-/obj/structure/barricade/wooden/crude,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafewar)
 "dBx" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
@@ -6522,14 +6532,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
-"dNG" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "dOC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6576,6 +6578,9 @@
 /obj/structure/chair/sofa/bench/right,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"eei" = (
+/turf/closed/indestructible/wood,
+/area/centcom/holding/cafewar)
 "egn" = (
 /obj/structure/bed/maint,
 /obj/item/toy/figure/prisoner,
@@ -6684,6 +6689,11 @@
 "eEg" = (
 /turf/open/floor/carpet/blue,
 /area/centcom/holding/cafepark)
+"eLd" = (
+/obj/structure/closet,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "eLV" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 9
@@ -6691,13 +6701,6 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
-"eMN" = (
-/obj/item/paper{
-	name = "notice";
-	info = "Dear Valued Patrons. Due to events outside of our control, we will have to be shutting down our beloved arena. Please do not break in and fight. No one will be here to see it."
-	},
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "eNA" = (
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 1
@@ -6714,6 +6717,14 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/interlink)
+"eUc" = (
+/obj/structure/barricade/wooden,
+/obj/structure/spacevine{
+	name = "thick vines";
+	opacity = 1
+	},
+/turf/open/misc/grass/planet,
+/area/centcom/holding/cafepark)
 "eXz" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 8
@@ -7002,10 +7013,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding/cafepark)
-"ggg" = (
-/obj/effect/gibspawner/human,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "gjy" = (
 /obj/effect/turf_decal/tile/bar/half,
 /turf/open/floor/iron/dark,
@@ -7401,10 +7408,6 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet/executive,
 /area/centcom/interlink)
-"hXE" = (
-/obj/machinery/vending/toyliberationstation,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "hXZ" = (
 /obj/structure/transit_tube/crossing,
 /obj/effect/turf_decal/sand/plating,
@@ -7554,6 +7557,10 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding/cafedorms)
+"iDu" = (
+/obj/effect/gibspawner/human,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "iEr" = (
 /obj/machinery/cryopod,
 /turf/open/floor/iron/dark/green,
@@ -7576,6 +7583,10 @@
 "iLk" = (
 /turf/open/indestructible/hotelwood,
 /area/centcom/interlink)
+"iOP" = (
+/obj/effect/gibspawner/xeno/bodypartless,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "iTZ" = (
 /turf/open/indestructible/hoteltile,
 /area/centcom/interlink)
@@ -7707,6 +7718,10 @@
 "jIj" = (
 /turf/open/floor/wood,
 /area/centcom/holding/cafedorms)
+"jJu" = (
+/obj/effect/gibspawner,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "jKe" = (
 /obj/machinery/shuttle_manipulator,
 /turf/open/floor/carpet/royalblack,
@@ -8135,6 +8150,12 @@
 	},
 /turf/open/misc/asteroid,
 /area/centcom/interlink)
+"liI" = (
+/obj/machinery/light,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "lkh" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -8189,6 +8210,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"lrI" = (
+/obj/machinery/vending/toyliberationstation,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "luy" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 4
@@ -8235,9 +8260,6 @@
 	},
 /turf/open/floor/engine,
 /area/cruiser_dock)
-"lAr" = (
-/turf/closed/indestructible/wood,
-/area/centcom/holding/cafewar)
 "lCi" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -8307,10 +8329,6 @@
 	},
 /turf/open/floor/plastic,
 /area/centcom/interlink)
-"lSl" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
 "lUt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -8342,6 +8360,10 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/misc/asteroid,
 /area/centcom/interlink)
+"mgg" = (
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "mgV" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
@@ -8690,6 +8712,10 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/holding/cafe)
+"nnB" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "noq" = (
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
@@ -9027,12 +9053,6 @@
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet,
 /area/centcom/interlink)
-"oyZ" = (
-/obj/structure/chair/stool/bar{
-	dir = 8
-	},
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafe)
 "oBy" = (
 /obj/structure/spacevine{
 	name = "thick vines";
@@ -9058,6 +9078,10 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/grimy,
 /area/centcom/interlink)
+"oQm" = (
+/obj/effect/gibspawner/robot,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "oQJ" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 4
@@ -9079,6 +9103,10 @@
 	},
 /turf/open/misc/asteroid,
 /area/centcom/interlink)
+"oSr" = (
+/obj/item/knife/combat,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "oSG" = (
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
@@ -9100,10 +9128,6 @@
 "oVj" = (
 /turf/open/floor/carpet/green,
 /area/centcom/interlink)
-"oWc" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "oZx" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -9227,11 +9251,6 @@
 /obj/item/bedsheet/nanotrasen,
 /turf/open/floor/iron,
 /area/centcom/interlink)
-"pEc" = (
-/obj/structure/closet,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "pGK" = (
 /obj/machinery/shower{
 	dir = 8
@@ -9513,10 +9532,6 @@
 "qyu" = (
 /turf/open/floor/iron/cafeteria,
 /area/centcom/interlink)
-"qzT" = (
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "qAL" = (
 /obj/structure/curtain,
 /turf/open/floor/plastic,
@@ -9985,6 +10000,15 @@
 /obj/machinery/telecomms/relay/preset/auto,
 /turf/open/floor/plating,
 /area/centcom/interlink)
+"szy" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "szI" = (
 /obj/machinery/light,
 /turf/open/floor/iron/white,
@@ -10045,15 +10069,6 @@
 	},
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafepark)
-"sRP" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "sSe" = (
 /obj/structure/sign/painting/library_secure,
 /turf/closed/indestructible/wood,
@@ -10206,14 +10221,6 @@
 /obj/machinery/armament_station/assault_operatives,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
-"tuH" = (
-/obj/structure/barricade/wooden,
-/obj/structure/spacevine{
-	name = "thick vines";
-	opacity = 1
-	},
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
 "tuO" = (
 /obj/effect/turf_decal/tile/blue/half,
 /turf/open/floor/iron/white,
@@ -10303,9 +10310,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
-"tGa" = (
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "tGP" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -10366,12 +10370,6 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/interlink)
-"tTX" = (
-/obj/machinery/light,
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "tVg" = (
 /obj/structure/falsewall/sandstone,
 /obj/structure/fans/tiny/invisible,
@@ -10670,6 +10668,11 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/cruiser_dock)
+"uXG" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "uXJ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -10968,6 +10971,12 @@
 	},
 /turf/open/misc/asteroid,
 /area/centcom/interlink)
+"wbV" = (
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "wcp" = (
 /obj/effect/turf_decal/arrows{
 	dir = 1
@@ -11003,13 +11012,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"wmi" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "wnE" = (
 /turf/open/indestructible/necropolis/air,
 /area/centcom/prison)
-"wop" = (
-/obj/effect/gibspawner,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "wpA" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 9
@@ -11064,10 +11077,6 @@
 	},
 /turf/open/floor/iron/dark/green/side,
 /area/centcom/interlink)
-"wxF" = (
-/obj/effect/gibspawner/xeno/bodypartless,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "wyP" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -11133,11 +11142,6 @@
 /mob/living/simple_animal/hostile/megafauna/bubblegum,
 /turf/open/indestructible/necropolis/air,
 /area/centcom/prison)
-"wJI" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "wMV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -58286,8 +58290,8 @@ aYr
 aqf
 aHM
 aUo
-oyZ
-oyZ
+wbV
+wbV
 aUo
 aUo
 aUo
@@ -58845,16 +58849,16 @@ agy
 aFP
 ajj
 ajj
-lAr
-lAr
-lAr
-lAr
-lAr
-lAr
-lAr
-lAr
-lAr
-lAr
+eei
+eei
+eei
+eei
+eei
+eei
+eei
+eei
+eei
+eei
 aaa
 aaa
 aaa
@@ -59102,16 +59106,16 @@ aFP
 ayd
 aFP
 ajj
-lAr
-wJI
-wJI
-sRP
-wJI
-wJI
-sRP
-wJI
-wJI
-lAr
+eei
+uXG
+uXG
+szy
+uXG
+uXG
+szy
+uXG
+uXG
+eei
 aaa
 aaa
 aaa
@@ -59359,16 +59363,16 @@ aLH
 aFP
 ajj
 ajj
-lAr
-tGa
-ggg
-tGa
-tGa
-oWc
-tGa
-tGa
-wJI
-lAr
+eei
+dmM
+iDu
+dmM
+dmM
+nnB
+dmM
+dmM
+uXG
+eei
 aaa
 aaa
 aaa
@@ -59615,17 +59619,17 @@ aFP
 aFP
 ahs
 ajj
-tuH
-lAr
-tGa
-qzT
-tGa
-tGa
-tGa
-tGa
-wxF
-tTX
-lAr
+eUc
+eei
+dmM
+mgg
+dmM
+dmM
+dmM
+dmM
+iOP
+liI
+eei
 aaa
 aaa
 aaa
@@ -59872,17 +59876,17 @@ ayd
 aFB
 awV
 aFP
-tuH
-lAr
-hXE
-tGa
-tGa
-tGa
-tGa
-tGa
-tGa
-wJI
-lAr
+eUc
+eei
+lrI
+dmM
+dmM
+oSr
+dmM
+dmM
+dmM
+uXG
+eei
 aaa
 aaa
 aaa
@@ -60127,19 +60131,19 @@ aFP
 aLH
 aFP
 aFP
-lSl
+bbW
 awV
-tuH
-dxY
-tGa
-tGa
-eMN
-wop
-tGa
-tGa
-tGa
-wJI
-lAr
+eUc
+cCL
+dmM
+dmM
+drj
+jJu
+dmM
+dmM
+dmM
+uXG
+eei
 aaa
 aaa
 aaa
@@ -60386,17 +60390,17 @@ aFP
 ahQ
 aFP
 ajj
-tuH
-lAr
-pEc
-tGa
-tGa
-tGa
-tGa
-qzT
-tGa
-wJI
-lAr
+eUc
+eei
+eLd
+dmM
+dmM
+oSr
+dmM
+mgg
+dmM
+uXG
+eei
 aaa
 aaa
 aaa
@@ -60644,16 +60648,16 @@ asX
 ahU
 ajj
 ajj
-lAr
-pEc
-bBe
-tGa
-tGa
-tGa
-tGa
-tGa
-tTX
-lAr
+eei
+eLd
+oQm
+dmM
+dmM
+dmM
+dmM
+dmM
+liI
+eei
 aaa
 aaa
 aaa
@@ -60901,16 +60905,16 @@ aFP
 aFP
 ajj
 ajj
-lAr
-tGa
-tGa
-tGa
-tGa
-tGa
-tGa
-tGa
-wJI
-lAr
+eei
+dmM
+dmM
+dmM
+dmM
+dmM
+dmM
+dmM
+uXG
+eei
 aaa
 aaa
 aaa
@@ -61158,16 +61162,16 @@ aCM
 aFB
 ajj
 ajj
-lAr
-wJI
-wJI
-dNG
-wJI
-wJI
-dNG
-wJI
-wJI
-lAr
+eei
+uXG
+uXG
+wmi
+uXG
+uXG
+wmi
+uXG
+uXG
+eei
 aaa
 aaa
 aaa
@@ -61415,16 +61419,16 @@ aMJ
 aFP
 ajj
 ajj
-lAr
-lAr
-lAr
-lAr
-lAr
-lAr
-lAr
-lAr
-lAr
-lAr
+eei
+eei
+eei
+eei
+eei
+eei
+eei
+eei
+eei
+eei
 aaa
 aaa
 aaa

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -4283,7 +4283,9 @@
 /turf/open/water/beach,
 /area/centcom/holding/cafepark)
 "aNN" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aNS" = (
@@ -5974,10 +5976,6 @@
 	},
 /turf/open/floor/carpet,
 /area/centcom/interlink)
-"bhg" = (
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "bhr" = (
 /obj/machinery/griddle,
 /obj/machinery/light{
@@ -6077,6 +6075,10 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/cruiser_dock)
+"bBe" = (
+/obj/effect/gibspawner/robot,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "bDJ" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorm23";
@@ -6113,11 +6115,6 @@
 /obj/structure/railing,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
-"bNo" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "bSX" = (
 /obj/machinery/light,
 /obj/machinery/vending/snack/blue,
@@ -6256,10 +6253,6 @@
 /obj/machinery/light,
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/holding/cafe)
-"cxb" = (
-/obj/effect/gibspawner/robot,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "cxz" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -6281,10 +6274,6 @@
 "cGG" = (
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/interlink)
-"cGI" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "cMM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -6391,13 +6380,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/holding/cafe)
-"djA" = (
-/obj/item/paper{
-	name = "notice";
-	info = "Dear Valued Patrons. Due to events outside of our control, we will have to be shutting down our beloved arena. Please do not break in and fight. No one will be here to see it."
-	},
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "doz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -6429,6 +6411,16 @@
 	},
 /turf/open/floor/carpet/executive,
 /area/centcom/interlink)
+"dxY" = (
+/obj/machinery/door/airlock{
+	id_tag = "CCD2";
+	name = "Fight Club"
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/wooden/crude,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafewar)
 "dBx" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
@@ -6530,6 +6522,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"dNG" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "dOC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6684,12 +6684,6 @@
 "eEg" = (
 /turf/open/floor/carpet/blue,
 /area/centcom/holding/cafepark)
-"eEx" = (
-/obj/machinery/light,
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "eLV" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 9
@@ -6697,6 +6691,13 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
+"eMN" = (
+/obj/item/paper{
+	name = "notice";
+	info = "Dear Valued Patrons. Due to events outside of our control, we will have to be shutting down our beloved arena. Please do not break in and fight. No one will be here to see it."
+	},
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "eNA" = (
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 1
@@ -7001,6 +7002,10 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding/cafepark)
+"ggg" = (
+/obj/effect/gibspawner/human,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "gjy" = (
 /obj/effect/turf_decal/tile/bar/half,
 /turf/open/floor/iron/dark,
@@ -7396,6 +7401,10 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet/executive,
 /area/centcom/interlink)
+"hXE" = (
+/obj/machinery/vending/toyliberationstation,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "hXZ" = (
 /obj/structure/transit_tube/crossing,
 /obj/effect/turf_decal/sand/plating,
@@ -7801,11 +7810,6 @@
 	},
 /turf/open/floor/plastic,
 /area/centcom/interlink)
-"jWk" = (
-/obj/structure/closet,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "jXl" = (
 /obj/effect/turf_decal/trimline/darkblue/warning,
 /turf/open/floor/iron/white,
@@ -7904,9 +7908,6 @@
 /obj/structure/window/spawner/north,
 /turf/open/floor/iron,
 /area/centcom/interlink)
-"ksU" = (
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "kvj" = (
 /obj/structure/chair/sofa{
 	dir = 4
@@ -8234,6 +8235,9 @@
 	},
 /turf/open/floor/engine,
 /area/cruiser_dock)
+"lAr" = (
+/turf/closed/indestructible/wood,
+/area/centcom/holding/cafewar)
 "lCi" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -8303,6 +8307,10 @@
 	},
 /turf/open/floor/plastic,
 /area/centcom/interlink)
+"lSl" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/misc/grass/planet,
+/area/centcom/holding/cafepark)
 "lUt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -8318,15 +8326,6 @@
 /obj/machinery/oven,
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
-"lYC" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "mbJ" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 30
@@ -8706,9 +8705,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
-"nta" = (
-/turf/closed/indestructible/wood,
-/area/centcom/holding/cafewar)
 "ntq" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
@@ -9031,6 +9027,12 @@
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet,
 /area/centcom/interlink)
+"oyZ" = (
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "oBy" = (
 /obj/structure/spacevine{
 	name = "thick vines";
@@ -9098,6 +9100,10 @@
 "oVj" = (
 /turf/open/floor/carpet/green,
 /area/centcom/interlink)
+"oWc" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "oZx" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -9221,6 +9227,11 @@
 /obj/item/bedsheet/nanotrasen,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"pEc" = (
+/obj/structure/closet,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "pGK" = (
 /obj/machinery/shower{
 	dir = 8
@@ -9502,6 +9513,10 @@
 "qyu" = (
 /turf/open/floor/iron/cafeteria,
 /area/centcom/interlink)
+"qzT" = (
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "qAL" = (
 /obj/structure/curtain,
 /turf/open/floor/plastic,
@@ -9882,10 +9897,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
-"rQB" = (
-/obj/effect/gibspawner,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "rUA" = (
 /obj/machinery/vending/ashclothingvendor,
 /turf/open/misc/dirt/planet,
@@ -10034,6 +10045,15 @@
 	},
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafepark)
+"sRP" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "sSe" = (
 /obj/structure/sign/painting/library_secure,
 /turf/closed/indestructible/wood,
@@ -10107,14 +10127,6 @@
 /obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/green,
 /area/centcom/interlink)
-"tdG" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "thU" = (
 /obj/machinery/door/poddoor/ert,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -10194,6 +10206,14 @@
 /obj/machinery/armament_station/assault_operatives,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"tuH" = (
+/obj/structure/barricade/wooden,
+/obj/structure/spacevine{
+	name = "thick vines";
+	opacity = 1
+	},
+/turf/open/misc/grass/planet,
+/area/centcom/holding/cafepark)
 "tuO" = (
 /obj/effect/turf_decal/tile/blue/half,
 /turf/open/floor/iron/white,
@@ -10213,10 +10233,6 @@
 /obj/structure/lattice,
 /turf/closed/indestructible/riveted,
 /area/centcom/interlink)
-"twg" = (
-/obj/effect/gibspawner/human,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "tym" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face.";
@@ -10287,6 +10303,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"tGa" = (
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "tGP" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -10347,10 +10366,12 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/interlink)
-"tQG" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
+"tTX" = (
+/obj/machinery/light,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "tVg" = (
 /obj/structure/falsewall/sandstone,
 /obj/structure/fans/tiny/invisible,
@@ -10835,14 +10856,6 @@
 	},
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafepark)
-"vGa" = (
-/obj/structure/barricade/wooden,
-/obj/structure/spacevine{
-	name = "thick vines";
-	opacity = 1
-	},
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
 "vLs" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -10993,6 +11006,10 @@
 "wnE" = (
 /turf/open/indestructible/necropolis/air,
 /area/centcom/prison)
+"wop" = (
+/obj/effect/gibspawner,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "wpA" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 9
@@ -11047,6 +11064,10 @@
 	},
 /turf/open/floor/iron/dark/green/side,
 /area/centcom/interlink)
+"wxF" = (
+/obj/effect/gibspawner/xeno/bodypartless,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "wyP" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -11112,6 +11133,11 @@
 /mob/living/simple_animal/hostile/megafauna/bubblegum,
 /turf/open/indestructible/necropolis/air,
 /area/centcom/prison)
+"wJI" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "wMV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -11187,16 +11213,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
-"xiv" = (
-/obj/machinery/door/airlock{
-	id_tag = "CCD2";
-	name = "Fight Club"
-	},
-/obj/structure/fans/tiny/invisible,
-/obj/effect/decal/cleanable/blood,
-/obj/structure/barricade/wooden/crude,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafewar)
 "xmS" = (
 /obj/structure/railing{
 	dir = 4
@@ -11327,10 +11343,6 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/interlink)
-"xSn" = (
-/obj/effect/gibspawner/xeno/bodypartless,
-/turf/open/floor/plating,
-/area/centcom/holding/cafewar)
 "xSv" = (
 /obj/machinery/button/door{
 	id = "dorm24";
@@ -58274,8 +58286,8 @@ aYr
 aqf
 aHM
 aUo
-aNN
-aNN
+oyZ
+oyZ
 aUo
 aUo
 aUo
@@ -58833,16 +58845,16 @@ agy
 aFP
 ajj
 ajj
-nta
-nta
-nta
-nta
-nta
-nta
-nta
-nta
-nta
-nta
+lAr
+lAr
+lAr
+lAr
+lAr
+lAr
+lAr
+lAr
+lAr
+lAr
 aaa
 aaa
 aaa
@@ -59090,16 +59102,16 @@ aFP
 ayd
 aFP
 ajj
-nta
-bNo
-bNo
-lYC
-bNo
-bNo
-lYC
-bNo
-bNo
-nta
+lAr
+wJI
+wJI
+sRP
+wJI
+wJI
+sRP
+wJI
+wJI
+lAr
 aaa
 aaa
 aaa
@@ -59347,16 +59359,16 @@ aLH
 aFP
 ajj
 ajj
-nta
-ksU
-twg
-ksU
-ksU
-cGI
-ksU
-ksU
-bNo
-nta
+lAr
+tGa
+ggg
+tGa
+tGa
+oWc
+tGa
+tGa
+wJI
+lAr
 aaa
 aaa
 aaa
@@ -59603,17 +59615,17 @@ aFP
 aFP
 ahs
 ajj
-vGa
-nta
-ksU
-bhg
-ksU
-ksU
-ksU
-ksU
-xSn
-eEx
-nta
+tuH
+lAr
+tGa
+qzT
+tGa
+tGa
+tGa
+tGa
+wxF
+tTX
+lAr
 aaa
 aaa
 aaa
@@ -59860,17 +59872,17 @@ ayd
 aFB
 awV
 aFP
-vGa
-nta
-ksU
-ksU
-ksU
-ksU
-ksU
-ksU
-ksU
-bNo
-nta
+tuH
+lAr
+hXE
+tGa
+tGa
+tGa
+tGa
+tGa
+tGa
+wJI
+lAr
 aaa
 aaa
 aaa
@@ -60115,19 +60127,19 @@ aFP
 aLH
 aFP
 aFP
-tQG
+lSl
 awV
-vGa
-xiv
-ksU
-ksU
-djA
-rQB
-ksU
-ksU
-ksU
-bNo
-nta
+tuH
+dxY
+tGa
+tGa
+eMN
+wop
+tGa
+tGa
+tGa
+wJI
+lAr
 aaa
 aaa
 aaa
@@ -60374,17 +60386,17 @@ aFP
 ahQ
 aFP
 ajj
-vGa
-nta
-jWk
-ksU
-ksU
-ksU
-ksU
-bhg
-ksU
-bNo
-nta
+tuH
+lAr
+pEc
+tGa
+tGa
+tGa
+tGa
+qzT
+tGa
+wJI
+lAr
 aaa
 aaa
 aaa
@@ -60632,16 +60644,16 @@ asX
 ahU
 ajj
 ajj
-nta
-jWk
-cxb
-ksU
-ksU
-ksU
-ksU
-ksU
-eEx
-nta
+lAr
+pEc
+bBe
+tGa
+tGa
+tGa
+tGa
+tGa
+tTX
+lAr
 aaa
 aaa
 aaa
@@ -60889,16 +60901,16 @@ aFP
 aFP
 ajj
 ajj
-nta
-ksU
-ksU
-ksU
-ksU
-ksU
-ksU
-ksU
-bNo
-nta
+lAr
+tGa
+tGa
+tGa
+tGa
+tGa
+tGa
+tGa
+wJI
+lAr
 aaa
 aaa
 aaa
@@ -61146,16 +61158,16 @@ aCM
 aFB
 ajj
 ajj
-nta
-bNo
-bNo
-tdG
-bNo
-bNo
-tdG
-bNo
-bNo
-nta
+lAr
+wJI
+wJI
+dNG
+wJI
+wJI
+dNG
+wJI
+wJI
+lAr
 aaa
 aaa
 aaa
@@ -61403,16 +61415,16 @@ aMJ
 aFP
 ajj
 ajj
-nta
-nta
-nta
-nta
-nta
-nta
-nta
-nta
-nta
-nta
+lAr
+lAr
+lAr
+lAr
+lAr
+lAr
+lAr
+lAr
+lAr
+lAr
 aaa
 aaa
 aaa

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -5850,6 +5850,7 @@
 /obj/item/hemostat/alien,
 /obj/item/scalpel/alien,
 /obj/item/circular_saw/alien,
+/obj/item/retractor/alien,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
@@ -5973,6 +5974,10 @@
 	},
 /turf/open/floor/carpet,
 /area/centcom/interlink)
+"bhg" = (
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "bhr" = (
 /obj/machinery/griddle,
 /obj/machinery/light{
@@ -6108,6 +6113,11 @@
 /obj/structure/railing,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"bNo" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "bSX" = (
 /obj/machinery/light,
 /obj/machinery/vending/snack/blue,
@@ -6246,6 +6256,10 @@
 /obj/machinery/light,
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/holding/cafe)
+"cxb" = (
+/obj/effect/gibspawner/robot,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "cxz" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -6267,6 +6281,10 @@
 "cGG" = (
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/interlink)
+"cGI" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "cMM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -6373,6 +6391,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/holding/cafe)
+"djA" = (
+/obj/item/paper{
+	name = "notice";
+	info = "Dear Valued Patrons. Due to events outside of our control, we will have to be shutting down our beloved arena. Please do not break in and fight. No one will be here to see it."
+	},
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "doz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -6659,6 +6684,12 @@
 "eEg" = (
 /turf/open/floor/carpet/blue,
 /area/centcom/holding/cafepark)
+"eEx" = (
+/obj/machinery/light,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "eLV" = (
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 9
@@ -7770,6 +7801,11 @@
 	},
 /turf/open/floor/plastic,
 /area/centcom/interlink)
+"jWk" = (
+/obj/structure/closet,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "jXl" = (
 /obj/effect/turf_decal/trimline/darkblue/warning,
 /turf/open/floor/iron/white,
@@ -7868,6 +7904,9 @@
 /obj/structure/window/spawner/north,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"ksU" = (
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "kvj" = (
 /obj/structure/chair/sofa{
 	dir = 4
@@ -8279,6 +8318,15 @@
 /obj/machinery/oven,
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
+"lYC" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "mbJ" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 30
@@ -8658,6 +8706,9 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
+"nta" = (
+/turf/closed/indestructible/wood,
+/area/centcom/holding/cafewar)
 "ntq" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
@@ -9831,6 +9882,10 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"rQB" = (
+/obj/effect/gibspawner,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "rUA" = (
 /obj/machinery/vending/ashclothingvendor,
 /turf/open/misc/dirt/planet,
@@ -10052,6 +10107,14 @@
 /obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/green,
 /area/centcom/interlink)
+"tdG" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "thU" = (
 /obj/machinery/door/poddoor/ert,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -10150,6 +10213,10 @@
 /obj/structure/lattice,
 /turf/closed/indestructible/riveted,
 /area/centcom/interlink)
+"twg" = (
+/obj/effect/gibspawner/human,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "tym" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face.";
@@ -10280,6 +10347,10 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/interlink)
+"tQG" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/misc/grass/planet,
+/area/centcom/holding/cafepark)
 "tVg" = (
 /obj/structure/falsewall/sandstone,
 /obj/structure/fans/tiny/invisible,
@@ -10764,6 +10835,14 @@
 	},
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafepark)
+"vGa" = (
+/obj/structure/barricade/wooden,
+/obj/structure/spacevine{
+	name = "thick vines";
+	opacity = 1
+	},
+/turf/open/misc/grass/planet,
+/area/centcom/holding/cafepark)
 "vLs" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -11108,6 +11187,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"xiv" = (
+/obj/machinery/door/airlock{
+	id_tag = "CCD2";
+	name = "Fight Club"
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/wooden/crude,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafewar)
 "xmS" = (
 /obj/structure/railing{
 	dir = 4
@@ -11238,6 +11327,10 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/interlink)
+"xSn" = (
+/obj/effect/gibspawner/xeno/bodypartless,
+/turf/open/floor/plating,
+/area/centcom/holding/cafewar)
 "xSv" = (
 /obj/machinery/button/door{
 	id = "dorm24";
@@ -58740,16 +58833,16 @@ agy
 aFP
 ajj
 ajj
-ajj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nta
+nta
+nta
+nta
+nta
+nta
+nta
+nta
+nta
+nta
 aaa
 aaa
 aaa
@@ -58997,16 +59090,16 @@ aFP
 ayd
 aFP
 ajj
-ajj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nta
+bNo
+bNo
+lYC
+bNo
+bNo
+lYC
+bNo
+bNo
+nta
 aaa
 aaa
 aaa
@@ -59252,18 +59345,18 @@ aFP
 aFP
 aLH
 aFP
-aFP
-aFP
 ajj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ajj
+nta
+ksU
+twg
+ksU
+ksU
+cGI
+ksU
+ksU
+bNo
+nta
 aaa
 aaa
 aaa
@@ -59509,18 +59602,18 @@ agy
 aFP
 aFP
 ahs
-aFP
-aFP
 ajj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vGa
+nta
+ksU
+bhg
+ksU
+ksU
+ksU
+ksU
+xSn
+eEx
+nta
 aaa
 aaa
 aaa
@@ -59765,19 +59858,19 @@ ahU
 aFP
 ayd
 aFB
+awV
 aFP
-aFP
-aFP
-ajj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vGa
+nta
+ksU
+ksU
+ksU
+ksU
+ksU
+ksU
+ksU
+bNo
+nta
 aaa
 aaa
 aaa
@@ -60022,19 +60115,19 @@ aFP
 aLH
 aFP
 aFP
-aFP
-aFP
-aFP
-ajj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tQG
+awV
+vGa
+xiv
+ksU
+ksU
+djA
+rQB
+ksU
+ksU
+ksU
+bNo
+nta
 aaa
 aaa
 aaa
@@ -60280,18 +60373,18 @@ aFP
 aFP
 ahQ
 aFP
-aFP
-aFP
 ajj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vGa
+nta
+jWk
+ksU
+ksU
+ksU
+ksU
+bhg
+ksU
+bNo
+nta
 aaa
 aaa
 aaa
@@ -60537,18 +60630,18 @@ aFB
 aeT
 asX
 ahU
-aFP
 ajj
 ajj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nta
+jWk
+cxb
+ksU
+ksU
+ksU
+ksU
+ksU
+eEx
+nta
 aaa
 aaa
 aaa
@@ -60796,16 +60889,16 @@ aFP
 aFP
 ajj
 ajj
-ajj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nta
+ksU
+ksU
+ksU
+ksU
+ksU
+ksU
+ksU
+bNo
+nta
 aaa
 aaa
 aaa
@@ -61053,16 +61146,16 @@ aCM
 aFB
 ajj
 ajj
-ajj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nta
+bNo
+bNo
+tdG
+bNo
+bNo
+tdG
+bNo
+bNo
+nta
 aaa
 aaa
 aaa
@@ -61310,16 +61403,16 @@ aMJ
 aFP
 ajj
 ajj
-ajj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nta
+nta
+nta
+nta
+nta
+nta
+nta
+nta
+nta
+nta
 aaa
 aaa
 aaa

--- a/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
+++ b/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
@@ -107,6 +107,7 @@
 	new /obj/item/clothing/neck/chameleon(src)
 	new /obj/item/storage/backpack/chameleon(src)
 	new /obj/item/storage/belt/chameleon(src)
+	new /obj/item/card/id/advanced/chameleon(src)
 
 /obj/item/card/id/advanced/ghost_cafe
 	name = "\improper Cafe ID"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I added a fighting pit to follow 
![image](https://user-images.githubusercontent.com/102828457/161395045-b14de8ea-88fc-49a3-9b81-b380b14933e4.png)
This ruling. You get a fence and knives. OpFor/ahelp/pray for other stuff.
I fixed the alien tools not having a retractor.
Added a Chameleon ID. For whatever reason people want it.
I also spun every single stool around. They were annoying me.

## How This Contributes To The Skyrat Roleplay Experience

People enjoy fighting in the Ghost Cafe. A ruling has been made that you must make an area for it.
 This gives them an area, with a note for explanation of why it is there.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Ghost Cafe has a fighting pit. You can also use a Chameleon ID.
qol: Ghost Cafe stools now properly face the correct direction. 
fix: There is now an Alien Retractor to match the rest of the kit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
