### PR TITLE
Removes the lathe tax from off-station lathes

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -182,7 +182,10 @@
 			var/datum/bank_account/our_acc = card.registered_account
 			if(our_acc.account_job && SSeconomy.get_dep_account(our_acc.account_job?.paycheck_department) == SSeconomy.get_dep_account(payment_department))
 				total_cost = 0 //We are not charging crew for printing their own supplies and equipment.
-	total_cost = (is_station_level(z) ? total_cost : 0) //SKYRAT EDIT
+	// SKYRAT EDIT START
+	if(!is_station_level(z) || is_mining_level(z))
+		total_cost = 0
+	//SKYRAT EDIT END
 	if(attempt_charge(src, usr, total_cost) & COMPONENT_OBJ_CANCEL_CHARGE)
 		return FALSE
 

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -182,6 +182,7 @@
 			var/datum/bank_account/our_acc = card.registered_account
 			if(our_acc.account_job && SSeconomy.get_dep_account(our_acc.account_job?.paycheck_department) == SSeconomy.get_dep_account(payment_department))
 				total_cost = 0 //We are not charging crew for printing their own supplies and equipment.
+	total_cost = (is_station_level(z) ? total_cost : 0) //SKYRAT EDIT
 	if(attempt_charge(src, usr, total_cost) & COMPONENT_OBJ_CANCEL_CHARGE)
 		return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
DS-2 and such can't use their lathes because they don't have bank accounts.

## How This Contributes To The Skyrat Roleplay Experience
Using them without having to spawn in credits is a good thing

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Off-station lathes are now free to use
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
