### PR TITLE
Fix honeybee unloading

### DIFF
--- a/modular_skyrat/modules/gun_cargo/code/objects/guns/interdyne.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/guns/interdyne.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/ballistic/automatic/pistol/firefly/smartdart
 	name = "\improper I-94 'Honeybee'"
-	desc = "A 9mm sidearm made by Armadyne and modified by Interdyne, it features a slightly modified paint job and sports a SmartDart underbarrel attachment which can be fired with right click."
+	desc = "A 9mm sidearm made by Armadyne and modified by Interdyne, it features a slightly modified paint job and sports a SmartDart underbarrel attachment."
 	company_flag = COMPANY_INTERDYNE
 	icon = 'modular_skyrat/modules/gun_cargo/icons/honeybee.dmi'
 	icon_state = "honeybee"
@@ -16,11 +16,20 @@
 	underbarrel.afterattack(target, user, flag, params)
 	return SECONDARY_ATTACK_CONTINUE_CHAIN
 
+/obj/item/gun/ballistic/automatic/pistol/firefly/smartdart/attack_hand_secondary(mob/user, list/modifiers)
+	underbarrel.attack_self(user, modifiers)
+	return SECONDARY_ATTACK_CONTINUE_CHAIN
+
 /obj/item/gun/ballistic/automatic/pistol/firefly/smartdart/attackby(obj/item/attacking_item, mob/user, params)
 	if(istype(attacking_item, /obj/item/reagent_containers/syringe/smartdart))
 		underbarrel.attackby(attacking_item, user, params)
 	else
 		..()
+
+/obj/item/gun/ballistic/automatic/pistol/firefly/smartdart/examine(mob/user)
+	. = ..()
+	. += "<br>You can fire the underbarrel device with [span_bold("right click")]."
+	. += "<br>You can unload the underbarrel device by [span_bold("right clicking with an empty hand")]."
 
 /obj/item/gun/syringe/smartdart/underbarrel
 	name = "SmartDart underbarrel device"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows you to properly unload the underbarrel device with RMB

## How This Contributes To The Skyrat Roleplay Experience
Oversights are bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can now unload the honeybee's underbarrel by right clicking on it with an empty hand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
