### PR TITLE
Returns Xenobiological Slime Hybrid sprites to their pre-Kapulimbs versions

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -806,15 +806,9 @@
 	if(draw_color)
 
 		//SKYRAT EDIT BEGIN - Alpha values on limbs //We check if the limb is attached and if the owner has an alpha value to append
-		if(owner && owner.dna.species)
-			limb.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]" //honestly this is cursed as hell
-		else //Limb is detached
-			limb.color = "[draw_color]"
+		limb.color = owner?.dna.species ? "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]" : "[draw_color]"
 		if(aux_zone)
-			if(owner && owner.dna.species)
-				aux.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]"
-			else
-				aux.color = "[draw_color]"
+			aux.color = owner?.dna.species ? "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]" : "[draw_color]"
 		//SKYRAT EDIT END
 
 	//EMISSIVE CODE START

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -804,7 +804,6 @@
 		draw_color ||= (species_color) || (skin_tone && skintone2hex(skin_tone))
 
 	if(draw_color)
-
 		//SKYRAT EDIT BEGIN - Alpha values on limbs //We check if the limb is attached and if the owner has an alpha value to append
 		limb.color = owner?.dna.species ? "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]" : "[draw_color]"
 		if(aux_zone)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -804,9 +804,9 @@
 		draw_color ||= (species_color) || (skin_tone && skintone2hex(skin_tone))
 
 	if(draw_color)
-		limb.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]" //SKYRAT EDIT - Alpha values on limbs //honestly this is cursed as hell
+		limb.color = "[draw_color][num2hex(owner?.dna.species.specific_alpha, 2)]" //SKYRAT EDIT - Alpha values on limbs //honestly this is cursed as hell
 		if(aux_zone)
-			aux.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]" //SKYRAT EDIT - Alpha values on limbs
+			aux.color = "[draw_color][num2hex(owner?.dna.species.specific_alpha, 2)]" //SKYRAT EDIT - Alpha values on limbs
 
 	//EMISSIVE CODE START
 	if(blocks_emissive)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -804,15 +804,18 @@
 		draw_color ||= (species_color) || (skin_tone && skintone2hex(skin_tone))
 
 	if(draw_color)
-		if(owner && owner.dna.species) //SKYRAT EDIT BEGIN - Alpha values on limbs //We check if the limb is attached and if the owner has an alpha value to append
+
+		//SKYRAT EDIT BEGIN - Alpha values on limbs //We check if the limb is attached and if the owner has an alpha value to append
+		if(owner && owner.dna.species)
 			limb.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]" //honestly this is cursed as hell
 		else //Limb is detached
-			limb.color = "[draw_color]" //SKYRAT EDIT END
+			limb.color = "[draw_color]"
 		if(aux_zone)
-			if(owner && owner.dna.species) //SKYRAT EDIT BEGIN - Alpha values on limbs
+			if(owner && owner.dna.species)
 				aux.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]"
 			else
-				aux.color = "[draw_color]" //SKYRAT EDIT END
+				aux.color = "[draw_color]"
+		//SKYRAT EDIT END
 
 	//EMISSIVE CODE START
 	if(blocks_emissive)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -804,9 +804,9 @@
 		draw_color ||= (species_color) || (skin_tone && skintone2hex(skin_tone))
 
 	if(draw_color)
-		limb.color = "[draw_color]"
+		limb.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]"
 		if(aux_zone)
-			aux.color = "[draw_color]"
+			aux.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]"
 
 	//EMISSIVE CODE START
 	if(blocks_emissive)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -804,9 +804,15 @@
 		draw_color ||= (species_color) || (skin_tone && skintone2hex(skin_tone))
 
 	if(draw_color)
-		limb.color = "[draw_color][num2hex(owner?.dna.species.specific_alpha, 2)]" //SKYRAT EDIT - Alpha values on limbs //honestly this is cursed as hell
+		if(owner && owner.dna.species) //SKYRAT EDIT BEGIN - Alpha values on limbs //We check if the limb is attached and if the owner has an alpha value to append
+			limb.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]" //honestly this is cursed as hell
+		else //Limb is detached
+			limb.color = "[draw_color]" //SKYRAT EDIT END
 		if(aux_zone)
-			aux.color = "[draw_color][num2hex(owner?.dna.species.specific_alpha, 2)]" //SKYRAT EDIT - Alpha values on limbs
+			if(owner && owner.dna.species) //SKYRAT EDIT BEGIN - Alpha values on limbs
+				aux.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]"
+			else
+				aux.color = "[draw_color]" //SKYRAT EDIT END
 
 	//EMISSIVE CODE START
 	if(blocks_emissive)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -804,7 +804,7 @@
 		draw_color ||= (species_color) || (skin_tone && skintone2hex(skin_tone))
 
 	if(draw_color)
