### PR TITLE
Synthetics mirroring other mutants pay

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic/_robotic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/robotic/_robotic.dm
@@ -24,7 +24,7 @@
 	coldmod = 1.2
 	heatmod = 2
 	siemens_coeff = 1.4 //Not more because some shocks will outright crit you, which is very unfun
-	payday_modifier = 0.5 //Robots are cheep labor
+	payday_modifier = 0.75 // Matches the rest of the pay penalties the non-human crew have
 	species_language_holder = /datum/language_holder/machine
 	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
 	mutantbrain = /obj/item/organ/brain/ipc_positron


### PR DESCRIPTION
*beeps

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates payrate for synthetics to match the rest of the non-human crew

## How This Contributes To The Skyrat Roleplay Experience

With the new paycheck system in place, this change is rather needed as the pentalty was far more impactful.

## Changelog

Changes the payrate of synthetics from .50 to .75 to match the other races that are non-human.

:cl:
balance: Makes synthetic species have a pay modifier that matches other mutant non-human races.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
