### PR TITLE
Adds bowman headset to HECU armaments

### DIFF
--- a/modular_skyrat/modules/black_mesa/code/armaments/armament_utility.dm
+++ b/modular_skyrat/modules/black_mesa/code/armaments/armament_utility.dm
@@ -60,3 +60,8 @@
 	item_type = /obj/item/suppressor
 	max_purchase = 4
 	cost = 4
+
+/datum/armament_entry/hecu/utility/bowman
+	item_type = /obj/item/radio/headset/headset_faction/bowman
+	max_purchase = 3
+	cost = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds 3 bowman headsets to the HECU armament vendor for 4 points each

## How This Contributes To The Skyrat Roleplay Experience
There's only one sound-protecting headset among the HECU, they should be able to get more.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: HECU can now buy bowman headsets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
