### PR TITLE
Adds Export Scanner To Cargo Borg

### DIFF
--- a/modular_skyrat/modules/cargoborg/code/robot_modules.dm
+++ b/modular_skyrat/modules/cargoborg/code/robot_modules.dm
@@ -15,6 +15,7 @@
 		/obj/item/dest_tagger,
 		/obj/item/crowbar/cyborg,
 		/obj/item/extinguisher,
+		/obj/item/export_scanner,
 	)
 	radio_channels = list(RADIO_CHANNEL_SUPPLY)
 	emag_modules = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Export Scanner to the cargo borg a tool all cargo techs have.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
![image](https://user-images.githubusercontent.com/71794877/162333936-743c6185-de32-41f0-a95c-89eca9089429.png)

## How This Contributes To The Skyrat Roleplay Experience
Cargo Borgs can now check the value of items and crates as well as check manifests for their value.
However they are unable to scan the tip for bounty cubes that will be left up to regular techs.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
Also bonus turns out the sm is worth not much.
![image](https://user-images.githubusercontent.com/71794877/162334014-e3f8fef0-8f8f-46cc-ac0d-79449e34c116.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Cargo Borgs now come equip with a export scanner.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
