### PR TITLE
[MODULAR] Makes Striped Thigh-Highs Colourable

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
@@ -187,6 +187,11 @@ GLOBAL_LIST_EMPTY(cached_mutant_icon_files)
 	icon_state = "socks_thigh"
 	use_static = null
 
+/datum/sprite_accessory/socks/striped_thigh
+	name = "Thigh-high (Striped)"
+	icon_state = "striped_thigh"
+	use_static = null
+
 /datum/sprite_accessory/socks/bee_thigh
 	name = "Thigh-high - Bee (Old)"
 	icon_state = "bee_thigh_old"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds the ability to colour striped thigh-highs just like you can with knee-highs in socks selection of the character creator.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Adds another opportunity, however minor, to customize character appearance and providing some more consistent behaviour.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now colour thigh-highs in the socks selection of the character creator.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

![image](https://user-images.githubusercontent.com/12377767/166695544-382539cd-ebb9-4fd5-99ab-2b89a31ac029.png)
