### PR TITLE
Ensures that our wider titlescreen is handled properly, so our splash screens are correctly centered

### DIFF
--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -97,7 +97,11 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	if(width == 480) // 480x480 is nonwidescreen
 		pixel_x = 0
 	else if(width == 608) // 608x480 is widescreen
-		pixel_x = 0 // SKYRAT EDIT - Re-centering the title screen - ORIGINAL: pixel_x = -64
+		pixel_x = -64
+	// SKYRAT EDIT START - Wider widescreen
+	else if(width == 672) // Skyrat's widescreen is slightly wider than /tg/'s, so we need to accomodate that too.
+		pixel_x = -96
+	// SKYRAT EDIT END
 
 /turf/closed/indestructible/splashscreen/vv_edit_var(var_name, var_value)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
I added a thing there before, now it's gone, and replaced with something better, now that it's set to the right spot on CentCom again.

## How This Contributes To The Skyrat Roleplay Experience
A centered title screen is a good title screen.

## Changelog

:cl: GoldenAlpharex
fix: Fixed the title screen being off-centered.
/:cl: