### PR TITLE
Icebox underground Consultant/blueshield offices

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -3642,10 +3642,10 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Bridge West Entrance"
 	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aYw" = (
@@ -9061,6 +9061,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"bVj" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "bVk" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
@@ -11847,11 +11855,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cIv" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/engineering/supermatter/room)
 "cIC" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -13570,6 +13573,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"dLQ" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "dLV" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
@@ -21937,6 +21946,9 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
+"inb" = (
+/turf/open/openspace,
+/area/hallway/primary/central)
 "inF" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line,
@@ -32443,6 +32455,18 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"ojO" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "oku" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45560,6 +45584,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"vlY" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/railing/corner,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "vme" = (
 /obj/machinery/door/airlock{
 	id_tag = "Toilet1";
@@ -47625,6 +47656,15 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/commons/storage/emergency/port)
+"wqE" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "wqS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -76332,9 +76372,9 @@ aJq
 aLX
 aLX
 aLX
-aLX
-aLX
-aJq
+vlY
+ojO
+dLQ
 aYl
 aYl
 aYl
@@ -76590,9 +76630,9 @@ aJn
 aJn
 aJn
 aJn
-aJs
-aJq
-tWP
+inb
+wqE
+bVj
 gGl
 gGl
 xty
@@ -76844,11 +76884,11 @@ aLX
 vHX
 aOE
 aJn
-iFZ
-iFZ
+inb
+inb
 aJn
-aJs
-aJq
+inb
+wqE
 aYn
 gGl
 vkz
@@ -77101,8 +77141,8 @@ aJs
 vHX
 aOE
 aJn
-iFZ
-iFZ
+inb
+inb
 aJw
 aVb
 aWH
@@ -77358,8 +77398,8 @@ aJs
 vHX
 bJx
 aJn
-iFZ
-iFZ
+inb
+inb
 izL
 lSx
 uyv
@@ -77615,8 +77655,8 @@ nmW
 vHX
 oQH
 aJn
-iFZ
-iFZ
+inb
+inb
 rup
 dbR
 xgT
@@ -77872,7 +77912,7 @@ aJr
 vHX
 aOE
 aJn
-iFZ
+inb
 rup
 rup
 rup
@@ -78129,7 +78169,7 @@ aGk
 vHX
 aOE
 aJn
-iFZ
+inb
 rup
 ofE
 bQR
@@ -78386,7 +78426,7 @@ aJq
 vHX
 aOE
 aJn
-iFZ
+inb
 rup
 lKi
 jHC
@@ -79492,7 +79532,7 @@ hua
 gLv
 uUh
 flT
-cIv
+iLd
 wfC
 fQX
 oJZ

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -15128,6 +15128,13 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
+"eCA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "eDG" = (
 /obj/effect/turf_decal/tile/red/full,
 /obj/structure/chair{
@@ -16485,6 +16492,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"fsi" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "fst" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17715,6 +17728,14 @@
 /obj/item/storage/box,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"gak" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "gao" = (
 /obj/item/stack/ore/iron,
 /obj/effect/turf_decal/stripes/line{
@@ -18295,6 +18316,9 @@
 	icon_state = "wood-broken2"
 	},
 /area/maintenance/fore/lesser)
+"gqa" = (
+/turf/closed/wall,
+/area/commons/vacant_room/commissary)
 "gqq" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -18550,6 +18574,18 @@
 /obj/item/poster/random_official,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"gxh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/south{
+	id = "commissarydoor";
+	name = "Commissary Door Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/iron/five,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "gxp" = (
 /obj/machinery/light_switch/directional/north,
 /obj/structure/cable,
@@ -19028,6 +19064,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"gKQ" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "gKS" = (
 /obj/machinery/disposal/bin,
 /obj/item/radio/intercom/prison/directional/north,
@@ -20623,6 +20666,17 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"hBm" = (
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutters";
+	name = "Vacant Commissary Shutters"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "hBn" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
@@ -21640,6 +21694,14 @@
 	dir = 1
 	},
 /area/service/hydroponics)
+"idt" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "idF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24354,6 +24416,15 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"jIr" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutters";
+	name = "Vacant Commissary Shutters"
+	},
+/obj/structure/table,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "jIw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -24827,6 +24898,21 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"jVC" = (
+/obj/machinery/button/door/directional/east{
+	id = "commissaryshutters";
+	name = "Commissary Shutters Control"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/screwdriver,
+/obj/item/wrench,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "jVL" = (
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
@@ -28826,6 +28912,13 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
+"mjW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/stack/package_wrap,
+/obj/item/hand_labeler,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "mkd" = (
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
@@ -30226,6 +30319,14 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
+"mXJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/secure/briefcase,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "mXU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -32363,6 +32464,13 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
 /area/maintenance/aft/greater)
+"ohc" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "ohp" = (
 /obj/machinery/meter{
 	name = "Mixed Air Tank In"
@@ -33006,6 +33114,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"oyN" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock{
+	id_tag = "commissarydoor";
+	name = "Commissary"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "oyV" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
@@ -36791,6 +36908,15 @@
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/iron,
 /area/service/janitor)
+"qDv" = (
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutters";
+	name = "Vacant Commissary Shutters"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "qDH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -45702,6 +45828,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half,
 /area/maintenance/department/medical/central)
+"vpP" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "vpU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -47814,6 +47947,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured,
 /area/medical/medbay/central)
+"wuB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "wuF" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/fore)
@@ -76370,7 +76509,7 @@ dZQ
 aaa
 aJq
 aLX
-aLX
+vpP
 aLX
 vlY
 ojO
@@ -76626,10 +76765,10 @@ sgN
 nAZ
 vHX
 oQH
-aJn
-aJn
-aJn
-aJn
+gqa
+oyN
+gqa
+aJw
 inb
 wqE
 bVj
@@ -76883,10 +77022,10 @@ sgN
 aLX
 vHX
 aOE
-aJn
-inb
-inb
-aJn
+gqa
+gak
+mXJ
+aJw
 inb
 wqE
 aYn
@@ -77140,9 +77279,9 @@ dxt
 aJs
 vHX
 aOE
-aJn
-inb
-inb
+gqa
+fsi
+mjW
 aJw
 aVb
 aWH
@@ -77397,9 +77536,9 @@ iGT
 aJs
 vHX
 bJx
-aJn
-inb
-inb
+gqa
+fsi
+gxh
 izL
 lSx
 uyv
@@ -77654,9 +77793,9 @@ dxt
 nmW
 vHX
 oQH
-aJn
-inb
-inb
+gqa
+ohc
+eCA
 rup
 dbR
 xgT
@@ -77911,8 +78050,8 @@ sgN
 aJr
 vHX
 aOE
-aJn
-inb
+qDv
+gKQ
 rup
 rup
 rup
@@ -78167,9 +78306,9 @@ bLy
 sgN
 aGk
 vHX
-aOE
-aJn
-inb
+idt
+hBm
+wuB
 rup
 ofE
 bQR
@@ -78425,8 +78564,8 @@ sgN
 aJq
 vHX
 aOE
-aJn
-inb
+jIr
+jVC
 rup
 lKi
 jHC

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -13595,6 +13595,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"dMh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood,
+/area/service/cafeteria)
 "dMH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -15132,7 +15141,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood/end,
+/turf/open/floor/wood,
 /area/service/cafeteria)
 "eDG" = (
 /obj/effect/turf_decal/tile/red/full,
@@ -16494,7 +16504,7 @@
 "fsi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "fst" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17728,7 +17738,7 @@
 /area/maintenance/port/greater)
 "gak" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "gao" = (
 /obj/item/stack/ore/iron,
@@ -18336,7 +18346,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "gqq" = (
 /obj/structure/window/reinforced{
@@ -18386,7 +18396,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "grt" = (
 /obj/structure/barricade/wooden,
@@ -18612,7 +18622,7 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "gxp" = (
 /obj/machinery/light_switch/directional/north,
@@ -19095,12 +19105,10 @@
 "gKQ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
 /obj/structure/chair/stool/directional/east{
 	name = "Jim Norton's Quebecois Coffee stool"
 	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/service/cafeteria)
 "gKS" = (
@@ -28937,7 +28945,7 @@
 	fair_market_price = 0;
 	name = "\improper Jim Norton's Quebecois Coffee"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "mkd" = (
 /turf/open/floor/iron,
@@ -29936,7 +29944,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "mLw" = (
 /obj/effect/landmark/start/depsec/engineering,
@@ -30356,7 +30364,7 @@
 /obj/item/clothing/suit/apron/chef{
 	name = "Jim Norton's Quebecois Coffee apron"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "mXU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -33087,7 +33095,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "oxg" = (
 /obj/machinery/rnd/production/techfab/department/medical,
@@ -33131,7 +33139,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "oxX" = (
 /obj/machinery/door/airlock/maintenance{
@@ -33197,7 +33205,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "oyV" = (
 /obj/machinery/airalarm/directional/west,
@@ -38092,7 +38100,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/cafeteria)
 "rjq" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -38510,9 +38518,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/security/processing)
-"rvy" = (
-/turf/open/floor/iron,
-/area/service/cafeteria)
 "rvJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77904,8 +77909,8 @@ dxt
 nmW
 vHX
 oQH
-rvy
-fsi
+qDv
+dMh
 eCA
 rup
 dbR
@@ -78161,7 +78166,7 @@ sgN
 aJr
 vHX
 aOE
-qDv
+hBm
 gKQ
 rup
 rup

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -15129,12 +15129,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
 "eCA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/cafeteria)
 "eDG" = (
 /obj/effect/turf_decal/tile/red/full,
 /obj/structure/chair{
@@ -16494,10 +16493,9 @@
 /area/engineering/supermatter)
 "fsi" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/cafeteria)
 "fst" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17730,12 +17728,8 @@
 /area/maintenance/port/greater)
 "gak" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/cafeteria)
 "gao" = (
 /obj/item/stack/ore/iron,
 /obj/effect/turf_decal/stripes/line{
@@ -18317,8 +18311,33 @@
 	},
 /area/maintenance/fore/lesser)
 "gqa" = (
-/turf/closed/wall,
-/area/commons/vacant_room/commissary)
+/obj/item/reagent_containers/food/condiment/milk{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/condiment/sugar{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/condiment/soymilk{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/ice{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/food/drinks/bottle/cream{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/structure/table{
+	name = "Jim Norton's Quebecois Coffee table"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/service/cafeteria)
 "gqq" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -18361,6 +18380,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
+"grn" = (
+/obj/machinery/door/window/right/directional/north{
+	name = "Jim Norton's Quebecois Coffee"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/service/cafeteria)
 "grt" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance{
@@ -18575,17 +18602,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "gxh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door/directional/south{
-	id = "commissarydoor";
-	name = "Commissary Door Lock";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
+/obj/structure/table/reinforced{
+	name = "Jim Norton's Quebecois Coffee table"
 	},
-/obj/structure/table,
-/obj/item/stack/sheet/iron/five,
+/obj/item/storage/fancy/donut_box,
+/obj/item/paper{
+	info = "Jim Norton's Quebecois Coffee.         You see, in 2265 the Quebecois had finally had enough of Canada's shit, and went to the one place that wasn't corrupted by Canuckistan.Je vais au seul endroit qui n'a pas ??? corrompu par les Canadiens ... ESPACE.";
+	name = "Coffee Shop";
+	pixel_x = -4;
+	pixel_y = 6
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/cafeteria)
 "gxp" = (
 /obj/machinery/light_switch/directional/north,
 /obj/structure/cable,
@@ -19067,10 +19095,14 @@
 "gKQ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/chair/stool/directional/east{
+	name = "Jim Norton's Quebecois Coffee stool"
+	},
+/turf/open/floor/wood,
+/area/service/cafeteria)
 "gKS" = (
 /obj/machinery/disposal/bin,
 /obj/item/radio/intercom/prison/directional/north,
@@ -20667,16 +20699,11 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "hBm" = (
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "commissaryshutters";
-	name = "Vacant Commissary Shutters"
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/turf/open/floor/wood,
+/area/service/cafeteria)
 "hBn" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
@@ -24417,14 +24444,11 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "jIr" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "commissaryshutters";
-	name = "Vacant Commissary Shutters"
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/obj/structure/table,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/turf/open/floor/wood,
+/area/service/cafeteria)
 "jIw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -24899,20 +24923,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jVC" = (
-/obj/machinery/button/door/directional/east{
-	id = "commissaryshutters";
-	name = "Commissary Shutters Control"
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/chair/stool/directional/west{
+	name = "Jim Norton's Quebecois Coffee stool"
 	},
-/obj/structure/rack,
-/obj/item/screwdriver,
-/obj/item/wrench,
-/obj/item/stack/cable_coil/five,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/turf/open/floor/wood,
+/area/service/cafeteria)
 "jVL" = (
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
@@ -28913,12 +28931,14 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "mjW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
+/obj/machinery/vending/coffee{
+	default_price = 0;
+	extra_price = 0;
+	fair_market_price = 0;
+	name = "\improper Jim Norton's Quebecois Coffee"
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/cafeteria)
 "mkd" = (
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
@@ -29906,6 +29926,18 @@
 /obj/item/stock_parts/cell/high/empty,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
+"mLg" = (
+/obj/structure/table{
+	name = "Jim Norton's Quebecois Coffee table"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/service/cafeteria)
 "mLw" = (
 /obj/effect/landmark/start/depsec/engineering,
 /obj/structure/cable,
@@ -30320,13 +30352,12 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "mXJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/storage/secure/briefcase,
-/obj/machinery/firealarm/directional/west,
 /obj/machinery/airalarm/directional/south,
+/obj/item/clothing/suit/apron/chef{
+	name = "Jim Norton's Quebecois Coffee apron"
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/cafeteria)
 "mXU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -32464,13 +32495,6 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
 /area/maintenance/aft/greater)
-"ohc" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
 "ohp" = (
 /obj/machinery/meter{
 	name = "Mixed Air Tank In"
@@ -33046,6 +33070,25 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"oxa" = (
+/obj/item/reagent_containers/food/drinks/mug/coco{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = -3
+	},
+/obj/structure/table/reinforced{
+	name = "Jim Norton's Quebecois Coffee table"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/service/cafeteria)
 "oxg" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -33081,6 +33124,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /turf/open/floor/glass/reinforced,
 /area/engineering/atmos/pumproom)
+"oxU" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/service/cafeteria)
 "oxX" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -33115,14 +33167,38 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "oyN" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	id_tag = "commissarydoor";
-	name = "Commissary"
+/obj/item/seeds/coffee{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/structure/barricade/wooden,
+/obj/item/seeds/coffee/robusta{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/seeds/coffee{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/storage/pill_bottle/happinesspsych{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/seeds/coffee{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/structure/table{
+	name = "Jim Norton's Quebecois Coffee table"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/service/cafeteria)
 "oyV" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
@@ -36909,14 +36985,11 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "qDv" = (
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "commissaryshutters";
-	name = "Vacant Commissary Shutters"
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/turf/open/floor/wood,
+/area/service/cafeteria)
 "qDH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -37996,6 +38069,31 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"rjo" = (
+/obj/item/food/cakeslice/pound_cake_slice{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/structure/table/reinforced{
+	name = "Jim Norton's Quebecois Coffee table"
+	},
+/obj/item/food/poppypretzel{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/obj/item/food/muffin/berry{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/food/hotcrossbun{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/service/cafeteria)
 "rjq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -38412,6 +38510,9 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/security/processing)
+"rvy" = (
+/turf/open/floor/iron,
+/area/service/cafeteria)
 "rvJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47948,11 +48049,21 @@
 /turf/open/floor/iron/textured,
 /area/medical/medbay/central)
 "wuB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/table{
+	name = "Jim Norton's Quebecois Coffee table"
+	},
+/obj/item/modular_computer/laptop/preset/civilian,
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = 5;
+	pixel_y = 12
+	},
+/turf/open/floor/wood,
+/area/service/cafeteria)
 "wuF" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/fore)
@@ -76765,7 +76876,7 @@ sgN
 nAZ
 vHX
 oQH
-gqa
+mLg
 oyN
 gqa
 aJw
@@ -77022,7 +77133,7 @@ sgN
 aLX
 vHX
 aOE
-gqa
+oxU
 gak
 mXJ
 aJw
@@ -77278,8 +77389,8 @@ txw
 dxt
 aJs
 vHX
-aOE
-gqa
+idt
+grn
 fsi
 mjW
 aJw
@@ -77536,8 +77647,8 @@ iGT
 aJs
 vHX
 bJx
-gqa
-fsi
+rjo
+oxa
 gxh
 izL
 lSx
@@ -77793,8 +77904,8 @@ dxt
 nmW
 vHX
 oQH
-gqa
-ohc
+rvy
+fsi
 eCA
 rup
 dbR
@@ -78306,7 +78417,7 @@ bLy
 sgN
 aGk
 vHX
-idt
+aOE
 hBm
 wuB
 rup

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -28071,6 +28071,11 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"lJl" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "lJG" = (
 /obj/structure/sign/warning/deathsposal{
 	pixel_y = 32
@@ -79787,7 +79792,7 @@ hua
 gLv
 uUh
 flT
-iLd
+lJl
 wfC
 fQX
 oJZ

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
@@ -16335,6 +16335,7 @@
 	},
 /obj/item/bedsheet/nanotrasen,
 /obj/structure/bed,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood,
 /area/blueshield)
 "cCi" = (
@@ -16846,6 +16847,8 @@
 	pixel_x = -10;
 	pixel_y = 6
 	},
+/obj/machinery/light/directional/north,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/carpet/executive,
 /area/blueshield)
 "fie" = (
@@ -17098,6 +17101,7 @@
 /area/service/lawoffice)
 "gMw" = (
 /obj/machinery/light/directional/east,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
 "gNv" = (
@@ -17176,6 +17180,7 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "hsP" = (
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood,
 /area/blueshield)
 "hyB" = (
@@ -17280,6 +17285,10 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"irF" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "iwH" = (
 /turf/closed/wall/r_wall,
 /area/security/brig)
@@ -18373,6 +18382,7 @@
 	pixel_y = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
 "skR" = (
@@ -18760,6 +18770,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/blueshield)
 "vsF" = (
@@ -19153,6 +19164,7 @@
 /area/command/heads_quarters/captain/private/nt_rep)
 "xPg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/blueshield)
 "yeE" = (
@@ -45258,7 +45270,7 @@ kOq
 fdJ
 xqZ
 tfD
-gqs
+irF
 qlm
 fBv
 dCz

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
@@ -17544,13 +17544,6 @@
 "jXo" = (
 /turf/closed/wall,
 /area/service/lawoffice)
-"jZr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/icemoon,
-/area/mine/storage)
 "kdd" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	dir = 8;
@@ -18639,6 +18632,9 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/iron,
 /area/security/prison)
+"utH" = (
+/turf/closed/wall/r_wall,
+/area/command/heads_quarters/captain/private/nt_rep)
 "uwk" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -44252,7 +44248,7 @@ hRS
 lfl
 lfl
 lfl
-dCz
+cDS
 cDS
 vXz
 vXz
@@ -44505,7 +44501,7 @@ gkA
 gkA
 gkA
 gkA
-hRS
+utH
 wxO
 iHD
 iHD
@@ -44762,11 +44758,11 @@ gqs
 gqs
 xap
 nqa
-hRS
+utH
 hkE
 qlm
 hLT
-dCz
+cDS
 fhx
 yeE
 dbP
@@ -45019,11 +45015,11 @@ gqs
 xtB
 xtB
 skl
-hRS
+utH
 hRS
 qbf
 rPc
-dCz
+cDS
 orW
 fwv
 cuk
@@ -45280,7 +45276,7 @@ tfD
 irF
 qlm
 fBv
-dCz
+cDS
 vhp
 jAp
 oEs
@@ -45537,7 +45533,7 @@ dyC
 qKe
 qlm
 hRS
-dCz
+cDS
 cDS
 vXz
 vXz
@@ -45790,7 +45786,7 @@ rLR
 fIi
 oBK
 xDT
-hRS
+utH
 oWy
 iHD
 gtO
@@ -46047,7 +46043,7 @@ bUT
 gqs
 qqh
 pXc
-hRS
+utH
 pmG
 hRS
 hRS
@@ -46304,7 +46300,7 @@ sQM
 nfO
 gMw
 bwP
-hRS
+utH
 ptS
 hRS
 aFp
@@ -46561,7 +46557,7 @@ gkA
 hRS
 hRS
 ddb
-hRS
+utH
 hRS
 hRS
 aFp
@@ -48120,7 +48116,7 @@ hRQ
 aMf
 aKq
 aAP
-jZr
+dAP
 aFp
 aPG
 aFp

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
@@ -1704,6 +1704,7 @@
 "afw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/storage)
 "afx" = (
@@ -2181,8 +2182,8 @@
 "ahf" = (
 /obj/structure/bed/maint,
 /obj/item/toy/plush/rouny{
-	name = "Therapy Dog";
-	desc = "What is this? Is this a dog?"
+	desc = "What is this? Is this a dog?";
+	name = "Therapy Dog"
 	},
 /obj/structure/cable,
 /obj/machinery/camera/directional/east{
@@ -2515,6 +2516,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/storage)
 "aid" = (
@@ -3311,8 +3313,8 @@
 /area/service/chapel)
 "alb" = (
 /obj/structure/chair{
-	name = "Judge";
-	dir = 8
+	dir = 8;
+	name = "Judge"
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood,
@@ -6021,8 +6023,8 @@
 /area/hallway/secondary/service)
 "aug" = (
 /obj/structure/chair{
-	name = "Judge";
-	dir = 8
+	dir = 8;
+	name = "Judge"
 	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Courtroom"
@@ -7314,22 +7316,22 @@
 /obj/machinery/button/door{
 	id = "Prison Gate";
 	name = "Prison Wing Lockdown";
+	pixel_x = 5;
 	pixel_y = 8;
-	req_access_txt = "2";
-	pixel_x = 5
+	req_access_txt = "2"
 	},
 /obj/machinery/button/door{
 	id = "Trial Transfer";
 	name = "Trial Transfer Lockdown";
+	pixel_x = -7;
 	pixel_y = 8;
-	req_access_txt = "2";
-	pixel_x = -7
+	req_access_txt = "2"
 	},
 /obj/machinery/button/door{
 	id = "Secure Gate";
 	name = "Cell Shutters";
-	pixel_y = -3;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = -3
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8011,6 +8013,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "aAR" = (
@@ -9047,8 +9052,8 @@
 /area/icemoon/underground/explored)
 "aEv" = (
 /obj/structure/chair{
-	name = "Judge";
-	dir = 8
+	dir = 8;
+	name = "Judge"
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
@@ -10877,6 +10882,9 @@
 	desc = "A sign that warns of dangerous gasses in the air, instructing you to wear internals.";
 	pixel_x = 30
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "aKr" = (
@@ -11521,6 +11529,9 @@
 /obj/structure/sign/warning/xeno_mining{
 	pixel_x = 29
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "aMg" = (
@@ -12418,9 +12429,9 @@
 /obj/machinery/button/door{
 	id = "Trial Transfer";
 	name = "Trial Transfer Lockdown";
+	pixel_x = -7;
 	pixel_y = -23;
-	req_access_txt = "2";
-	pixel_x = -7
+	req_access_txt = "2"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/textured,
@@ -13926,7 +13937,10 @@
 /area/commons/lounge)
 "aTQ" = (
 /obj/machinery/light/directional/north,
-/turf/open/misc/asteroid/snow/icemoon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/icemoon,
 /area/mine/storage)
 "aTS" = (
 /obj/structure/disposalpipe/segment{
@@ -15479,9 +15493,9 @@
 /area/security/prison)
 "aYt" = (
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
 	id = "Cell 1";
-	name = "Cell 1";
-	dir = 8
+	name = "Cell 1"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half{
@@ -16127,6 +16141,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"bwP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "byM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -16177,8 +16196,8 @@
 /area/security/prison)
 "bQZ" = (
 /obj/machinery/button/door/directional/east{
-	name = "Privacy Shutters"s;
-	id = "kanyewest"
+	id = "kanyewest";
+	name = "Privacy Shutters"s
 	},
 /obj/structure/chair/office{
 	dir = 8
@@ -16204,6 +16223,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/icemoon,
 /area/security/execution/education)
+"bUT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "bUU" = (
 /obj/structure/chair{
 	dir = 4
@@ -16225,10 +16250,10 @@
 "cak" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/interrogation{
+	dir = 1;
 	name = "isolation room monitor";
 	network = list("isolation");
-	pixel_y = -32;
-	dir = 1
+	pixel_y = -32
 	},
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/suit/straight_jacket{
@@ -16298,10 +16323,27 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"cuk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet/executive,
+/area/blueshield)
+"cyH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/item/bedsheet/nanotrasen,
+/obj/structure/bed,
+/turf/open/floor/wood,
+/area/blueshield)
 "cCi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/ai_monitored/security/armory)
+"cDS" = (
+/turf/closed/wall/r_wall,
+/area/blueshield)
 "cDX" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -16382,6 +16424,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured,
 /area/security/brig)
+"dbP" = (
+/obj/structure/table/wood,
+/obj/item/coin/antagtoken,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/executive,
+/area/blueshield)
 "dcd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16396,6 +16445,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/lawyer,
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"ddb" = (
+/obj/machinery/door/airlock/corporate{
+	name = "Nanotrasen Consultant's Office";
+	req_access_txt = "101"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "ddn" = (
 /obj/machinery/door/airlock/external{
 	name = "Service Hall Exit";
@@ -16419,6 +16478,10 @@
 /obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/iron/smooth,
 /area/security/prison)
+"dfN" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
+/area/blueshield)
 "diF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -16489,6 +16552,17 @@
 	},
 /turf/closed/wall,
 /area/maintenance/fore)
+"dyC" = (
+/obj/machinery/door/airlock/corporate{
+	name = "Nanotrasen Consultant's Office";
+	req_access_txt = "101"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "dzv" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/blue{
@@ -16500,12 +16574,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
+"dzJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/blueshield)
+"dAP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/icemoon,
+/area/mine/storage)
 "dBz" = (
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"dCz" = (
+/turf/closed/wall,
+/area/blueshield)
 "dGI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16656,8 +16744,8 @@
 	id = "visitation";
 	name = "Visitation Shutters";
 	pixel_x = 6;
-	req_access_txt = "2";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access_txt = "2"
 	},
 /obj/machinery/button/flasher{
 	id = "visitorflash";
@@ -16682,6 +16770,33 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/fore)
+"eNa" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes/cigars/cohiba{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/storage/fancy/cigarettes/cigars/cohiba{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/lighter{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = 10;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "eNB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -16704,6 +16819,35 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"fbh" = (
+/obj/structure/closet/secure_closet/blueshield,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/blueshield)
+"fdJ" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/command/heads_quarters/captain/private/nt_rep)
+"fhx" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/phone{
+	pixel_x = -10;
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/executive,
+/area/blueshield)
 "fie" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron,
@@ -16712,10 +16856,33 @@
 /obj/structure/sign/poster/official/help_others,
 /turf/closed/wall/ice,
 /area/icemoon/underground/explored)
+"fst" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/external{
+	glass = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/command/heads_quarters/captain/private/nt_rep)
 "fvW" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"fwv" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 8
+	},
+/turf/open/floor/carpet/executive,
+/area/blueshield)
+"fBv" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "fDO" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon{
@@ -16733,6 +16900,10 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"fIi" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/green,
+/area/command/heads_quarters/captain/private/nt_rep)
 "fPI" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -16799,6 +16970,16 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"gkA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "consultantprivacy";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/command/heads_quarters/captain/private/nt_rep)
 "gmI" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/blue{
@@ -16820,6 +17001,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"gqs" = (
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "grz" = (
 /obj/structure/flora/grass/green,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -16828,6 +17012,16 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
+"gtO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/external{
+	glass = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/command/heads_quarters/captain/private/nt_rep)
 "gur" = (
 /obj/machinery/button/door/directional/east{
 	id = "lawyer_blast";
@@ -16902,6 +17096,16 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"gMw" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
+"gNv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/underground/explored)
 "gQr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner/north,
@@ -16940,6 +17144,10 @@
 "hjR" = (
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
+"hkE" = (
+/obj/structure/stairs/east,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "hmF" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
@@ -16967,6 +17175,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"hsP" = (
+/turf/open/floor/wood,
+/area/blueshield)
 "hyB" = (
 /obj/structure/table,
 /obj/machinery/door/poddoor/shutters{
@@ -16984,11 +17195,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"hLT" = (
+/obj/machinery/light/directional/south,
+/obj/structure/chair/sofa/bench/left{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "hMl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"hRQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/mine/storage)
+"hRS" = (
+/turf/closed/wall,
+/area/command/heads_quarters/captain/private/nt_rep)
 "hSM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -17061,6 +17288,12 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"iCF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/green,
+/area/command/heads_quarters/captain/private/nt_rep)
 "iFe" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner/east,
@@ -17068,6 +17301,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/education)
+"iHD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "iIl" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/random/contraband/prison,
@@ -17146,6 +17385,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"jcw" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/command/heads_quarters/captain/private/nt_rep)
 "jtI" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Service Hall Exit";
@@ -17190,6 +17433,22 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/security/prison)
+"jAp" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/bottle/kahlua{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/turf/open/floor/carpet/executive,
+/area/blueshield)
 "jAJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
@@ -17197,6 +17456,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"jCK" = (
+/obj/machinery/button/door/directional/west{
+	id = "ntconshutter";
+	name = "Shutter controls";
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "jDw" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
@@ -17242,6 +17511,12 @@
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"jJZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/icemoon,
+/area/command/heads_quarters/captain/private/nt_rep)
 "jPG" = (
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /obj/machinery/light/directional/east,
@@ -17253,11 +17528,18 @@
 "jXo" = (
 /turf/closed/wall,
 /area/service/lawoffice)
+"jZr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/icemoon,
+/area/mine/storage)
 "kdd" = (
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
 	id = "Cell 3";
-	name = "Cell 3";
-	dir = 8
+	name = "Cell 3"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half{
@@ -17302,6 +17584,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"ksy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "ntconshutter";
+	name = "Privacy Shutter"
+	},
+/turf/open/floor/plating,
+/area/command/heads_quarters/captain/private/nt_rep)
 "ktP" = (
 /obj/structure/flora/rock/pile/icy,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -17328,6 +17618,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
+"kOq" = (
+/turf/open/floor/carpet/green,
+/area/command/heads_quarters/captain/private/nt_rep)
 "kQI" = (
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
@@ -17368,6 +17661,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"lfl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/command/heads_quarters/captain/private/nt_rep)
 "lji" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/textured,
@@ -17417,6 +17714,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"lXr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/command/heads_quarters/captain/private/nt_rep)
 "lZn" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
@@ -17518,6 +17821,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
+"nfO" = (
+/obj/structure/filingcabinet/employment,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "nhV" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/grille,
@@ -17525,6 +17832,17 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plating,
 /area/security/courtroom)
+"nlC" = (
+/obj/machinery/door/airlock/corporate/glass{
+	name = "Blueshield's Office";
+	req_access_txt = "20"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/blueshield)
 "nlE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -17533,6 +17851,13 @@
 	dir = 1
 	},
 /area/security/prison)
+"nqa" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "nvs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17547,6 +17872,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/detectives_office)
+"nLO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "nNt" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -17590,8 +17920,8 @@
 "nTC" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/camera/directional/south{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Cells"
+	c_tag = "Security - Permabrig Cells";
+	network = list("ss13","prison")
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
@@ -17610,12 +17940,21 @@
 	},
 /obj/item/pen,
 /obj/machinery/camera/directional/south{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Recreation"
+	c_tag = "Security - Permabrig Recreation";
+	network = list("ss13","prison")
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"orW" = (
+/obj/machinery/computer/crew,
+/obj/machinery/button/curtain{
+	id = "blueprivacy";
+	pixel_x = -6;
+	pixel_y = 22
+	},
+/turf/open/floor/carpet/executive,
+/area/blueshield)
 "ovA" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17635,6 +17974,22 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"oBK" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_y = 3
+	},
+/obj/item/pen/fountain{
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/green,
+/area/command/heads_quarters/captain/private/nt_rep)
+"oEs" = (
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/turf/open/floor/carpet/executive,
+/area/blueshield)
 "oEV" = (
 /turf/open/floor/iron/smooth_half,
 /area/security/prison)
@@ -17666,10 +18021,17 @@
 /obj/item/cultivator,
 /turf/open/floor/grass,
 /area/security/prison)
+"oWy" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "pbE" = (
 /obj/structure/toilet/greyscale{
-	dir = 4;
-	cistern = 1
+	cistern = 1;
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -17717,6 +18079,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_half,
 /area/security/prison)
+"pmG" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plating,
+/area/command/heads_quarters/captain/private/nt_rep)
+"ptS" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/command/heads_quarters/captain/private/nt_rep)
 "ptT" = (
 /obj/machinery/vending/cola/sodie,
 /obj/structure/cable,
@@ -17735,6 +18105,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"pJE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/secure_closet/nanotrasen_consultant/station,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "pOS" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17742,10 +18117,29 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/ai_monitored/security/armory)
+"pUq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
+"pXc" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "pYL" = (
 /obj/structure/grille,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"qbf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/directional/north{
+	c_tag = "Consultant Lobby"
+	},
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "qgK" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -17757,6 +18151,12 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/edge,
 /area/security/prison)
+"qlm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "qmv" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -17770,6 +18170,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"qqh" = (
+/obj/effect/landmark/start/nanotrasen_consultant,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "qyM" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Security - Lower Brig Cells";
@@ -17800,6 +18207,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"qKe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "qOu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/south,
@@ -17892,6 +18305,10 @@
 	dir = 1
 	},
 /area/security/brig)
+"rLR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/green,
+/area/command/heads_quarters/captain/private/nt_rep)
 "rMW" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red,
@@ -17902,6 +18319,12 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"rPc" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "rVq" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Permabrig Maintenance"
@@ -17935,6 +18358,23 @@
 	dir = 1
 	},
 /area/security/prison)
+"skl" = (
+/obj/structure/table/wood,
+/obj/machinery/button/curtain{
+	id = "consultantprivacy";
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Consultant's Office"
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "skR" = (
 /obj/structure/table,
 /obj/item/folder,
@@ -17977,6 +18417,14 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"sCK" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "ntconshutter";
+	name = "Privacy Shutter"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/command/heads_quarters/captain/private/nt_rep)
 "sHV" = (
 /obj/structure/closet{
 	name = "Evidence Closet 1"
@@ -17993,6 +18441,10 @@
 /obj/machinery/plate_press,
 /turf/open/floor/plating,
 /area/security/prison)
+"sQM" = (
+/obj/structure/aquarium,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "tap" = (
 /obj/machinery/vending/cola/red,
 /obj/structure/cable,
@@ -18023,6 +18475,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"tfD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "ConsultantPrivacy";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/command/heads_quarters/captain/private/nt_rep)
 "tqm" = (
 /obj/machinery/shower{
 	pixel_y = 12
@@ -18057,6 +18519,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
+"tGs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/centcom,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "tJO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner/east,
@@ -18174,6 +18644,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig)
+"uCl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/blueshield)
 "uLl" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -18219,6 +18694,16 @@
 /obj/structure/sign/poster/official/obey,
 /turf/closed/wall/r_wall,
 /area/security/prison/visit)
+"uZE" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "consultantprivacy";
+	name = "curtain"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/command/heads_quarters/captain/private/nt_rep)
 "vcS" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side{
@@ -18248,12 +18733,35 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
+"vhp" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Blueshield's office"
+	},
+/obj/machinery/modular_computer/console/preset/command,
+/turf/open/floor/carpet/executive,
+/area/blueshield)
 "vjJ" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/firealarm/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"vlu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood,
+/area/blueshield)
+"vrw" = (
+/obj/machinery/door/airlock/corporate{
+	name = "Blueshield's Quarters";
+	req_access_txt = "20"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/blueshield)
 "vsF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18323,6 +18831,21 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/hallway/secondary/service)
+"vUo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/green,
+/area/command/heads_quarters/captain/private/nt_rep)
+"vXz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "blueprivacy";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/blueshield)
 "vXT" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
@@ -18370,6 +18893,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"whh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/snowed/icemoon,
+/area/blueshield)
 "wop" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18423,6 +18953,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"wxO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "wzf" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/side,
@@ -18433,6 +18967,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
+"wBK" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/green,
+/area/command/heads_quarters/captain/private/nt_rep)
 "wCX" = (
 /obj/machinery/button/flasher{
 	id = "executionflash";
@@ -18457,15 +18995,25 @@
 /area/security/prison/safe)
 "wJt" = (
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
 	id = "Cell 2";
-	name = "Cell 2";
-	dir = 8
+	name = "Cell 2"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
 /area/security/brig)
+"xap" = (
+/obj/structure/chair/comfy/brown{
+	color = "#c45c57";
+	desc = "Remarkably soft, with plush cozy cushions, premium memory-foam and covered in stain-resistant fabric. Made by Kat-Kea???!";
+	dir = 4;
+	name = "Premium Cozy Chair"
+	},
+/obj/effect/landmark/start/nanotrasen_consultant,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "xaF" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/glass/bowl,
@@ -18546,6 +19094,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
+"xqZ" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/green,
+/area/command/heads_quarters/captain/private/nt_rep)
 "xru" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18556,6 +19111,10 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
+"xtB" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
 "xwV" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /obj/structure/disposalpipe/segment,
@@ -18575,6 +19134,38 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/textured,
 /area/security/brig)
+"xDT" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/item/stamp/centcom{
+	pixel_y = 9
+	},
+/obj/item/stamp/denied{
+	pixel_x = 5
+	},
+/obj/item/stamp{
+	pixel_x = -5
+	},
+/turf/open/floor/carpet/green,
+/area/command/heads_quarters/captain/private/nt_rep)
+"xPg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/blueshield)
+"yeE" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/executive,
+/area/blueshield)
+"yfV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/blueshield)
 "yiQ" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -43380,20 +43971,20 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aFp
+aFp
+aFp
+aFp
+aFp
+aFp
+aFp
+aFp
+aFp
+aFp
+aFp
+aFp
+aFp
+aFp
 aak
 aak
 aak
@@ -43632,25 +44223,25 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aFp
+aFp
+aFp
+aFp
+aFp
+aFp
+hRS
+lfl
+lfl
+lfl
+dCz
+cDS
+vXz
+vXz
+vXz
+cDS
+vXz
+cDS
+aFp
 aak
 aak
 aak
@@ -43888,26 +44479,26 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aFp
+aFp
+gkA
+gkA
+gkA
+gkA
+gkA
+hRS
+wxO
+iHD
+iHD
+nlC
+yfV
+uCl
+uCl
+vlu
+dCz
+cyH
+vXz
+aFp
 aak
 aak
 aqn
@@ -44144,27 +44735,27 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aFp
+aFp
+uZE
+uZE
+gqs
+gqs
+xap
+nqa
+hRS
+hkE
+qlm
+hLT
+dCz
+fhx
+yeE
+dbP
+dzJ
+vrw
+uCl
+vXz
+aFp
 aak
 aak
 asT
@@ -44401,27 +44992,27 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aFp
+gkA
+uZE
+gqs
+gqs
+xtB
+xtB
+skl
+hRS
+hRS
+qbf
+rPc
+dCz
+orW
+fwv
+cuk
+hsP
+dCz
+xPg
+vXz
+aFp
 aak
 aak
 aqn
@@ -44658,29 +45249,29 @@ aak
 aak
 aak
 aak
+aFp
+gkA
+kOq
+kOq
+kOq
+kOq
+fdJ
+xqZ
+tfD
+gqs
+qlm
+fBv
+dCz
+vhp
+jAp
+oEs
+dfN
+dCz
+fbh
+vXz
+aFp
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aFp
 aNH
 aNH
 aNH
@@ -44915,29 +45506,29 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aNH
+aFp
+gkA
+wBK
+hRS
+vUo
+rLR
+rLR
+iCF
+dyC
+qKe
+qlm
+hRS
+dCz
+cDS
+vXz
+vXz
+vXz
+cDS
+vXz
+cDS
+aFp
+aFp
+aFp
 aNH
 aNH
 aNH
@@ -45172,32 +45763,32 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aNH
-aNH
-aNH
-aNH
+aFp
+gkA
+kOq
+kOq
+rLR
+fIi
+oBK
+xDT
+hRS
+oWy
+iHD
+gtO
+lXr
+fst
+jJZ
+gNv
+gNv
+whh
+gNv
+gNv
+gNv
+dAP
+dAP
+dAP
+dAP
+dAP
 aak
 aak
 aak
@@ -45429,25 +46020,22 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aFp
+gkA
+gkA
+gqs
+bUT
+gqs
+qqh
+pXc
+hRS
+pmG
+hRS
+hRS
+hRS
+hRS
+jcw
+aFp
 aak
 aak
 aNH
@@ -45455,6 +46043,9 @@ aNH
 aNH
 aNH
 aNH
+aNH
+aNH
+dAP
 aNH
 aak
 aak
@@ -45686,21 +46277,21 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aFp
+aFp
+uZE
+uZE
+sQM
+nfO
+gMw
+bwP
+hRS
+ptS
+hRS
+aFp
+aFp
+aFp
+aFp
 aak
 aak
 aak
@@ -45711,7 +46302,7 @@ aNH
 aHZ
 aNH
 aNH
-aNH
+dAP
 aNH
 aak
 aak
@@ -45944,17 +46535,17 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aFp
+aFp
+gkA
+gkA
+hRS
+hRS
+ddb
+hRS
+hRS
+hRS
+aFp
 aak
 aak
 aak
@@ -45968,7 +46559,7 @@ aos
 aSR
 aNH
 aNH
-aNH
+dAP
 aNH
 aak
 aak
@@ -46202,16 +46793,16 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aFp
+aFp
+ksy
+eNa
+jCK
+nLO
+ksy
+aFp
+aFp
+aFp
 aak
 aak
 aak
@@ -46225,7 +46816,7 @@ avD
 aGD
 aNH
 aNH
-aNH
+dAP
 aEt
 aak
 aak
@@ -46460,13 +47051,13 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aFp
+ksy
+qqh
+pUq
+pJE
+ksy
+aFp
 aak
 aak
 aak
@@ -46482,7 +47073,7 @@ atV
 aXV
 aXV
 aTE
-aNH
+dAP
 aEt
 aEt
 aEt
@@ -46717,13 +47308,13 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aFp
+ksy
+sCK
+tGs
+ksy
+ksy
+aFp
 aak
 aak
 aak
@@ -46739,7 +47330,7 @@ abU
 aAs
 aXV
 aTE
-aNH
+dAP
 aFp
 aFp
 aFp
@@ -46974,13 +47565,13 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aFp
+aFp
+ksy
+ksy
+ksy
+aFp
+aFp
 aak
 aak
 aak
@@ -46996,7 +47587,7 @@ aqi
 aFy
 aXV
 aTE
-aNH
+dAP
 aFp
 aFp
 aFp
@@ -47232,11 +47823,11 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
+aFp
+aFp
+aFp
+aFp
+aFp
 aak
 aak
 aak
@@ -47506,11 +48097,11 @@ aXV
 aHy
 afw
 aic
-aBJ
+hRQ
 aMf
 aKq
 aAP
-asT
+jZr
 aFp
 aPG
 aFp

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above_skyrat.dmm
@@ -16323,6 +16323,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"css" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/blueshield,
+/turf/open/floor/wood,
+/area/blueshield)
 "cuk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -16880,6 +16886,7 @@
 	color = "#596479";
 	dir = 8
 	},
+/obj/effect/landmark/start/blueshield,
 /turf/open/floor/carpet/executive,
 /area/blueshield)
 "fBv" = (
@@ -44765,7 +44772,7 @@ yeE
 dbP
 dzJ
 vrw
-uCl
+css
 vXz
 aFp
 aak


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, I took a lot of inspiration from the blueshift offices when making this. Entrance is in the left bridge area, yes it makes less room to get in, no you weren't using that much space anyways.
~~As the office is directly underneath the windowed area to the left of the bridge, the snow there has been removed so as to allow you to watch the consultant chew out officers for breaking regs, or whatever they do in their offices.~~ Ganymede asked for a cafe, so there we are, a cafe.
Consultant's office has two desks, a fishtank, and the famous employment records, while their bedroom has the pile of smokes and booze/shotglasses from blueshift rep's office. Blueshield gets drinks, and some consoles.
There's a one by one maintenance room with a space heater, god knows they'll need it with the included exterior airlock.
Blueshield and rep offices have privacy shutters/curtains, lobby does not. You cannot have your cake and eat it too.
Beds of both rooms have been strategically positioned so that, as long as they stay entirely on their beds themselves, nobody will be able to peep on either one without removing a window or a wall, in both cases getting command on their asses for breaking into the bridge. So, ya know. Enjoy your "privacy".

My main reason for this PR, and the way I did it, was the lack of a rep's office on blueshift, and wanting to make more use of the extensive space provided by icebox, and for further clarification, I explicitly wanted to put it close to the bridge. Also something something fuck box layouts.

~~Oh yeah, and I stealth removed that FUCKING double plasma window around the SM. It's annoyed me for absolutely forever and I'm truly so tired of it.~~ I got told to not do this, so... eh. Whatever.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Consultant and bluey offices on icebox. What's not to love?

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Pictures
![image](https://user-images.githubusercontent.com/29469766/162115582-04634340-a753-4083-af7e-a484c30ce035.png)
![image](https://user-images.githubusercontent.com/29469766/162115613-17081dcd-1d1b-4ae2-8885-65ca9f28e8c7.png)
![image](https://user-images.githubusercontent.com/29469766/162115631-9aae9d4a-802d-4b48-ad4b-2406116c924d.png)

As a parting note, this will allow players to create whatever they want in that area above the rep's office without needing a holofan, as the area won't have any special air to deal with. Also yes, I tested all this.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Blueshield and Nanotrasen Consultant's offices have made their way to icebox
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
