### PR TITLE
Fixes Synthetics being unable to get their right digitigrade leg to not be white

### DIFF
--- a/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/robotic/_mutant_robotic_bodyparts.dm
+++ b/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/robotic/_mutant_robotic_bodyparts.dm
@@ -56,6 +56,7 @@
 	icon_static = 'modular_skyrat/master_files/icons/mob/species/synthmammal_parts_greyscale.dmi'
 	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/synthmammal_parts_greyscale.dmi'
 	uses_mutcolor = TRUE
+	should_draw_greyscale = TRUE
 	limb_id = "digitigrade"
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC | BODYTYPE_DIGITIGRADE
 	base_limb_id = SPECIES_SYNTHMAMMAL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
We just forgot to allow them to use greyscale on that limb in particular. Whoops!

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/13298.

## How This Contributes To The Skyrat Roleplay Experience
They otherwise look so silly!

## Changelog

:cl: GoldenAlpharex
fix: Synthetics being will finally be able to recolor their right leg properly.
/:cl: