### PR TITLE
Icebox package sorting fix

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -18243,7 +18243,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
-	sortType = 23
+	sortType = 7
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)


### PR DESCRIPTION
## About The Pull Request

Fixes the sorting on icebox so packages can be sent to Security once again.
Seems a sorting pipe was incorrectly flagged for Genetics in the security section.

## How This Contributes To The Skyrat Roleplay Experience

Cargo can continue their robust security deliveries!
resolves #12691 


## Changelog

:cl: Deek-Za
fix: Fixed security sorting pipe issues on Icebox Station.
/:cl: