### PR TITLE
add tape & recorder QoL Improvement

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -310,6 +310,20 @@
 	canprint = FALSE
 	addtimer(VARSET_CALLBACK(src, canprint, TRUE), 30 SECONDS)
 
+/obj/item/taperecorder/verb/WipeTapeInRecorder()
+	set name = "Wipe Tape"
+
+	if(!mytape || mytape.unspooled)
+		return
+	if(recording)
+		return
+	if(playing)
+		return
+	else
+		mytape.used_capacity = 0;
+		mytape.storedinfo = new;
+		mytape.timestamp = new;
+		to_chat(usr, "<span class='notice'>You wipe this tape entirely.")
 
 //empty tape recorders
 /obj/item/taperecorder/empty
@@ -402,6 +416,19 @@
 /obj/item/tape/proc/respool()
 	cut_overlay("ribbonoverlay")
 	unspooled = FALSE
+
+/obj/item/tape/proc/wipeproc()
+	used_capacity = 0;
+	storedinfo = new;
+	timestamp = new;
+
+/obj/item/tape/verb/wipeverb()
+	set name = "Wipe Tape";
+	if(unspooled)
+		to_chat(usr, "<span class='notice'>You scrub the magnetic strip clean of its contents.")
+		wipeproc()
+	else if(!unspooled)
+		to_chat(usr, "<span class='notice'>You need to pull out the tape's magnetic strips first.")
 
 /obj/item/tape/proc/tapeflip()
 	//first we save a copy of our current side


### PR DESCRIPTION
Quality of life improvements to tape and recorder, so that player are no longer needing to lug around multiple tapes for prolonged interviews. This should be helpful for psychologists, investigators, lawyers, etc.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<strong>Single Tweak</strong>

         I only edited one file: 'taperecorder.dm'. I added quality of life functionality
    to both the tape recorder and individual tapes for them to be wiped.  


## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

<strong>Increased RP Flexibility Through Convenience</strong>

         I have recently attempted to play a 'Journalist' character and
    found that prolonged interviews are hampered by how many tapes you need
    to record the entire interview. This is a hassle for both finding
    enough tapes, carrying them, and managing them. 

         The tape recorder has a transcript-printing functionality, which means
     once a tape is full a player can print out everything recorded, meaning
     there is no further reason to retain a tape that can no longer be used
     for recording. This allows for an easy way of recording and documenting
     events without fearing for the loss of content because you need to
     either make, find or swap tapes every 10 minutes.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: NX115
qol: Tape recorder tapes can now be wiped for re-use, by unspooling the tape and wiping it. Remember to print your transcripts if you want to save the contents!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
