### PR TITLE
Makes examine block HR's format better collapse

### DIFF
--- a/code/__DEFINES/~skyrat_defines/chat.dm
+++ b/code/__DEFINES/~skyrat_defines/chat.dm
@@ -1,5 +1,7 @@
 
 #define MESSAGE_TYPE_MENTOR "mentor"
 
+#define EXAMINE_SECTION_BREAK "<hr>"
+
 /// Adds a generic box around whatever message you're sending in chat. Really makes things stand out.
 #define examine_block(str) ("<div class='examine_block'>" + str + "</div>")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -636,7 +636,7 @@
 
 	if(custom_materials)
 		// SKYRAT EDIT ADDITION BEGIN - HR sections
-		if(custom_materials.len > 1)
+		if(length(custom_materials) > 1)
 			. += EXAMINE_SECTION_BREAK //SKYRAT EDIT ADDITION
 		//SKYRAT EDIT ADDITION END
 
@@ -646,7 +646,7 @@
 		. += "<u>It is made out of [english_list(materials_list)]</u>."
 
 		// SKYRAT EDIT ADDITION BEGIN - HR sections
-		if(custom_materials.len > 1)
+		if(length(custom_materials) > 1)
 			. += EXAMINE_SECTION_BREAK //SKYRAT EDIT ADDITION
 		//SKYRAT EDIT ADDITION END
 	if(reagents)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -628,28 +628,37 @@
  * Produces a signal [COMSIG_PARENT_EXAMINE]
  */
 /atom/proc/examine(mob/user)
-	. = list("[get_examine_string(user, TRUE)].<hr>")
+	. = list("[get_examine_string(user, TRUE)].", EXAMINE_SECTION_BREAK) // SKYRAT EDIT CHANGE - original: list("[get_examine_string(user, TRUE)].")
 
 	. += get_name_chaser(user)
 	if(desc)
 		. += desc
 
 	if(custom_materials)
-		. += "<hr>" //SKYRAT EDIT ADDITION
+		// SKYRAT EDIT ADDITION BEGIN - HR sections
+		if(custom_materials.len > 1)
+			. += EXAMINE_SECTION_BREAK //SKYRAT EDIT ADDITION
+		//SKYRAT EDIT ADDITION END
+
 		var/list/materials_list = list()
 		for(var/datum/material/current_material as anything in custom_materials)
 			materials_list += "[current_material.name]"
 		. += "<u>It is made out of [english_list(materials_list)]</u>."
+
+		// SKYRAT EDIT ADDITION BEGIN - HR sections
+		if(custom_materials.len > 1)
+			. += EXAMINE_SECTION_BREAK //SKYRAT EDIT ADDITION
+		//SKYRAT EDIT ADDITION END
 	if(reagents)
-		. += "<hr>" //SKYRAT EDIT ADDITION
 		if(reagents.flags & TRANSPARENT)
+			. += EXAMINE_SECTION_BREAK //SKYRAT EDIT ADDITION - HR sections
 			. += "It contains:"
 			if(length(reagents.reagent_list))
 				if(user.can_see_reagents()) //Show each individual reagent
 					for(var/datum/reagent/current_reagent as anything in reagents.reagent_list)
-						. += "[round(current_reagent.volume, 0.01)] units of [current_reagent.name]"
+						. += "&bull; [round(current_reagent.volume, 0.01)] units of [current_reagent.name]" // SKYRAT EDIT CHANGE - added bullet
 					if(reagents.is_reacting)
-						. += span_warning("It is currently reacting!")
+						. += span_warning("&nbsp;&nbsp;It is currently reacting!") // SKYRAT EDIT CHANGE - added spacing
 					. += span_notice("The solution's pH is [round(reagents.ph, 0.01)] and has a temperature of [reagents.chem_temp]K.")
 				else //Otherwise, just show the total volume
 					var/total_volume = 0
@@ -658,6 +667,7 @@
 					. += "[total_volume] units of various reagents"
 			else
 				. += "Nothing."
+			. += EXAMINE_SECTION_BREAK //SKYRAT EDIT ADDITION
 		else if(reagents.flags & AMOUNT_VISIBLE)
 			if(reagents.total_volume)
 				. += span_notice("It has [reagents.total_volume] unit\s left.")

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -6,7 +6,7 @@
 	var/t_has = p_have()
 	var/t_is = p_are()
 
-	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!<hr>")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!", EXAMINE_SECTION_BREAK) // SKYRAT EDIT CHANGE - HR padding
 	var/obscured = check_obscured_slots()
 
 	if (handcuffed)
@@ -24,6 +24,9 @@
 
 	if (back)
 		. += "[t_He] [t_has] [back.get_examine_string(user)] on [t_his] back."
+
+	. += EXAMINE_SECTION_BREAK // SKYRAT EDIT ADDITION - hr sections
+
 	var/appears_dead = FALSE
 	if (stat == DEAD)
 		appears_dead = TRUE

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -34,7 +34,7 @@
 	else
 		species_name_string = ", [prefix_a_or_an(dna.species.name)] <EM>[dna.species.name]</EM>!"
 
-	. = list("<span class='info'>This is <EM>[!obscure_name ? name : "Unknown"]</EM>[species_name_string]<hr>") //SKYRAT EDIT CHANGE
+	. = list("<span class='info'>This is <EM>[!obscure_name ? name : "Unknown"]</EM>[species_name_string]", EXAMINE_SECTION_BREAK) //SKYRAT EDIT CHANGE
 	if(species_visible) //If they have a custom species shown, show the real one too
 		if(dna.features["custom_species"])
 			. += "[t_He] [t_is] [prefix_a_or_an(dna.species.name)] [dna.species.name]!"
@@ -47,13 +47,13 @@
 	if(dna?.species && !skipface)
 		apparent_species = ", \an [dna.species.name]"
 	. = list("<span class='info'>*---------*\nThis is <EM>[!obscure_name ? name : "Unknown"][apparent_species]</EM>!")
-	
+
 	. = list("<span class='info'>*---------*\nThis is <EM>[!obscure_name ? name : "Unknown"]</EM>!")
 
 	var/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 	*/ //SKYRAT EDIT END
-	
+
 	//uniform
 	if(w_uniform && !(obscured & ITEM_SLOT_ICLOTHING) && !(w_uniform.item_flags & EXAMINE_SKIP))
 		//accessory
@@ -130,6 +130,8 @@
 		. += "[t_He] [t_is] wearing [wear_id.get_examine_string(user)]."
 
 		. += wear_id.get_id_examine_strings(user)
+
+	. += EXAMINE_SECTION_BREAK // SKYRAT EDIT ADDITION - hr sections
 
 	//Status effects
 	var/list/status_examines = status_effect_examines()

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/ai/examine(mob/user)
-	. = list("<span class='info'>This is [icon2html(src, user)] <EM>[src]</EM>!<hr>") //SKYRAT EDIT CHANGE
+	. = list("<span class='info'>This is [icon2html(src, user)] <EM>[src]</EM>!", EXAMINE_SECTION_BREAK) //SKYRAT EDIT CHANGE
 	if (stat == DEAD)
 		. += span_deadsay("It appears to be powered-down.")
 	else

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -90,7 +90,7 @@
 			text_span = "purple"
 		if(THEME_HOLY)
 			text_span = "blue"
-	. = list("<span class='[text_span]'>This is [icon2html(src, user)] \a <b>[src]</b>!\n[desc]<hr>") //SKYRAT EDIT CHANGE
+	. = list("<span class='[text_span]'>This is [icon2html(src, user)] \a <b>[src]</b>!\n[desc]", EXAMINE_SECTION_BREAK) //SKYRAT EDIT CHANGE
 	if(health < maxHealth)
 		if(health >= maxHealth/2)
 			. += span_warning("[t_He] look[t_s] slightly dented.")

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -249,7 +249,7 @@
 	dust()
 
 /mob/living/simple_animal/drone/examine(mob/user)
-	. = list("<span class='info'>This is [icon2html(src, user)] \a <b>[src]</b>!<hr>") //SKYRAT EDIT CHANGE
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <b>[src]</b>!", EXAMINE_SECTION_BREAK) //SKYRAT EDIT CHANGE
 
 	//Hands
 	for(var/obj/item/I in held_items)

--- a/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
@@ -19,7 +19,7 @@
 
 /mob/living/simple_animal/hostile/guardian/dextrous/examine(mob/user)
 	if(dextrous)
-		. = list("<span class='info'>This is [icon2html(src)] \a <b>[src]</b>!\n[desc]<hr>") //SKYRAT EDIT CHANGE
+		. = list("<span class='info'>This is [icon2html(src)] \a <b>[src]</b>!\n[desc]", EXAMINE_SECTION_BREAK) //SKYRAT EDIT CHANGE
 		for(var/obj/item/I in held_items)
 			if(!(I.item_flags & ABSTRACT))
 				. += "It has [I.get_examine_string(user)] in its [get_held_index_name(get_held_index_of_item(I))]."

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -438,7 +438,7 @@
 	return
 
 /mob/living/simple_animal/slime/examine(mob/user)
-	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!<hr>") //SKYRAT EDIT CHANGE
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!", EXAMINE_SECTION_BREAK) //SKYRAT EDIT CHANGE
 	if (stat == DEAD)
 		. += span_deadsay("It is limp and unresponsive.")
 	else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -493,12 +493,12 @@
 
 	//SKYRAT EDIT ADDITION
 	if(result.len)
-		for(var/i = 1, i <= result.len, i++)
+		for(var/i = 1, i <= length(result), i++)
 			if(result[i] != EXAMINE_SECTION_BREAK)
 				result[i] += "\n"
 			else
 				// remove repeated <hr's> and ones on the ends.
-				if(i == 1 || i == result.len || result[i - 1] == EXAMINE_SECTION_BREAK)
+				if(i == 1 || i == length(result) || result[i - 1] == EXAMINE_SECTION_BREAK)
 					result.Cut(i, i + 1)
 					i--
 	//SKYRAT EDIT END

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -494,8 +494,13 @@
 	//SKYRAT EDIT ADDITION
 	if(result.len)
 		for(var/i = 1, i <= result.len, i++)
-			if(!findtext(result[i], "<hr>"))
+			if(result[i] != EXAMINE_SECTION_BREAK)
 				result[i] += "\n"
+			else
+				// remove repeated <hr's> and ones on the ends.
+				if(i == 1 || i == result.len || result[i - 1] == EXAMINE_SECTION_BREAK)
+					result.Cut(i, i + 1)
+					i--
 	//SKYRAT EDIT END
 
 	to_chat(src, "<div class='examine_block'><span class='infoplain'>[result.Join()]</span></div>") //SKYRAT EDIT CHANGE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -493,12 +493,12 @@
 
 	//SKYRAT EDIT ADDITION
 	if(result.len)
-		for(var/i = 1, i <= length(result), i++)
+		for(var/i in 1 to length(result))
 			if(result[i] != EXAMINE_SECTION_BREAK)
 				result[i] += "\n"
 			else
 				// remove repeated <hr's> and ones on the ends.
-				if(i == 1 || i == length(result) || result[i - 1] == EXAMINE_SECTION_BREAK)
+				if((i == 1) || (i == length(result)) || (result[i - 1] == EXAMINE_SECTION_BREAK))
 					result.Cut(i, i + 1)
 					i--
 	//SKYRAT EDIT END


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Makes it so consecutive `<hr>` breaks in an examine block are reduced to a single one, and a block and start or end with one.
- Also eliminated usage of `findtext()` in favor of literal comparison in examinate.
- Also bulleted reagent formatting, and added a break between carbon clothing and all the status stuff.

![image](https://user-images.githubusercontent.com/1185434/166123493-13e1e942-3808-4f00-9ee7-09d240ac2325.png)
![image](https://user-images.githubusercontent.com/1185434/166123477-25130121-0b56-418c-b170-bd219f7ddbe7.png)

### Preview of PR this is for:

![image](https://user-images.githubusercontent.com/1185434/166123519-d720f220-13c7-4f07-ae2a-5a4e4809325a.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

better formatting

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Examine block HR section breaks are now handled such that they don't repeat or show up at the bottom.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
