### PR TITLE
CI, Shadowperson, Nightmare, Holodeck, Lore & Description Runtimes & Moth Eyes Fixing Combo PR

### DIFF
--- a/code/modules/antagonists/nightmare/nightmare.dm
+++ b/code/modules/antagonists/nightmare/nightmare.dm
@@ -13,4 +13,5 @@
 	name = "Nightmare (Preview only)"
 
 /datum/outfit/nightmare/post_equip(mob/living/carbon/human/human, visualsOnly)
-	human.set_species(/datum/species/shadow/nightmare)
+	if(SSoverlays.initialized == TRUE)
+		human.set_species(/datum/species/shadow/nightmare) // SKYRAT EDIT: Ours does not work with nightmares, so we have a special copy of the TG version!

--- a/code/modules/antagonists/nightmare/nightmare.dm
+++ b/code/modules/antagonists/nightmare/nightmare.dm
@@ -13,5 +13,5 @@
 	name = "Nightmare (Preview only)"
 
 /datum/outfit/nightmare/post_equip(mob/living/carbon/human/human, visualsOnly)
-	if(SSoverlays.initialized == TRUE)
-		human.set_species(/datum/species/shadow/nightmare) // SKYRAT EDIT: Ours does not work with nightmares, so we have a special copy of the TG version!
+	if(SSoverlays.initialized == TRUE) // SKYRAT EDIT: Fixing CI by delaying this for our custom system.
+		human.set_species(/datum/species/shadow/nightmare) // SKYRAT EDIT

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -92,13 +92,8 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 
 /obj/machinery/computer/holodeck/LateInitialize()//from here linked is populated and the program list is generated. its also set to load the offline program
 	linked = GLOB.areas_by_type[mapped_start_area]
-	// SKYRAT EDIT BEGIN: Fixing CI with our maps
-	bottom_left = locate(linked?.x, linked?.y, src.z)
-	if(!bottom_left)
-		log_world("No matching holodeck area found - Skyrat Edition (addition?)")
-		qdel(src)
-		return
-		// SKYRAT EDIT END
+	bottom_left = locate(linked.x, linked.y, src.z)
+
 	var/area/computer_area = get_area(src)
 	if(istype(computer_area, /area/holodeck))
 		log_mapping("Holodeck computer cannot be in a holodeck, This would cause circular power dependency.")

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -92,8 +92,13 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 
 /obj/machinery/computer/holodeck/LateInitialize()//from here linked is populated and the program list is generated. its also set to load the offline program
 	linked = GLOB.areas_by_type[mapped_start_area]
-	bottom_left = locate(linked?.x, linked?.y, src.z) // SKYRAT EDIT: Fixing CI with our maps
-
+	// SKYRAT EDIT BEGIN: Fixing CI with our maps
+	bottom_left = locate(linked?.x, linked?.y, src.z)
+	if(!bottom_left)
+		log_world("No matching holodeck area found - Skyrat Edition (addition?)")
+		qdel(src)
+		return
+		// SKYRAT EDIT END
 	var/area/computer_area = get_area(src)
 	if(istype(computer_area, /area/holodeck))
 		log_mapping("Holodeck computer cannot be in a holodeck, This would cause circular power dependency.")

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -92,7 +92,7 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 
 /obj/machinery/computer/holodeck/LateInitialize()//from here linked is populated and the program list is generated. its also set to load the offline program
 	linked = GLOB.areas_by_type[mapped_start_area]
-	bottom_left = locate(linked.x, linked.y, src.z)
+	bottom_left = locate(linked?.x, linked?.y, src.z) // SKYRAT EDIT: Fixing CI with our maps
 
 	var/area/computer_area = get_area(src)
 	if(istype(computer_area, /area/holodeck))

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -17,7 +17,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC
 	mutanteyes = /obj/item/organ/eyes/night_vision
 	species_language_holder = /datum/language_holder/shadowpeople
-	examine_limb_id = SPECIES_SHADOW
+	examine_limb_id = SPECIES_SHADOW // SKYRAT EDIT: Fixing Shadowpeople
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/l_arm/shadow,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/r_arm/shadow,

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -17,7 +17,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC
 	mutanteyes = /obj/item/organ/eyes/night_vision
 	species_language_holder = /datum/language_holder/shadowpeople
-
+	examine_limb_id = SPECIES_SHADOW
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/l_arm/shadow,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/r_arm/shadow,

--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -100,15 +100,6 @@
 	ignore += typesof(/turf/open/openspace/ocean)
 	//Baseturf editors can only go up to ten, stop this.
 	ignore += typesof(/obj/effect/baseturf_helper)
-	// I have no idea why this is failing to delete.
-	ignore += list(
-		/obj/item/bodypart/head/shadow,
-		/obj/item/bodypart/chest/shadow,
-		/obj/item/bodypart/l_arm/shadow,
-		/obj/item/bodypart/r_arm/shadow,
-		/obj/item/bodypart/l_leg/shadow,
-		/obj/item/bodypart/r_leg/shadow,
-	)
 	//SKYRAT EDIT END
 
 	var/list/cached_contents = spawn_at.contents.Copy()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -288,8 +288,8 @@ GLOBAL_LIST_EMPTY(customizable_races)
 /datum/species/vampire
 	mutant_bodyparts = list()
 
-/datum/species/hemophage
-	mutant_bodyparts = list()
+/* /datum/species/hemophage
+	mutant_bodyparts = list() */ // Expanded in another file.
 
 /datum/species/plasmaman
 	mutant_bodyparts = list()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -288,9 +288,6 @@ GLOBAL_LIST_EMPTY(customizable_races)
 /datum/species/vampire
 	mutant_bodyparts = list()
 
-/* /datum/species/hemophage
-	mutant_bodyparts = list() */ // Expanded in another file.
-
 /datum/species/plasmaman
 	mutant_bodyparts = list()
 	can_have_genitals = FALSE

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
@@ -76,3 +76,9 @@
 	if(BMS)
 		markings = assemble_body_markings_from_set(BMS, passed_features, src)
 	return markings
+
+/datum/species/akula/get_species_description()
+	return placeholder_description
+
+/datum/species/akula/get_species_lore()
+	return list(placeholder_lore)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
@@ -82,7 +82,7 @@
 	return markings
 
 /datum/species/aquatic/get_species_description()
-	return "Placeholder Description - Fill me!"
+	return placeholder_description
 
 /datum/species/aquatic/get_species_lore()
-	return list("Placeholder Lore - Fill me!")
+	return list(placeholder_lore)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
@@ -80,3 +80,9 @@
 	if(BMS)
 		markings = assemble_body_markings_from_set(BMS, passed_features, src)
 	return markings
+
+/datum/species/aquatic/get_species_description()
+	return "Placeholder Description - Fill me!"
+
+/datum/species/aquatic/get_species_lore()
+	return list("Placeholder Lore - Fill me!")

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
@@ -26,3 +26,9 @@
 	disliked_food = JUNKFOOD | FRIED | CLOTH //Dwarves hate foods that have no nutrition other than alcohol.
 	species_language_holder = /datum/language_holder/dwarf
 	learnable_languages = list(/datum/language/common, /datum/language/dwarf)
+
+/datum/species/dwarf/get_species_description()
+	return placeholder_description
+
+/datum/species/dwarf/get_species_lore()
+	return list(placeholder_lore)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/ghoul.dm
@@ -217,3 +217,9 @@
 	var/obj/item/bodypart/r_arm/part_default_r_arm = /obj/item/bodypart/r_arm
 	var/obj/item/bodypart/l_leg/part_default_l_leg = /obj/item/bodypart/l_leg
 	var/obj/item/bodypart/r_leg/part_default_r_leg = /obj/item/bodypart/r_leg
+
+/datum/species/ghoul/get_species_description()
+	return placeholder_description
+
+/datum/species/ghoul/get_species_lore()
+	return list(placeholder_lore)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
@@ -83,7 +83,9 @@
 		vampire.IgniteMob()
 
 /datum/species/hemophage/get_species_description()
-	return placeholder_description
+	return "Oftentimes feared for the different bits of folklore surrounding their condition, \
+		Hemophages are typically mixed amongst the crew, hiding away their blood-deficiency and \
+		the benefits that come from it from most, to enjoy a nearly-normal existence on the Frontier."
 
 /datum/species/hemophage/get_species_lore()
 	return list("Though known by many other names, 'Hemophages' are those that have found themselves the host of a bloodthirsty infection. Initially entering their hosts through the bloodstream, or activating after a period of dormancy in infants, this infection initially travels to the chest first. Afterwards, it infects several cells, making countless alterations to their genetic sequence, until it starts rapidly expanding and taking over every nearby organ, notably the heart, lungs, and stomach, forming a massive tumor vaguely reminiscent of an overgrown, coal-black heart, that hijacks them for its own benefit, and in exchange, allows the host to 'sense' the quality, and amount of blood currently occupying their body.",

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
@@ -86,7 +86,11 @@
 	return placeholder_description
 
 /datum/species/hemophage/get_species_lore()
-	return list(placeholder_lore)
+	return list("Though known by many other names, 'Hemophages' are those that have found themselves the host of a bloodthirsty infection. Initially entering their hosts through the bloodstream, or activating after a period of dormancy in infants, this infection initially travels to the chest first. Afterwards, it infects several cells, making countless alterations to their genetic sequence, until it starts rapidly expanding and taking over every nearby organ, notably the heart, lungs, and stomach, forming a massive tumor vaguely reminiscent of an overgrown, coal-black heart, that hijacks them for its own benefit, and in exchange, allows the host to 'sense' the quality, and amount of blood currently occupying their body.",
+    "While this kills the host initially, the tumor will jumpstart the body and begin functioning as a surrogate to keep their host going. This does confer certain advantages to the host, in the interest of keeping them alive; working anaerobically, requiring no food to function, and extending their lifespan dramatically. However, this comes at a cost, as the tumor changes their host into an obligate hemophage; only the enzymes, and iron in blood being able to fuel them. If they are to run out of blood, the tumor will begin consuming its own host.",
+    "Historically, Hemophages have caused great societal strife through their very existence. Many have reported dread on having someone reveal they require blood to survive, worse on learning they have been undead, espiecally in 'superstitious' communities. In many places they occupy a sort of second class, unable to live normal lives due to their condition being a sort of skeleton in their closet. Some can actually be found in slaughterhouses or the agricultural industry, gaining easy access to a large supply of animal blood to feed their eternal thirst.",
+    "Others find their way into mostly-vampiric communities, turning others into their own kind; though, the virus can only transmit to hosts that are incredibly low on blood, taking advantage of their reduced immune system efficiency and higher rate of blood creation to be able to survive the initial few days within their host.",
+    "\"What the fuck does any of this mean?\" - Doctor Micheals, reading their CentCom report about the new 'hires'.")
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/bat
 	name = "Bat Form"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage.dm
@@ -82,6 +82,11 @@
 		vampire.adjust_fire_stacks(3 * delta_time)
 		vampire.IgniteMob()
 
+/datum/species/hemophage/get_species_description()
+	return placeholder_description
+
+/datum/species/hemophage/get_species_lore()
+	return list(placeholder_lore)
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/bat
 	name = "Bat Form"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
@@ -29,3 +29,9 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	payday_modifier = 0.75
 	examine_limb_id = SPECIES_HUMAN
+
+/datum/species/humanoid/get_species_description()
+	return placeholder_description
+
+/datum/species/humanoid/get_species_lore()
+	return list(placeholder_lore)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
@@ -31,7 +31,7 @@
 	examine_limb_id = SPECIES_HUMAN
 
 /datum/species/humanoid/get_species_description()
-	return placeholder_description + "\n This is a template species for your own creations!"
+	return "\n This is a template species for your own creations!"
 
 /datum/species/humanoid/get_species_lore()
 	return list("Make sure you fill out your own custom species lore!")

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
@@ -31,7 +31,7 @@
 	examine_limb_id = SPECIES_HUMAN
 
 /datum/species/humanoid/get_species_description()
-	return "\n This is a template species for your own creations!"
+	return "This is a template species for your own creations!"
 
 /datum/species/humanoid/get_species_lore()
 	return list("Make sure you fill out your own custom species lore!")

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
@@ -31,7 +31,7 @@
 	examine_limb_id = SPECIES_HUMAN
 
 /datum/species/humanoid/get_species_description()
-	return placeholder_description
+	return placeholder_description + "\n This is a template species for your own creations!"
 
 /datum/species/humanoid/get_species_lore()
-	return list(placeholder_lore)
+	return list("Make sure you fill out your own custom species lore!")

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
@@ -48,3 +48,9 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/l_leg/mutant/insect,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/r_leg/mutant/insect,
 	)
+
+/datum/species/insect/get_species_description()
+	return placeholder_description
+
+/datum/species/insect/get_species_lore()
+	return list(placeholder_lore)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
@@ -105,7 +105,7 @@
 	return markings
 
 /datum/species/mammal/get_species_description()
-	return placeholder_description + "\n This is a template species for your own creations!"
+	return "\n This is a template species for your own creations!"
 
 
 /datum/species/mammal/get_species_lore()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
@@ -105,7 +105,7 @@
 	return markings
 
 /datum/species/mammal/get_species_description()
-	return "\n This is a template species for your own creations!"
+	return "This is a template species for your own creations!"
 
 
 /datum/species/mammal/get_species_lore()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
@@ -105,7 +105,8 @@
 	return markings
 
 /datum/species/mammal/get_species_description()
-	return placeholder_description
+	return placeholder_description + "\n This is a template species for your own creations!"
+
 
 /datum/species/mammal/get_species_lore()
-	return list(placeholder_lore)
+	return list("Make sure you fill out your own custom species lore!")

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
@@ -104,3 +104,8 @@
 		markings = assemble_body_markings_from_set(BMS, passed_features, src)
 	return markings
 
+/datum/species/mammal/get_species_description()
+	return placeholder_description
+
+/datum/species/mammal/get_species_lore()
+	return list(placeholder_lore)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/moth.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/moth.dm
@@ -1,25 +1,13 @@
 /datum/species/moth
-	mutant_bodyparts = list()
 	default_mutant_bodyparts = list(
 		"fluff" = "None",
 		"wings" = ACC_RANDOM,
 		"moth_antennae" = ACC_RANDOM
 	)
-	species_traits = list(
-		LIPS,
-		NOEYESPRITES,
-		HAS_FLESH,
-		HAS_BONE,
-		HAS_MARKINGS,
-		MUTCOLORS
-	)
-	inherent_traits = list(
-		TRAIT_ADVANCEDTOOLUSER,
-		TRAIT_CAN_STRIP,
-		TRAIT_CAN_USE_FLIGHT_POTION,
-	)
-	learnable_languages = list(/datum/language/common, /datum/language/moffic)
-	payday_modifier = 0.75
+
+/datum/species/moth/New()
+	. = ..()
+	species_traits |= MUTCOLORS
 
 /datum/species/moth/get_random_body_markings(list/passed_features)
 	var/name = "None"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/placeholder_helper.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/placeholder_helper.dm
@@ -1,4 +1,4 @@
 /datum/species
-	var/placeholder_description = "Placeholder Description! Please fill me out!"
-	var/placeholder_lore = "Placeholder Lore! Please fill me out!"
+	var/placeholder_description = "Placeholder Description! Please fill me out! Ask a developer for guidance."
+	var/placeholder_lore = "Placeholder Lore! Come fill me out! Ask a developer for guidance."
 	payday_modifier = 0.75

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/placeholder_helper.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/placeholder_helper.dm
@@ -1,0 +1,4 @@
+/datum/species
+	var/placeholder_description = "Placeholder Description! Please fill me out!"
+	var/placeholder_lore = "Placeholder Lore! Please fill me out!"
+	payday_modifier = 0.75

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/placeholder_helper.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/placeholder_helper.dm
@@ -1,4 +1,4 @@
 /datum/species
-	var/placeholder_description = "Placeholder Description! Please fill me out! Ask a developer for guidance."
-	var/placeholder_lore = "Placeholder Lore! Come fill me out! Ask a developer for guidance."
+	var/placeholder_description = "Placeholder Description! Will you be the only to write a description?  (Contact a maintainer today!)"
+	var/placeholder_lore = "Placeholder Lore! Will you be the one to add lore here? (Contact a maintainer today!)"
 	payday_modifier = 0.75

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic/_robotic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic/_robotic.dm
@@ -64,3 +64,9 @@
 
 /datum/species/robotic/get_types_to_preload()
 	return ..() - typesof(/obj/item/organ/cyberimp/arm/power_cord) // Don't cache things that lead to hard deletions.
