### PR TITLE
[MODULAR][FIX] Beepsky no longer goes after people wielding medical guns

### DIFF
--- a/modular_skyrat/modules/cellguns/code/mediguns.dm
+++ b/modular_skyrat/modules/cellguns/code/mediguns.dm
@@ -13,6 +13,7 @@
 	charge_sections = 3
 	maxcells = 3
 	allowed_cells = list(/obj/item/weaponcell/medical)
+	item_flags = null
 
 // Standard medigun - this is what you will get from Cargo, most likely.
 /obj/item/gun/energy/cell_loaded/medigun/standard

--- a/modular_skyrat/modules/medical/code/smartdarts.dm
+++ b/modular_skyrat/modules/medical/code/smartdarts.dm
@@ -47,6 +47,7 @@
 	icon = 'modular_skyrat/modules/medical/icons/obj/dartguns.dmi'
 	icon_state = "smartdartgun"
 	has_gun_safety = TRUE
+	item_flags = null
 
 /obj/item/gun/syringe/smartdart/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes `needs_permit` item flag from both mediguns and smartdart guns, meaning that beepsky will no longer chase arrest people using either of them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
These are non-harmful medical weapons that are primarily used to heal people, and medical personnel do not have weapon permits on their ID. It doesn't make sense for beepsky to arrest medical staff that are using gear within their job description. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: beepsky now no longer goes after people wielding Mediguns and SmartDart guns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
