### PR TITLE
Makes prefs apply correctly again

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -563,8 +563,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/character_preview_view)
 		if (preference.savefile_identifier != PREFERENCE_CHARACTER)
 			continue
 	// SKYRAT EDIT
-		if(preference.is_accessible(src)) // Only apply preferences you can actually access.
-			preference.apply_to_human(character, read_preference(preference.type), src)
+		preference.apply_to_human(character, read_preference(preference.type), src)
 
 	for (var/datum/preference_middleware/preference_middleware as anything in middleware)
 		preference_middleware.apply_to_human(character, src)


### PR DESCRIPTION
Hey, the is_accessible proc checks a lot of things, most notably it checks that the character select menu is open and on the correct page. This little if statement here makes it so half, or all if the menu isn't open, don't even apply to you. You need to actually test your shit. 
