### PR TITLE
[Non-Modular] Fixes borg expander exploit

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -558,6 +558,9 @@
 			to_chat(usr, span_warning("This unit already has an expand module installed!"))
 			return FALSE
 		// SKYRAT EDIT BEGIN
+		if(R.model.model_select_icon == "nomod")
+			to_chat(usr, span_warning("Default models cannot take expand or shrink upgrades."))
+			return FALSE
 		if((R_TRAIT_WIDE in R.model.model_features) || (R_TRAIT_TALL in R.model.model_features))
 			to_chat(usr, span_warning("This unit's chassis cannot be enlarged any further."))
 			return FALSE


### PR DESCRIPTION
## About The Pull Request

Default models could previously take the expand upgrade and bring it into a newly selected model.

## Changelog
:cl:
fix: Fixed a way to still expand borg sprites already bigger than 32px
/:cl: