### PR TITLE
Ghost role appearance change restriction

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -15,6 +15,7 @@
 	the fresh air of Earth. These thoughts are dispelled by yet another recollection of how you got here... "
 	spawner_job_path = /datum/job/hermit
 	quirks_enabled = TRUE // SKYRAT EDIT ADDITION - ghost role loadouts
+	random_appearance = FALSE // SKYRAT EDIT ADDITION
 
 /obj/effect/mob_spawn/ghost_role/human/hermit/Initialize(mapload)
 	. = ..()
@@ -81,6 +82,7 @@
 	spawner_job_path = /datum/job/beach_bum
 	outfit = /datum/outfit/beachbum
 	quirks_enabled = TRUE // SKYRAT EDIT ADDITION - ghost role loadouts
+	random_appearance = FALSE // SKYRAT EDIT ADDITION
 
 /obj/effect/mob_spawn/ghost_role/human/beach/lifeguard
 	you_are_text = "You're a spunky lifeguard!"
@@ -121,6 +123,7 @@
 	flavour_text = "Time to mix drinks and change lives. Smoking space drugs makes it easier to understand your patrons' odd dialect."
 	spawner_job_path = /datum/job/space_bartender
 	outfit = /datum/outfit/spacebartender
+	random_appearance = FALSE // SKYRAT EDIT ADDITION
 
 /datum/outfit/spacebartender
 	name = "Space Bartender"
@@ -156,6 +159,7 @@
 	Estimated time of last contact: Deployment, 5000 millennia ago."
 	spawner_job_path = /datum/job/lifebringer
 	restricted_species = list(/datum/species/pod) //SKYRAT EDIT ADDITION
+	random_appearance = FALSE // SKYRAT EDIT ADDITION
 
 /obj/effect/mob_spawn/ghost_role/human/seed_vault/Initialize(mapload)
 	. = ..()
@@ -224,6 +228,7 @@
 	var/datum/team/ashwalkers/team
 	var/obj/structure/ash_walker_eggshell/eggshell
 	restricted_species = list(/datum/species/lizard/ashwalker) //SKYRAT EDIT ADDITION
+	random_appearance = FALSE // SKYRAT EDIT ADDITION
 
 /obj/effect/mob_spawn/ghost_role/human/ash_walker/Destroy()
 	eggshell = null
@@ -281,6 +286,7 @@
 	spawner_job_path = /datum/job/lavaland_syndicate
 	loadout_enabled = TRUE // SKYRAT EDIT ADDITION - ghost role loadouts
 	quirks_enabled = TRUE // SKYRAT EDIT ADDITION - ghost role loadouts
+	random_appearance = FALSE // SKYRAT EDIT ADDITION
 
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/special(mob/living/new_spawn)
 	. = ..()

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -68,6 +68,7 @@
 	flavour_text = "Cater to visiting guests with your fellow staff, advertise the hotel, and make sure the manager doesn't fire you. Remember, the customer is always right!"
 	important_text = "Do NOT leave the hotel, as that is grounds for contract termination."
 	spawner_job_path = /datum/job/hotel_staff
+	random_appearance = FALSE // SKYRAT EDIT ADDITION
 
 /datum/outfit/hotelstaff
 	name = "Hotel Staff"

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -133,7 +133,7 @@
 
 	// SKYRAT EDIT ADDITION
 	/// Do we use a random appearance for this ghost role?
-	var/random_appearance = FALSE
+	var/random_appearance = TRUE
 	/// Can we use our loadout for this role?
 	var/loadout_enabled = FALSE
 	/// Can we use our quirks for this role?

--- a/modular_skyrat/modules/black_mesa/code/ghost_spawners.dm
+++ b/modular_skyrat/modules/black_mesa/code/ghost_spawners.dm
@@ -7,6 +7,7 @@
 	you_are_text = "You are a scientist in a top secret government facility. You blacked out. Now, you have woken up to the horrors that lay within."
 	flavour_text = "You are a scientist in a top secret government facility. You blacked out. Now, you have woken up to the horrors that lay within."
 	restricted_species = list(/datum/species/human)
+	random_appearance = FALSE
 
 /obj/effect/mob_spawn/ghost_role/human/black_mesa/special(mob/living/carbon/human/spawned_human)
 	. = ..()

--- a/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
+++ b/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
@@ -52,6 +52,7 @@
 	outfit = /datum/outfit
 	you_are_text = "You are a Cafe Visitor!"
 	flavour_text = "You are off-duty and have decided to visit your favourite cafe. Enjoy yourself."
+	random_appearance = FALSE
 
 /obj/effect/mob_spawn/ghost_role/human/ghostcafe/special(mob/living/carbon/human/new_spawn)
 	. = ..()

--- a/modular_skyrat/modules/mapping/code/mob_spawns.dm
+++ b/modular_skyrat/modules/mapping/code/mob_spawns.dm
@@ -26,6 +26,8 @@
 	prompt_name = "DS2 personnel"
 	you_are_text = "You are a syndicate operative, employed in a top secret research facility developing biological weapons."
 	flavour_text = "Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. Continue operating as best you can, and try to keep a low profile."
+	quirks_enabled = TRUE
+	random_appearance = FALSE
 
 /obj/effect/mob_spawn/ghost_role/human/ds2/prisoner
 	name = "Syndicate Prisoner"
@@ -47,7 +49,6 @@
 	important_text = "You are not an antagonist."
 	outfit = /datum/outfit/ds2/syndicate
 	loadout_enabled = TRUE
-	quirks_enabled = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/ds2/syndicate/special(mob/living/new_spawn)
 	. = ..()
@@ -191,6 +192,7 @@
 	you_are_text = "You were running cargo, a typical freight job until pirates attacked. You and your crewmates just barely made it, but the engines are shot. You're trapped in space now, only able to work together to survive this nightmare."
 	flavour_text = "You were running cargo, a typical freight job until pirates attacked. You and your crewmates just barely made it, but the engines are shot. You're trapped in space now, only able to work together to survive this nightmare."
 	important_text = "Work with your crew and don't abandon them. You are not directly working with NT, you are an independent freighter crew for the ship's Chief. Your job was merely being a deckhand doing freight work and helping with kitchen prep."
+	random_appearance = FALSE
 
 /datum/outfit/freighter_crew
 	name = "Freighter Crew"
@@ -212,6 +214,7 @@
 	you_are_text = "You were running cargo, a typical freight job until pirates attacked. You and your crewmates just barely made it, but the engines are shot. You're trapped in space now, only able to work together to survive this nightmare."
 	flavour_text = "You were running cargo, a typical freight job until pirates attacked. You and your crewmates just barely made it, but the engines are shot. You're trapped in space now, only able to work together to survive this nightmare."
 	important_text = "Work with your crew and don't abandon them. You are not directly working with NT, you are an independent freighter crew working under the ship Chief. Your role was to be an excavation and salvage worker for the ship."
+	random_appearance = FALSE
 
 /datum/outfit/freighter_excavator
 	name = "Freighter Excavator"
@@ -240,6 +243,7 @@
 	you_are_text = "You and your crew were running a normal freight haul until a pirate attack knocked out the engines. All you can do now is try and survive and keep your crew alive."
 	flavour_text = "You and your crew were running a normal freight haul until a pirate attack knocked out the engines. All you can do now is try and survive and keep your crew alive."
 	important_text = "Do not abandon your crew, lead them and work with them to survive. You are not directly working with NT, you are an independent freighter crew. You are the captain of the ship, which you purchased a while ago, and are in charge of the crew."
+	random_appearance = FALSE
 
 /datum/outfit/freighter_boss
 	name = "Freighter Boss"
@@ -266,6 +270,7 @@
 	outfit = /datum/outfit/tarkon
 	loadout_enabled = TRUE
 	quirks_enabled = TRUE
+	random_appearance = FALSE
 
 /datum/outfit/tarkon
 	uniform = /obj/item/clothing/under/rank/cargo/tech/skyrat/utility


### PR DESCRIPTION
## About The Pull Request

Disables selecting your custom character when spawning into a ghost role by default. Enables it on ghost roles that should have it.

## Changelog
:cl:
fix: You can no longer turn into your selected character when spawning as a ghost role that it doesn't make sense for.
/:cl: