### PR TITLE
[MODULAR] Crew monitoring console now becomes needy when the crew is.

### DIFF
--- a/modular_skyrat/modules/crewconsole/glow.dm
+++ b/modular_skyrat/modules/crewconsole/glow.dm
@@ -1,0 +1,27 @@
+#define SENSORS_UPDATE_PERIOD 10 SECONDS //Why is this not a global define, why do I have to define it again
+
+
+/obj/machinery/computer/crew
+	luminosity = 1
+	light_power = 3
+
+/obj/machinery/computer/crew/Initialize(mapload, obj/item/circuitboard/C)
+	. = ..()
+	alarm()
+
+/obj/machinery/computer/crew/proc/alarm()
+	var/canalarm = FALSE
+
+	for(var/list/player_record as anything in GLOB.crewmonitor.update_data(src.z))
+		if(player_record["health"] <= MAX_LIVING_HEALTH / 2)
+
+			canalarm = TRUE
+
+	if(canalarm)
+		playsound(src, 'sound/machines/twobeep.ogg', 50, TRUE)
+		set_light((initial(light_range) + 3), 3, CIRCUIT_COLOR_SECURITY, TRUE)
+
+	else
+		set_light((initial(light_range)), initial(light_power), initial(light_color), TRUE)
+	addtimer(CALLBACK(src, .proc/alarm), SENSORS_UPDATE_PERIOD)
+	return canalarm

--- a/modular_skyrat/modules/crewconsole/glow.dm
+++ b/modular_skyrat/modules/crewconsole/glow.dm
@@ -4,18 +4,31 @@
 /obj/machinery/computer/crew
 	luminosity = 1
 	light_power = 3
-
+	var/canalarm = FALSE
+	var/obj/item/radio/radio
 /obj/machinery/computer/crew/Initialize(mapload, obj/item/circuitboard/C)
 	. = ..()
+
+	radio = new/obj/item/radio(src)
+	radio.set_listening(FALSE)
 	alarm()
 
 /obj/machinery/computer/crew/proc/alarm()
-	var/canalarm = FALSE
+	canalarm = FALSE
+	var/injuredcount = 0
 
-	for(var/list/player_record as anything in GLOB.crewmonitor.update_data(src.z))
-		if(player_record["health"] <= HEALTH_THRESHOLD_CRIT)
-
+	for(var/tracked_mob in GLOB.suit_sensors_list)
+		var/mob/living/carbon/human/mob = tracked_mob
+		if(mob.z != src.z  && !HAS_TRAIT(mob, TRAIT_MULTIZ_SUIT_SENSORS))
+			continue
+		var/obj/item/clothing/under/uniform = mob.w_uniform
+		if(uniform.sensor_mode >= SENSOR_VITALS && HAS_TRAIT(mob, TRAIT_CRITICAL_CONDITION) || mob.stat == DEAD)
+			injuredcount++
 			canalarm = TRUE
+		if(uniform.sensor_mode == SENSOR_LIVING && mob.stat == DEAD)
+			injuredcount++
+			canalarm = TRUE
+
 
 	if(canalarm)
 		playsound(src, 'sound/machines/twobeep.ogg', 50, TRUE)
@@ -24,6 +37,14 @@
 	else
 		set_light((initial(light_range)), initial(light_power), initial(light_color), TRUE)
 	addtimer(CALLBACK(src, .proc/alarm), SENSORS_UPDATE_PERIOD)
+	if(prob(1))
+		alert_radio(canalarm, injuredcount)
 	return canalarm
+
+/obj/machinery/computer/crew/proc/alert_radio(canalarm, injuredcount)
+	if(canalarm)
+		radio.set_frequency(FREQ_MEDICAL)
+		radio.talk_into(src, "There are [injuredcount] crewmembers in dire need of medical aid.", RADIO_CHANNEL_MEDICAL)
+
 
 #undef SENSORS_UPDATE_PERIOD

--- a/modular_skyrat/modules/crewconsole/glow.dm
+++ b/modular_skyrat/modules/crewconsole/glow.dm
@@ -13,7 +13,7 @@
 	var/canalarm = FALSE
 
 	for(var/list/player_record as anything in GLOB.crewmonitor.update_data(src.z))
-		if(player_record["health"] <= MAX_LIVING_HEALTH / 2)
+		if(player_record["health"] <= HEALTH_THRESHOLD_CRIT)
 
 			canalarm = TRUE
 

--- a/modular_skyrat/modules/crewconsole/glow.dm
+++ b/modular_skyrat/modules/crewconsole/glow.dm
@@ -25,3 +25,4 @@
 		set_light((initial(light_range)), initial(light_power), initial(light_color), TRUE)
 	addtimer(CALLBACK(src, .proc/alarm), SENSORS_UPDATE_PERIOD)
 	return canalarm
+#undef SENSORS_UPDATE_PERIOD

--- a/modular_skyrat/modules/crewconsole/glow.dm
+++ b/modular_skyrat/modules/crewconsole/glow.dm
@@ -25,7 +25,7 @@
 		if(uniform.sensor_mode >= SENSOR_VITALS && HAS_TRAIT(mob, TRAIT_CRITICAL_CONDITION) || mob.stat == DEAD)
 			injuredcount++
 			canalarm = TRUE
-		if(uniform.sensor_mode == SENSOR_LIVING && mob.stat == DEAD)
+		else if(uniform.sensor_mode == SENSOR_LIVING && mob.stat == DEAD)
 			injuredcount++
 			canalarm = TRUE
 

--- a/modular_skyrat/modules/crewconsole/glow.dm
+++ b/modular_skyrat/modules/crewconsole/glow.dm
@@ -25,4 +25,5 @@
 		set_light((initial(light_range)), initial(light_power), initial(light_color), TRUE)
 	addtimer(CALLBACK(src, .proc/alarm), SENSORS_UPDATE_PERIOD)
 	return canalarm
+
 #undef SENSORS_UPDATE_PERIOD

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4918,6 +4918,7 @@
 #include "modular_skyrat\modules\cortical_borer\code\cortical_borer_egg.dm"
 #include "modular_skyrat\modules\cortical_borer\code\cortical_borer_items.dm"
 #include "modular_skyrat\modules\crafting\crafting_skyrat.dm"
+#include "modular_skyrat\modules\crewconsole\glow.dm"
 #include "modular_skyrat\modules\cryosleep\code\ai.dm"
 #include "modular_skyrat\modules\cryosleep\code\config.dm"
 #include "modular_skyrat\modules\cryosleep\code\cryopod.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alright. So, with the scarcity of handheld crew monitors, combined with people cryoing with gear, taking job slots, not doing their jobs late into the round, and breaking the need to glue yourself to a console otherwise... I have decided to make the Crew Monitor consoles glow a nice red and beep quietly every 10 seconds while there are ongoing medical emergencies (on sensors only).

This should prevent incidents I have seen in the past where admin intervention is require 30+ minutes after someone died on sensors because medical cannot be bothered to do their jobs or respond to suit sensors... command surprised pikachu'ing when they hear someone's been dead 30+.. etc... 

This should attract attention to the crew console when someone is soft crit or worse on it. 

## How This Contributes To The Skyrat Roleplay Experience

It sucks to be a player watching medical fumble around bored when there's people dead on suit sensors. When there are no dedicated paramedics that are amazing at their jobs, this will make medical noticing you FAR more likely. It also makes sense a bit for a system that detects emergencies to also alert you, like medibots do. 


## Media
![dreamseeker_zB0q7ZbHi7](https://user-images.githubusercontent.com/77420409/165019028-5f362397-e119-4d96-8a10-0b8de7929ab5.png)

https://user-images.githubusercontent.com/77420409/165019077-d82c7e77-84ec-43ff-bb08-131aa5c028ea.mp4

https://user-images.githubusercontent.com/77420409/165019092-4f4ed12f-dbd1-49ff-b5e9-016e8680a8f5.mp4





## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Suit sensors console beeps and glows for the injured.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
