### PR TITLE
Adds commonly emoted emotes as emotes.

### DIFF
--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -307,6 +307,21 @@
 	message = "squints."
 	message_AI = "zooms in."
 
+/datum/emote/living/smirk
+	key = "smirk"
+	key_third_person = "smirks"
+	message = "smirks."
+
+/datum/emote/living/eyeroll
+	key = "eyeroll"
+	key_third_person = "rolls their eyes"
+	message = "rolls their eyes."
+
+/datum/emote/living/huff
+	key = "huffs"
+	key_third_person = "huffs"
+	message = "huffs!"
+
 /datum/emote/living/clear
 	key = "clear"
 	key_third_person = "clears their throat"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -289,6 +289,40 @@
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/twobeep.ogg'
 	mob_type_allowed_typecache = list(/mob/living) //Beep already exists on brains and silicons
 
+/datum/emote/living/blink2
+	key = "blink2"
+	key_third_person = "blinks twice"
+	message = "blinks twice."
+	message_AI = "has their display flicker twice."
+
+/datum/emote/living/rblink
+	key = "rblink"
+	key_third_person = "rapidly blinks"
+	message = "rapidly blinks!"
+	message_AI = "has their display port flash rapidly!"
+
+/datum/emote/living/squint
+	key = "squint"
+	key_third_person = "squints"
+	message = "squints."
+	message_AI = "zooms in."
+
+/datum/emote/living/clear
+	key = "clear"
+	key_third_person = "clears their throat"
+	message = "clears their throat."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+
+/datum/emote/living/clear/get_sound(mob/living/user)
+	if(isvox(user))
+		return 'modular_skyrat/modules/emotes/sound/emotes/voxcough.ogg'
+	if(iscarbon(user))
+		if(user.gender == MALE)
+			return 'modular_skyrat/modules/emotes/sound/emotes/male/male_cough_2.ogg',
+		return 'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_1.ogg',
+	return
+
 // Avian revolution
 /datum/emote/living/bawk
 	key = "bawk"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -326,17 +326,6 @@
 	key = "clear"
 	key_third_person = "clears their throat"
 	message = "clears their throat."
-	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
-
-/datum/emote/living/clear/get_sound(mob/living/user)
-	if(isvox(user))
-		return 'modular_skyrat/modules/emotes/sound/emotes/voxcough.ogg'
-	if(iscarbon(user))
-		if(user.gender == MALE)
-			return 'modular_skyrat/modules/emotes/sound/emotes/male/male_cough_2.ogg')
-		return 'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_1.ogg')
-	return
 
 // Avian revolution
 /datum/emote/living/bawk

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -322,6 +322,11 @@
 	key_third_person = "huffs"
 	message = "huffs!"
 
+/datum/emote/living/etwitch
+	key = "etwitch"
+	key_third_person = "twitches their ears"
+	message = "twitches their ears!"
+
 /datum/emote/living/clear
 	key = "clear"
 	key_third_person = "clears their throat"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -334,8 +334,8 @@
 		return 'modular_skyrat/modules/emotes/sound/emotes/voxcough.ogg'
 	if(iscarbon(user))
 		if(user.gender == MALE)
-			return 'modular_skyrat/modules/emotes/sound/emotes/male/male_cough_2.ogg',
-		return 'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_1.ogg',
+			return 'modular_skyrat/modules/emotes/sound/emotes/male/male_cough_2.ogg')
+		return 'modular_skyrat/modules/emotes/sound/emotes/female/female_cough_1.ogg')
 	return
 
 // Avian revolution


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I love alliteration. Though it's less alliteration and more three of the same words repeated.
Anyway. This adds
-Blink2
Which is commonly known as blinkblinks. I think that is a LRP name. Or in common terms; stupid. So it's Blink 2, you blink twice.
-Rblink
Rapidly blinks. To...rapidly blink.
-Squint
Three guesses as to what that does!
-Clear
Clear your throat. ~~I have used cough sounds as a placeholder. Feel free to replace them.~~
No sounds as I can't get it to work.
-Smirk
You smirk. This is pretty obvious.
-Eyeroll
Roll your eyes.
-Huff
Huff and not puff. No sound effects because it's all horses and dogs.
-ETwitch
Twitch your ears.

## How This Contributes To The Skyrat Roleplay Experience

Less time to type means more time to roleplay. As we all know, quantity equals quality.
Or to quote a Maximalist phrase; "More is More."

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Cursor
add: Some commonly typed emotes are now quick emoteable. These include; Blink2, RBlink, Squint, Eyeroll, Smirk, Huff, ETwitch and Clear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
