### PR TITLE
Gun cargo orders now show up in briefcases

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -121,6 +121,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	var/value = 0
 	var/purchases = 0
 	var/list/goodies_by_buyer = list() // if someone orders more than GOODY_FREE_SHIPPING_MAX goodies, we upcharge to a normal crate so they can't carry around 20 combat shotties
+	var/list/forced_briefcases = list() //SKYRAT EDIT
 
 	for(var/datum/supply_order/spawning_order in SSshuttle.shopping_list)
 		if(!empty_turfs.len)
@@ -154,6 +155,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		if(spawning_order.paying_account)
 			if(spawning_order.pack.goody)
 				LAZYADD(goodies_by_buyer[spawning_order.paying_account], spawning_order)
+			if(istype(spawning_order, /datum/supply_order/armament))
+				LAZYADD(forced_briefcases[spawning_order.paying_account], spawning_order)
 			paying_for_this.bank_card_talk("Cargo order #[spawning_order.id] has shipped. [price] credits have been charged to your bank account.")
 			var/datum/bank_account/department/cargo = SSeconomy.get_dep_account(ACCOUNT_CAR)
 			cargo.adjust_money(price - spawning_order.pack.get_cost()) //Cargo gets the handling fee
@@ -163,7 +166,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		QDEL_NULL(spawning_order.applied_coupon)
 
 		spawning_order.on_spawn() //SKYRAT EDIT
-		if(!spawning_order.pack.goody) //we handle goody crates below
+		if(!spawning_order.pack.goody && !istype(spawning_order, /datum/supply_order/armament)) //we handle goody crates below //SKYRAT EDIT
 			spawning_order.generate(pick_n_take(empty_turfs))
 
 		SSblackbox.record_feedback("nested tally", "cargo_imports", 1, list("[spawning_order.pack.get_cost()]", "[spawning_order.pack.name]"))
@@ -200,6 +203,35 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 				misc_contents[buyer] += item
 			misc_costs[buyer] += our_order.pack.cost
 			misc_order_num[buyer] = "[misc_order_num[buyer]]#[our_order.id]  "
+	//SKYRAT EDIT START
+	for(var/briefcase_order in forced_briefcases)
+		var/list/buying_account_orders = forced_briefcases[briefcase_order]
+		var/datum/bank_account/buying_account = briefcase_order
+		var/buyer = buying_account.account_holder
+		var/buying_acc_order_num = length(buying_account_orders)
+		for(var/datum/supply_order/armament/the_order in buying_account_orders)
+			if(!the_order.item_amount || (the_order.item_amount == 1))
+				continue
+			buying_acc_order_num += the_order.item_amount - 1
+
+		if(buying_acc_order_num > GOODY_FREE_SHIPPING_MAX) // no free shipping, send a crate
+			var/obj/structure/closet/crate/secure/owned/our_crate = new /obj/structure/closet/crate/secure/owned(pick_n_take(empty_turfs))
+			our_crate.buyer_account = buying_account
+			our_crate.name = "armament case - purchased by [buyer]"
+			miscboxes[buyer] = our_crate
+		else //free shipping in a case
+			miscboxes[buyer] = new /obj/item/storage/lockbox/order(pick_n_take(empty_turfs))
+			var/obj/item/storage/lockbox/order/our_case = miscboxes[buyer]
+			our_case.buyer_account = buying_account
+			miscboxes[buyer].name = "armament case - purchased by [buyer]"
+		misc_contents[buyer] = list()
+
+		for(var/datum/supply_order/order in buying_account_orders)
+			for (var/item in order.pack.contains)
+				misc_contents[buyer] += item
+			misc_costs[buyer] += order.pack.cost
+			misc_order_num[buyer] = "[misc_order_num[buyer]]#[order.id]  "
+	//SKYRAT EDIT END
 
 	for(var/I in miscboxes)
 		var/datum/supply_order/SO = new/datum/supply_order()

--- a/modular_skyrat/modules/gun_cargo/code/armament_component.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_component.dm
@@ -397,7 +397,8 @@
 		created_order = new(created_pack, name, rank, ckey, paying_account = buyer, reason = reason)
 	else
 		created_order = new(created_pack, name, rank, ckey, reason = reason)
-	created_order.interest_addition = 1 * ammo_purchase_num
+	created_order.interest_addition = ammo_purchase_num
+	created_order.item_amount = ammo_purchase_num
 	var/datum/computer_file/program/budgetorders/file_p = parent_prog
 	if(console_state == CARGO_CONSOLE)
 		created_order.generateRequisition(get_turf(parent))

--- a/modular_skyrat/modules/gun_cargo/code/datums/cargo_order.dm
+++ b/modular_skyrat/modules/gun_cargo/code/datums/cargo_order.dm
@@ -5,6 +5,8 @@
 	var/datum/component/armament/cargo_gun/used_component
 	/// How much it'll add to a company's interest on-buy
 	var/interest_addition
+	/// If the order has multiple items in it, how many? Is null by default, set only if there's more than one item.
+	var/item_amount
 
 /datum/supply_order/armament/Destroy(force, ...)
 	selected_entry = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If an order has less than 5 items, it shows up in a briefcase, not a crate

## How This Contributes To The Skyrat Roleplay Experience
Planned feature and it's convenient not to have 30 crates in the shuttle every cycle

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Gun cargo orders usually show up in briefcases now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
