### PR TITLE
Revival of #3223 (Makes Quad-Sec only work inside /area/security)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1732,8 +1732,10 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes
 	var/obj/item/organ/liver/liver = drinker.getorganslot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		drinker.heal_bodypart_damage(1 * REM * delta_time, 1 * REM * delta_time)
-		. = TRUE
+		if(istype(get_area(drinker), /area/security)) // Skyrat edit , it checks for area now - Start
+			drinker.heal_bodypart_damage(1 * REM * delta_time, 1 * REM * delta_time)
+			. = TRUE
+		return ..() // SKYRAT EDIT: End - This line and the above few have only indentation changes.
 	return ..()
 
 /datum/reagent/consumable/ethanol/quintuple_sec
@@ -1752,8 +1754,10 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes but STRONG..
 	var/obj/item/organ/liver/liver = drinker.getorganslot(ORGAN_SLOT_LIVER)
 	if(liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		drinker.heal_bodypart_damage(2 * REM * delta_time, 2 * REM *  delta_time, 2 * REM * delta_time)
-		. = TRUE
+		if(istype(get_area(drinker), /area/security)) // Skyrat edit , it checks for area now - Start
+			drinker.heal_bodypart_damage(2 * REM * delta_time, 2 * REM *  delta_time, 2 * REM * delta_time)
+			. = TRUE
+		return ..() // SKYRAT EDIT: End - This line and the above few have only indentation changes.	
 	return ..()
 
 /datum/reagent/consumable/ethanol/grasshopper


### PR DESCRIPTION
## About The Pull Request

So at some point #3223 was reverted at some point, this implements it back. For those who don't know, this PR made quadruple sec only work in security areas to prevent it from being passive healing with no adverse side effects in combat scenarios.

## How This Contributes To The Skyrat Roleplay Experience

See original PR for their reasoning

## Changelog

:cl: MLGTASTICa
balance: Quadruple Security now only heals inside security areas
/:cl: