### PR TITLE
ashwalkers now have an incentive to live longer

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -241,6 +241,7 @@
 	spawned_human.fully_replace_character_name(null,random_unique_lizard_name(gender))
 	loadout_enabled = TRUE //SKYRAT EDIT ADDITION
 	. = ..()
+	spawned_human.AddComponent(/datum/component/elder_ash)
 	// SKYRAT EDIT END
 	to_chat(spawned_human, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Invade the strange structure of the outsiders if you must. Do not cause unnecessary destruction, as littering the wastes with ugly wreckage is certain to not gain you favor. Glory to the Necropolis!</b>")
 

--- a/modular_skyrat/modules/ashwalkers/code/species/elder.dm
+++ b/modular_skyrat/modules/ashwalkers/code/species/elder.dm
@@ -1,0 +1,35 @@
+/**
+ * Rewarding Ashwalkers for lasting long enough in the round
+ * 30 minutes: speed
+ * 60 minutes: armor
+ * 90 minutes: fire breath
+ */
+
+/datum/movespeed_modifier/elder_speed
+	multiplicative_slowdown = -0.2
+
+/datum/component/elder_ash
+	///the parent of the component must be a human
+	var/mob/living/carbon/human/human_parent
+
+/datum/component/elder_ash/Initialize()
+	if(!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+	human_parent = parent
+	addtimer(CALLBACK(src, .proc/elder_speed), 30 MINUTES)
+	addtimer(CALLBACK(src, .proc/elder_armor), 60 MINUTES)
+	addtimer(CALLBACK(src, .proc/elder_breath), 90 MINUTES)
+
+/datum/component/elder_ash/proc/elder_speed()
+	human_parent.add_movespeed_modifier(/datum/movespeed_modifier/elder_speed)
+	to_chat(human_parent, span_warning("As time passes, you feel that your legs have become stronger-- your walking is more efficient."))
+
+/datum/component/elder_ash/proc/elder_armor()
+	human_parent.dna.species.armor = 30
+	to_chat(human_parent, span_warning("As time passes, you feel that your scales have hardened-- you can take hits better."))
+
+/datum/component/elder_ash/proc/elder_breath()
+	var/datum/action/cooldown/mob_cooldown/fire_breath/granted_action
+	granted_action = new()
+	granted_action.Grant(human_parent)
+	to_chat(human_parent, span_warning("As time passes, an ancient power within you has awakened-- the power of fire is yours!"))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4763,6 +4763,7 @@
 #include "modular_skyrat\modules\ashwalkers\code\items\ash_weapon.dm"
 #include "modular_skyrat\modules\ashwalkers\code\items\ashwalker_shaman.dm"
 #include "modular_skyrat\modules\ashwalkers\code\species\Ashwalkers.dm"
+#include "modular_skyrat\modules\ashwalkers\code\species\elder.dm"
 #include "modular_skyrat\modules\assault_operatives\code\areas.dm"
 #include "modular_skyrat\modules\assault_operatives\code\assault_operatives.dm"
 #include "modular_skyrat\modules\assault_operatives\code\assault_operatives_outfits.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ashwalkers get stronger after 30, 60, and 90 minutes
speed, armor, and fire breath.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
ashwalkers need to strive to live longer. For story purposes, older ashies should be raising and help teach the newly arisen ashies. This increase in power can create some form of "superiority" over the younger ashies.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: ashies get stronger after 30, 60, and 90 minutes being alive (individually)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
