### PR TITLE
Armament Fixes

### DIFF
--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -28,7 +28,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 /datum/controller/subsystem/processing/station/proc/SetupTraits()
 	// SKYRAT EDIT ADDITION
 	#ifdef LOWMEMORYMODE // NO MORE FUCKING STUPID STATION TRAITS ON STARTUP WHEN IM TESTING SHIT FUCK YOU
-		return
+	return
 	#endif
 	// SKYRAT EDIT END
 

--- a/modular_skyrat/modules/armaments/code/armament_component.dm
+++ b/modular_skyrat/modules/armaments/code/armament_component.dm
@@ -50,7 +50,7 @@
 	if(!user.can_interact_with(parent_atom))
 		return
 
-	if(!istype(item, /obj/item/armament_points_card))
+	if(!istype(item, /obj/item/armament_points_card) || inserted_card)
 		return
 
 	item.forceMove(parent_atom)

--- a/tgui/packages/tgui/interfaces/ArmamentStation.js
+++ b/tgui/packages/tgui/interfaces/ArmamentStation.js
@@ -77,8 +77,7 @@ export const ArmamentStation = (props, context) => {
                                 fontSize="15px"
                                 textAlign="center"
                                 selected={weapon === item.ref}
-                                disabled={item.purchased >= item.quantity
-                                  || item.purchased >= item.quantity}
+                                color={item.purchased >= item.quantity ? "bad" : "default"}
                                 width="100%"
                                 key={item.ref}
                                 onClick={() =>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stuffing a second armament card into a vendor would effectively delete the first, woo.
Also allows you to purchase ammo for out-of-stock guns

## How This Contributes To The Skyrat Roleplay Experience
bugs bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can no longer insert an armament card into a vendor with one already inside.
fix: You can purchase ammo for out-of-stock armaments.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
