### PR TITLE
Robotic race heads are robotic again.

### DIFF
--- a/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/robotic/_mutant_robotic_bodyparts.dm
+++ b/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/robotic/_mutant_robotic_bodyparts.dm
@@ -5,7 +5,7 @@
 	is_dimorphic = TRUE
 	should_draw_greyscale = TRUE
 	uses_mutcolor = TRUE
-	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC | BODYTYPE_SNOUTED //This is temporary. Ideally the "snout" external organ adds to this.
+	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC | BODYTYPE_SNOUTED //This is temporary. Ideally the "snout" external organ adds to this.
 
 /obj/item/bodypart/chest/robot/mutant
 	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/synthmammal_parts_greyscale.dmi'


### PR DESCRIPTION
## About The Pull Request

Due to a minor oversight, robotic race heads are actually organic. 
Alters and fixes the issue.
resolves #12871 

## How This Contributes To The Skyrat Roleplay Experience

Just a fix to get robotics working properly again. And also preventing any accidental repair mistakes. I.e. someone bludgeoning a synth to death trying to weld them.

## Changelog

:cl: Deek-Za
fix: Robotic race heads are robotic again.
/:cl:
