### PR TITLE
Disable erp items on a new config entry

### DIFF
--- a/config/skyrat/skyrat_config.txt
+++ b/config/skyrat/skyrat_config.txt
@@ -96,6 +96,7 @@ SSDECAY_DISABLE_NESTS
 
 ## Disables any ERP preferences for codebases that don't want it.
 #DISABLE_ERP_PREFERENCES
+#DISABLE_LEWD_ITEMS
 #ERP_EMOTES_TO_DISABLE cum
 
 ## Lobby Camera Intro

--- a/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
@@ -1,6 +1,9 @@
 /datum/config_entry/flag/disable_erp_preferences
 	default = FALSE
 
+/datum/config_entry/flag/disable_lewd_items
+	default = FALSE
+
 /datum/config_entry/str_list/erp_emotes_to_disable
 
 /datum/config_entry/str_list/erp_emotes_to_disable/ValidateAndSet(str_val)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_remove_erp_items.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_remove_erp_items.dm
@@ -1,229 +1,229 @@
 /obj/item/storage/box/milking_kit/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/storage/box/xstand_kit/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/storage/box/bdsmbed_kit/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/storage/box/strippole_kit/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/storage/box/shibari_stand/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/paper/shibari_kit_instructions/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/sextoy/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/mask/ballgag/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/reagent_containers/glass/lewd_filter/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/mask/gas/bdsm_mask/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/suit/corset/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/head/domina_cap/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/storage/belt/erpbelt/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/glasses/hypno/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/shoes/dominaheels/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/gloves/ball_mittens/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/gloves/ball_mittens_reinforced/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/suit/straight_jacket/kinky_sleepbag/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/ears/kinky_headphones/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/glasses/blindfold/kinky/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/neck/kink_collar/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/lustwish_discount/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/tickle_feather/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/mask/leatherwhip/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/kinky_shocker/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/condom_pack/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/under/stripper_outfit/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/structure/pole/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/polepack/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/bdsm_bed_kit/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/structure/chair/x_stand/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/x_stand_kit/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/structure/chair/milking_machine/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/milking_machine/constructionkit/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/bdsm_candle/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/spanking_pad/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/restraints/handcuffs/lewd/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/strapon_dildo/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/key/kink_collar/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/mind_controller/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/neck/mind_collar/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/restraints/handcuffs/milker/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/vending_refill/lustwish/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/machinery/vending/dorms/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/structure/bed/bdsm_bed/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/strapon/Initialize()
 	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
+	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR adds a config entry, which is now used to determine should lewd (ERP) items be removed from the game.

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
Other Skyrat forks, who disable ERP preferences, may still have ERP items scattered on the maps for flavour they provide

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: ERP items are now disabled with DISABLE_LEWD_ITEMS config entry instead of DISABLE_ERP_PREFERENCES
config: DISABLE_LEWD_ITEMS entry added
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
