### PR TITLE
Fixes Blueshift spawning the wrong kind of space turfs on the bottom Z-level when replacing turfs

### DIFF
--- a/_maps/blueshift.json
+++ b/_maps/blueshift.json
@@ -18,7 +18,6 @@
 	"traits": [
 		{
 			"Up": 1,
-			"Baseturf": "/turf/open/space/basic",
 			"Linkage": "Cross"
 		},
 		{


### PR DESCRIPTION
## About The Pull Request
It really was as simple as that.

`/turf/open/space/basic` doesn't get Initialize()'d. This isn't so much of a problem for round-start space tiles, because I'm pretty sure they got something funky going on to make it happen slightly later, instead.

But as for the baseturf, it basically shouldn't've been set to this, pretty much.

Can't blame 'em, though, it's not the wildest assumption to make for someone that doesn't know the difference between `/turf/open/space` and `/turf/open/space/basic`.

## How This Contributes To The Skyrat Roleplay Experience
Hopefully will reduce by a fair amount the quantity of runtimes related to space turfs interacting poorly with atmos on Blueshift.

Do note that this doesn't fix all the issues there is, there's some more, but I'll find them in due time.

## Changelog

:cl: GoldenAlpharex
fix: Fixed Blueshift spawning space that couldn't be interacted with on its bottom-most level, when a plating turf is removed.
/:cl: