### PR TITLE
Adds gun cleaning kits to assault op lockers

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -6237,6 +6237,7 @@
 	layer = 2.9
 	},
 /obj/structure/closet/syndicate/personal,
+/obj/item/gun_maintenance_supplies,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "cwh" = (
@@ -6452,6 +6453,9 @@
 /area/cruiser_dock)
 "dHn" = (
 /obj/structure/table/reinforced,
+/obj/item/gun_maintenance_supplies,
+/obj/item/gun_maintenance_supplies,
+/obj/item/gun_maintenance_supplies,
 /turf/open/floor/engine,
 /area/cruiser_dock)
 "dHO" = (
@@ -6773,6 +6777,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/item/gun_maintenance_supplies,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "fta" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Assault op armory lockers get a gun cleaning kit.

## How This Contributes To The Skyrat Roleplay Experience
As an assault op, i dirtied my gun so badly it jammed every three shots *twice*, and there's no simple way of getting more.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Assault ops now get a gun cleaning kit in their lockers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
