### PR TITLE
Fixes Chem Dispenser upgraded reagents

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -475,6 +475,10 @@
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		if (M.rating > 1)
 			dispensable_reagents |= upgrade_reagents
+		if (M.rating > 2)
+			dispensable_reagents |= upgrade_reagents2
+		if (M.rating > 3)
+			dispensable_reagents |= upgrade_reagents3
 		parts_rating += M.rating
 	powerefficiency = round(newpowereff, 0.01)
 

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -475,10 +475,12 @@
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		if (M.rating > 1)
 			dispensable_reagents |= upgrade_reagents
+		//SKYRAT EDIT START
 		if (M.rating > 2)
 			dispensable_reagents |= upgrade_reagents2
 		if (M.rating > 3)
 			dispensable_reagents |= upgrade_reagents3
+		//SKYRAT EDIT END
 		parts_rating += M.rating
 	powerefficiency = round(newpowereff, 0.01)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
#1931 added chemical reagents for manips past t2, but never... added them to the chem dispenser, this fixes that.

## How This Contributes To The Skyrat Roleplay Experience
Things working as intended is good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Chemical dispensers now add reagents for manipulators past tier 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