+
+/datum/species/robotic/get_species_description()
+	return placeholder_description
+
+/datum/species/robotic/get_species_lore()
+	return list(placeholder_lore)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -7,6 +7,12 @@
 	learnable_languages = list(/datum/language/common, /datum/language/slime)
 	payday_modifier = 0.75
 
+/datum/species/jelly/get_species_description()
+	return placeholder_description
+
+/datum/species/jelly/get_species_lore()
+	return list(placeholder_lore)
+
 /datum/species/jelly/roundstartslime
 	name = "Xenobiological Slime Hybrid"
 	id = SPECIES_SLIMESTART

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
@@ -47,7 +47,11 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/l_leg/mutant/skrell,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/r_leg/mutant/skrell,
 	)
+/datum/species/skrell/get_species_description()
+	return placeholder_description
 
+/datum/species/skrell/get_species_lore()
+	return list(placeholder_lore)
 /obj/item/organ/tongue/skrell
 	name = "internal vocal sacs"
 	desc = "An Strange looking sac."

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -91,3 +91,9 @@
 		randname += " [pick(GLOB.last_names_taj)]"
 
 	return randname
+
+/datum/species/tajaran/get_species_description()
+	return placeholder_description
+
+/datum/species/tajaran/get_species_lore()
+	return list(placeholder_lore)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
@@ -73,3 +73,9 @@
 	returned["mcolor2"] = second_color
 	returned["mcolor3"] = second_color
 	return returned
+
+/datum/species/unathi/get_species_description()
+	return placeholder_description
+
+/datum/species/unathi/get_species_lore()
+	return list(placeholder_lore)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vox.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vox.dm
@@ -109,3 +109,9 @@
 
 /datum/species/vox/set_custom_worn_icon(item_slot, obj/item/item, icon/icon)
 	item.worn_icon_vox = icon
+
+/datum/species/vox/get_species_description()
+	return placeholder_description
+
+/datum/species/vox/get_species_lore()
+	return list(placeholder_lore)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/vulpkanin.dm
@@ -91,3 +91,9 @@
 		randname += " [pick(GLOB.last_names_vulp)]"
 
 	return randname
+
+/datum/species/vulpkanin/get_species_description()
+	return placeholder_description
+
+/datum/species/vulpkanin/get_species_lore()
+	return list(placeholder_lore)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
@@ -41,3 +41,9 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/l_leg/mutant/xenohybrid,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/r_leg/mutant/xenohybrid,
 	)
+
+/datum/species/xeno/get_species_description()
+	return placeholder_description
+
+/datum/species/xeno/get_species_lore()
+	return list(placeholder_lore)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5028,6 +5028,7 @@
 #include "modular_skyrat\modules\customization\modules\mob\living\carbon\human\species\lizard.dm"
 #include "modular_skyrat\modules\customization\modules\mob\living\carbon\human\species\mammal.dm"
 #include "modular_skyrat\modules\customization\modules\mob\living\carbon\human\species\moth.dm"
+#include "modular_skyrat\modules\customization\modules\mob\living\carbon\human\species\placeholder_helper.dm"
 #include "modular_skyrat\modules\customization\modules\mob\living\carbon\human\species\podweak.dm"
 #include "modular_skyrat\modules\customization\modules\mob\living\carbon\human\species\roundstartslime.dm"
 #include "modular_skyrat\modules\customization\modules\mob\living\carbon\human\species\skrell.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Our things are all out of sorts, so I spent the day chasing down these things in the quest for a green checkmark. 
Tested to work and not cause runtimes, but logic errors may be new with the shadowperson fix. Currently, they appear as a naked human on the preference menu. I'll take that over runtimes and failing CI, though! They work properly otherwise!

## How This Contributes To The Skyrat Roleplay Experience

Makes development easier once again when CI works. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Moth eyes work again.
fix: Shadowpeople & nightmares on the preferences no longer cause the game to fail CI & Runtime.
fix: Lore and Descriptions no longer runtime from no content. There is still no real content. 
fix: CI works again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
