### PR TITLE
[NEEDS CONFIG CHANGE][Non-Modular] Makes CorpRegs readable again

### DIFF
--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -312,7 +312,8 @@
 	icon_state = "bookSpaceLaw"
 	starting_author = "Nanotrasen"
 	starting_title = "Space Law"
-	page_link = "Space_Law"
+	//page_link = "Space_Law" //ORIGINAL
+	page_link = "Corporate_Regulations" //SKYRAT EDIT CHANGE
 
 /obj/item/book/manual/wiki/security_space_law/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] pretends to read \the [src] intently... then promptly dies of laughter!"))


### PR DESCRIPTION
## About The Pull Request
Fixes Corporate Regulations to actually work.

NOTE: The config for wiki urls at time of posting is currently set to `https://skyrat13.tk/wiki/index.php/Main_Page`

This breaks every manual in the game.

The link needs to be set to `https://skyrat13.tk/wiki/index.php` 

so that urls actually bring you to the correct page

## How This Contributes To The Skyrat Roleplay Experience

I can't even read!

## Changelog

:cl:
fix: Corporate Regulations can finally be read in-game again
/:cl:
