### PR TITLE
Assops can buy more PML-9 Ammo

### DIFF
--- a/modular_skyrat/modules/assault_operatives/code/armaments/_armament_primary.dm
+++ b/modular_skyrat/modules/assault_operatives/code/armaments/_armament_primary.dm
@@ -11,7 +11,7 @@
 /datum/armament_entry/assault_operatives/primary/submachinegun/wildcat
 	item_type = /obj/item/gun/ballistic/automatic/cfa_wildcat
 	cost = 5
-	
+
 /datum/armament_entry/assault_operatives/primary/submachinegun/lynx
 	item_type = /obj/item/gun/ballistic/automatic/cfa_lynx
 	cost = 7
@@ -63,9 +63,11 @@
 
 /datum/armament_entry/assault_operatives/primary/special/rocket_launcher
 	item_type = /obj/item/gun/ballistic/rocketlauncher/unrestricted
+	magazine = /obj/item/ammo_casing/caseless/rocket
+	magazine_cost = 2
 
 /datum/armament_entry/assault_operatives/primary/special/rocket_launcher/after_equip(turf/safe_drop_location, obj/item/item_to_equip)
 	var/obj/item/storage/box/ammo_box/spawned_box = new(safe_drop_location)
 	spawned_box.name = "ROCKETS - [item_to_equip.name]"
-	for(var/i in 1 to 5)
+	for(var/i in 1 to 3)
 		new /obj/item/ammo_casing/caseless/rocket(spawned_box)

--- a/modular_skyrat/modules/assault_operatives/code/armaments/_armament_primary.dm
+++ b/modular_skyrat/modules/assault_operatives/code/armaments/_armament_primary.dm
@@ -64,7 +64,6 @@
 /datum/armament_entry/assault_operatives/primary/special/rocket_launcher
 	item_type = /obj/item/gun/ballistic/rocketlauncher/unrestricted
 	magazine = /obj/item/ammo_casing/caseless/rocket
-	magazine_cost = 2
 
 /datum/armament_entry/assault_operatives/primary/special/rocket_launcher/after_equip(turf/safe_drop_location, obj/item/item_to_equip)
 	var/obj/item/storage/box/ammo_box/spawned_box = new(safe_drop_location)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows assops to buy more PML-9 ammo at a cost of 1 point/rocket. As balance, the amount of rockets it spawns with has been reduced to three.

## How This Contributes To The Skyrat Roleplay Experience
I want to use this as a legitimate primary for 15 points, not get 5 shots and discard.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Assault Ops can now purchase PML-9 Ammo
balance: PML-9 armament now spawns with 3 rockets instead of 5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
