### PR TITLE
Cargo gets a small kickback from gun orders

### DIFF
--- a/modular_skyrat/modules/gun_cargo/code/datums/cargo_pack.dm
+++ b/modular_skyrat/modules/gun_cargo/code/datums/cargo_pack.dm
@@ -1,7 +1,11 @@
+#define CARGO_CUT 0.05
+
 /datum/supply_pack/armament
 
 /datum/supply_pack/armament/generate(atom/A, datum/bank_account/paying_account)
 	. = ..()
+	var/datum/bank_account/cargo_dep = SSeconomy.get_dep_account(ACCOUNT_CAR)
+	cargo_dep.account_balance += (cost * CARGO_CUT)
 	if(!(CONFIG_GET(flag/permit_pins)))
 		return
 	var/obj/structure/container = .
@@ -12,3 +16,4 @@
 		var/obj/item/firing_pin/permit_pin/new_pin = new(gun_actually)
 		gun_actually.pin = new_pin
 
+#undef CARGO_CUT

--- a/modular_skyrat/modules/gun_cargo/code/datums/cargo_pack.dm
+++ b/modular_skyrat/modules/gun_cargo/code/datums/cargo_pack.dm
@@ -5,7 +5,7 @@
 /datum/supply_pack/armament/generate(atom/A, datum/bank_account/paying_account)
 	. = ..()
 	var/datum/bank_account/cargo_dep = SSeconomy.get_dep_account(ACCOUNT_CAR)
-	cargo_dep.account_balance += (cost * CARGO_CUT)
+	cargo_dep.account_balance += round(cost * CARGO_CUT)
 	if(!(CONFIG_GET(flag/permit_pins)))
 		return
 	var/obj/structure/container = .


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cargo now gets a 5% kickback from all guncargo orders

## How This Contributes To The Skyrat Roleplay Experience
ICly, it makes sense for these non-NT companies to send some money cargo's way as encouragement to keep selling their things. OOCly, it encourages cargo to accept gun orders, private or not, because *money*.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Cargo gets 5% of the money from all guncargo orders
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
