### PR TITLE
Blob Enhancements 1

### DIFF
--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -13,7 +13,7 @@
 
 // Generic blob defines
 
-#define BLOB_BASE_POINT_RATE 2 // Base amount of points per process()
+#define BLOB_BASE_POINT_RATE 3 // Base amount of points per process(+1 SkyRat change) 
 #define BLOB_EXPAND_COST 4 // Price to expand onto a new tile
 #define BLOB_ATTACK_REFUND 2 // Points 'refunded' when the expand attempt actually attacks something instead
 #define BLOB_BRUTE_RESIST 0.5 // Brute damage taken gets multiplied by this value

--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -13,7 +13,7 @@
 
 // Generic blob defines
 
-#define BLOB_BASE_POINT_RATE 3 // Base amount of points per process(+1 SkyRat change) 
+#define BLOB_BASE_POINT_RATE 2.5 // Base amount of points per process(+1 SkyRat change) 
 #define BLOB_EXPAND_COST 4 // Price to expand onto a new tile
 #define BLOB_ATTACK_REFUND 2 // Points 'refunded' when the expand attempt actually attacks something instead
 #define BLOB_BRUTE_RESIST 0.5 // Brute damage taken gets multiplied by this value


### PR DESCRIPTION
With the current state of SR Blob being so... sad.... we've discussed it in the admin circle and will be giving teeny tiny buffs. The first here is a simple Point rate boost.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The blob hasn't been touched in quite some time whereas we've had many revisions to weapons since, notably how the current state of armament has made it to where only 1 or 2 strains have even a small chance at surviving since all the other ones are shut down instantly. This is the first test to bring Blobs up to a fighting chance against a crew that spends a lot more time in maintenance than our TG Parents.



## How This Contributes To The Skyrat Roleplay Experience

Blobs are often caught before they can really even stand a chance, the past 15 monitored blob events only 1 got near critical mass where all others failed to even reach 50 tiles. The goal of this change is to give a small boost and see how it pans out before addressing the strains themselves and/or other parts if this doesn't give the desired results.

## Changelog


:cl:
balance: Changes the point generation from 2 to 2.5
/:cl:

