### PR TITLE
Default Gulag Shuttle fix

### DIFF
--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -104,7 +104,9 @@
 	width = 9;
 	port_direction = 4
 	},
-/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/airlock/titanium{
+	name = "Labor Shuttle Airlock"
+	},
 /turf/open/floor/plating,
 /area/shuttle/labor)
 "r" = (
@@ -119,21 +121,15 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
 /area/shuttle/labor)
-"W" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Labor Shuttle Airlock"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/labor)
 
 (1,1,1) = {"
 a
 a
-i
+b
 a
 a
 b
-W
+b
 a
 a
 "}
@@ -173,7 +169,7 @@ s
 (5,1,1) = {"
 a
 a
-b
+i
 a
 a
 a


### PR DESCRIPTION
Fixes the doors no longer on the side that connects to the station/camp

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Brings the doors back to the correct side of the shuttle

## How This Contributes To The Skyrat Roleplay Experience

They can now enter/leave the gulag shuttle

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix:: fixed improper placement of the doors

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