-		limb.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]" //SKYRAT EDIT - Alpha values on limbs //honstly this is cursed as hell
+		limb.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]" //SKYRAT EDIT - Alpha values on limbs //honestly this is cursed as hell
 		if(aux_zone)
 			aux.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]" //SKYRAT EDIT - Alpha values on limbs
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -804,9 +804,9 @@
 		draw_color ||= (species_color) || (skin_tone && skintone2hex(skin_tone))
 
 	if(draw_color)
-		limb.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]"
+		limb.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]" //SKYRAT EDIT - Alpha values on limbs //honstly this is cursed as hell
 		if(aux_zone)
-			aux.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]"
+			aux.color = "[draw_color][num2hex(owner.dna.species.specific_alpha, 2)]" //SKYRAT EDIT - Alpha values on limbs
 
 	//EMISSIVE CODE START
 	if(blocks_emissive)

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -88,6 +88,7 @@
 /obj/item/bodypart/r_leg/slime
 	limb_id = SPECIES_SLIMEPERSON
 
+//SKYRAT ADDITION BEGIN -  Roundstartslime bodyparts for Kapulimbs
 ///ROUNDSTARTSLIME
 /obj/item/bodypart/head/roundstartslime
 	limb_id = SPECIES_SLIMEPERSON //same icon state, no real reason to make a new define
@@ -115,6 +116,7 @@
 	limb_id = SPECIES_SLIMEPERSON
 	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
 
+//SKYRAT ADDITION END
 ///ZOMBIE
 /obj/item/bodypart/head/zombie
 	limb_id = SPECIES_ZOMBIE

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -88,35 +88,6 @@
 /obj/item/bodypart/r_leg/slime
 	limb_id = SPECIES_SLIMEPERSON
 
-//SKYRAT ADDITION BEGIN -  Roundstartslime bodyparts for Kapulimbs
-///ROUNDSTARTSLIME
-/obj/item/bodypart/head/roundstartslime
-	limb_id = SPECIES_SLIMEPERSON //same icon state, no real reason to make a new define
-	is_dimorphic = TRUE
-	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi' //Sprite override to not use default slime sprites
-
-/obj/item/bodypart/chest/roundstartslime
-	limb_id = SPECIES_SLIMEPERSON
-	is_dimorphic = TRUE
-	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
-
-/obj/item/bodypart/l_arm/roundstartslime
-	limb_id = SPECIES_SLIMEPERSON
-	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
-
-/obj/item/bodypart/r_arm/roundstartslime
-	limb_id = SPECIES_SLIMEPERSON
-	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
-
-/obj/item/bodypart/l_leg/roundstartslime
-	limb_id = SPECIES_SLIMEPERSON
-	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
-
-/obj/item/bodypart/r_leg/roundstartslime
-	limb_id = SPECIES_SLIMEPERSON
-	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
-
-//SKYRAT ADDITION END
 ///ZOMBIE
 /obj/item/bodypart/head/zombie
 	limb_id = SPECIES_ZOMBIE

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -88,6 +88,33 @@
 /obj/item/bodypart/r_leg/slime
 	limb_id = SPECIES_SLIMEPERSON
 
+///ROUNDSTARTSLIME
+/obj/item/bodypart/head/roundstartslime
+	limb_id = SPECIES_SLIMEPERSON //same icon state, no real reason to make a new define
+	is_dimorphic = TRUE
+	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi' //Sprite override to not use default slime sprites
+
+/obj/item/bodypart/chest/roundstartslime
+	limb_id = SPECIES_SLIMEPERSON
+	is_dimorphic = TRUE
+	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
+
+/obj/item/bodypart/l_arm/roundstartslime
+	limb_id = SPECIES_SLIMEPERSON
+	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
+
+/obj/item/bodypart/r_arm/roundstartslime
+	limb_id = SPECIES_SLIMEPERSON
+	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
+
+/obj/item/bodypart/l_leg/roundstartslime
+	limb_id = SPECIES_SLIMEPERSON
+	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
+
+/obj/item/bodypart/r_leg/roundstartslime
+	limb_id = SPECIES_SLIMEPERSON
+	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
+
 ///ZOMBIE
 /obj/item/bodypart/head/zombie
 	limb_id = SPECIES_ZOMBIE

--- a/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/roundstartslime_bodyparts.dm
+++ b/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/roundstartslime_bodyparts.dm
@@ -1,0 +1,27 @@
+// Roundstartslimes!
+
+/obj/item/bodypart/head/roundstartslime
+	limb_id = SPECIES_SLIMEPERSON //same icon state, no real reason to make a new define
+	is_dimorphic = TRUE
+	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
+
+/obj/item/bodypart/chest/roundstartslime
+	limb_id = SPECIES_SLIMEPERSON
+	is_dimorphic = TRUE
+	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
+
+/obj/item/bodypart/l_arm/roundstartslime
+	limb_id = SPECIES_SLIMEPERSON
+	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
+
+/obj/item/bodypart/r_arm/roundstartslime
+	limb_id = SPECIES_SLIMEPERSON
+	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
+
+/obj/item/bodypart/l_leg/roundstartslime
+	limb_id = SPECIES_SLIMEPERSON
+	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'
+
+/obj/item/bodypart/r_leg/roundstartslime
+	limb_id = SPECIES_SLIMEPERSON
+	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/slime_parts_greyscale.dmi'

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -26,7 +26,7 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/l_leg/slime,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/r_leg/slime,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/slime,
-
+	)
 /datum/action/innate/slime_change
 	name = "Alter Form"
 	check_flags = AB_CHECK_CONSCIOUS

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -19,6 +19,14 @@
 	specific_alpha = 155
 	markings_alpha = 130 //This is set lower than the other so that the alpha values don't stack on top of each other so much
 
+	bodypart_overrides = list( //Overriding jelly bodyparts
+		BODY_ZONE_L_ARM = /obj/item/bodypart/l_arm/slime,
+		BODY_ZONE_R_ARM = /obj/item/bodypart/r_arm/slime,
+		BODY_ZONE_HEAD = /obj/item/bodypart/head/slime,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/l_leg/slime,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/r_leg/slime,
+		BODY_ZONE_CHEST = /obj/item/bodypart/chest/slime,
+
 /datum/action/innate/slime_change
 	name = "Alter Form"
 	check_flags = AB_CHECK_CONSCIOUS

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -27,6 +27,7 @@
 		BODY_ZONE_R_LEG = /obj/item/bodypart/r_leg/slime,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/slime,
 	)
+
 /datum/action/innate/slime_change
 	name = "Alter Form"
 	check_flags = AB_CHECK_CONSCIOUS

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -20,12 +20,12 @@
 	markings_alpha = 130 //This is set lower than the other so that the alpha values don't stack on top of each other so much
 
 	bodypart_overrides = list( //Overriding jelly bodyparts
-		BODY_ZONE_L_ARM = /obj/item/bodypart/l_arm/slime,
-		BODY_ZONE_R_ARM = /obj/item/bodypart/r_arm/slime,
-		BODY_ZONE_HEAD = /obj/item/bodypart/head/slime,
-		BODY_ZONE_L_LEG = /obj/item/bodypart/l_leg/slime,
-		BODY_ZONE_R_LEG = /obj/item/bodypart/r_leg/slime,
-		BODY_ZONE_CHEST = /obj/item/bodypart/chest/slime,
+		BODY_ZONE_L_ARM = /obj/item/bodypart/l_arm/roundstartslime,
+		BODY_ZONE_R_ARM = /obj/item/bodypart/r_arm/roundstartslime,
+		BODY_ZONE_HEAD = /obj/item/bodypart/head/roundstartslime,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/l_leg/roundstartslime,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/r_leg/roundstartslime,
+		BODY_ZONE_CHEST = /obj/item/bodypart/chest/roundstartslime,
 	)
 
 /datum/action/innate/slime_change

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4588,6 +4588,7 @@
 #include "modular_skyrat\master_files\code\modules\surgery\bodyparts\species_parts\_mutant_bodyparts.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\bodyparts\species_parts\akula_bodyparts.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\bodyparts\species_parts\ghoul_bodyparts.dm"
+#include "modular_skyrat\master_files\code\modules\surgery\bodyparts\species_parts\roundstartslime_bodyparts.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\bodyparts\species_parts\insect_bodyparts.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\bodyparts\species_parts\skrell_bodyparts.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\bodyparts\species_parts\teshari_bodyparts.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title says it all.
This change was more than likely unintentional.

Creates new bodyparts for roundstartslime, using their old modular sprites, and overrides `/datum/species/jelly/roundstartslime`'s limbs with them.

Additionally adds alpha value support to limb overlays, based on `species.specific_alpha`.

closes #12729 


Before:
![grafik](https://user-images.githubusercontent.com/83819203/163405067-9b1a668b-bc41-421c-a141-e457c78a7635.png)
After:
![grafik](https://user-images.githubusercontent.com/83819203/163405097-dadef03b-3fb4-4645-8c43-52452978a206.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Many players would like their characters to look the same way as they did before Kapulimbs.
Also, inconsistent sprites bad.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Xenobiological Slime Hybrid sprites are back to normal.
fix: Limbs can now be see-through again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
