### PR TITLE
[NO GBP]Fixes lizards not having snouts

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
@@ -1,5 +1,6 @@
 /datum/species/lizard
 	mutant_bodyparts = list()
+	external_organs = list()
 	species_traits = list(
 		MUTCOLORS,
 		EYECOLOR,


### PR DESCRIPTION
## About The Pull Request
I'll figure out a smarter way to deal with all of this later. But for now, gotta fix it.

## How This Contributes To The Skyrat Roleplay Experience
Snouted lizards enjoy having snouts.

## Changelog

:cl: GoldenAlpharex
fix: Lizards can now have snouts again.
/:cl: