### PR TITLE
Guncargo balance update 3: traitor edition

### DIFF
--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -26,7 +26,7 @@
 			with suppressors."
 	progression_minimum = 10 MINUTES
 	item = /obj/item/gun/ballistic/automatic/pistol
-	cost = 6 //SKYRAT EDIT: ORIGINAL COST 7
+	cost = 5 //SKYRAT EDIT: ORIGINAL COST 7
 	purchasable_from = ~UPLINK_CLOWN_OPS
 
 /datum/uplink_item/dangerous/throwingweapons

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -15,7 +15,7 @@
 	desc = "An innocent-looking toy pistol designed to fire foam darts. Comes loaded with riot-grade \
 			darts effective at incapacitating a target."
 	item = /obj/item/gun/ballistic/automatic/pistol/toy/riot
-	cost = 2
+	cost = 1 //SKYRAT EDIT: ORIGINAL COST 2
 	surplus = 10
 
 // Low progression cost
@@ -26,7 +26,7 @@
 			with suppressors."
 	progression_minimum = 10 MINUTES
 	item = /obj/item/gun/ballistic/automatic/pistol
-	cost = 7
+	cost = 6 //SKYRAT EDIT: ORIGINAL COST 7
 	purchasable_from = ~UPLINK_CLOWN_OPS
 
 /datum/uplink_item/dangerous/throwingweapons
@@ -96,6 +96,6 @@
 	desc = "A brutally simple Syndicate revolver that fires .357 Magnum rounds and has 7 chambers."
 	item = /obj/item/gun/ballistic/revolver
 	progression_minimum = 30 MINUTES
-	cost = 13
+	cost = 12 //SKYRAT EDIT: ORIGINAL COST 13
 	surplus = 50
 	purchasable_from = ~UPLINK_CLOWN_OPS

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -320,7 +320,8 @@
 /datum/uplink_item/suits/energy_shield_traitor
 	name = "MODsuit Energy Shield Module"
 	desc = "An energy shield module for a MODsuit. The shields can handle up to three impacts \
-			within a short duration and will rapidly recharge while not under fire."
+			within a short duration and will rapidly recharge while not under fire. \
+			Costs 3 complexity to use in a MODsuit."
 	item = /obj/item/mod/module/energy_shield
 	cost = 12
 

--- a/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
+++ b/modular_skyrat/master_files/code/modules/uplink/uplink_items.dm
@@ -24,13 +24,13 @@
 	name = "Toy Submachine Gun"
 	desc = "A fully-loaded Donksoft bullpup submachine gun that fires riot grade darts with a 20-round magazine."
 	item = /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot
-	cost = 5
+	cost = 4
 
 /datum/uplink_item/dangerous/revolver_alt
 	name = "Unica Six Revolver"
 	desc = "A retro high-powered autorevolver typically used by officers of the New Russia military. Uses .357 ammo."
 	item = /obj/item/gun/ballistic/revolver/mateba
-	cost = 13
+	cost = 12
 	surplus = 50
 	progression_minimum = 30 MINUTES
 
@@ -49,7 +49,7 @@
 	desc = "A fully-loaded Scarborough Arms bullpup submachine gun. The C-20r fires .45 rounds with a \
 			24-round magazine and is compatible with suppressors."
 	item = /obj/item/gun/ballistic/automatic/c20r/unrestricted
-	cost = 14
+	cost = 12
 	progression_minimum = 35 MINUTES
 
 /datum/uplink_item/dangerous/shotgun_traitor
@@ -57,7 +57,7 @@
 	desc = "A fully-loaded semi-automatic drum-fed shotgun. Compatible with all 12g rounds. Designed for close \
 			quarter anti-personnel engagements."
 	item = /obj/item/gun/ballistic/shotgun/bulldog/unrestricted
-	cost = 13
+	cost = 12
 	progression_minimum = 35 MINUTES
 
 /datum/uplink_item/dangerous/shield_traitor
@@ -284,7 +284,6 @@
 	desc = "An alternative 8-round meteorslug magazine for use in the Bulldog shotgun. \
 		Great for blasting airlocks off their frames and knocking down enemies."
 	item = /obj/item/ammo_box/magazine/m12g/meteor
-	cost = 3
 	purchasable_from = ALL
 
 /datum/uplink_item/ammo/shotgun/slug_traitor
@@ -292,7 +291,6 @@
 	desc = "An additional 8-round slug magazine for use with the Bulldog shotgun. \
 			Now 8 times less likely to shoot your pals."
 	item = /obj/item/ammo_box/magazine/m12g/slug
-	cost = 3
 	purchasable_from = ALL
 
 /datum/uplink_item/ammo/shotgun/empty_traitor
@@ -318,6 +316,13 @@
 	item = /obj/item/clothing/suit/armor/bulletproof
 	cost = 1
 	progression_minimum = 15 MINUTES
+
+/datum/uplink_item/suits/energy_shield_traitor
+	name = "MODsuit Energy Shield Module"
+	desc = "An energy shield module for a MODsuit. The shields can handle up to three impacts \
+			within a short duration and will rapidly recharge while not under fire."
+	item = /obj/item/mod/module/energy_shield
+	cost = 12
 
 //HELMETS
 /datum/uplink_item/suits/swathelmet_traitor

--- a/modular_skyrat/modules/gun_cargo/code/gun_companies.dm
+++ b/modular_skyrat/modules/gun_cargo/code/gun_companies.dm
@@ -37,3 +37,6 @@
 
 /obj/item/gun/syringe
 	company_flag = COMPANY_INTERDYNE
+
+/obj/item/gun/ballistic/automatic/pistol
+	company_flag = COMPANY_SCARBOROUGH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Riot pistol 2 -> 1
- Makarov 7 -> 5
- Revolvers 13 -> 12
- Riot SMG 5 -> 4
- Meteorslug & Slug Bulldog ammo 3 -> 2
- Bulldog 14 -> 12
- C-20R 13 -> 12

Added Energy shield module to uplinks for 12 TC

## How This Contributes To The Skyrat Roleplay Experience
Traitors are a tad on the back foot right now, these changes should make uplink guns a bit cheaper to buy, and the energy shield module should help them not get fucked up as badly. Changes aren't too drastic to reduce the dreaded *powercreep*.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Reduced cost of uplink firearms
add: Energy shield MODsuit module for 12 TC to uplinks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
