### PR TITLE
Gets rid of glock safeties

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -36,6 +36,7 @@
 	emp_damageable = TRUE
 	armadyne = TRUE
 	fire_delay = 1.90
+	has_gun_safety = FALSE
 
 /obj/item/ammo_box/magazine/multi_sprite/g17
 	name = "9x19mm double stack magazine"
@@ -77,6 +78,7 @@
 	mag_display = FALSE
 	mag_display_ammo = FALSE
 	can_flashlight = TRUE
+	has_gun_safety = FALSE
 
 /obj/item/ammo_box/magazine/multi_sprite/g18
 	name = "extended 9x19mm magazine"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes safeties from the glock 17 and 18. Glocks have their safeties in the trigger, just don't fire the thing 😏 

## How This Contributes To The Skyrat Roleplay Experience
Realism?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Glocks no longer have safeties
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
