### PR TITLE
Until Skyrat's host faces punishment for the way he treats his staff, his developers, and his players, I will be closing all of my PRs. After what came to light today on the ss13 reddit, I am not comfortable with developing for Skyrat anymore.

### DIFF
--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -1,3 +1,4 @@
+GLOBAL_VAR(economy_collapse) // SKYRAT EDIT ADDITION
 /obj/item/suspiciousphone
 	name = "suspicious phone"
 	desc = "This device raises pink levels to unknown highs."
@@ -15,6 +16,11 @@
 	if(dumped)
 		to_chat(user, span_warning("You already activated Protocol CRAB-17."))
 		return FALSE
+	// SKYRAT EDIT BEGIN
+	if(economy_collapse)
+		to_chat(user, span_warning("The economy has already collapsed once, a second collapse would end society as we know it."))
+		return
+	// SKYRAT EDIT END
 	if(tgui_alert(user, "Are you sure you want to crash this market with no survivors?", "Protocol CRAB-17", list("Yes", "No")) == "Yes")
 		if(dumped || QDELETED(src)) //Prevents fuckers from cheesing alert
 			return FALSE
@@ -31,6 +37,7 @@
 			B.being_dumped = TRUE
 		new /obj/effect/dumpeet_target(targetturf, L)
 		dumped = TRUE
+		economy_collapse = TRUE
 
 /obj/structure/checkoutmachine
 	name = "\improper Nanotrasen Space-Coin Market"

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -17,7 +17,7 @@ GLOBAL_VAR(economy_collapse) // SKYRAT EDIT ADDITION
 		to_chat(user, span_warning("You already activated Protocol CRAB-17."))
 		return FALSE
 	// SKYRAT EDIT BEGIN
-	if(economy_collapse)
+	if(GLOB.economy_collapse)
 		to_chat(user, span_warning("The economy has already collapsed once, a second collapse would end society as we know it."))
 		return
 	// SKYRAT EDIT END

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -37,7 +37,7 @@ GLOBAL_VAR(economy_collapse) // SKYRAT EDIT ADDITION
 			B.being_dumped = TRUE
 		new /obj/effect/dumpeet_target(targetturf, L)
 		dumped = TRUE
-		economy_collapse = TRUE
+		GLOB.economy_collapse = TRUE
 
 /obj/structure/checkoutmachine
 	name = "\improper Nanotrasen Space-Coin Market"


### PR DESCRIPTION
# I am not comfortable with my work being used by the host of Skyrat after what he did to players, staff, and developers came to light today on the ss13 reddit. As such, I am closing all of my PRs until change occurs and I feel comfortable working here again. I apologize to any players looking forward to these features.

Crab-17 is supposed to only be a once a round purchase, but after the upstream rework of how uplink items work this feature broke and different uplinks can buy multiple crab-17 phones. 

I've opted to patch this issue temporarily down here via adding a global check for whether the economy has already crashed once until upstream fixes this issue. I've alerted the dev who broke it in the past, but they likely forgot as they've been busy with other projects, so I'll ask them about it again.

This prevents double dumping of the economy if a dump has already occurred.
:cl:
fix: CRAB-17 only works once a round now.
/:cl: