### PR TITLE
Fixes some in-hand sprites/defines. 

### DIFF
--- a/code/__DEFINES/~skyrat_defines/reskin_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/reskin_defines.dm
@@ -3,3 +3,6 @@
 #define RESKIN_WORN_ICON "reskin_worn_icon"
 #define RESKIN_WORN_ICON_STATE "reskin_worn_icon_state"
 #define RESKIN_SUPPORTS_VARIATIONS_FLAGS "reskin_supports_variations_flags"
+#define RESKIN_INHAND_L "reskin_inhand_l"
+#define RESKIN_INHAND_R "reskin_inhand_r"
+#define RESKIN_INHAND_STATE "reskin_inhand_state"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1387,6 +1387,12 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 		else
 			icon_state = unique_reskin[pick][RESKIN_WORN_ICON_STATE]
 
+	if(unique_reskin[pick][RESKIN_INHAND_L])
+		lefthand_file = unique_reskin[pick][RESKIN_INHAND_L]
+	if(unique_reskin[pick][RESKIN_INHAND_R])
+		righthand_file = unique_reskin[pick][RESKIN_INHAND_R]
+	if(unique_reskin[pick][RESKIN_INHAND_STATE])
+		inhand_icon_state = unique_reskin[pick][RESKIN_INHAND_STATE]
 	if(unique_reskin[pick][RESKIN_SUPPORTS_VARIATIONS_FLAGS])
 		supports_variations_flags = unique_reskin[pick][RESKIN_SUPPORTS_VARIATIONS_FLAGS]
 	if(ishuman(M))


### PR DESCRIPTION
Part of the Goofsec 2.0 PR which fixed the resprites of some objects like sec belts and others on-sprite and in-hand. Recreated as an atomized fix with permission from the original creator.  Done with webedit so no squashing on the commits. 