### PR TITLE
[NONMODULAR] Snerfs (Snail Nerfs)

### DIFF
--- a/code/datums/elements/snail_crawl.dm
+++ b/code/datums/elements/snail_crawl.dm
@@ -31,5 +31,5 @@
 
 	var/turf/open/OT = get_turf(snail)
 	if(istype(OT))
-		OT.MakeSlippery(TURF_WET_WATER, 1.5 SECONDS) //SKYRAT EDIT: Roundstart Snails - No more lube
+		OT.MakeSlippery(TURF_WET_WATER, 1 SECONDS) //SKYRAT EDIT: Roundstart Snails - No more lube
 		return TRUE

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -429,7 +429,7 @@
 	desc = "A minutely toothed, chitious ribbon, which as a side effect, makes all snails talk IINNCCRREEDDIIBBLLYY SSLLOOWWLLYY."
 	modifies_speech = TRUE
 
-/obj/item/organ/tongue/snail/modify_speech(datum/source, list/speech_args)
+/*/obj/item/organ/tongue/snail/modify_speech(datum/source, list/speech_args) //SKYRAT EDIT - Roundstart Snails: Less annoying speech.
 	var/new_message
 	var/message = speech_args[SPEECH_MESSAGE]
 	for(var/i in 1 to length(message))
@@ -437,7 +437,7 @@
 			new_message += message[i] + message[i] + message[i] //aaalllsssooo ooopppeeennn tttooo sssuuuggggggeeessstttiiiooonsss
 		else
 			new_message += message[i]
-	speech_args[SPEECH_MESSAGE] = new_message
+	speech_args[SPEECH_MESSAGE] = new_message*/
 
 /obj/item/organ/tongue/ethereal
 	name = "electric discharger"

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -428,8 +428,8 @@
 	color = "#96DB00" // TODO proper sprite, rather than recoloured pink tongue
 	desc = "A minutely toothed, chitious ribbon, which as a side effect, makes all snails talk IINNCCRREEDDIIBBLLYY SSLLOOWWLLYY."
 	modifies_speech = TRUE
-
-/*/obj/item/organ/tongue/snail/modify_speech(datum/source, list/speech_args) //SKYRAT EDIT - Roundstart Snails: Less annoying speech.
+/*
+/obj/item/organ/tongue/snail/modify_speech(datum/source, list/speech_args) //SKYRAT EDIT - Roundstart Snails: Less annoying speech.
 	var/new_message
 	var/message = speech_args[SPEECH_MESSAGE]
 	for(var/i in 1 to length(message))
@@ -437,8 +437,8 @@
 			new_message += message[i] + message[i] + message[i] //aaalllsssooo ooopppeeennn tttooo sssuuuggggggeeessstttiiiooonsss
 		else
 			new_message += message[i]
-	speech_args[SPEECH_MESSAGE] = new_message*/
-
+	speech_args[SPEECH_MESSAGE] = new_message
+*/
 /obj/item/organ/tongue/ethereal
 	name = "electric discharger"
 	desc = "A sophisticated ethereal organ, capable of synthesising speech via electrical discharge."


### PR DESCRIPTION
## About The Pull Request
This takes away the ssspppeeeccchhh mmmooodddiiifffiiieeerrrsss fffrrrooommm sssnnnaaaiiilllpppeeeooopppllleee and also lowers the amount of tiles behind them that are watered.

## How This Contributes To The Skyrat Roleplay Experience
The ssspppeeeccchhh mmmooodddiiifffiiieeerrr literally tttrrriiipppllleeesss your sentence length in a way that can become very unreadable if you were to talk for too long. I've been told it makes them hard to RP with, so it must go. I'll revisit this within the next ten years. I don't want the slipping to be too annoying either.

## Changelog
:cl:
del: Removes snail speech modifier. Try using a lot of ellipses instead!
del: Lowers the amount of water that snails leave behind.
/:cl:
