### PR TITLE
Puts tacticool skirtleneck next to the tacticool turtleneck in the loadout menu, adds replica centcom turtlenecks as loadout options

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -419,6 +419,18 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	name = "Tactitool Turtleneck"
 	item_path = /obj/item/clothing/under/syndicate/tacticool/sensors
 
+/datum/loadout_item/under/miscellaneous/tactical_skirt
+	name = "Tactitool Skirtleneck"
+	item_path = /obj/item/clothing/under/syndicate/tacticool/skirt/sensors
+
+/datum/loadout_item/under/miscellaneous/centcool_turtleneck
+	name = "Replica CentCom Turtleneck"
+	item_path = /obj/item/clothing/under/rank/centcom/officer/replica
+
+/datum/loadout_item/under/miscellaneous/centcool_skirtleneck
+	name = "Replica CentCom Skirtleneck"
+	item_path = /obj/item/clothing/under/rank/centcom/officer_skirt/replica
+
 /datum/loadout_item/under/miscellaneous/tactical_pants
 	name = "Tactical Pants"
 	item_path = /obj/item/clothing/under/pants/tactical
@@ -451,10 +463,6 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 /datum/loadout_item/under/miscellaneous/tactical_british
 	name = "British Tactical Sweater"
 	item_path = /obj/item/clothing/under/uvf
-
-/datum/loadout_item/under/miscellaneous/tactical_skirt
-	name = "Tactitool Skirtleneck"
-	item_path = /obj/item/clothing/under/syndicate/tacticool/skirt/sensors
 
 /datum/loadout_item/under/miscellaneous/cream_sweater
 	name = "Cream Sweater"
@@ -572,22 +580,22 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	name = "Black Cargo Uniform"
 	item_path = /obj/item/clothing/under/rank/cargo/tech/skyrat/evil
 	restricted_roles = list(JOB_CARGO_TECHNICIAN)
-	
+
 /datum/loadout_item/under/miscellaneous/cargo_turtle
 	name = "Cargo Turtleneck"
 	item_path = /obj/item/clothing/under/rank/cargo/tech/skyrat/turtleneck
 	restricted_roles = list(JOB_CARGO_TECHNICIAN)
-	
+
 /datum/loadout_item/under/miscellaneous/cargo_skirtle
 	name = "Cargo Skirtleneck"
 	item_path = /obj/item/clothing/under/rank/cargo/tech/skyrat/turtleneck/skirt
 	restricted_roles = list(JOB_CARGO_TECHNICIAN)
-	
+
 /datum/loadout_item/under/miscellaneous/qm_skirtle
 	name = "Quartermaster's Skirtleneck"
 	item_path = /obj/item/clothing/under/rank/cargo/qm/skyrat/turtleneck/skirt
 	restricted_roles = list(JOB_QUARTERMASTER)
-	
+
 /datum/loadout_item/under/miscellaneous/qm_gorka
 	name = "Quartermaster's Gorka Uniform"
 	item_path = /obj/item/clothing/under/rank/cargo/qm/skyrat/gorka


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As the title would imply, I've moved the tacticool skirtleneck next to the non-skirt version, as they are basically the same thing with the only difference being a skirt or not, thus it didn't make sense to have them be separate in the menu.
The replica centcom turtleneck and its matching skirt have also been added to the loadout menu, because sometimes you just need a green turtleneck to complete a look.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Makes finding the skirt version of the tacticool turtleneck slightly faster, allows more roundstart outfit options for those turtleneck enjoyers who want something other than black or really dark blue

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Replica centcom turtlenecks and their skirt variants have been added to the loadout menu
qol: The tacticool skirtleneck has been moved next to the non-skirt version, as the two are basically the same thing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
