### PR TITLE
Adds the ability to examine turf liquid

### DIFF
--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_effect.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_effect.dm
@@ -529,14 +529,19 @@
 	if(!length(reagent_list))
 		return
 
-	if(examiner.can_see_reagents()) //Show each individual reagent
-		examine_text += "<hr>"
+	if(examiner.can_see_reagents())
+		// Show each individual reagent
+		examine_text += EXAMINE_SECTION_BREAK
 		examine_text += "\The [source] [liquid_state_messages["[liquid_state]"]]:"
+
 		for(var/datum/reagent/current_reagent as anything in reagent_list)
 			var/volume = reagent_list[current_reagent]
-			examine_text += "[round(volume, 0.01)] units of [initial(current_reagent.name)]"
+			examine_text += "&bull; [round(volume, 0.01)] units of [initial(current_reagent.name)]"
+
 		examine_text += span_notice("The solution has a temperature of [temp]K.")
-	else //Otherwise, just show the total volume
+		examine_text += EXAMINE_SECTION_BREAK
+	else
+		 // Otherwise, just show the total volume
 		examine_text += span_notice("\The [source] [liquid_state_messages["[liquid_state]"]] various reagents.")
 
 /obj/effect/temp_visual/liquid_splash

--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_effect.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_effect.dm
@@ -545,7 +545,6 @@
 			examine_list += span_notice("There is [replacetext(liquid_state_template, "$", "[volume] units of [reagent_name]")] here.")
 		else
 			// Show each individual reagent
-			examine_list += EXAMINE_SECTION_BREAK
 			examine_list += "There is [replacetext(liquid_state_template, "$", "the following")] here:"
 
 			for(var/datum/reagent/reagent_type as anything in reagent_list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Follows the rules of reagent containers where you need science glasses or equivalent to see the specific reagents.

First is without ability to see reagents, rest are with ability.

![image](https://user-images.githubusercontent.com/1185434/166401929-82716410-fba8-413c-9231-a4ac83a24314.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

What the heck am I wading around in?

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can now identify what liquid a floor is covered in, if you have a reagent scanner / reagent glasses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
