### PR TITLE
Fixes mining boot icon

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/shoes/boots.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/shoes/boots.dm
@@ -1,3 +1,3 @@
 /obj/item/clothing/shoes/workboots/mining
-	icon = 'modular_skyrat/master_files/icons/mob/clothing/feet.dmi' //To keep the old version before #8911
+	icon = 'modular_skyrat/master_files/icons/obj/clothing/shoes.dmi' //To keep the old version before #8911
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/feet.dmi' //To keep the old version before #8911


### PR DESCRIPTION
## About The Pull Request

They had the mob icon as the obj icon. This made them very small. No bueno.

## Changelog
:cl:
fix: The mining boots object icon is no longer tiny.
/:cl: