### PR TITLE
Bans some stackable quirk combos

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -30,7 +30,6 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Nerve Stapled", "Pacifist", "Nearsighted"),
 		list("No Guns", "Chunky Fingers"),
 		list("Mute", "Social Anxiety"),
-		list("Mute", "Linguist"),
 		list("No Guns", "Stormtrooper Aim")
 		//SKYRAT EDIT ADDITION END
 	)

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -28,9 +28,9 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Extrovert", "Introvert"),
 		//SKYRAT EDIT ADDITION BEGIN
 		list("Nerve Stapled", "Pacifist", "Nearsighted"),
-		list("No Guns", "Chunky Fingers")
-		list("Mute", "Social Anxiety")
-		list("Mute", "Linguist")
+		list("No Guns", "Chunky Fingers"),
+		list("Mute", "Social Anxiety"),
+		list("Mute", "Linguist"),
 		list("No Guns", "Stormtrooper Aim")
 		//SKYRAT EDIT ADDITION END
 	)

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -29,6 +29,9 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		//SKYRAT EDIT ADDITION BEGIN
 		list("Nerve Stapled", "Pacifist", "Nearsighted"),
 		list("No Guns", "Chunky Fingers")
+		list("Mute", "Social Anxiety")
+		list("Mute", "Linguist")
+		list("No Guns", "Stormtrooper Aim")
 		//SKYRAT EDIT ADDITION END
 	)
 

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -28,9 +28,9 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Extrovert", "Introvert"),
 		//SKYRAT EDIT ADDITION BEGIN
 		list("Nerve Stapled", "Pacifist", "Nearsighted"),
-		list("No Guns", "Chunky Fingers"),
+		list("No Guns", "Chunky Fingers", "Stormtrooper Aim"),
 		list("Mute", "Social Anxiety"),
-		list("No Guns", "Stormtrooper Aim")
+		list("No Guns", "Pacifist")
 		//SKYRAT EDIT ADDITION END
 	)
 


### PR DESCRIPTION
## About The Pull Request

Makes a few trait combos (all of them include a skyrat exclusive trait) incompatible, mostly to prevent easy stacking of quirk points. I will take suggestions for more.
Currently includes:
No Guns, Chunky Fingers, and Stormtrooper Aim (Aim only applies to guns, both quirks prevent you from shooting all/almost all guns)
Mute and Social Anxiety (You can't stutter if you can't talk)
Pacifist and No Guns (Too much overlap)

## How This Contributes To The Skyrat Roleplay Experience
It's balanced

## Changelog
:cl:
balance: You can no longer stack some redundant trait combos.
/:cl: