### PR TITLE
Makes the lathe tax a server config, fixes off-station roles, fixes cyborgs and drones interactions. 

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -172,7 +172,7 @@
 		if(!reagents.has_reagent(R, D.reagents_list[R]*print_quantity/coeff))
 			say("Not enough reagents to complete prototype[print_quantity > 1? "s" : ""].")
 			return FALSE
-/* 	var/total_cost = LATHE_TAX // SKYRAT EDIT BEGIN - Lathe Tax Un-fucking
+/* 	var/total_cost = LATHE_TAX // SKYRAT EDIT BEGIN - Lathe Tax un-scuffing
 	if(is_station_level(z) && isliving(usr)) //We don't block purchases off station Z.
 		var/mob/living/user = usr
 		var/obj/item/card/id/card = user.get_idcard(TRUE)

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -172,7 +172,7 @@
 		if(!reagents.has_reagent(R, D.reagents_list[R]*print_quantity/coeff))
 			say("Not enough reagents to complete prototype[print_quantity > 1? "s" : ""].")
 			return FALSE
-	var/total_cost = LATHE_TAX
+/* 	var/total_cost = LATHE_TAX // SKYRAT EDIT BEGIN - Lathe Tax Un-fucking
 	if(is_station_level(z) && isliving(usr)) //We don't block purchases off station Z.
 		var/mob/living/user = usr
 		var/obj/item/card/id/card = user.get_idcard(TRUE)
@@ -189,8 +189,8 @@
 		var/mob/living/silicon/robot/borg = usr
 		if(!borg.cell)
 			return
-		borg.cell.use(SILICON_LATHE_TAX)
-
+		borg.cell.use(SILICON_LATHE_TAX) */
+	skyrat_lathe_tax() // SKYRAT EDIT ADDITION
 	materials.mat_container.use_materials(efficient_mats, print_quantity)
 	materials.silo_log(src, "built", -print_quantity, "[D.name]", efficient_mats)
 	for(var/R in D.reagents_list)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -509,3 +509,7 @@ MAXFINE 2000
 
 ## Whether native FoV is enabled for all people.
 #NATIVE_FOV
+
+## How much does the protolathe cost to use on station? Disabled is off.
+
+##PROTOLATHE_TAX 10

--- a/modular_skyrat/master_files/code/modules/research/techweb/protolathe.dm
+++ b/modular_skyrat/master_files/code/modules/research/techweb/protolathe.dm
@@ -1,0 +1,28 @@
+/obj/machinery/rnd/production
+	var/total_cost = 0
+	var/on_station_lathe = TRUE
+	var/free_lathe = FALSE
+/obj/machinery/rnd/production/proc/skyrat_lathe_tax()
+	total_cost ? (free_lathe ? 0 : total_cost) : (CONFIG_GET(number/protolathe_tax))
+
+	if(is_station_level(z) && on_station_lathe && total_cost && !free_lathe)
+		var/mob/living/user = usr
+		var/obj/item/card/id/card = user.get_idcard(TRUE)
+		if(!card && istype(user.pulling, /obj/item/card/id))
+			card = user.pulling
+		if(card)
+			var/datum/bank_account/our_acc = card.registered_account
+			if(our_acc.account_job && SSeconomy.get_dep_account(our_acc.account_job?.paycheck_department) == SSeconomy.get_dep_account(payment_department))
+				total_cost = 0 //We are not charging crew for printing their own supplies and equipment.
+		if(!iscarbon(usr)) // catch all cyborg types
+			total_cost = 0
+	if(attempt_charge(src, usr, total_cost) & COMPONENT_OBJ_CANCEL_CHARGE)
+		return FALSE
+
+/obj/machinery/rnd/production/protolathe/offstation
+	on_station_lathe = FALSE
+
+/datum/config_entry/number/protolathe_tax
+	default = 0
+	min_val = 0
+	max_val = 65535

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4629,6 +4629,7 @@
 #include "modular_skyrat\master_files\code\modules\research\designs\biogenerator_designs.dm"
 #include "modular_skyrat\master_files\code\modules\research\designs\misc_designs.dm"
 #include "modular_skyrat\master_files\code\modules\research\techweb\all_nodes.dm"
+#include "modular_skyrat\master_files\code\modules\research\techweb\protolathe.dm"
 #include "modular_skyrat\master_files\code\modules\shuttle\shuttle.dm"
 #include "modular_skyrat\master_files\code\modules\spells\wizard.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\bodyparts\species_parts\_mutant_bodyparts.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alright. I know the admins are drown in problems with the lathe tax, all midrounds are shut down from using the lathe right now, and the thing doesn't even get the right bank account for your ID right now - only the one paired to your mob - never a stolen ID or anything.

This PR makes it a config variable - how much is charged, and fixes all thats listed in the title. 

## How This Contributes To The Skyrat Roleplay Experience

Step one in un-janking the lathe tax. Moves it to a modular proc. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Allows non-carbons to interact and print once again. Call your local AI, maybe. 
config: Lathe tax is now a config option
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
