### PR TITLE
Fixes missing inhands for the norwind, vintorez, and DTR rifles

### DIFF
--- a/modular_skyrat/modules/goofsec/code/projectiles.dm
+++ b/modular_skyrat/modules/goofsec/code/projectiles.dm
@@ -38,7 +38,7 @@
 	worn_icon_state = "norwind_worn"
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_OCLOTHING
-	inhand_icon_state = "vintorez"
+	inhand_icon_state = "vintorez_worn"
 	burst_size = 2
 	fire_delay = 4
 	fire_sound = null
@@ -71,7 +71,7 @@
 	icon_state = "norwind"
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_OCLOTHING
-	inhand_icon_state = "norwind"
+	inhand_icon_state = "norwind_worn"
 	worn_icon = 'modular_skyrat/modules/sec_haul/icons/guns/norwind.dmi'
 	worn_icon_state = "norwind_worn"
 	can_bayonet = TRUE
@@ -105,7 +105,7 @@
 	righthand_file = 'modular_skyrat/modules/sec_haul/icons/guns/inhands/righthand.dmi'
 	lefthand_file = 'modular_skyrat/modules/sec_haul/icons/guns/inhands/lefthand.dmi'
 	inhand_icon_state = "ostwind"
-	icon_state = "ostwind"
+	icon_state = "ostwind_worn"
 	worn_icon = 'modular_skyrat/modules/sec_haul/icons/guns/ostwind.dmi'
 	worn_icon_state = "ostwind_worn"
 	w_class = WEIGHT_CLASS_BULKY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turns out someone had just added _worn to the ends of the sprite names, which I mean alright?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
You know maybe it would be better if you could see that someone was holding a 12mm dmr or assault rifle

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed the Norwind, Vintorez, and DTR rifles all missing inhand sprites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
