### PR TITLE
Meta bs gas vendor tweak

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -31535,6 +31535,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/bluespace_vendor/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "kgl" = (
@@ -49144,7 +49145,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/bluespace_vendor/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "qID" = (
@@ -52487,7 +52487,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/bluespace_vendor/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -60975,17 +60974,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/security/office)
-"vlz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/bluespace_vendor/directional/north,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "vlQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -85112,7 +85100,7 @@ baE
 bnM
 baE
 baE
-vlz
+jMF
 nRF
 bNK
 ikK

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -49145,6 +49145,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/bluespace_vendor/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "qID" = (
@@ -60974,6 +60975,17 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/security/office)
+"vlz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/bluespace_vendor/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "vlQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -85100,7 +85112,7 @@ baE
 bnM
 baE
 baE
-jMF
+vlz
 nRF
 bNK
 ikK


### PR DESCRIPTION
## About The Pull Request

If you've played on Meta recently, you'll notice that the blue space gas dispenser is currently *in* the salon door.
Simple fix. Moves it to the side of the door.

![image](https://user-images.githubusercontent.com/84706993/163656263-5179715a-073b-456c-b7be-b9cb014912af.png)

![image](https://user-images.githubusercontent.com/84706993/163656255-c1a8c194-4f06-4829-be77-f0d23f9f4127.png)


## How This Contributes To The Skyrat Roleplay Experience

Just fixes a small map error. 
Also resolves #12611 

## Changelog

:cl: Deek-Za
fix: Put bluespace vendor in its proper place on Metastation
/:cl:

