### PR TITLE
Fixes Medbay sec checkpoint Door controller

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -36617,10 +36617,6 @@
 /area/commons/dorms)
 "lWE" = (
 /obj/item/radio/intercom/directional/west,
-/obj/machinery/button/door/directional/west{
-	id_tag = "MedbayFoyer";
-	pixel_y = -9
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
@@ -36630,6 +36626,12 @@
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = 3;
 	pixel_y = 4
+	},
+/obj/machinery/button/door/directional/west{
+	pixel_y = -9;
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	id = "MedbayFoyer"
 	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
@@ -36772,6 +36774,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
+/obj/machinery/button/door/directional/north,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "lYO" = (

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -36774,7 +36774,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/machinery/button/door/directional/north,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "lYO" = (


### PR DESCRIPTION
## About The Pull Request

Fixes the orderly's door control button in his checkpoint. They can now open/close medbay foyer doors as needed.
Resolves #12946 
## How This Contributes To The Skyrat Roleplay Experience

Just gets things workin' right. Prevents orderlies from having to get up and walking around to operate the inner set of doors. 

## Changelog

:cl:
fix: Meta Orderly's door control button is working once again.
/:cl: