### PR TITLE
Ghost Cafe lock fix

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -5835,6 +5835,16 @@
 /obj/structure/railing,
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"boa" = (
+/obj/machinery/button/door{
+	id = "ghostcaferesort2";
+	name = "Resort Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -24;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/holding/cafedorms)
 "bot" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	desc = "A simple drain.";
@@ -73107,7 +73117,7 @@ xxv
 jBF
 jIj
 jIj
-lct
+boa
 gMw
 vsW
 gMw


### PR DESCRIPTION
## About The Pull Request

Per the reported issue. Just a quick fix to make the rooms (Beachside, north and south) lock properly. Both locks were set to the same door, causing said issue.
Resolves #13175 

## How This Contributes To The Skyrat Roleplay Experience

More space so you can do wholesome things in peace.

## Changelog

:cl:
fix: Fixed a door bolt button not bolting the proper door in the Ghost Cafe.
/:cl: