### PR TITLE
There Is Only One Free Man aka Stop Cloning Gordon Freeman aka Make This Var Standard for new Mob Code

### DIFF
--- a/modular_skyrat/modules/black_mesa/code/mobs/gordon_freeman.dm
+++ b/modular_skyrat/modules/black_mesa/code/mobs/gordon_freeman.dm
@@ -20,6 +20,7 @@
 	wander = FALSE
 	attack_sound = 'modular_skyrat/master_files/sound/weapons/crowbar2.ogg'
 	loot = list(/obj/item/crowbar/freeman/ultimate, /obj/item/keycard/freeman_boss_exit)
+	gold_core_spawnable = NO_SPAWN
 
 /obj/structure/xen_pylon/freeman
 	shield_range = 30


### PR DESCRIPTION
## About The Pull Request

Removes Gordon Freeman from the gold slime core pool

## How This Contributes To The Skyrat Roleplay Experience

jesus funkin christ

gold_core_spawnable var should be a requirement if you add any mobs to the game

I can only handle having to fight off random hostile mobs with 1000 health that can three shot everyone once and it wasn't funny the first time yes this is an ided PR

coders PLEASE

also yeah we don't want the funny crowbar on station in crew hands either

## Changelog

:cl:
fix: Gordon Freeman can no longer be cloned through esoteric means related to bluespace and gold slime cores. Stay in Half Life IDIOT.
/:cl:
