### PR TITLE
Gun Cargo balance pass 1

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -676,7 +676,7 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 
 /obj/item/suppressor
 	name = "suppressor"
-	desc = "A syndicate small-arms suppressor for maximum espionage."
+	desc = "A Scarborough Arms small-arms suppressor for maximum espionage." //SKYRAT EDIT
 	icon = 'icons/obj/guns/ballistic.dmi'
 	icon_state = "suppressor"
 	w_class = WEIGHT_CLASS_TINY

--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/armadyne.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/armadyne.dm
@@ -53,11 +53,6 @@
 	subcategory = ARMAMENT_SUBCATEGORY_ASSAULTRIFLE
 	interest_required = HIGH_INTEREST
 
-/datum/armament_entry/cargo_gun/armadyne/rifle/ripper
-	item_type = /obj/item/gun/ballistic/automatic/dmr
-	lower_cost = CARGO_CRATE_VALUE * 24
-	upper_cost = CARGO_CRATE_VALUE * 28
-
 /datum/armament_entry/cargo_gun/armadyne/rifle/norwind
 	item_type = /obj/item/gun/energy/norwind
 	lower_cost = CARGO_CRATE_VALUE * 10

--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/nanotrasen.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/nanotrasen.dm
@@ -48,8 +48,3 @@
 	lower_cost = CARGO_CRATE_VALUE * 12
 	upper_cost = CARGO_CRATE_VALUE * 16
 	interest_required = PASSED_INTEREST
-
-/datum/armament_entry/cargo_gun/nanotrasen/rifle/boarder
-	item_type = /obj/item/gun/ballistic/automatic/ar
-	lower_cost = CARGO_CRATE_VALUE * 28
-	upper_cost = CARGO_CRATE_VALUE * 32

--- a/modular_skyrat/modules/gunsgalore/code/ammo/ammo.dm
+++ b/modular_skyrat/modules/gunsgalore/code/ammo/ammo.dm
@@ -13,7 +13,7 @@
 
 /obj/projectile/bullet/a792x33
 	name = "7.92x33 bullet"
-	damage = 40
+	damage = 32
 	wound_bonus = 10
 	wound_falloff_tile = 0
 //
@@ -45,9 +45,7 @@
 
 /obj/projectile/bullet/a762x25
 	name = "7.62x25 bullet"
-	damage = 22
-	wound_bonus = 30
-	armour_penetration = 8
+	damage = 20
 	wound_falloff_tile = 0
 //
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR does the following:

- Removes the Ripper and Boarder
- removes armor pen and wound bonus from ppsh ammo, 22 -> 20 damage
- STG damage 40 -> 32
- Edits the description of the suppressor to not be syndicate

## How This Contributes To The Skyrat Roleplay Experience

- These guns massively outclass near-everything else and are relatively easy to obtain (unlike the m-90gl), and are ERT weapons.
- making this gun not rediculous
- ditto
- Bluie starts with one

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Boarder and Ripper removed from guncargo
balance: removes armor pen and wound bonus from ppsh ammo, 22 -> 20 damage
balance: STG damage 40 -> 32
spellcheck: Suppressor no longer mentions the syndicate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
