### PR TITLE
Crew Monitor Icons

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -150,7 +150,7 @@ const CrewTableEntry = (props, context) => {
       {/* SKYRAT EDIT END */}
       <Table.Cell collapsing textAlign="center">
         {/* SKYRAT EDIT START - Displaying status Icons */}
-        {oxydam !== undefined ?(
+        {oxydam !== undefined ? (
           <Icon
             name={healthToAttribute(
               oxydam,
@@ -165,11 +165,12 @@ const CrewTableEntry = (props, context) => {
               brutedam,
               HEALTH_COLOR_BY_LEVEL)}
             size={1} />
-            ) : (life_status ? (
-              <Icon name="heart" color="#17d568" size={1} />
-            ) : (
-              <Icon name="skull" color="#B7410E" size={1} />
-            ))}
+        ) : (
+          life_status ? (
+            <Icon name="heart" color="#17d568" size={1} />
+          ) : (
+            <Icon name="skull" color="#B7410E" size={1} />
+          ))}
         {/* SKYRAT EDIT END */}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -165,16 +165,11 @@ const CrewTableEntry = (props, context) => {
               brutedam,
               HEALTH_COLOR_BY_LEVEL)}
             size={1} />
-        ) : ( life_status ?
-          <Icon
-            name="heart"
-            color="#ffffff"
-            size={1} />
-            : <Icon
-              name="skull"
-              color="#ffffff"
-              size={1} />
-        )}
+            ) : (life_status ? (
+              <Icon name="heart" color="#17d568" size={1} />
+            ) : (
+              <Icon name="skull" color="#B7410E" size={1} />
+            ))}
         {/* SKYRAT EDIT END */}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -13,8 +13,8 @@ const HEALTH_COLOR_BY_LEVEL = [
   '#e74c3c',
   '#801308', // SKYRAT EDIT - Original'#ed2814' - darker to help distinguish better,
 ];
