### PR TITLE
Adds back the arrival hangars from before the map reset (for meta and delta)

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -5381,11 +5381,18 @@
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice)
 "bdo" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/chair/sofa/bench{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ert-lz-port"
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port"
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bdO" = (
@@ -5472,6 +5479,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"bel" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/closet/firecloset/wall{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "beo" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -6411,6 +6429,22 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
+"bpO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ert-lz-port"
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	space_dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "bqm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -6661,13 +6695,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
-"bta" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "btb" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -6918,9 +6945,18 @@
 	},
 /area/maintenance/port/fore)
 "bvJ" = (
-/obj/effect/landmark/start/hangover/closet,
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ert-lz-starboard"
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port"
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bvO" = (
@@ -7503,6 +7539,17 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"bDg" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/entry)
 "bDs" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line,
@@ -12080,6 +12127,22 @@
 	dir = 1
 	},
 /area/service/kitchen)
+"crU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "crW" = (
 /obj/machinery/cryopod{
 	dir = 1
@@ -12887,6 +12950,17 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"cAn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/moth_hardhat{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cAy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13605,6 +13679,21 @@
 "cIH" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science)
+"cII" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/entry)
 "cIO" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -19206,6 +19295,14 @@
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
 /area/medical/surgery/theatre)
+"dpD" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/entry)
 "dpE" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -27123,6 +27220,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science)
+"ewV" = (
+/obj/structure/fluff/metalpole{
+	dir = 10
+	},
+/obj/structure/fluff/metalpole/end{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "exf" = (
 /obj/structure/cable,
 /obj/structure/table/wood,
@@ -30051,21 +30157,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/service/theater)
-"fth" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Docking Port"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "ftj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30478,6 +30569,9 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"fzl" = (
+/turf/open/space/basic,
+/area/hallway/secondary/entry)
 "fzv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/poster/random/directional/west,
@@ -31171,6 +31265,15 @@
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria,
 /area/service/cafeteria)
+"fKZ" = (
+/obj/structure/fluff/metalpole{
+	dir = 10
+	},
+/obj/structure/fluff/metalpole/end{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "fLC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -40741,6 +40844,13 @@
 "iQv" = (
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"iQy" = (
+/obj/structure/fluff/metalpole{
+	dir = 6
+	},
+/obj/structure/fluff/metalpole/end,
+/turf/open/space/basic,
+/area/space/nearstation)
 "iQz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41493,6 +41603,18 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"jek" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/entry)
 "jew" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41907,6 +42029,15 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"jkS" = (
+/obj/structure/fluff/metalpole{
+	dir = 1
+	},
+/obj/structure/fluff/metalpole/end/right{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "jlh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -49858,6 +49989,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"lMx" = (
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "lMJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -52434,11 +52570,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
-"myS" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "myU" = (
 /obj/structure/table/reinforced,
 /obj/item/analyzer{
@@ -56784,23 +56915,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"nRS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Docking Port";
-	space_dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "nRT" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -60032,6 +60146,11 @@
 	},
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
+"oPn" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/space/basic,
+/area/space/nearstation)
 "oPu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -61372,10 +61491,12 @@
 /turf/open/floor/iron,
 /area/security/office)
 "pmV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
+/obj/docking_port/stationary/random{
+	id = "pod_lavaland";
+	name = "lavaland"
+	},
+/turf/open/space/basic,
+/area/space)
 "pnj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -62671,6 +62792,14 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port/greater)
+"pHS" = (
+/obj/structure/fluff/metalpole{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pHV" = (
 /obj/structure/table/glass,
 /obj/item/folder/yellow,
@@ -64097,6 +64226,12 @@
 /obj/effect/turf_decal/trimline/blue/end,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"qek" = (
+/obj/structure/fluff/metalpole{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "qes" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -64509,13 +64644,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"qlu" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "qlv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -65171,17 +65299,6 @@
 /obj/item/taperecorder,
 /turf/open/floor/iron/grimy,
 /area/command/bridge)
-"qtX" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Arrivals Dock - Fore Starboard";
-	name = "dock camera"
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "quh" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67129,6 +67246,22 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/service/kitchen/abandoned)
+"qWv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ert-lz-starboard"
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	space_dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "qWz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
@@ -67185,12 +67318,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/meeting_room/council)
-"qXS" = (
-/obj/effect/spawner/random/vending/snackvend,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "qYc" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/table/reinforced,
@@ -67455,6 +67582,18 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"rbT" = (
+/obj/docking_port/stationary{
+	dheight = 3;
+	dir = 8;
+	dwidth = 8;
+	height = 11;
+	id = "ferry_home";
+	name = "Port Bay 2";
+	width = 20
+	},
+/turf/open/space/basic,
+/area/space)
 "rca" = (
 /turf/closed/wall,
 /area/command/gateway)
@@ -68502,16 +68641,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
-"rsc" = (
-/obj/docking_port/stationary{
-	dwidth = 2;
-	height = 13;
-	id = "ferry_home";
-	name = "port bay 2";
-	width = 5
-	},
-/turf/open/space/basic,
-/area/space)
 "rsd" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -68989,6 +69118,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"rAS" = (
+/obj/structure/fluff/metalpole{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rBv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/loading_area,
@@ -69438,6 +69574,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
+"rKx" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/entry)
 "rKA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/glass,
@@ -70176,14 +70323,6 @@
 /obj/item/stamp/cmo,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
-"rWF" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/chair/sofa/bench/left{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "rWG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -72267,11 +72406,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
-"sCx" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/firecloset,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "sCJ" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -74568,6 +74702,15 @@
 /obj/item/lipstick/random,
 /turf/open/floor/iron,
 /area/service/salon)
+"tmT" = (
+/obj/structure/fluff/metalpole{
+	dir = 1
+	},
+/obj/structure/fluff/metalpole/end/left{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "tmU" = (
 /obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -75042,6 +75185,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"tuL" = (
+/obj/structure/table/glass,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "tuR" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
@@ -76981,11 +77130,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"tZL" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "tZP" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/cigarette/cigar/cohiba{
@@ -79375,6 +79519,21 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
+"uOA" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/entry)
 "uOU" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red{
@@ -81937,20 +82096,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/service/theater/abandoned)
-"vFx" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "External Docking Port";
-	space_dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "vFB" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/sofa/right{
@@ -86493,22 +86638,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
-"xcI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Docking Port"
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "xcQ" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
@@ -125569,11 +125698,11 @@ aad
 aad
 aad
 aad
-aad
 aaO
 apq
 aaO
 aad
+aaa
 aaa
 aaa
 aad
@@ -125826,11 +125955,11 @@ aad
 aaa
 aaa
 aad
-aaa
 aaO
 app
 aaO
 aaO
+abf
 abf
 abf
 aaO
@@ -126072,8 +126201,8 @@ aaa
 aaa
 aaa
 aaa
-abf
-abf
+aaa
+abe
 abf
 abf
 abf
@@ -126083,12 +126212,12 @@ abf
 aaO
 aaO
 abf
-aej
 aaO
-fXn
+crU
 aaO
-qXS
+lMx
 aKc
+tuL
 dUo
 xsQ
 aaO
@@ -126327,15 +126456,15 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaO
+abE
 aaO
-aaO
-ilu
-agB
-bta
-adQ
-bta
-adQ
 igz
 ilu
 agB
@@ -126583,16 +126712,16 @@ aaa
 aaa
 aaa
 aaa
-rsc
-vFx
+aaa
+aaa
 pmV
-fth
-ves
-ves
-ves
-ayN
-ves
-ayN
+aaa
+aaa
+aaa
+afT
+abC
+aca
+abC
 qqf
 ves
 ves
@@ -126841,15 +126970,15 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaO
+aNG
 aaO
-aaO
-wKU
-aco
-qtX
-wKU
-qtX
-wKU
 abP
 wKU
 aco
@@ -127100,8 +127229,8 @@ aaa
 aaa
 aaa
 aaa
-abf
-abf
+aaa
+abe
 abf
 abf
 abf
@@ -127113,14 +127242,14 @@ aaO
 abf
 acY
 aaO
-xcI
 aaO
-myS
-fDa
+aaO
+abf
 bdo
-rWF
+bdo
+abf
 aaO
-xcI
+aaO
 aaO
 aej
 abf
@@ -127362,23 +127491,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 qYo
 aaa
-qYo
 aaa
-aaO
-app
-aaO
-aaO
-aaO
-aaO
-aaO
-aaO
-app
-aaO
+aaa
+fKZ
+aaa
+qYo
+fKZ
+aaa
+aaa
+bkF
+jek
+dpD
+wXG
+fzl
+fzl
+rAS
 aaa
 aaa
 aaa
@@ -127619,28 +127748,28 @@ aaa
 aaa
 aaa
 aaa
+oPn
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bkF
+uOA
+rKx
+wXG
 qYo
 qYo
-qYo
-aaO
-nRS
-aaO
-qYo
+pHS
 aaa
 aaa
-qYo
-aaO
-nRS
-aaO
 aaa
 aaa
-aad
-aad
-aad
+aaa
 aaO
 anm
 tyN
@@ -127886,18 +128015,18 @@ aaa
 aaa
 aaa
 aaa
+llk
+bpO
+bpO
+brM
+aaa
+aaa
+qek
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aad
-aaO
+iQy
 aaO
 lHU
 vkc
@@ -128149,14 +128278,14 @@ aaa
 aaa
 aaa
 aaa
+tmT
 aaa
 aaa
 aaa
 aaa
-aad
-acY
-qlu
-anm
+aaa
+abf
+cAn
 mOJ
 ves
 xfv
@@ -128410,8 +128539,8 @@ aaa
 aaa
 aaa
 aaa
-aaO
-aaO
+aaa
+aaa
 aaO
 lHU
 tyN
@@ -128667,9 +128796,9 @@ aaa
 aaa
 aaa
 aaa
-vFx
-pmV
-fth
+aaa
+aaa
+aaO
 lLY
 tyN
 bSS
@@ -128924,8 +129053,8 @@ aaa
 aaa
 aaa
 aaa
-aaO
-aaO
+aaa
+aaa
 aaO
 vVy
 tyN
@@ -129173,18 +129302,18 @@ aaa
 aaa
 aaa
 aaa
+rbT
+aaa
+aaa
+aaa
+jkS
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aad
-aej
-fkq
-bia
+abf
+bel
 ves
 icj
 aqp
@@ -129428,18 +129557,18 @@ aaa
 aaa
 aaa
 aaa
+llk
+qWv
+qWv
+brM
+aaa
+aaa
+qek
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aad
-aaO
+iQy
 aaO
 bia
 ves
@@ -129675,28 +129804,28 @@ aaa
 aaa
 aaa
 aaa
+oPn
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bkF
+cII
+bDg
+wXG
 qYo
 qYo
-qYo
-aaO
-apq
-aaO
-qYo
+pHS
 aaa
 aaa
-qYo
-aaO
-apq
-aaO
 aaa
 aaa
-aad
-aad
-aad
+aaa
 aaO
 bia
 gtS
@@ -129932,23 +130061,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 qYo
 aaa
-qYo
 aaa
-aaO
-app
-aaO
-aaO
-aaO
-aaO
-aaO
-aaO
-app
-aaO
+aaa
+ewV
+aaa
+qYo
+ewV
+aaa
+aaa
+bkF
+jek
+dpD
+wXG
+aaa
+aaa
+rAS
 aaa
 aaa
 aaa
@@ -130197,14 +130326,14 @@ aaO
 abf
 aej
 aaO
-fXn
 aaO
-sCx
-xsQ
+aaO
+abf
 bvJ
-tZL
+bvJ
+abf
 aaO
-fXn
+aaO
 aaO
 acY
 abf

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -2373,6 +2373,15 @@
 /obj/item/clothing/head/soft/rainbow,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"awQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "awS" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -3632,6 +3641,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"aIX" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "aJb" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/machinery/door/airlock/rd{
@@ -4496,9 +4512,6 @@
 	name = "Escape Pod One";
 	space_dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aUd" = (
@@ -5219,6 +5232,10 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/lobby)
+"bbV" = (
+/obj/machinery/computer/shuttle/arrivals/recall,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "bca" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor2";
@@ -6566,6 +6583,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"bsE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/hallway/secondary/entry)
 "bsH" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Port Primary Hallway - Starboard"
@@ -6651,11 +6677,6 @@
 "btL" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
-"btO" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/computer/shuttle/arrivals/recall,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "bue" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -6814,6 +6835,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"bym" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "byy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7080,7 +7107,20 @@
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "bCH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bCI" = (
@@ -7799,17 +7839,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bMB" = (
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Arrivals - Aft Arm"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/entry)
 "bMZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -7885,13 +7914,6 @@
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"bOd" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Arrivals - Aft Arm - Far"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "bOi" = (
 /obj/structure/table,
 /obj/item/clothing/mask/cigarette/pipe,
@@ -10121,6 +10143,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"cpm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cpC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -10978,6 +11013,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"cBB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cBC" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty{
@@ -14282,6 +14329,10 @@
 /obj/item/clothing/suit/hooded/wintercoat/science,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"dul" = (
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "duo" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -14381,6 +14432,10 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/iron/dark/textured,
 /area/medical/cryo)
+"dvs" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "dvt" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -14693,7 +14748,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "dzB" = (
@@ -14752,7 +14806,7 @@
 /area/service/kitchen)
 "dAk" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "dAn" = (
@@ -17329,6 +17383,24 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"ewt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
+"ewu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "ewT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17552,15 +17624,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
-"eBG" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-20"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "eCd" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -18003,6 +18066,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"eJv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "eKh" = (
 /obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/plating,
@@ -18453,13 +18526,6 @@
 /mob/living/simple_animal/pet/dog/corgi/puppy/slime,
 /turf/open/floor/grass,
 /area/science/research)
-"eQQ" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "eRd" = (
 /obj/structure/table,
 /obj/item/hfr_box/corner,
@@ -18479,10 +18545,16 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "eRG" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "eRN" = (
@@ -19229,6 +19301,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"ffl" = (
+/obj/structure/mopbucket,
+/obj/item/storage/box/lights/mixed,
+/obj/item/mop,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ffm" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19388,6 +19466,11 @@
 	dir = 1
 	},
 /area/command/gateway)
+"fjc" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "fjA" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
@@ -20184,7 +20267,13 @@
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "fza" = (
-/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "fzi" = (
@@ -20705,6 +20794,13 @@
 	dir = 8
 	},
 /area/medical/medbay/lobby)
+"fHF" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Arrivals - Aft Arm - Lounge"
+	},
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/hallway/secondary/entry)
 "fJd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -20838,7 +20934,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "fKR" = (
@@ -21509,6 +21607,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/tcommsat/computer)
+"fYU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "fZq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -21839,6 +21946,13 @@
 "gfu" = (
 /turf/closed/wall,
 /area/medical/office)
+"gfI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "gfU" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/aisat/exterior)
@@ -22318,12 +22432,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"gqn" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "gqC" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
@@ -23145,10 +23253,12 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "gGG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "gGL" = (
@@ -23439,12 +23549,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"gPu" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "gPF" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
@@ -23754,17 +23858,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"gWs" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 13;
-	id = "ferry_home";
-	name = "port bay 2";
-	width = 5
-	},
-/turf/open/space/basic,
-/area/space)
 "gWx" = (
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
@@ -24757,6 +24850,9 @@
 	},
 /turf/open/floor/carpet/green,
 /area/command/heads_quarters/captain/private/nt_rep)
+"htr" = (
+/turf/open/floor/iron/dark/smooth_large,
+/area/hallway/secondary/entry)
 "htv" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -25458,6 +25554,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark/corner,
 /area/engineering/storage_shared)
+"hIj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "hIt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -26000,6 +26103,10 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"hUL" = (
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/hallway/secondary/entry)
 "hUV" = (
 /obj/structure/closet{
 	name = "Evidence Closet 5"
@@ -26823,11 +26930,6 @@
 /obj/machinery/exodrone_launcher,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"imD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum/external,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "imL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29366,6 +29468,18 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"jpV" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 1;
+	height = 13;
+	id = "arrivals_stationary";
+	name = "arrivals";
+	roundstart_template = null;
+	width = 5
+	},
+/turf/open/space/basic,
+/area/space)
 "jqb" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Xenolab";
@@ -30126,6 +30240,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"jES" = (
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Airlock";
+	space_dir = 2
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "jEX" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plating,
@@ -30143,15 +30265,6 @@
 /obj/structure/sign/poster/party_game,
 /turf/closed/wall,
 /area/space/nearstation)
-"jFE" = (
-/obj/machinery/door/airlock/external{
-	name = "Transport Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "jFF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -31954,6 +32067,18 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"kos" = (
+/obj/docking_port/stationary{
+	dheight = 3;
+	dir = 2;
+	dwidth = 8;
+	height = 11;
+	id = "ferry_home";
+	name = "Port Bay 2";
+	width = 20
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "koz" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
@@ -32153,6 +32278,13 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/qm)
+"ktV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "ktW" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
@@ -33635,10 +33767,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
-"kVt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "kVC" = (
 /obj/structure/rack,
 /obj/item/electronics/apc,
@@ -33693,6 +33821,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"kWH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "kWP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33999,9 +34137,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "lcw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/status_display/evac/directional,
+/turf/closed/wall,
 /area/hallway/secondary/entry)
 "ldb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -35231,19 +35368,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"lAb" = (
-/obj/structure/sign/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/entry)
 "lAr" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/machinery/camera/directional/north{
@@ -35827,6 +35951,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"lLJ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "lLS" = (
 /obj/item/crowbar,
 /obj/item/wrench,
@@ -36258,14 +36387,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"lVo" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "lVw" = (
 /obj/machinery/newscaster/directional/west,
 /obj/structure/cable,
@@ -36602,13 +36723,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"lZX" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "mac" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -37329,14 +37443,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
-"mmM" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/entry)
 "mmO" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/maintenance,
@@ -38393,14 +38499,24 @@
 /obj/item/food/deadmouse,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"mGB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "mGD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "mGT" = (
@@ -38670,11 +38786,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"mLE" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "mLN" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/west{
@@ -38987,22 +39098,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"mRZ" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Arrivals - Middle Arm - Far"
-	},
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"mSc" = (
-/obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/entry)
 "mSp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -39559,12 +39654,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"ncm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "ncw" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -39660,11 +39749,16 @@
 /turf/open/floor/plating,
 /area/commons/fitness/recreation)
 "ndE" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -39789,16 +39883,6 @@
 /obj/structure/sign/poster/contraband/missing_gloves,
 /turf/closed/wall,
 /area/commons/storage/primary)
-"ngb" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Arrivals - Middle Arm"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "ngd" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -40020,17 +40104,6 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"nji" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 1;
-	height = 13;
-	id = "arrivals_stationary";
-	name = "arrivals";
-	width = 5
-	},
-/turf/open/space/basic,
-/area/space)
 "njk" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -41135,6 +41208,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"nFV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/hallway/secondary/entry)
 "nGb" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -41582,15 +41664,6 @@
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"nML" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-06"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "nMR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -41636,13 +41709,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
-"nNx" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "nNE" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -42166,11 +42232,6 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
-"nYL" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "nYM" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Medbay Surgery C";
@@ -42383,14 +42444,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark,
 /area/science/lab)
-"ocA" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/entry)
 "ocE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44368,15 +44421,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/white,
 /area/science/research)
-"oRL" = (
-/obj/machinery/door/airlock/external{
-	name = "Auxiliary Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "whiteship-dock"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "oRQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
@@ -44551,8 +44595,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "oUK" = (
@@ -45169,14 +45217,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"peW" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "pfk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -45429,6 +45469,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"pna" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark/smooth_large,
+/area/hallway/secondary/entry)
 "pnc" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
 /obj/structure/disposalpipe/segment,
@@ -46354,6 +46404,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/lesser)
+"pFL" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "pFS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47375,17 +47433,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"pZS" = (
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "qah" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"qao" = (
+/obj/structure/chair/sofa/bench/right,
+/turf/open/floor/iron/dark/smooth_large,
+/area/hallway/secondary/entry)
 "qaJ" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/corner{
@@ -47663,17 +47720,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"qgO" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/entry)
 "qgY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -48740,6 +48786,18 @@
 "qBq" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/hallway/secondary/entry)
+"qBx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "qBH" = (
 /obj/machinery/mechpad,
 /turf/open/floor/circuit/green,
@@ -49368,11 +49426,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "qPM" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/status_display/ai/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "qPQ" = (
 /obj/structure/disposalpipe/segment{
@@ -49592,6 +49659,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/abandoned)
+"qTq" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port)
 "qTx" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/mining,
@@ -49853,8 +49926,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "qYy" = (
@@ -49874,15 +49951,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"qZm" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/sign/poster/official/random/directional/east,
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/entry)
 "qZs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50557,6 +50625,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"rol" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "rop" = (
 /obj/structure/sign/map/right{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -51103,6 +51181,25 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"rwJ" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Arrivals - Aft Arm"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white/corner,
+/area/hallway/secondary/entry)
 "rwN" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/camera/autoname/directional/south,
@@ -51491,6 +51588,23 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"rGe" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/corner,
+/area/hallway/secondary/entry)
 "rGg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51533,11 +51647,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
-"rGS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "rGV" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -51994,6 +52103,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"rOX" = (
+/obj/item/toy/plush/fox{
+	desc = "An adorable stuffed toy of a Fox. This one is obviously a mother. You can tell. You just can.";
+	name = "Foxwife plushie"
+	},
+/obj/item/food/lasagna,
+/obj/item/paper/fluff/stations/centcom/disk_memo{
+	info = "hey hun, i brought you lasagna <3 keep working hard, i love you!"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "rOZ" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #3";
@@ -52294,13 +52414,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"rTV" = (
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "rUa" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53172,6 +53285,19 @@
 /obj/effect/turf_decal/siding/red,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
+"snq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "snt" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -54234,6 +54360,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"sKo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white/corner,
+/area/hallway/secondary/entry)
 "sKJ" = (
 /obj/item/beacon,
 /obj/effect/turf_decal/delivery,
@@ -55457,13 +55598,6 @@
 /obj/structure/cable,
 /turf/open/floor/grass,
 /area/medical/virology)
-"thi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "thq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
@@ -55715,6 +55849,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/aft/greater)
+"tmv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "tmK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55782,13 +55922,6 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"toJ" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "toP" = (
 /obj/structure/rack,
 /obj/item/stock_parts/matter_bin,
@@ -56059,22 +56192,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/gateway)
-"ttd" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
+"ttl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"ttl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/trash/janitor_supplies,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/port)
 "ttu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -56855,14 +56984,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"tIZ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "tJi" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/light/directional/north,
@@ -57390,6 +57511,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"tSb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "tSf" = (
 /obj/structure/closet/secure_closet/courtroom,
 /obj/machinery/light_switch/directional/north,
@@ -57851,6 +57982,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"ubB" = (
+/turf/open/floor/iron/stairs{
+	dir = 4
+	},
+/area/hallway/secondary/entry)
 "ubL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -58087,8 +58223,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "uhd" = (
@@ -58352,6 +58492,14 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"ulW" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/table,
+/turf/open/floor/iron/dark/smooth_large,
+/area/hallway/secondary/entry)
+"ulY" = (
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "uml" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
@@ -58421,25 +58569,11 @@
 /turf/open/floor/wood,
 /area/service/library)
 "unB" = (
-/obj/structure/sign/map/right{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-right-MS";
-	pixel_y = -32
+/obj/structure/closet/firecloset/full,
+/obj/structure/sign/warning/fire{
+	pixel_x = 32
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-03"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white/corner,
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "unE" = (
 /obj/machinery/light/directional/north,
@@ -58447,8 +58581,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "unJ" = (
@@ -58531,6 +58669,12 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark/textured,
 /area/engineering/atmos)
+"uoQ" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/hallway/secondary/entry)
 "uoY" = (
 /obj/machinery/shower{
 	name = "emergency shower";
@@ -58601,7 +58745,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "uqX" = (
@@ -59254,6 +59400,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engineering/atmospherics_engine)
+"uEf" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "uEx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -60062,6 +60215,17 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"uSK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/stairs{
+	dir = 4
+	},
+/area/hallway/secondary/entry)
 "uSQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -60796,6 +60960,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
+"vib" = (
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/dark/smooth_large,
+/area/hallway/secondary/entry)
 "vio" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -61055,8 +61223,12 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "vmr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/structure/crate,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;27;37"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "vmJ" = (
@@ -61244,6 +61416,11 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
+"vpf" = (
+/obj/structure/chair/sofa/bench/left,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark/smooth_large,
+/area/hallway/secondary/entry)
 "vpC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/east,
@@ -61383,15 +61560,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"vsz" = (
-/obj/machinery/door/airlock/external{
-	name = "Transport Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "vsE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61801,6 +61969,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/aft/lesser)
+"vBE" = (
+/obj/structure/fans/tiny/forcefield{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "vBH" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/blue{
@@ -62202,6 +62376,10 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"vJr" = (
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "vJt" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/west,
@@ -62389,6 +62567,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
+"vMG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "vNi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
@@ -62601,16 +62789,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"vRv" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "vRT" = (
 /obj/machinery/light/directional/south,
 /obj/item/stack/sheet/cardboard{
@@ -62778,11 +62956,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
-"vUg" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "vUk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64355,6 +64528,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
+"wDh" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/hallway/secondary/entry)
 "wDi" = (
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg2"
@@ -64796,6 +64973,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"wNg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Arrivals - Aft Arm - Far"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "wNm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64976,6 +65163,13 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
+"wPs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "wPI" = (
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/blue{
@@ -65441,6 +65635,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"wXZ" = (
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "wYa" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -65983,6 +66184,15 @@
 /obj/item/pen/red,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"xhC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "xhF" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -66818,6 +67028,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"xxx" = (
+/obj/effect/turf_decal/delivery,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
+"xxC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/directional/south,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "xxG" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood{
@@ -67245,6 +67470,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"xEV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "xEW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -67324,6 +67557,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"xGx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/hallway/secondary/entry)
 "xGy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -67655,15 +67894,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"xMf" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/assistant,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "xMs" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm/directional/south,
@@ -67882,7 +68112,6 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "xQh" = (
-/obj/machinery/firealarm/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Arrivals - Station Entrance"
 	},
@@ -68303,14 +68532,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"xZa" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;27"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "xZh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -68387,6 +68608,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"yaw" = (
+/obj/structure/chair/sofa/bench,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/dark/smooth_large,
+/area/hallway/secondary/entry)
 "yaC" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
@@ -68473,13 +68699,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/aft)
-"ycW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "ycZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68525,10 +68744,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
-"ydM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/entry)
 "ydX" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -74830,6 +75045,7 @@ aaa
 aaa
 aaa
 aaa
+quc
 aaa
 aaa
 aaa
@@ -74841,8 +75057,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+quc
 aaa
 aaa
 aaa
@@ -75087,6 +75302,7 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
 aaa
@@ -75098,8 +75314,7 @@ aaa
 aaa
 aaa
 aaa
-aac
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -75344,6 +75559,7 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
 aaa
@@ -75355,8 +75571,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -75601,6 +75816,7 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
 aaa
@@ -75612,8 +75828,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -75858,6 +76073,7 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
 aaa
@@ -75869,8 +76085,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -76111,24 +76326,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aRA
+aVs
+aVs
+aRA
+aRA
+vBE
+vBE
+vBE
+vBE
+vBE
+vBE
+vBE
+vBE
+vBE
+vBE
+vBE
+aRA
+aRA
 aaa
 aaa
 aaa
@@ -76368,24 +76583,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-gWs
-aaa
-aaa
-aaa
-aaa
+aVs
+vib
+uoQ
+fHF
+xEV
+awQ
+bym
+awQ
+bym
+awQ
+bym
+awQ
+bym
+awQ
+bym
+awQ
+ewt
+aVs
 aaa
 aaa
 aaa
@@ -76625,24 +76840,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-imD
-vsz
+aRA
+ulW
+htr
+hUL
+aIX
+tmv
+tmv
+tmv
+tmv
+tmv
+tmv
+tmv
+tmv
+tmv
+tmv
+tmv
+hIj
 aVs
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -76882,24 +77097,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-quc
-aaa
-aaa
-quc
-aaa
-aaa
-aaa
-aaa
-aaa
-quc
 aVs
-ncm
-aVs
-aaa
-aaa
-aaa
+qao
+htr
+hUL
+aWU
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+gfI
+aRA
 aaa
 aaa
 aaa
@@ -77139,24 +77354,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-lMJ
-aaa
-aaa
-lMJ
-aaa
-aaa
-aaa
-aaa
-aaa
 aVs
+yaw
+htr
+hUL
+aWU
+ulY
+ulY
+ulY
+ulY
+ulY
+dvs
+ulY
+ulY
+ulY
+ulY
+ulY
+aVu
 aVs
-jFE
-aVs
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -77396,24 +77611,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-lMJ
-aaa
-aaa
-lMJ
-aaa
-aaa
-aaa
-aaa
-aaa
 aVs
-tMX
-aWT
+vpf
+xGx
+hUL
+aWU
+ulY
+dvs
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+dvs
+ulY
+aVu
 aVs
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -77653,24 +77868,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-lMJ
-aaa
-aaa
-lMJ
-aaa
-aaa
-aaa
-aaa
-aaa
-aVs
-aVu
+aRA
+wDh
+nFV
+hUL
 aWU
-aVs
-aaa
-aaa
-aaa
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+xxC
+aRA
 aaa
 aaa
 aaa
@@ -77903,31 +78118,31 @@ aaa
 lMJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+quc
 lMJ
-aaa
-aaa
 lMJ
-aaa
-aaa
-aaa
+lMJ
+quc
 aaa
 aaa
 aVs
-aVu
+htr
+pna
+hUL
 aWU
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+aVu
 aVs
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -78159,32 +78374,32 @@ aVs
 aVs
 aVs
 aVs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aVs
-aVs
-aVs
-aVs
-aVs
 lMJ
 lMJ
-lMJ
+aaa
+aaa
+aaa
 lMJ
 lMJ
 aVs
-aVu
+aVs
+htr
+bsE
+hUL
 aWU
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+aVu
 aVs
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -78414,10 +78629,8 @@ nZg
 aUb
 aVt
 aWT
-aVs
+eqE
 lMJ
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -78427,21 +78640,23 @@ aaa
 aaa
 lMJ
 aVs
-eBG
-aWT
+ubB
+uSK
+aRA
+fjc
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+aVu
 aVs
-aox
-quc
-aox
-quc
-aox
-aVs
-nML
-aWU
-aVs
-aVs
-aVs
-aaa
 aaa
 aaa
 aaa
@@ -78671,10 +78886,8 @@ bsk
 aUc
 aVu
 aWU
-eqE
+aVs
 lMJ
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -78684,21 +78897,23 @@ aaa
 aaa
 lMJ
 eqE
+ktV
+tSb
+aRA
+lLJ
+ulY
+dvs
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+dvs
+ulY
 aVu
-aWU
-aRA
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-aRA
-bWa
-aWU
-oRL
-pZS
-oRL
-aaa
+jES
 aaa
 aaa
 aaa
@@ -78927,11 +79142,9 @@ aRA
 aSI
 aRA
 bFH
-aWU
-aVs
+uEf
+aRA
 lMJ
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -78941,22 +79154,24 @@ aaa
 aaa
 lMJ
 aVs
-eQQ
+aVu
+ewu
+aRA
 aWU
-aVs
-aaa
-aaa
-aaa
-aaa
-aaa
-aVs
-eQQ
-aWU
-oRL
-aZZ
-oRL
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+aVu
+jES
 qtR
-aaa
 aaa
 aaa
 aaa
@@ -79184,35 +79399,35 @@ aRA
 aRA
 aRA
 eIn
-aWV
-aRA
-lMJ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aVs
-aVs
-aVs
-peW
-aWU
-aVs
-aaa
-aaa
-aaa
-aaa
-aaa
-eqE
-xMf
 aWU
 aVs
 aVs
 aVs
 aaa
+aaa
+aaa
+aaa
+aaa
+aVs
+aVs
+aVs
+bWa
+fYU
+aVs
+aWU
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+aVu
+aVs
 aaa
 aaa
 aaa
@@ -79442,11 +79657,9 @@ aaa
 aRA
 aVx
 aWU
-aVs
-aVs
-aVs
-aaa
-aaa
+djz
+aZZ
+uZJ
 aaa
 aaa
 aaa
@@ -79455,21 +79668,23 @@ aaa
 fqs
 bsk
 djC
-aVu
-mRZ
-aRA
-aaa
-aaa
-aaa
-aaa
-aaa
+wXZ
+fYU
 aVs
-eQQ
 aWU
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+aVu
 aVs
-aaa
-lMJ
-aaa
 aaa
 aaa
 aaa
@@ -79699,11 +79914,9 @@ aDb
 aDb
 aVu
 aWU
-djz
-aZZ
-uZJ
-aaa
-aaa
+aVs
+aVs
+aVs
 aaa
 aaa
 aaa
@@ -79713,20 +79926,22 @@ aVs
 aVs
 aVs
 aVu
-nNx
+fYU
 aVs
-aaa
-aaa
-aaa
-aaa
-aaa
-aRA
-aVu
 aWU
+ulY
+ulY
+ulY
+kos
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+aVu
 aVs
-aaa
-lMJ
-aaa
 aaa
 aaa
 aaa
@@ -79955,12 +80170,10 @@ grw
 aSJ
 aDb
 hnm
-aWU
+wdq
+aWT
+xxx
 aVs
-aVs
-aVs
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -79970,20 +80183,22 @@ aVs
 rqY
 tMX
 oSK
-dAk
+fYU
 aVs
-aaa
-aaa
-aaa
-aaa
-aaa
-aVs
-aVu
-bOd
+aWU
+ulY
+dvs
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+dvs
+ulY
+wNg
 aRA
-lMJ
-lMJ
-aaa
 aaa
 aaa
 aaa
@@ -80212,8 +80427,8 @@ aRE
 aSK
 cYL
 fKP
-wdq
-aWT
+bvF
+aWU
 baa
 aVs
 aaa
@@ -80221,26 +80436,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aVs
-btO
+bbV
 aVu
 bvF
-dAk
+vMG
+aRA
+aWU
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+aVu
 aVs
-aaa
-aaa
-aaa
-aaa
-aaa
-aVs
-thi
-dAk
-aVs
-aaa
-lMJ
-aaa
 aaa
 aaa
 aaa
@@ -80478,26 +80693,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aVs
 sKJ
 aVu
 bvF
+rol
+aRA
 dAk
-aVs
-aaa
-aaa
-aaa
-aaa
-aaa
-aVs
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
 aVu
-dAk
 aVs
-aaa
-lMJ
-aaa
 aaa
 aaa
 aaa
@@ -80735,26 +80950,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aVs
 baa
+aVu
+bvF
 gGG
-kVt
-ttd
+eqE
+lLJ
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+wPs
 aRA
-aaa
-aaa
-aaa
-aaa
-aaa
-aRA
-bWa
-gqn
-aRA
-lMJ
-lMJ
-aaa
 aaa
 aaa
 aaa
@@ -80992,26 +81207,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aVs
 dWE
 jZF
 bsn
-gPu
+gGG
+pFL
+aWU
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+xhC
 aVs
-aaa
-aaa
-aaa
-aaa
-aaa
-aVs
-aVu
-dAk
-aVs
-aaa
-lMJ
-aaa
 aaa
 aaa
 aaa
@@ -81249,26 +81464,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aVs
 aVs
 aVs
-aVu
-lVo
-aRA
-aaf
-imD
-vsz
+ktV
+gGG
+pFL
+aWU
+ulY
+dvs
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+dvs
+ulY
+cBB
 aVs
-aaf
-aRA
-toJ
-lZX
-aVs
-aaa
-lMJ
-aaa
 aaa
 aaa
 aaa
@@ -81506,26 +81721,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 fqs
 bsk
 djC
 aVu
-rTV
+gGG
+pFL
+aWU
+ulY
+ulY
+ulY
+ulY
+ulY
+dvs
+ulY
+ulY
+ulY
+ulY
+ulY
+qBx
 aRA
-aVs
-aVs
-ncm
-aVs
-aVs
-aRA
-bWa
-ydM
-alK
-alK
-alK
-alK
 aox
 aox
 aox
@@ -81763,25 +81978,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aVs
 aVs
 aVs
-ycW
-ngb
-aRA
-nYL
-aVs
-jFE
-aVs
-mLE
-aRA
 aVu
-mmM
-xZa
-koV
-bbL
+gGG
+pFL
+aWU
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+ulY
+snq
 alK
 alK
 alK
@@ -82018,29 +82233,29 @@ lMJ
 aaa
 aaa
 aaa
-aaa
-aaa
-nji
+jpV
 aaa
 lMJ
 aVs
 fcT
 oSK
-tIZ
+gGG
+aRA
+wdq
 mGD
-qPM
-qPM
-qPM
-qPM
-qPM
+cpm
+cpm
+sKo
+rGe
+rwJ
 qPM
 eRG
-lAb
-alK
 ttl
-bbL
-ako
+ttl
+ttl
+mGB
 alK
+rOX
 pOI
 qAO
 fmc
@@ -82276,26 +82491,26 @@ aRA
 aVs
 aVs
 aVs
-aVs
-aVs
 aRA
 aRA
 aRA
 tLy
 bvF
+gGG
+aRA
 lcw
-vUg
+aRA
 bCH
 fza
-mSc
-qZm
-ocA
-bJo
-bMB
+alK
+alK
+alK
+alK
+alK
 unB
 alK
 vmr
-bbL
+alK
 alK
 alK
 alK
@@ -82533,26 +82748,26 @@ nZp
 nZp
 nZp
 tPW
-nZp
-nZp
+kWH
+eJv
 xQh
-vRv
+nZp
 nZp
 mgz
 rGg
 rGg
-vUg
-bCH
+rGg
+rGg
 blU
 alK
+qTq
+ffl
+vJr
 alK
 alK
 alK
-alK
-alK
-alK
-rGS
-bbL
+rLW
+dul
 bPL
 alK
 ffU
@@ -82798,7 +83013,7 @@ bEt
 bEt
 bEt
 vba
-qgO
+poK
 jEJ
 bCI
 bEo


### PR DESCRIPTION
## About The Pull Request

Adds back the old arrivals from before the map reset, no fuss.

## How This Contributes To The Skyrat Roleplay Experience

Works with the centcom shuttle we have i suppose, just generally something that had to be done but hadn't been done yet.

## Changelog



:cl:
fix: Reverts Delta arrivals back to how they used to be for skyrat before the map reset.
fix: Reverts Meta arrivals back to how they used to be for skyrat before the map reset.
/:cl:


