### PR TITLE
Fixes gun cargo orders

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -166,7 +166,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		QDEL_NULL(spawning_order.applied_coupon)
 
 		spawning_order.on_spawn() //SKYRAT EDIT
-		if(!spawning_order.pack.goody && !istype(spawning_order, /datum/supply_order/armament)) //we handle goody crates below //SKYRAT EDIT
+		if(!spawning_order.pack.goody && !(spawning_order?.paying_account in forced_briefcases)) //we handle goody crates below //SKYRAT EDIT
 			spawning_order.generate(pick_n_take(empty_turfs))
 
 		SSblackbox.record_feedback("nested tally", "cargo_imports", 1, list("[spawning_order.pack.get_cost()]", "[spawning_order.pack.name]"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The briefcase PR fucked up when you tried to *not* private-order something, this fixes that, they now appear again

closes #13098
closes #13105 
## How This Contributes To The Skyrat Roleplay Experience
bugs are bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Guncargo crates should appear again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
