### PR TITLE
Fixes briefcase departmental order access for guncargo

### DIFF
--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -173,12 +173,12 @@
 	name = "security medal box"
 	desc = "A locked box used to store medals to be given to members of the security department."
 	req_access = list(ACCESS_HOS)
-	
+
 /obj/item/storage/lockbox/medal/med
 	name = "medical medal box"
 	desc = "A locked box used to store medals to be given to members of the medical department."
 	req_access = list(ACCESS_CMO)
-	
+
 /obj/item/storage/lockbox/medal/med/PopulateContents()
 	new /obj/item/clothing/accessory/medal/med_medal(src)
 	new /obj/item/clothing/accessory/medal/med_medal2(src)
@@ -227,6 +227,11 @@
 /obj/item/storage/lockbox/order/Initialize(mapload, datum/bank_account/_buyer_account)
 	. = ..()
 	buyer_account = _buyer_account
+	//SKYRAT EDIT START
+	if(istype(buyer_account, /datum/bank_account/department))
+		department_purchase = TRUE
+		department_account = buyer_account
+	//SKYRAT EDIT END
 
 /obj/item/storage/lockbox/order/attackby(obj/item/W, mob/user, params)
 	if(!istype(W, /obj/item/card/id))
@@ -236,7 +241,7 @@
 	if(iscarbon(user))
 		add_fingerprint(user)
 
-	if(id_card.registered_account != buyer_account)
+	if((id_card.registered_account != buyer_account) && !(department_purchase && (id_card.registered_account?.account_job?.paycheck_department) == (department_account.department_id)))
 		to_chat(user, span_warning("Bank account does not match with buyer!"))
 		return
 

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -241,7 +241,7 @@
 	if(iscarbon(user))
 		add_fingerprint(user)
 
-	if((id_card.registered_account != buyer_account) && !(department_purchase && (id_card.registered_account?.account_job?.paycheck_department) == (department_account.department_id)))
+	if((id_card.registered_account != buyer_account) && !(department_purchase && (id_card.registered_account?.account_job?.paycheck_department) == (department_account.department_id))) //SKYRAT EDIT
 		to_chat(user, span_warning("Bank account does not match with buyer!"))
 		return
 

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -214,7 +214,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 				continue
 			buying_acc_order_num += the_order.item_amount - 1
 
-		if(buying_acc_order_num > GOODY_FREE_SHIPPING_MAX) // no free shipping, send a crate
+		if(buying_acc_order_num > 2) // no free shipping, send a crate
 			var/obj/structure/closet/crate/secure/owned/our_crate = new /obj/structure/closet/crate/secure/owned(pick_n_take(empty_turfs))
 			our_crate.buyer_account = buying_account
 			our_crate.name = "armament crate - purchased by [buyer]"

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -217,12 +217,15 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		if(buying_acc_order_num > GOODY_FREE_SHIPPING_MAX) // no free shipping, send a crate
 			var/obj/structure/closet/crate/secure/owned/our_crate = new /obj/structure/closet/crate/secure/owned(pick_n_take(empty_turfs))
 			our_crate.buyer_account = buying_account
-			our_crate.name = "armament case - purchased by [buyer]"
+			our_crate.name = "armament crate - purchased by [buyer]"
 			miscboxes[buyer] = our_crate
 		else //free shipping in a case
 			miscboxes[buyer] = new /obj/item/storage/lockbox/order(pick_n_take(empty_turfs))
 			var/obj/item/storage/lockbox/order/our_case = miscboxes[buyer]
 			our_case.buyer_account = buying_account
+			if(istype(our_case.buyer_account, /datum/bank_account/department))
+				our_case.department_purchase = TRUE
+				our_case.department_account = our_case.buyer_account
 			miscboxes[buyer].name = "armament case - purchased by [buyer]"
 		misc_contents[buyer] = list()
 

--- a/modular_skyrat/modules/gun_cargo/code/objects/box.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/box.dm
@@ -13,3 +13,9 @@
 /obj/item/storage/box/syringes/piercing/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/syringe/bluespace(src)
+
+/obj/item/storage/lockbox/order
+	/// Bool if this was departmentally ordered or not
+	var/department_purchase
+	/// Department of the person buying the crate if buying via the NIRN app.
+	var/datum/bank_account/department/department_account


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Dep orders couldn't be unlocked before if they were in cases, they can now.
Also fixes an issue where some items may not spawn in briefcases, now they do.

## How This Contributes To The Skyrat Roleplay Experience
Bugs bad.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Gun briefcases ordered through gun cargo on departmental budget can now be unlocked
fix: Items in guncargo briefcases shouldn't disappear on-order now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
