### PR TITLE
Restores the RedSec vendor to the Cafe

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -11304,11 +11304,11 @@
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafe)
 "ycT" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/structure/spacevine{
 	name = "thick vines";
 	opacity = 1
 	},
+/obj/machinery/vending/wardrobe/sec_wardrobe/red,
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "ydM" = (

--- a/modular_skyrat/modules/sec_haul/code/misc/vending.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/vending.dm
@@ -90,6 +90,12 @@
 
 //List for the old one, for when its mapped in; curates it nicely, adds /redsec to the items, and also prevents some conflicts with the above vendor
 /obj/machinery/vending/wardrobe/sec_wardrobe/red
+	name = "\improper SecDrobe"
+	desc = "A vending machine for security and security-related clothing!"
+	product_ads = "Beat perps in style!;It's red so you can't see the blood!;You have the right to be fashionable!;Now you can be the fashion police you always wanted to be!"
+	vend_reply = "Thank you for using the SecDrobe!"
+	icon = 'icons/obj/vending.dmi'
+	icon_state = "secdrobe"
 	products = list(/obj/item/clothing/suit/hooded/wintercoat/security/redsec = 3,
 					/obj/item/storage/backpack/security/redsec = 3,
 					/obj/item/storage/backpack/satchel/sec/redsec = 3,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.
I also made the red vendor different from the Blue one, so you can tell it's...Well, the red one.

## How This Contributes To The Skyrat Roleplay Experience

The joke with the red vendor is that it's been tossed into a cave and left to grow over. That doesn't work if it's the exact same vendor.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Cursor
fix: Ghost Cafe management have returned the red sec vendor.
fix: RedSec vendor is now red.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
