### PR TITLE
IPC: Mix N' Match Edition

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/mutant_parts.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/mutant_parts.dm
@@ -869,6 +869,56 @@
 	relevant_mutant_bodypart = "ipc_chassis"
 	type_to_check = /datum/preference/toggle/ipc_chassis
 
+
+/// IPC Head
+
+/datum/preference/toggle/ipc_head
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "ipc_head_toggle"
+	relevant_mutant_bodypart = "ipc_head"
+	default_value = FALSE
+
+/datum/preference/toggle/ipc_head/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return TRUE // we dont actually want this to do anything
+
+/datum/preference/toggle/ipc_head/is_accessible(datum/preferences/preferences)
+	var/passed_initial_check = ..(preferences)
+	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
+	return passed_initial_check || allowed
+
+/datum/preference/choiced/ipc_head
+	savefile_key = "feature_ipc_head"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	relevant_mutant_bodypart = "ipc_head"
+
+/datum/preference/choiced/ipc_head/is_accessible(datum/preferences/preferences)
+	var/passed_initial_check = ..(preferences)
+	var/allowed = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
+	var/part_enabled = preferences.read_preference(/datum/preference/toggle/ipc_head)
+	return ((passed_initial_check || allowed) && part_enabled)
+
+/datum/preference/choiced/ipc_head/init_possible_values()
+	return assoc_to_keys(GLOB.sprite_accessories["ipc_head"])
+
+/datum/preference/choiced/ipc_head/apply_to_human(mob/living/carbon/human/target, value)
+	if(!target.dna.mutant_bodyparts[relevant_mutant_bodypart])
+		target.dna.mutant_bodyparts[relevant_mutant_bodypart] = list(MUTANT_INDEX_NAME = "None", MUTANT_INDEX_COLOR_LIST = list("#FFFFFF", "#FFFFFF", "#FFFFFF"), MUTANT_INDEX_EMISSIVE_LIST = list(FALSE, FALSE, FALSE))
+	target.dna.mutant_bodyparts[relevant_mutant_bodypart][MUTANT_INDEX_NAME] = value
+
+/datum/preference/choiced/ipc_head/create_default_value()
+	var/datum/sprite_accessory/ipc_head/default = /datum/sprite_accessory/ipc_head/none
+	return initial(default.name)
+
+/datum/preference/tri_color/ipc_head
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "ipc_head_color"
+	relevant_mutant_bodypart = "ipc_head"
+	type_to_check = /datum/preference/toggle/ipc_head
+
+
 /// Skrell Hair
 
 /datum/preference/toggle/skrell_hair

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/ipc.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/ipc.dm
@@ -234,3 +234,61 @@
 /datum/sprite_accessory/ipc_chassis/e3n
 	name = "E3N AI"
 	icon_state = "e3n"
+
+//Heads - snowflake phantom accessory for choosing IPC heads (hell yeah!)
+/datum/sprite_accessory/ipc_head
+	icon = null
+	icon_state = "ipc"
+	color_src = null
+	factual = FALSE
+	key = "ipc_head"
+	generic = "Head Type"
+
+/datum/sprite_accessory/ipc_head/none
+	name = "None"
+	icon_state = "none"
+
+/datum/sprite_accessory/ipc_head/mcgreyscale
+	name = "Morpheus Cyberkinetics(Greyscale)"
+	icon_state = "mcgipc"
+	color_src = 1 //Here it's used to tell apart greyscalling
+
+/datum/sprite_accessory/ipc_head/bishopcyberkinetics
+	name = "Bishop Cyberkinetics"
+	icon_state = "bshipc"
+
+/datum/sprite_accessory/ipc_head/bishopcyberkinetics2
+	name = "Bishop Cyberkinetics 2.0"
+	icon_state = "bs2ipc"
+
+/datum/sprite_accessory/ipc_head/hephaestussindustries
+	name = "Hephaestus Industries"
+	icon_state = "hsiipc"
+
+/datum/sprite_accessory/ipc_head/hephaestussindustries2
+	name = "Hephaestus Industries 2.0"
+	icon_state = "hi2ipc"
+
+/datum/sprite_accessory/ipc_head/shellguardmunitions
+	name = "Shellguard Munitions Standard Series"
+	icon_state = "sgmipc"
+
+/datum/sprite_accessory/ipc_head/wardtakahashimanufacturing
+	name = "Ward-Takahashi Manufacturing"
+	icon_state = "wtmipc"
+
+/datum/sprite_accessory/ipc_head/xionmanufacturinggroup
+	name = "Xion Manufacturing Group"
+	icon_state = "xmgipc"
+
+/datum/sprite_accessory/ipc_head/xionmanufacturinggroup2
+	name = "Xion Manufacturing Group 2.0"
+	icon_state = "xm2ipc"
+
+/datum/sprite_accessory/ipc_head/zenghupharmaceuticals
+	name = "Zeng-Hu Pharmaceuticals"
+	icon_state = "zhpipc"
+
+/datum/sprite_accessory/ipc_head/e3n
+	name = "E3N AI"
+	icon_state = "e3n"

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic/ipc.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic/ipc.dm
@@ -14,7 +14,8 @@
 	default_mutant_bodyparts = list(
 		"ipc_antenna" = ACC_RANDOM,
 		"ipc_screen" = ACC_RANDOM,
-		"ipc_chassis" = ACC_RANDOM
+		"ipc_chassis" = ACC_RANDOM,
+		"ipc_head" = ACC_RANDOM
 	)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	hair_alpha = 210
@@ -58,15 +59,21 @@
 		screen = new
 		screen.Grant(transformer)
 	var/chassis = transformer.dna.mutant_bodyparts["ipc_chassis"]
-	if(!chassis)
+	var/head = transformer.dna.mutant_bodyparts["ipc_head"]
+	if(!chassis && !head)
 		return
 	var/datum/sprite_accessory/ipc_chassis/chassis_of_choice = GLOB.sprite_accessories["ipc_chassis"][chassis["name"]]
-	if(chassis_of_choice)
-		examine_limb_id = chassis_of_choice.icon_state
-		// We want to ensure that the IPC gets their chassis correctly.
+	var/datum/sprite_accessory/ipc_head/head_of_choice = GLOB.sprite_accessories["ipc_head"][head["name"]]
+	if(chassis_of_choice || head_of_choice)
+		examine_limb_id = chassis_of_choice?.icon_state ? chassis_of_choice.icon_state : head_of_choice.icon_state
+		// We want to ensure that the IPC gets their chassis and their head correctly.
 		for(var/obj/item/bodypart/limb as anything in transformer.bodyparts)
-			if(limb.body_part == CHEST)
-				limb.limb_id = chassis_of_choice.icon_state != "None" ? chassis_of_choice.icon_state : "ipc"
+			if(chassis && limb.body_part == CHEST)
+				limb.limb_id = chassis_of_choice.icon_state != "none" ? chassis_of_choice.icon_state : "ipc"
+				continue
+
+			if(head && limb.body_part == HEAD)
+				limb.limb_id = head_of_choice.icon_state != "none" ? head_of_choice.icon_state : "ipc"
 
 		if(chassis_of_choice.color_src)
 			species_traits += MUTCOLORS
@@ -75,9 +82,10 @@
 /datum/species/robotic/ipc/replace_body(mob/living/carbon/target, datum/species/new_species)
 	..()
 	var/chassis = target.dna.mutant_bodyparts["ipc_chassis"]
-	var/datum/sprite_accessory/ipc_chassis/chassis_of_choice = GLOB.sprite_accessories["ipc_chassis"][chassis]
 	if(!chassis)
 		return
+	var/datum/sprite_accessory/ipc_chassis/chassis_of_choice = GLOB.sprite_accessories["ipc_chassis"][chassis["name"]]
+
 	for(var/obj/item/bodypart/iterating_bodypart as anything in target.bodyparts) //Override bodypart data as necessary
 		iterating_bodypart.uses_mutcolor = chassis_of_choice.color_src ? TRUE : FALSE
 		if(iterating_bodypart.uses_mutcolor)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic/ipc.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic/ipc.dm
@@ -45,20 +45,25 @@
 	sleep(3 SECONDS)*/
 	H.dna.mutant_bodyparts["ipc_screen"][MUTANT_INDEX_NAME] = "Blank"
 
-/datum/species/robotic/ipc/on_species_gain(mob/living/carbon/human/C)
+/datum/species/robotic/ipc/on_species_gain(mob/living/carbon/human/transformer)
 	. = ..()
 	if(!screen)
 		screen = new
-		screen.Grant(C)
-	var/chassis = C.dna.mutant_bodyparts["ipc_chassis"]
+		screen.Grant(transformer)
+	var/chassis = transformer.dna.mutant_bodyparts["ipc_chassis"]
 	if(!chassis)
 		return
-	var/datum/sprite_accessory/ipc_chassis/chassis_of_choice = GLOB.sprite_accessories["ipc_chassis"][chassis]
+	var/datum/sprite_accessory/ipc_chassis/chassis_of_choice = GLOB.sprite_accessories["ipc_chassis"][chassis["name"]]
 	if(chassis_of_choice)
 		examine_limb_id = chassis_of_choice.icon_state
+		// We want to ensure that the IPC gets their chassis correctly.
+		for(var/obj/item/bodypart/limb as anything in transformer.bodyparts)
+			if(limb.body_part == CHEST)
+				limb.limb_id = chassis_of_choice.icon_state != "None" ? chassis_of_choice.icon_state : "ipc"
+
 		if(chassis_of_choice.color_src)
 			species_traits += MUTCOLORS
-		C.update_body()
+		transformer.update_body()
 
 /datum/species/robotic/ipc/replace_body(mob/living/carbon/target, datum/species/new_species)
 	..()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic/ipc.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic/ipc.dm
@@ -32,7 +32,7 @@
 
 /datum/species/robotic/ipc/spec_revival(mob/living/carbon/human/transformer)
 	. = ..()
-	switch_to_screen(transformer, "BSOD")
+	switch_to_screen(transformer, "Console")
 	addtimer(CALLBACK(src, .proc/switch_to_screen, transformer, saved_screen), 5 SECONDS)
 
 /datum/species/robotic/ipc/spec_death(gibbed, mob/living/carbon/human/transformer)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic/ipc.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic/ipc.dm
@@ -30,20 +30,27 @@
 	var/datum/action/innate/monitor_change/screen
 	var/saved_screen = "Blank"
 
-/datum/species/robotic/ipc/spec_revival(mob/living/carbon/human/H)
+/datum/species/robotic/ipc/spec_revival(mob/living/carbon/human/transformer)
 	. = ..()
-	//TODO: fix this
-	/*H.dna.mutant_bodyparts["ipc_screen"][MUTANT_INDEX_NAME] = "BSOD"
-	sleep(3 SECONDS)*/
-	H.dna.mutant_bodyparts["ipc_screen"][MUTANT_INDEX_NAME] = saved_screen
+	switch_to_screen(transformer, "BSOD")
+	addtimer(CALLBACK(src, .proc/switch_to_screen, transformer, saved_screen), 5 SECONDS)
 
-/datum/species/robotic/ipc/spec_death(gibbed, mob/living/carbon/human/H)
+/datum/species/robotic/ipc/spec_death(gibbed, mob/living/carbon/human/transformer)
 	. = ..()
-	saved_screen = H.dna.mutant_bodyparts["ipc_screen"][MUTANT_INDEX_NAME]
-	//TODO: fix this
-	/*H.dna.mutant_bodyparts["ipc_screen"][MUTANT_INDEX_NAME] = "BSOD"
-	sleep(3 SECONDS)*/
-	H.dna.mutant_bodyparts["ipc_screen"][MUTANT_INDEX_NAME] = "Blank"
+	saved_screen = transformer.dna.mutant_bodyparts["ipc_screen"][MUTANT_INDEX_NAME]
+	switch_to_screen(transformer, "BSOD")
+	addtimer(CALLBACK(src, .proc/switch_to_screen, transformer, "Blank"), 5 SECONDS)
+
+/**
+ * Simple proc to switch the screen of an IPC and ensuring it updates their appearance.
+ *
+ * Arguments:
+ * * transformer - The human that will be affected by the screen change (read: IPC).
+ * * screen_name - The name of the screen to switch the ipc_screen mutant bodypart to.
+ */
+/datum/species/robotic/ipc/proc/switch_to_screen(mob/living/carbon/human/tranformer, screen_name)
+	tranformer.dna.mutant_bodyparts["ipc_screen"][MUTANT_INDEX_NAME] = screen_name
+	tranformer.update_body()
 
 /datum/species/robotic/ipc/on_species_gain(mob/living/carbon/human/transformer)
 	. = ..()

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
@@ -472,19 +472,37 @@ export const ipc_antenna_emissive: Feature<boolean[]> = {
 
 export const ipc_chassis_toggle: FeatureToggle = {
   name: "IPC Chassis",
-  description: "Add some lore for your species! Won't show up if there's no custom species.",
+  description: "Allows customization of an IPC's chassis! Only works for IPCs.",
   component: CheckboxInput,
 };
 
 export const feature_ipc_chassis: Feature<string> = {
   name: "IPC Chassis Selection",
-  description: "Want to have a fancy species name? Put it here, or leave it blank.",
+  description: "Allows customization of an IPC's chassis! Only works for IPCs.",
   component: FeatureDropdownInput,
 };
 
 export const ipc_chassis_color: Feature<string[]> = {
   name: "IPC Chassis Colors",
-  description: "Want to have a fancy species name? Put it here, or leave it blank.",
+  description: "Allows customization of an IPC's chassis! Only works for IPCs, for chassis that support greyscale coloring.",
+  component: FeatureTriColorInput,
+};
+
+export const ipc_head_toggle: FeatureToggle = {
+  name: "IPC Head",
+  description: "Allows customization of an IPC's head! Only works for IPCs.",
+  component: CheckboxInput,
+};
+
+export const feature_ipc_head: Feature<string> = {
+  name: "IPC Head Selection",
+  description: "Allows customization of an IPC's head! Only works for IPCs.",
+  component: FeatureDropdownInput,
+};
+
+export const ipc_head_color: Feature<string[]> = {
+  name: "IPC Head Colors",
+  description: "Allows customization of an IPC's head! Only works for IPCs, for heads that support greyscale coloring.",
   component: FeatureTriColorInput,
 };
 


### PR DESCRIPTION
## About The Pull Request
Someone mentioned "oh hey this probably fixes IPCs too" in https://github.com/Skyrat-SS13/Skyrat-tg/pull/13156, but, obviously, since we're here, no, that other PR didn't fix IPCs.

So here we are, it's 2 AM, I spent the last two hours fixing IPCs. Why? I don't know, I guess I really just hate myself sometimes.

So I ended up fixing IPC chassis, since it simply didn't work. Then I went "why can't they select heads though?" which I subsequently fixed thanks to ctrl-c, ctrl-v and "find and replace". It went splendidly.

Finally, I also fixed the BSOD not appearing when they died, and instead of using the BSOD when they come back to life, I made it use the Console screen instead, which I believe makes a ***lot*** more sense.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/12915 (the glass gas mask issue is separate and should be in a separate issue)

Thanks to Kapu for showing me how Shiptest had done it, it gave me inspiration on how to fix the BSOD for us.

## How This Contributes To The Skyrat Roleplay Experience
Now you can have a cool head and a cool chassis again (limbs sold separately, in https://github.com/Skyrat-SS13/Skyrat-tg/pull/13156).

![image](https://user-images.githubusercontent.com/58045821/165452480-c4354606-63d6-450d-8657-091ed1c4f09d.png)

## Changelog
:cl: GoldenAlpharex
fix: IPCs will now encounter a BSOD (blue-screen-of-death) when dying, before their display goes blank, and will get their screen temporarily set to the Console one upon revival, as previously intended.
refactor: Refactored how IPCs were setting up their chassis and their head, allowing them to be properly set for real this time. Let your imagination go wild!
/:cl: