### PR TITLE
Ghost role loadout/quirk fix

### DIFF
--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -192,9 +192,9 @@
 			var/mob/living/carbon/human/spawned_human = spawned_mob
 			mob_possessor?.client?.prefs?.safe_transfer_prefs_to(spawned_human)
 			spawned_human.dna.update_dna_identity()
-			if(loadout_enabled)
-				SSquirks.AssignQuirks(spawned_human, mob_possessor.client)
 			if(quirks_enabled)
+				SSquirks.AssignQuirks(spawned_human, mob_possessor.client)
+			if(loadout_enabled)
 				spawned_human.equip_outfit_and_loadout(outfit, mob_possessor.client.prefs)
 	// SKYRAT EDIT END
 	if(mob_possessor)


### PR DESCRIPTION
https://github.com/Skyrat-SS13/Skyrat-tg/pull/12366 oops

## Changelog
:cl:
fix: Hermits can now use quirks and not loadouts, as was intended.
/:cl: