### PR TITLE
Headshot removal

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/headshot.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/headshot.dm
@@ -16,6 +16,7 @@
 
 /datum/preference/text/headshot/is_valid(value)
 	if(!length(value)) //Just to get blank ones out of the way
+		usr?.client?.prefs?.headshot = null
 		return TRUE
 	if(!findtext(value, "https://", 1, 9))
 		to_chat(usr, span_warning("You need \"https://\" in the link!"))
@@ -34,7 +35,7 @@
 		to_chat(usr, span_notice("Keep in mind that the photo will be downsized to 250x250 pixels, so the more square the photo, the better it will look."))
 		log_game("[usr] has set their Headshot image to '[value]'.")
 	stored_link[usr?.ckey] = value
-	usr?.client.prefs.headshot = value
+	usr?.client?.prefs.headshot = value
 	return TRUE
 
 /datum/preference/text/headshot/is_accessible(datum/preferences/preferences)


### PR DESCRIPTION
## About The Pull Request

You can now remove a headshot, unlike before where it wouldn't save.

## How This Contributes To The Skyrat Roleplay Experience

I totally didn't add a joke headshot image then get stuck with it for days.

## Changelog
:cl:
fix: Headshots can now properly be removed if you so wish.
/:cl: