### PR TITLE
Snouts Refactor: Less Hardcoding Edition

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/mutant_parts.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/mutant_parts.dm
@@ -196,7 +196,7 @@
 	target.dna.mutant_bodyparts[relevant_mutant_bodypart][MUTANT_INDEX_NAME] = value
 	var/obj/item/bodypart/head/our_head = target.get_bodypart(BODY_ZONE_HEAD)
 	our_head.bodytype |= BODYTYPE_SNOUTED
-	target.dna.species.bodytype |= BODYTYPE_SNOUTED // Snowflake code alert
+	our_head.synchronize_bodytypes(target)
 
 /datum/preference/choiced/snout/create_default_value()
 	var/datum/sprite_accessory/snouts/none/default = /datum/sprite_accessory/snouts/none

--- a/modular_skyrat/master_files/code/modules/mod/modules/_module.dm
+++ b/modular_skyrat/master_files/code/modules/mod/modules/_module.dm
@@ -22,10 +22,8 @@
 		if(mod.chestplate && (mod.chestplate.supports_variations_flags & CLOTHING_DIGITIGRADE_VARIATION) && (mod.wearer.dna.species.bodytype & BODYTYPE_DIGITIGRADE))
 			suit_supports_variations_flags |= CLOTHING_DIGITIGRADE_VARIATION
 
-		if(mod.helmet && (mod.helmet.supports_variations_flags & CLOTHING_SNOUTED_VARIATION) && mod.wearer.dna.species.mutant_bodyparts["snout"])
-			var/datum/sprite_accessory/snouts/snout = GLOB.sprite_accessories["snout"][mod.wearer.dna.species.mutant_bodyparts["snout"][MUTANT_INDEX_NAME]]
-			if(snout.use_muzzled_sprites)
-				suit_supports_variations_flags |= CLOTHING_SNOUTED_VARIATION
+		if(mod.helmet && (mod.helmet.supports_variations_flags & CLOTHING_SNOUTED_VARIATION) && mod.wearer.dna.species.bodytype & BODYTYPE_SNOUTED)
+			suit_supports_variations_flags |= CLOTHING_SNOUTED_VARIATION
 
 	var/icon_to_use = 'icons/mob/clothing/modsuit/mod_modules.dmi'
 	var/icon_state_to_use = module_icon_state

--- a/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/_mutant_bodyparts.dm
+++ b/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/_mutant_bodyparts.dm
@@ -40,7 +40,7 @@
 	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/mammal_parts_greyscale.dmi'
 	limb_id = SPECIES_MAMMAL
 	uses_mutcolor = TRUE
-	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC | BODYTYPE_SNOUTED //This is temporary. Ideally the "snout" external organ adds to this.
+	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC
 
 /obj/item/bodypart/chest/mutant
 	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/mammal_parts_greyscale.dmi'

--- a/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/lizard_bodyparts.dm
+++ b/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/lizard_bodyparts.dm
@@ -1,5 +1,6 @@
 /obj/item/bodypart/head/lizard
 	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/lizard_parts_greyscale.dmi'
+	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC // You're too slow Kapu, I did it myself ;)
 
 /obj/item/bodypart/chest/lizard
 	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/lizard_parts_greyscale.dmi'

--- a/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/robotic/_mutant_robotic_bodyparts.dm
+++ b/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/robotic/_mutant_robotic_bodyparts.dm
@@ -5,7 +5,7 @@
 	is_dimorphic = TRUE
 	should_draw_greyscale = TRUE
 	uses_mutcolor = TRUE
-	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC | BODYTYPE_SNOUTED //This is temporary. Ideally the "snout" external organ adds to this.
+	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 
 /obj/item/bodypart/chest/robot/mutant
 	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/synthmammal_parts_greyscale.dmi'

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY(cached_mutant_icon_files)
 	///Notable things that have it set to FALSE are things that need special setup, such as genitals
 	var/generic
 
-	/// For all the flags that you need to pass from a sprite_accessory to an external_organ, when it's linked to one.
+	/// For all the flags that you need to pass from a sprite_accessory to an organ, when it's linked to one.
 	/// (i.e. passing through the fact that a snout should or shouldn't use a muzzled sprite for head worn items)
 	var/flags_for_organ = NONE
 

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
@@ -1,5 +1,8 @@
 GLOBAL_LIST_EMPTY(cached_mutant_icon_files)
 
+/// The flag to show that snouts should use the muzzled sprite.
+#define SPRITE_ACCESSORY_USE_MUZZLED_SPRITE (1<<0)
+
 /datum/sprite_accessory
 	///Unique key of an accessroy. All tails should have "tail", ears "ears" etc.
 	var/key = null
@@ -12,6 +15,10 @@ GLOBAL_LIST_EMPTY(cached_mutant_icon_files)
 	///Set this to a name, then the accessory will be shown in preferences, if a species can have it. Most accessories have this
 	///Notable things that have it set to FALSE are things that need special setup, such as genitals
 	var/generic
+
+	/// For all the flags that you need to pass from a sprite_accessory to an external_organ, when it's linked to one.
+	/// (i.e. passing through the fact that a snout should or shouldn't use a muzzled sprite for head worn items)
+	var/flags_for_organ = NONE
 
 	color_src = USE_ONE_COLOR
 

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/snout.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/snout.dm
@@ -2,7 +2,8 @@
 	key = "snout"
 	generic = "Snout"
 	icon = 'modular_skyrat/master_files/icons/mob/sprite_accessory/lizard_snouts.dmi'
-	var/use_muzzled_sprites = TRUE
+	flags_for_organ = SPRITE_ACCESSORY_USE_MUZZLED_SPRITE
+	organ_type = /obj/item/organ/external/snout
 	recommended_species = list(SPECIES_SYNTHMAMMAL, SPECIES_MAMMAL, SPECIES_LIZARD, SPECIES_UNATHI, SPECIES_LIZARD_ASH, SPECIES_LIZARD_SILVER)
 	relevent_layers = list(BODY_ADJ_LAYER, BODY_FRONT_LAYER)
 	genetic = TRUE
@@ -12,10 +13,30 @@
 		return TRUE
 	return FALSE
 
+/obj/item/organ/external/snout
+	mutantpart_key = "snout"
+	mutantpart_info = list(MUTANT_INDEX_NAME = "None", MUTANT_INDEX_COLOR_LIST = list("#FFFFFF", "#FFFFFF", "#FFFFFF"))
+
+/obj/item/organ/external/snout/Insert(mob/living/carbon/reciever, special, drop_if_replaced)
+	if(sprite_accessory_flags & SPRITE_ACCESSORY_USE_MUZZLED_SPRITE)
+		var/obj/item/bodypart/limb = reciever.get_bodypart(zone)
+
+		if(limb)
+			limb.bodytype |= BODYTYPE_SNOUTED
+			limb.synchronize_bodytypes(reciever)
+
+	return ..()
+
+
+/obj/item/organ/external/snout/Remove(mob/living/carbon/organ_owner, special)
+	if(ownerlimb)
+		ownerlimb.bodytype &= ~BODYTYPE_SNOUTED
+	return ..()
+
 /datum/sprite_accessory/snouts/none
 	name = "None"
 	icon_state = "none"
-	use_muzzled_sprites = FALSE
+	flags_for_organ = NONE
 	factual = FALSE
 
 /datum/sprite_accessory/snouts/mammal
@@ -355,10 +376,10 @@
 	name = "Stubby"
 	icon_state = "stubby"
 	color_src = USE_MATRIXED_COLORS
-	use_muzzled_sprites = FALSE
+	flags_for_organ = NONE
 
 /datum/sprite_accessory/snouts/mammal/leporid
 	name = "Leporid"
 	icon_state = "leporid"
 	color_src = USE_MATRIXED_COLORS
-	use_muzzled_sprites = FALSE
+	flags_for_organ = NONE

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -554,6 +554,7 @@ GLOBAL_LIST_EMPTY(customizable_races)
 		var/datum/sprite_accessory/SA = GLOB.sprite_accessories[key][C.dna.mutant_bodyparts[key][MUTANT_INDEX_NAME]]
 		if(SA?.factual && SA.organ_type)
 			var/obj/item/organ/path = new SA.organ_type
+			path.sprite_accessory_flags = SA.flags_for_organ
 			if(robot_organs)
 				path.status = ORGAN_ROBOTIC
 				path.organ_flags |= ORGAN_SYNTHETIC

--- a/modular_skyrat/modules/customization/modules/surgery/organs/organ.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/organ.dm
@@ -4,6 +4,8 @@
 	var/list/list/mutantpart_info
 	/// Do we drop when organs are spilling?
 	var/drop_when_organ_spilling = TRUE
+	/// Special flags that need to be passed over from the sprite_accessory to the organ (but not the opposite).
+	var/sprite_accessory_flags = NONE
 
 /obj/item/organ/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
As it turns out, the `BODYTYPE_SNOUTED` was actually inherent to lizards, all types of synths (that used the mutant robot head, anyway) and to mammals. Meaning that they were forced to use it, *all the time*, whereas everyone else was unable to use it, even if they were actually using a snout.

This was something Kapu didn't bother fixing, but I did it, for us, because I don't really think it matters to them, considering it's not exactly like they had more than just lizards that could have snouts anyway.

Now, everyone will have their bodytypes properly updated to reflect the presence or absence of a snout. Hell yeah.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/13179.

## How This Contributes To The Skyrat Roleplay Experience
`BODYTYPE_SNOUTED` now works properly. You're welcome for your immersion, for I have saved it.

## Changelog

:cl: GoldenAlpharex
refactor: Refactored how snouts worked, ensuring that they are linked to an actual external organ now, which allows for much more dynamic management of snouted variants of articles of clothing.
fix: Lizards, mammals and synthetics are no longer forced to use snouted sprites for headgear 24/7, and will now only use them when necessary.
code: Improved slightly the code for MODsuit module snout detection, making it slightly better.
/:cl: