### PR TITLE
Adjusts interlink spawn locations

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -368,8 +368,14 @@
 /turf/open/misc/grass/planet,
 /area/centcom/holding/cafepark)
 "ahu" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /obj/effect/landmark/latejoin,
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/iron/cafeteria,
 /area/centcom/interlink)
 "ahy" = (
 /turf/open/floor/iron/dark/green/corner{
@@ -792,6 +798,7 @@
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/mineral/titanium,
 /area/centcom/interlink)
 "alb" = (
@@ -1134,6 +1141,7 @@
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/mineral/titanium,
 /area/centcom/interlink)
 "ang" = (
@@ -2231,7 +2239,6 @@
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
-/obj/effect/landmark/latejoin,
 /turf/open/floor/iron/brown/side{
 	dir = 6
 	},
@@ -2962,6 +2969,7 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/mineral/titanium,
 /area/centcom/interlink)
 "aCJ" = (
@@ -3133,6 +3141,7 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/mineral/titanium,
 /area/centcom/interlink)
 "aDK" = (
@@ -3754,6 +3763,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/mineral/titanium,
 /area/centcom/interlink)
 "aJy" = (
@@ -5102,7 +5112,6 @@
 /area/centcom/holding/cafepark)
 "aTn" = (
 /obj/structure/chair/sofa/left,
-/obj/effect/landmark/latejoin,
 /turf/open/floor/iron/brown/side{
 	dir = 5
 	},
@@ -5566,6 +5575,7 @@
 /obj/structure/chair/sofa/bench{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/mineral/titanium,
 /area/centcom/interlink)
 "aXl" = (
@@ -5982,6 +5992,7 @@
 	contents = newlist(/obj/item/toy/snappop/phoenix);
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
 "bkA" = (
@@ -7879,7 +7890,6 @@
 /obj/structure/chair/sofa/right{
 	dir = 1
 	},
-/obj/effect/landmark/latejoin,
 /turf/open/floor/iron/brown/side{
 	dir = 4
 	},
@@ -8689,9 +8699,7 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/interlink)
 "nxG" = (
-/obj/structure/closet/secure_closet/brig/genpop{
-	opened = 0
-	},
+/obj/structure/closet/secure_closet/brig/genpop,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "nyc" = (
@@ -8989,9 +8997,7 @@
 /turf/open/misc/asteroid,
 /area/centcom/interlink)
 "oGV" = (
-/obj/structure/closet/secure_closet/brig/genpop{
-	opened = 0
-	},
+/obj/structure/closet/secure_closet/brig/genpop,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -9362,15 +9368,9 @@
 /turf/open/floor/iron/stairs,
 /area/centcom/interlink)
 "qml" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/structure/chair/sofa/bench,
 /obj/effect/landmark/latejoin,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "qnD" = (
 /obj/structure/toilet{
@@ -9949,7 +9949,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/landmark/latejoin,
 /turf/open/floor/iron/brown/side{
 	dir = 4
 	},
@@ -10006,13 +10005,7 @@
 /turf/open/floor/carpet/executive,
 /area/centcom/interlink)
 "sYI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/blue,
 /obj/effect/landmark/latejoin,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
@@ -10050,8 +10043,18 @@
 /turf/open/floor/carpet/orange,
 /area/centcom/interlink)
 "tcR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/effect/landmark/latejoin,
-/turf/open/floor/carpet/green,
+/turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "thU" = (
 /obj/machinery/door/poddoor/ert,
@@ -10457,18 +10460,11 @@
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafepark)
 "uvB" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
 /obj/effect/landmark/latejoin,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "uyr" = (
 /obj/structure/chair/sofa/bench/right{
@@ -10718,10 +10714,6 @@
 "vxA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -18374,7 +18366,7 @@ odG
 aHC
 cmu
 oVj
-tcR
+oVj
 oVj
 aHC
 aaa
@@ -18615,7 +18607,7 @@ axU
 aCJ
 aCJ
 hpS
-pAC
+ahu
 ime
 aHC
 oyX
@@ -20666,7 +20658,7 @@ aHC
 asI
 hvQ
 aFE
-sYd
+aOT
 aOT
 aOT
 dFM
@@ -22984,7 +22976,7 @@ mih
 aNb
 aKj
 aKj
-aDn
+hFE
 aKj
 shf
 aly
@@ -23770,7 +23762,7 @@ dfQ
 dfQ
 uGJ
 dfQ
-wfh
+hvQ
 hvQ
 wcp
 aHC
@@ -24281,7 +24273,7 @@ hvQ
 gBT
 cnS
 kQt
-qml
+uDv
 dfQ
 dfQ
 hvQ
@@ -24534,7 +24526,7 @@ nxG
 aHC
 hvQ
 hvQ
-wfh
+hvQ
 mqd
 snU
 snU
@@ -24796,9 +24788,9 @@ uXJ
 cnS
 cnS
 jTG
-iWd
+vxA
 lUt
-wfh
+hvQ
 hvQ
 hvQ
 aHC
@@ -25303,14 +25295,14 @@ vUk
 aXG
 aXG
 aHC
-akk
+qml
 hvQ
 hvQ
-mqd
+sYI
 snU
 vEn
 cnS
-vxA
+cnS
 jzj
 hvQ
 hvQ
@@ -25562,7 +25554,7 @@ lab
 aHC
 akk
 hvQ
-wfh
+hvQ
 uXJ
 iWd
 iWd
@@ -25822,7 +25814,7 @@ hvQ
 hvQ
 dfQ
 dfQ
-sYI
+xga
 ooR
 cnS
 klo
@@ -26078,12 +26070,12 @@ amv
 hvQ
 hvQ
 dfQ
-dfQ
+tcR
 dfQ
 xga
 ooR
 klo
-wfh
+hvQ
 hvQ
 hvQ
 aHC
@@ -26333,11 +26325,11 @@ hvQ
 qlO
 wcp
 hvQ
-wfh
+hvQ
 dfQ
 dfQ
 dfQ
-uvB
+dfQ
 xga
 lUt
 hvQ
@@ -26849,7 +26841,7 @@ hvQ
 hvQ
 jUz
 aBm
-afe
+uvB
 wkD
 aBm
 afe
@@ -27848,14 +27840,14 @@ ajh
 cGG
 cGG
 cGG
-ahu
+cGG
 cGG
 cGG
 ati
 cGG
 cGG
 cGG
-ahu
+cGG
 cGG
 cGG
 aQz


### PR DESCRIPTION
## About The Pull Request

More spawns on the starboard-side shuttle. No spawns in the cafe area. Shifts a few other ones around for flavour (one by washing machine, another by the arcade, moves a few in the south area to the benches instead of randomly in the middle).

![image](https://user-images.githubusercontent.com/8881105/162791777-ea064ce3-b2b6-49e0-87ed-6921bdd3cae9.png)

## How This Contributes To The Skyrat Roleplay Experience

Spawning on top of people is bad. Spawning in places that make a little more sense than randomly in the middle of a room is good.

## Changelog
:cl:
qol: Late joiners no longer spawn in chairs in the interlink cafe
/:cl: