### PR TITLE
Assault Shuttle Runtime Fix

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -10077,8 +10077,8 @@
 "sqo" = (
 /obj/docking_port/stationary{
 	dir = 8;
-	dwidth = 8;
-	height = 27;
+	dwidth = 7;
+	height = 21;
 	id = "goldeneye_cruiser_dock";
 	name = "Goldeneye Satellite Dock";
 	roundstart_template = /datum/map_template/shuttle/goldeneye_cruiser;

--- a/_maps/shuttles/skyrat/goldeneye_cruiser.dmm
+++ b/_maps/shuttles/skyrat/goldeneye_cruiser.dmm
@@ -86,8 +86,7 @@
 /area/shuttle/syndicate/cruiser/engineering)
 "bz" = (
 /obj/structure/toilet{
-	dir = 1;
-	icon_state = "toilet00"
+	dir = 1
 	},
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark/textured_large,
@@ -208,7 +207,6 @@
 	id = "cruiserhallshutters";
 	name = "Hall Shutters";
 	pixel_x = 8;
-	pixel_y = 0;
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -809,7 +807,6 @@
 	id = "cruiserhallshutters";
 	name = "Hall Shutters";
 	pixel_x = -22;
-	pixel_y = 0;
 	req_access_txt = "150"
 	},
 /obj/structure/cable,
@@ -943,8 +940,7 @@
 /area/shuttle/syndicate/cruiser/brig)
 "tY" = (
 /obj/machinery/sleeper/syndie{
-	dir = 8;
-	icon_state = "sleeper_s"
+	dir = 8
 	},
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/firealarm/directional/east,
@@ -1006,14 +1002,14 @@
 "vo" = (
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 8;
+	dwidth = 7;
 	height = 21;
 	hidden = 1;
 	id = "goldeneye_cruiser";
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "goldeneye cruiser";
 	port_direction = 4;
-	width = 27
+	width = 31
 	},
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/delivery/white,
@@ -1486,7 +1482,6 @@
 	id = "cruiserhallshutters";
 	name = "Hall Shutters";
 	pixel_x = -22;
-	pixel_y = 0;
 	req_access_txt = "150"
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -1558,7 +1553,6 @@
 /obj/effect/turf_decal/bot_white,
 /obj/structure/chair/comfy/shuttle/tactical,
 /obj/machinery/turretid{
-	control_area = null;
 	name = "Internal Turret Control";
 	pixel_y = 30;
 	req_access = null;
@@ -1713,8 +1707,7 @@
 /area/shuttle/syndicate/cruiser/airlock)
 "JA" = (
 /obj/machinery/computer/operating{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/medical)
@@ -1752,8 +1745,7 @@
 /area/shuttle/syndicate/cruiser/hallway)
 "JN" = (
 /obj/machinery/sleeper/syndie{
-	dir = 8;
-	icon_state = "sleeper_s"
+	dir = 8
 	},
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/light/no_nightlight/directional/east,
@@ -1763,7 +1755,6 @@
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/turretid{
-	control_area = null;
 	name = "Internal Turret Control";
 	pixel_y = 30;
 	req_access = null;
@@ -2509,8 +2500,7 @@
 /area/shuttle/syndicate/cruiser/brig)
 "Zk" = (
 /obj/machinery/sleeper/syndie{
-	dir = 8;
-	icon_state = "sleeper_s"
+	dir = 8
 	},
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/textured_large,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

New Assault shuttle did not set the docking port variables correctly resulting in run times

## How This Contributes To The Skyrat Roleplay Experience

Functional Content is Good++

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Assault Operatives have now completed basic flight training and can dock the shuttle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
