### PR TITLE
[MODULAR] Defines 9x19 Peacekeeper Bullets

### DIFF
--- a/code/__DEFINES/~skyrat_defines/projectiles.dm
+++ b/code/__DEFINES/~skyrat_defines/projectiles.dm
@@ -4,6 +4,7 @@
 #define CALIBER_473MM "473mm"
 #define CALIBER_6MM "6mm"
 #define CALIBER_10MMAUTO "10x25mm"
+#define CALIBER_9MMPEACE "9x19mm"
 
 /// The caliber used by the Automag.
 #define CALIBER_44 ".44 AMP"

--- a/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
@@ -67,7 +67,7 @@
 	desc = "A 9x19mm bullet casing with a low powder load to prevent breaches."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/ammo_cartridges.dmi'
 	icon_state = "sl-casing"
-	caliber = CALIBER_9MM
+	caliber = CALIBER_9MMPEACE
 	projectile_type = /obj/projectile/bullet/advanced/b9mm
 
 /obj/projectile/bullet/advanced/b9mm
@@ -80,7 +80,6 @@
 	desc = "A 9x19mm jacketed hollowpoint casing."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/ammo_cartridges.dmi'
 	icon_state = "sh-casing"
-	caliber = CALIBER_9MM
 	projectile_type = /obj/projectile/bullet/advanced/b9mm/hp
 
 /obj/projectile/bullet/advanced/b9mm/hp
@@ -96,7 +95,6 @@
 	desc = "A 9mm intelligent high-impact dispersal foam bullet casing."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/ammo_cartridges.dmi'
 	icon_state = "si-casing"
-	caliber = CALIBER_9MM
 	projectile_type = /obj/projectile/bullet/advanced/b9mm/ihdf
 	harmful = FALSE
 
@@ -112,7 +110,6 @@
 	desc = "A 9mm rubber bullet casing."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/ammo_cartridges.dmi'
 	icon_state = "sr-casing"
-	caliber = CALIBER_9MM
 	projectile_type = /obj/projectile/bullet/advanced/b9mm/rubber
 	harmful = FALSE
 

--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -38,7 +38,7 @@
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'
 	icon_state = "g17"
 	ammo_type = /obj/item/ammo_casing/b9mm
-	caliber = CALIBER_9MM
+	caliber = CALIBER_9MMPEACE
 	max_ammo = 17
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
@@ -80,7 +80,7 @@
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'
 	icon_state = "g18"
 	ammo_type = /obj/item/ammo_casing/b9mm
-	caliber = CALIBER_9MM
+	caliber = CALIBER_9MMPEACE
 	max_ammo = 33
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
@@ -214,7 +214,7 @@
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'
 	icon_state = "pdh"
 	ammo_type = /obj/item/ammo_casing/b9mm
-	caliber = CALIBER_9MM
+	caliber = CALIBER_9MMPEACE
 	max_ammo = 16
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
@@ -335,7 +335,7 @@
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'
 	icon_state = "g17"
 	ammo_type = /obj/item/ammo_casing/b9mm
-	caliber = CALIBER_9MM
+	caliber = CALIBER_9MMPEACE
 	max_ammo = 12
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
@@ -374,7 +374,7 @@
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'
 	icon_state = "pdh"
 	ammo_type = /obj/item/ammo_casing/b9mm
-	caliber = CALIBER_9MM
+	caliber = CALIBER_9MMPEACE
 	max_ammo = 12
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
@@ -469,7 +469,7 @@
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'
 	icon_state = "croon"
 	ammo_type = /obj/item/ammo_casing/b9mm
-	caliber = CALIBER_9MM
+	caliber = CALIBER_9MMPEACE
 	max_ammo = 8
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
 
@@ -568,7 +568,7 @@
 /obj/item/ammo_box/magazine/internal/cylinder/revolution
 	name = "revolver cylinder"
 	ammo_type = /obj/item/ammo_casing/b9mm
-	caliber = CALIBER_9MM
+	caliber = CALIBER_9MMPEACE
 	max_ammo = 8
 
 /obj/item/ammo_box/revolver/revolution
@@ -578,7 +578,7 @@
 	ammo_type = /obj/item/ammo_casing/b9mm
 	max_ammo = 8
 	multiple_sprites = AMMO_BOX_FULL_EMPTY_BASIC
-	caliber = CALIBER_9MM
+	caliber = CALIBER_9MMPEACE
 	start_empty = TRUE
 
 /obj/item/ammo_box/revolver/revolution/full


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For some reason 9x25 (original 9mm) and 9x19 Peacekeeper bullets were defined together (same as the 10mm and 10mm Magnum problem we had before). This PR creates a skyrat define for 9x19mm bullets and applies it to the according guns.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Preventing powergaming and exploiting oversights by loading 9x25 to 9x19 pistols. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ErdinyoBarboza
fix: 9x19mm now is properly defined and cant be loaded to 9x25mm magazines and vice versa.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
