### PR TITLE
Fixes OPFOR cancel buttons

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -316,7 +316,7 @@
 				return
 			var/denied_reason = tgui_input_text(usr, "Denial Reason", "Enter a reason for denying this application:")
 			// Checking to see if the user is spamming the button, async and all.
-			if(status == OPFOR_STATUS_DENIED)
+			if((status == OPFOR_STATUS_DENIED) || !denied_reason)
 				return
 			SSopposing_force.deny(src, denied_reason, usr)
 		if("mute_request_updates")
@@ -335,6 +335,8 @@
 			if(!check_rights(R_ADMIN))
 				return
 			var/denied_reason = tgui_input_text(usr, "Denial Reason", "Enter a reason for denying this objective:")
+			if(!denied_reason)
+				return
 			deny_objective(usr, edited_objective, denied_reason)
 		if("approve_equipment")
 			var/datum/opposing_force_selected_equipment/equipment = locate(params["selected_equipment_ref"]) in selected_equipment
@@ -350,6 +352,8 @@
 			if(!check_rights(R_ADMIN))
 				return
 			var/denied_reason = tgui_input_text(usr, "Denial Reason", "Enter a reason for denying this objective:")
+			if(!denied_reason)
+				return
 			deny_equipment(usr, equipment, denied_reason)
 		if("flw_user")
 			if(!check_rights(R_ADMIN))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Admins couldn't cancel denying an OPFOR. Now, if you hit cancel, close the window, or enter an empty reason (you should write one anyway, honestly), it doesn't deny.

## How This Contributes To The Skyrat Roleplay Experience
Bugs bad.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Staff can now cancel denying an OPFOR.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