-
-const HEALTH_ICON_BY_LEVEL = [// SKYRAT EDIT ADDITION  - Icon status list
+// SKYRAT ADDITION  - Icon status list
+const HEALTH_ICON_BY_LEVEL = [
   'heart',
   'heart',
   'heart',
@@ -22,7 +22,7 @@ const HEALTH_ICON_BY_LEVEL = [// SKYRAT EDIT ADDITION  - Icon status list
   'heartbeat',
   'skull',
 ];
-
+//SKRAY ADDITION - END:
 const jobIsHead = jobId => jobId % 10 === 0;
 
 const jobToColor = jobId => {
@@ -51,12 +51,13 @@ const jobToColor = jobId => {
   return COLORS.department.other;
 };
 
-// SKYRAT EDIT - ORIGINAL: 
+// SKYRAT EDIT - START: 
 const healthToAttribute = (oxy, tox, burn, brute, attributeList) => {
   const healthSum = oxy + tox + burn + brute;
   const level = Math.min(Math.max(Math.ceil(healthSum / 31), 0), 5);
   return attributeList[level];
 };
+//SKRAY EDIT - END:
 
 const HealthStat = props => {
   const { type, value } = props;

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -22,7 +22,7 @@ const HEALTH_ICON_BY_LEVEL = [
   'heartbeat',
   'skull',
 ];
-//SKRAY ADDITION - END:
+// SKRAY ADDITION - END:
 const jobIsHead = jobId => jobId % 10 === 0;
 
 const jobToColor = jobId => {
@@ -57,7 +57,7 @@ const healthToAttribute = (oxy, tox, burn, brute, attributeList) => {
   const level = Math.min(Math.max(Math.ceil(healthSum / 31), 0), 5);
   return attributeList[level];
 };
-//SKRAY EDIT - END:
+// SKRAY EDIT - END:
 
 const HealthStat = props => {
   const { type, value } = props;
@@ -102,11 +102,11 @@ const CrewTable = (props, context) => {
         <Table.Cell bold collapsing textAlign="center">
           Vitals
         </Table.Cell>
-        <Table.Cell bold>
+        <Table.Cell bold collapsing textAlign="center">
           Position
         </Table.Cell>
-        {!!data.link_allowed && (
-          <Table.Cell bold collapsing>
+        {(
+          <Table.Cell bold collapsing textAlign="center">
             Tracking
           </Table.Cell>
         )}
@@ -171,9 +171,9 @@ const CrewTableEntry = (props, context) => {
             color="#ffffff" 
             size={1} />
             :<Icon
-            name="skull"
-            color="#ffffff"
-            size={1} />
+              name="skull"
+              color="#ffffff"
+              size={1} />
         )}
         {/* SKYRAT EDIT END */}
       </Table.Cell>
@@ -193,7 +193,7 @@ const CrewTableEntry = (props, context) => {
         )}
       </Table.Cell>
       <Table.Cell>
-        {area !== undefined ? area : <Icon name="question" color="#ffffff" size={1} /> }
+        {area !== undefined ? area : <Icon name="question" color="#ffffff" size={1} /> } // SKYRAT EDIT - Icon from text 'N/A'
       </Table.Cell>
       {!!link_allowed && (
         <Table.Cell collapsing>

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -1,6 +1,6 @@
 import { sortBy } from 'common/collections';
 import { useBackend } from '../backend';
-import { Box, Button, ColorBox, Section, Table, Icon } from '../components'; // SKYRAT EDIT - ORIGINAL: import { Box, Button, ColorBox, Section, Table }
+import { Box, Button, ColorBox, Section, Table, Icon } from '../components'; // SKYRAT EDIT - ORIGINAL: import { Box, Button, Section, Table }
 import { COLORS } from '../constants';
 import { Window } from '../layouts';
 
@@ -51,7 +51,7 @@ const jobToColor = jobId => {
   return COLORS.department.other;
 };
 
- // SKYRAT EDIT - ORIGINAL: 
+     // SKYRAT EDIT - ORIGINAL: 
 const healthToAttribute = (oxy, tox, burn, brute, attributeList) => {
   const healthSum = oxy + tox + burn + brute;
   const level = Math.min(Math.max(Math.ceil(healthSum / 31), 0), 5);
@@ -148,14 +148,28 @@ const CrewTableEntry = (props, context) => {
       </Table.Cell>
       {/* SKYRAT EDIT END */}
       <Table.Cell collapsing textAlign="center">
+	  {/* SKYRAT EDIT START - Displaying status Icons */}
         {oxydam !== undefined ?(
-			<Icon 
-				name={healthToAttribute(oxydam, toxdam, burndam, brutedam, HEALTH_ICON_BY_LEVEL)}
-				color={healthToAttribute(oxydam, toxdam, burndam, brutedam, HEALTH_COLOR_BY_LEVEL)}
-				size={1}/>
-				) : (
-				life_status ? <Icon name="heart" color="#ffffff" size={1} /> : <Icon name="skull" color="#ffffff" size={1} />
-		)}
+          <Icon 
+            name={healthToAttribute(
+             oxydam,
+             toxdam,
+             burndam,
+             brutedam,
+             HEALTH_ICON_BY_LEVEL)}
+            color={healthToAttribute(
+             oxydam,
+             toxdam,
+             burndam,
+             brutedam,
+             HEALTH_COLOR_BY_LEVEL)}
+            size={1}/>
+        ) : (
+            life_status ? 
+            <Icon name="heart" color="#ffffff" size={1} />:
+            <Icon name="skull" color="#ffffff" size={1} />
+          )}
+      {/* SKYRAT EDIT END */}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
         {oxydam !== undefined ? (

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -19,7 +19,7 @@ const HEALTH_ICON_BY_LEVEL = [// SKYRAT EDIT ADDITION  - Icon status list
   'heart',
   'heart',
   'heart',
-  'crutch',
+  'heartbeat',
   'skull',
 ];
 
@@ -166,13 +166,13 @@ const CrewTableEntry = (props, context) => {
             size={1} />
         ) : (
           life_status ? <Icon 
-              name="heart" 
-              color="#ffffff" 
+            name="heart" 
+            color="#ffffff" 
             size={1} />
             :<Icon
-              name="skull"
-              color="#ffffff"
-              size={1} />
+            name="skull"
+            color="#ffffff"
+            size={1} />
         )}
         {/* SKYRAT EDIT END */}
       </Table.Cell>

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -148,7 +148,7 @@ const CrewTableEntry = (props, context) => {
       </Table.Cell>
       {/* SKYRAT EDIT END */}
       <Table.Cell collapsing textAlign="center">
-       {/* SKYRAT EDIT START - Displaying status Icons */}
+        {/* SKYRAT EDIT START - Displaying status Icons */}
         {oxydam !== undefined ?(
           <Icon 
             name={healthToAttribute(
@@ -165,10 +165,15 @@ const CrewTableEntry = (props, context) => {
               HEALTH_COLOR_BY_LEVEL)}
             size={1} />
         ) : (
-          life_status ? 
-              <Icon name="heart" color="#ffffff" size={1} />
-            :<Icon name="skull" color="#ffffff" size={1} />
-            )}
+          life_status ? <Icon 
+              name="heart" 
+              color="#ffffff" 
+            size={1} />
+            :<Icon
+              name="skull"
+              color="#ffffff"
+              size={1} />
+        )}
         {/* SKYRAT EDIT END */}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -102,11 +102,11 @@ const CrewTable = (props, context) => {
         <Table.Cell bold collapsing textAlign="center">
           Vitals
         </Table.Cell>
-        <Table.Cell bold collapsing textAlign="center">
+        <Table.Cell bold collapsing textAlign="center">{/* SKYRAT EDIT - Centers the text*/}
           Position
         </Table.Cell>
         {(
-          <Table.Cell bold collapsing textAlign="center">
+          <Table.Cell bold collapsing textAlign="center">{/* SKYRAT EDIT - Centers the text and removes old code blocking it from appearing*/}
             Tracking
           </Table.Cell>
         )}

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -166,7 +166,8 @@ const CrewTableEntry = (props, context) => {
               HEALTH_COLOR_BY_LEVEL)}
             size={1} />
         ) : (
-          life_status ? <Icon
+          life_status ?
+          <Icon
             name="heart"
             color="#ffffff"
             size={1} />

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -170,10 +170,10 @@ const CrewTableEntry = (props, context) => {
             name="heart" 
             color="#ffffff" 
             size={1} />
-            :<Icon
-              name="skull"
-              color="#ffffff"
-              size={1} />
+            : <Icon
+                name="skull" 
+                color="#ffffff" 
+                size={1} />
         )}
         {/* SKYRAT EDIT END */}
       </Table.Cell>
@@ -193,7 +193,7 @@ const CrewTableEntry = (props, context) => {
         )}
       </Table.Cell>
       <Table.Cell>
-        {area !== undefined ? area : <Icon name="question" color="#ffffff" size={1} /> } // SKYRAT EDIT - Icon from text 'N/A'
+        {area !== undefined ? area : <Icon name="question" color="#ffffff" size={1} /> } {/* SKYRAT EDIT - Icon from text 'N/A*/}
       </Table.Cell>
       {!!link_allowed && (
         <Table.Cell collapsing>

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -170,7 +170,7 @@ const CrewTableEntry = (props, context) => {
             name="heart"
             color="#ffffff"
             size={1} />
-          : <Icon
+            : <Icon
               name="skull"
               color="#ffffff"
               size={1} />

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -1,6 +1,6 @@
 import { sortBy } from 'common/collections';
 import { useBackend } from '../backend';
-import { Box, Button, ColorBox, Section, Table, Icon } from '../components'; // SKYRAT EDIT - ORIGINAL: import { Box, Button, Section, Table }
+import { Box, Button, Section, Table, Icon } from '../components'; // SKYRAT EDIT - ORIGINAL: import { Box, Button, Section, Colorbox Table }
 import { COLORS } from '../constants';
 import { Window } from '../layouts';
 
@@ -51,7 +51,7 @@ const jobToColor = jobId => {
   return COLORS.department.other;
 };
 
-     // SKYRAT EDIT - ORIGINAL: 
+// SKYRAT EDIT - ORIGINAL: 
 const healthToAttribute = (oxy, tox, burn, brute, attributeList) => {
   const healthSum = oxy + tox + burn + brute;
   const level = Math.min(Math.max(Math.ceil(healthSum / 31), 0), 5);
@@ -148,28 +148,28 @@ const CrewTableEntry = (props, context) => {
       </Table.Cell>
       {/* SKYRAT EDIT END */}
       <Table.Cell collapsing textAlign="center">
-	  {/* SKYRAT EDIT START - Displaying status Icons */}
+       {/* SKYRAT EDIT START - Displaying status Icons */}
         {oxydam !== undefined ?(
           <Icon 
             name={healthToAttribute(
-             oxydam,
-             toxdam,
-             burndam,
-             brutedam,
-             HEALTH_ICON_BY_LEVEL)}
+              oxydam,
+              toxdam,
+              burndam,
+              brutedam,
+              HEALTH_ICON_BY_LEVEL)}
             color={healthToAttribute(
-             oxydam,
-             toxdam,
-             burndam,
-             brutedam,
-             HEALTH_COLOR_BY_LEVEL)}
-            size={1}/>
+              oxydam,
+              toxdam,
+              burndam,
+              brutedam,
+              HEALTH_COLOR_BY_LEVEL)}
+            size={1} />
         ) : (
-            life_status ? 
-            <Icon name="heart" color="#ffffff" size={1} />:
-            <Icon name="skull" color="#ffffff" size={1} />
-          )}
-      {/* SKYRAT EDIT END */}
+          life_status ? 
+              <Icon name="heart" color="#ffffff" size={1} />
+            :<Icon name="skull" color="#ffffff" size={1} />
+            )}
+        {/* SKYRAT EDIT END */}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
         {oxydam !== undefined ? (

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -51,7 +51,7 @@ const jobToColor = jobId => {
   return COLORS.department.other;
 };
 
-// SKYRAT EDIT - START: 
+// SKYRAT EDIT - START:
 const healthToAttribute = (oxy, tox, burn, brute, attributeList) => {
   const healthSum = oxy + tox + burn + brute;
   const level = Math.min(Math.max(Math.ceil(healthSum / 31), 0), 5);
@@ -151,7 +151,7 @@ const CrewTableEntry = (props, context) => {
       <Table.Cell collapsing textAlign="center">
         {/* SKYRAT EDIT START - Displaying status Icons */}
         {oxydam !== undefined ?(
-          <Icon 
+          <Icon
             name={healthToAttribute(
               oxydam,
               toxdam,
@@ -166,14 +166,14 @@ const CrewTableEntry = (props, context) => {
               HEALTH_COLOR_BY_LEVEL)}
             size={1} />
         ) : (
-          life_status ? <Icon 
-            name="heart" 
-            color="#ffffff" 
+          life_status ? <Icon
+            name="heart"
+            color="#ffffff"
             size={1} />
-            : <Icon
-                name="skull" 
-                color="#ffffff" 
-                size={1} />
+          : <Icon
+              name="skull"
+              color="#ffffff"
+              size={1} />
         )}
         {/* SKYRAT EDIT END */}
       </Table.Cell>

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -4,13 +4,23 @@ import { Box, Button, ColorBox, Section, Table, Icon } from '../components'; // 
 import { COLORS } from '../constants';
 import { Window } from '../layouts';
 
+
 const HEALTH_COLOR_BY_LEVEL = [
   '#17d568',
-  '#2ecc71',
+  '#c4cf2d', // SKYRAT EDIT - Original'#2ecc71' - moved to make it visually different,
   '#e67e22',
   '#ed5100',
   '#e74c3c',
-  '#ed2814',
+  '#801308', // SKYRAT EDIT - Original'#ed2814' - darker to help distinguish better,
+];
+
+const HEALTH_ICON_BY_LEVEL = [// SKYRAT EDIT ADDITION  - Icon status list
+  'heart',
+  'heart',
+  'heart',
+  'heart',
+  'crutch',
+  'skull',
 ];
 
 const jobIsHead = jobId => jobId % 10 === 0;
@@ -41,10 +51,11 @@ const jobToColor = jobId => {
   return COLORS.department.other;
 };
 
-const healthToColor = (oxy, tox, burn, brute) => {
+ // SKYRAT EDIT - ORIGINAL: 
+const healthToAttribute = (oxy, tox, burn, brute, attributeList) => {
   const healthSum = oxy + tox + burn + brute;
-  const level = Math.min(Math.max(Math.ceil(healthSum / 25), 0), 5);
-  return HEALTH_COLOR_BY_LEVEL[level];
+  const level = Math.min(Math.max(Math.ceil(healthSum / 31), 0), 5);
+  return attributeList[level];
 };
 
 const HealthStat = props => {
@@ -137,16 +148,14 @@ const CrewTableEntry = (props, context) => {
       </Table.Cell>
       {/* SKYRAT EDIT END */}
       <Table.Cell collapsing textAlign="center">
-        {life_status ? (
-          <ColorBox
-            color={healthToColor(
-              oxydam,
-              toxdam,
-              burndam,
-              brutedam)} />
-        ) : (
-          <ColorBox color={'#ed2814'} />
-        )}
+        {oxydam !== undefined ?(
+			<Icon 
+				name={healthToAttribute(oxydam, toxdam, burndam, brutedam, HEALTH_ICON_BY_LEVEL)}
+				color={healthToAttribute(oxydam, toxdam, burndam, brutedam, HEALTH_COLOR_BY_LEVEL)}
+				size={1}/>
+				) : (
+				life_status ? <Icon name="heart" color="#ffffff" size={1} /> : <Icon name="skull" color="#ffffff" size={1} />
+		)}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
         {oxydam !== undefined ? (
@@ -164,7 +173,7 @@ const CrewTableEntry = (props, context) => {
         )}
       </Table.Cell>
       <Table.Cell>
-        {area !== undefined ? area : 'N/A'}
+        {area !== undefined ? area : <Icon name="question" color="#ffffff" size={1} /> }
       </Table.Cell>
       {!!link_allowed && (
         <Table.Cell collapsing>

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -165,8 +165,7 @@ const CrewTableEntry = (props, context) => {
               brutedam,
               HEALTH_COLOR_BY_LEVEL)}
             size={1} />
-        ) : (
-          life_status ?
+        ) : ( life_status ?
           <Icon
             name="heart"
             color="#ffffff"


### PR DESCRIPTION
Adds icons to the Crew Monitor to spread out the colors as well as add specific icons for death/critical.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the crew monitor tgui to be a little more friendly on the eyes, making it easier to tell the differences relating to individual crew health.

## How This Contributes To The Skyrat Roleplay Experience

Makes it easier for those with color challenges to spot the few-shades-of-red-difference between somewhat hurt, critical and dead. I also gave a Question mark to Binary trackers rather than it just saying N/A. Binary sensors will state Alive/Dead still alongside a subsequent skull or heart.

## Changelog
![image_2022-04-13_185755405](https://user-images.githubusercontent.com/22140677/163288472-ae826be6-fb22-47d2-a576-cd3a06ac29f1.png)
![image_2022-04-13_185740537](https://user-images.githubusercontent.com/22140677/163288444-54807bb8-f3e7-498a-8f42-73b335ab28c0.png)

- Adds icons to states of life
- Adds icons to N/A tracking on Binary sensors
- Changes the math to better suit SkyRat's player health pool rather than TG's 
- Changes the harmed state to be yellow-green rather than a slightly darker shade of green from healthy
- Changes the death state to be a darker read rather than a slightly darker shade of red from Crit

:cl:
add: icons to all states of living on the Crew Monitor
expansion: Critical and death now have a visual icon difference
del: old attribute math and gave it something more dynamic
/:cl:
