### PR TITLE
Adds crew manifest to tablets by default

### DIFF
--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -175,6 +175,7 @@
 
 	store_file(new /datum/computer_file/program/messenger(src))
 	store_file(new /datum/computer_file/program/notepad(src))
+	store_file(new /datum/computer_file/program/crew_manifest(src)) // SKYRAT EDIT ADD
 
 // For borg integrated tablets. No downloader.
 /obj/item/computer_hardware/hard_drive/small/integrated/install_default_programs()


### PR DESCRIPTION
https://github.com/Skyrat-SS13/Skyrat-tg/pull/12920 lost the behaviour of https://github.com/Skyrat-SS13/Skyrat-tg/pull/5468

They technically still can't be downloaded.

## Changelog
:cl:
fix: The crew manifest is installed by default on all tablets, as it was on PDAs.
/:cl: