### PR TITLE
Fixes serviettes

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/serviette.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/serviette.dm
@@ -95,7 +95,7 @@
 	update_icon()
 
 /obj/item/serviette_pack/attack_self(mob/user, obj/item/I)
-	if(!servleft)
+	if(servleft)
 		to_chat(user, span_notice("You take a serviette from [src]."))
 		servleft--
 		var/obj/item/serviette/used_serviette = new /obj/item/serviette


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows you to take shit out of serviette packs again
fixes #13249 
## How This Contributes To The Skyrat Roleplay Experience
Bugs bad
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Serviettes now can be taken out of their packs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
