### PR TITLE
medibots no longer try to heal synths

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -439,6 +439,10 @@
 			var/obj/item/clothing/CH = H.head
 			if (CS.clothing_flags & CH.clothing_flags & THICKMATERIAL)
 				return FALSE // Skip over them if they have no exposed flesh.
+		// SKYRAT EDIT ADDITION START
+		if(H.mob_biotypes & MOB_ROBOTIC)
+			return FALSE
+		// SKYRAT EDIT ADDITION END
 
 	if(medical_mode_flags & MEDBOT_DECLARE_CRIT && C.health <= 0) //Critical condition! Call for help!
 		declare(C)


### PR DESCRIPTION
## About The Pull Request

Medibots now check if their target is synthetic before trying to heal them.

## How This Contributes To The Skyrat Roleplay Experience

No more medibots infinitely chasing a synth they can't even heal.

## Changelog
:cl:
qol: Medibots no longer try to assist the synths they can't heal.
/:cl: