### PR TITLE
Ensures that a few sounds that shouldn't go through walls, don't go through them

### DIFF
--- a/modular_skyrat/modules/indicators/code/combat_indicator.dm
+++ b/modular_skyrat/modules/indicators/code/combat_indicator.dm
@@ -29,7 +29,7 @@ GLOBAL_VAR_INIT(combat_indicator_overlay, GenerateCombatOverlay())
 	if (combat_indicator_vehicle)
 		if(world.time > vehicle_next_combat_popup) // As of the time of writing, COMBAT_NOTICE_COOLDOWN is 10 secs, so this is asking "has 10 secs past between last activation of CI?"
 			vehicle_next_combat_popup = world.time + COMBAT_NOTICE_COOLDOWN
-			playsound(src, 'sound/machines/chime.ogg', 10, TRUE)
+			playsound(src, 'sound/machines/chime.ogg', 10, TRUE, ignore_walls = FALSE)
 			flick_emote_popup_on_obj("combat", 20)
 			visible_message(span_boldwarning("[src] prepares for combat!"))
 		combat_indicator_vehicle = TRUE

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibrator.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibrator.dm
@@ -185,21 +185,21 @@
 	switch(vibration_mode)
 		if("low")
 			toy_on = TRUE
-			playsound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+			playsound(loc, 'sound/weapons/magin.ogg', 20, TRUE, ignore_walls = FALSE)
 			soundloop1.start()
 		if("medium")
 			toy_on = TRUE
-			playsound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+			playsound(loc, 'sound/weapons/magin.ogg', 20, TRUE, ignore_walls = FALSE)
 			soundloop1.stop()
 			soundloop2.start()
 		if("hard")
 			toy_on = TRUE
-			playsound(loc, 'sound/weapons/magin.ogg', 20, TRUE)
+			playsound(loc, 'sound/weapons/magin.ogg', 20, TRUE, ignore_walls = FALSE)
 			soundloop2.stop()
 			soundloop3.start()
 		if("off")
 			toy_on = FALSE
-			playsound(loc, 'sound/weapons/magout.ogg', 20, TRUE)
+			playsound(loc, 'sound/weapons/magout.ogg', 20, TRUE, ignore_walls = FALSE)
 			soundloop3.stop()
 
 #undef DEFAULT_AROUSAL_INCREASE

--- a/modular_skyrat/modules/modular_items/lewd_items/code/technical_stuff_for_lewd.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/technical_stuff_for_lewd.dm
@@ -29,6 +29,7 @@
 	falloff_distance = 1
 	falloff_exponent = 5
 	extra_range = SILENCED_SOUND_EXTRARANGE
+	ignore_walls = FALSE
 
 /datum/looping_sound/vibrator/low
 	volume = 80

--- a/modular_skyrat/modules/reagent_forging/code/anvil.dm
+++ b/modular_skyrat/modules/reagent_forging/code/anvil.dm
@@ -49,7 +49,7 @@
 		return FALSE
 
 /obj/structure/reagent_anvil/hammer_act(mob/living/user, obj/item/tool)
-	playsound(src, 'modular_skyrat/modules/reagent_forging/sound/forge.ogg', 50, TRUE)
+	playsound(src, 'modular_skyrat/modules/reagent_forging/sound/forge.ogg', 50, TRUE, ignore_walls = FALSE)
 	var/obj/item/forging/incomplete/search_incomplete_src = locate(/obj/item/forging/incomplete) in contents
 	if(!search_incomplete_src)
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
Some of these sounds were going through walls, and for everyone's sanity, they won't go through walls any longer.

## How This Contributes To The Skyrat Roleplay Experience
Honestly, having a headache from hearing an anvil being repeatedly smashed against by someone else is genuinely one of the most irritating thing there is.

## Changelog

:cl: GoldenAlpharex
fix: Certain noises that shouldn't go through walls, will no longer go through walls.
qol: Anvil-hitting noises no longer go through walls. You can thank me later.
/:cl: