### PR TITLE
Fixed Veteran-Only species being selectable by non-Veterans

### DIFF
--- a/code/modules/client/preferences/species.dm
+++ b/code/modules/client/preferences/species.dm
@@ -32,9 +32,14 @@
 	return values
 
 /datum/preference/choiced/species/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/prefs)
+	// SKYRAT EDIT START - Veteran-only races
+	var/datum/species/value_typepath = value
+	if(initial(value_typepath.veteran_only) && !is_veteran_player(target.client))
+		value = create_default_value()
+	// SKYRAT EDIT END
 	target.set_species(value, FALSE, FALSE, prefs?.features.Copy(), prefs?.mutant_bodyparts.Copy(), prefs?.body_markings.Copy()) // SKYRAT EDIT - Customization
 
-//SKYRAT EDIT ADDITION
+	//SKYRAT EDIT ADDITION
 	target.dna.update_body_size()
 
 	for(var/organ_key in list(ORGAN_SLOT_VAGINA, ORGAN_SLOT_PENIS, ORGAN_SLOT_BREASTS, ORGAN_SLOT_ANUS))
@@ -66,6 +71,7 @@
 		data[species_id]["enabled_features"] = species.get_features()
 		data[species_id]["perks"] = species.get_species_perks()
 		data[species_id]["diet"] =  species.get_species_diet()
+		data[species_id]["veteran_only"] = species.veteran_only // SKYRAT EDIT ADDITION - Veteran races
 
 		qdel(species)
 


### PR DESCRIPTION
## About The Pull Request
Does what it says on the tin. I now added some extra verification so that, now, if the race is veteran-only and you're trying to apply those prefs to yourself as a non-Veteran, it's not going to work, which means nobody is going to be grandfathered in for a bug.

## How This Contributes To The Skyrat Roleplay Experience
Veteran-Only means Veteran-Only, otherwise it loses all meaning.

## Changelog

:cl: GoldenAlpharex
fix: Fixed Hemophages being selectable by non-Veteran. If you were a non-Veteran and had a Hemophage, it'll convert them to a human when you spawn in, but I'd still recommend making the change to human yourself, just in case something funky happens. The alternative to that is to become a Veteran if you want to keep your Hemophage :)
/:cl: