### PR TITLE
[NON MODULAR] Changes the gas experiments to discounts, instead of requirements

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1013,7 +1013,7 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser = 4000)
-	required_experiments = list(/datum/experiment/ordnance/gaseous/noblium)
+	// required_experiments = list(/datum/experiment/ordnance/gaseous/noblium) SKYRAT EDIT - Commented out
 
 /////////////////////////Clown tech/////////////////////////
 /datum/techweb_node/clown
@@ -1256,7 +1256,7 @@
 		"cybernetic_stomach_tier3",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
-	required_experiments = list(/datum/experiment/ordnance/gaseous/bz)
+	// required_experiments = list(/datum/experiment/ordnance/gaseous/bz) SKYRAT EDIT - Commented out
 
 /datum/techweb_node/cyber_implants
 	id = "cyber_implants"
@@ -1286,7 +1286,7 @@
 		"ci-toolset",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-	required_experiments = list(/datum/experiment/ordnance/gaseous/nitrium)
+	// required_experiments = list(/datum/experiment/ordnance/gaseous/nitrium) SKYRAT EDIT - Commented out
 
 /datum/techweb_node/combat_cyber_implants
 	id = "combat_cyber_implants"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1011,8 +1011,8 @@
 	design_ids = list(
 		"quadultra_micro_laser",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser = 4000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000) // SKYRAT EDIT - ORIGINAL: 5000
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser = 4000) // SKYRAT EDIT - Original: discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser = 4000)
 	// required_experiments = list(/datum/experiment/ordnance/gaseous/noblium) SKYRAT EDIT - Commented out
 
 /////////////////////////Clown tech/////////////////////////
@@ -1255,7 +1255,8 @@
 		"cybernetic_lungs_tier3",
 		"cybernetic_stomach_tier3",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 8000) // Skyrat Edit - original: 1500
+	discount_experiments = list(/datum/experiment/ordnance/gaseous/bz = 4000) // Skyrat edit: Addition
 	// required_experiments = list(/datum/experiment/ordnance/gaseous/bz) SKYRAT EDIT - Commented out
 
 /datum/techweb_node/cyber_implants
@@ -1285,7 +1286,8 @@
 		"ci-surgery",
 		"ci-toolset",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500) // Skyrat Edit - original: 2500
+	discount_experiments = list(/datum/experiment/ordnance/gaseous/nitrium) // Skyrat Edit - Addition
 	// required_experiments = list(/datum/experiment/ordnance/gaseous/nitrium) SKYRAT EDIT - Commented out
 
 /datum/techweb_node/combat_cyber_implants

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1286,8 +1286,8 @@
 		"ci-surgery",
 		"ci-toolset",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500) // Skyrat Edit - original: 2500
-	discount_experiments = list(/datum/experiment/ordnance/gaseous/nitrium) // Skyrat Edit - Addition
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500) // Skyrat Edit - original: 2500
+	discount_experiments = list(/datum/experiment/ordnance/gaseous/nitrium = 4500) // Skyrat Edit - Addition
 	// required_experiments = list(/datum/experiment/ordnance/gaseous/nitrium) SKYRAT EDIT - Commented out
 
 /datum/techweb_node/combat_cyber_implants

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1012,7 +1012,7 @@
 		"quadultra_micro_laser",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000) // SKYRAT EDIT - ORIGINAL: 5000
-	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser = 4000) // SKYRAT EDIT - Original: discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser = 4000)
+	discount_experiments = list(/datum/experiment/ordnance/gaseous/noblium = 6000) // SKYRAT EDIT - Original: discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser = 4000)
 	// required_experiments = list(/datum/experiment/ordnance/gaseous/noblium) SKYRAT EDIT - Commented out
 
 /////////////////////////Clown tech/////////////////////////


### PR DESCRIPTION
## About The Pull Request

Changes the gas experiments (all) to discounts, as opposed to hard requirements  with as little edits to the files as possible, namely, because after sitting on it for a good long while, I don't really think there's been a benefit from it at all, besides barring previously available non-issue causing content behind an atmos-knowledge gate that i've struggled to find anyone who knows it, that would even want to play sci.

Idea stolen from (https://github.com/tgstation/tgstation/pull/65933)
## How This Contributes To The Skyrat Roleplay Experience

what it says on the tin.

## Changelog



:cl:
balance: Made the gas experiments discounts as opposed to hard requirements.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
