### PR TITLE
Scarborough Arms now requires emag

### DIFF
--- a/modular_skyrat/modules/gun_cargo/code/armament_component.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_component.dm
@@ -82,7 +82,7 @@
 				break
 
 			var/obj/machinery/computer/cargo/cargo_comp = parent
-			if(selected_company.illegal && !cargo_comp.contraband)
+			if(selected_company.illegal && !(cargo_comp.obj_flags & EMAGGED))
 				illegal_failure = TRUE
 				break
 


### PR DESCRIPTION
## About The Pull Request

Changes Scarborough requirement from contraband to emag

## How This Contributes To The Skyrat Roleplay Experience

Multitooling the board every round for an AKM and bulldog shotgun is, while funny, not exactly even vaguely resemblant to balance.

## Changelog
:cl:
balance: Scarborough Arms now needs an emagged supply console to purchase.
/:cl: