### PR TITLE
[NON-MODULAR] Reduces the required rep in objectives for getting a final objective spawn. 

### DIFF
--- a/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
@@ -11,7 +11,7 @@
 	abstract_type = /datum/traitor_objective/final
 	progression_minimum = 140 MINUTES
 
-	var/progression_points_in_objectives = 140 MINUTES //skyrat edit: original value 20 MINUTES
+	var/progression_points_in_objectives = 45 MINUTES //skyrat edit: original value 20 MINUTES
 
 /// Determines if this final objective can be taken. Should be put into every final objective's generate function.
 /datum/traitor_objective/final/proc/can_take_final_objective()

--- a/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
@@ -11,7 +11,7 @@
 	abstract_type = /datum/traitor_objective/final
 	progression_minimum = 140 MINUTES
 
-	var/progression_points_in_objectives = 45 MINUTES //skyrat edit: original value 20 MINUTES
+	var/progression_points_in_objectives = 75 MINUTES //skyrat edit: original value 20 MINUTES
 
 /// Determines if this final objective can be taken. Should be put into every final objective's generate function.
 /datum/traitor_objective/final/proc/can_take_final_objective()


### PR DESCRIPTION
## About The Pull Request

Reduces the required rep for a final objective to appear to a practically achievable level in-round (45 from 120.) 

## How This Contributes To The Skyrat Roleplay Experience

Final objectives basically didn't exist with my last change while we were still feeling out dynamic (also, they were incorrectly counting rep from time after progression traitors first dropped, not just objectives.) Having them show up is more interesting and contributes towards progtot 'wrapping up' in a way that gets everybody (now much more armed and up to handling them) involved. This still requires a decent amount of objective rep that should be a challenge to traitors to stay active in pursuing. 

## Changelog

Reduces progression traitors' objective rep cost for final objectives to appear from the previous 120 (practically unreachable) to 45 (much more realistic but still quite a bit.) 

:cl:
balance: Progression traitors' final objectives can now appear after they've completed 45 rep worth of objectives (down from an unseen 120.)
/:cl: