### PR TITLE
Changes the security channel colours for tgui

### DIFF
--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -346,7 +346,7 @@ em {
 }
 
 .secradio {
-  color: #dd3535;
+  color: #00ffff; // SKYRAT EDIT CHANGE
 }
 
 .medradio {

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -364,7 +364,7 @@ em {
 }
 
 .secradio {
-  color: #a30000;
+  color: #006969; // SKYEAT EDIT CHANGE
 }
 
 .medradio {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Security doesn't seem to be able to listen to the radio well, at all, chronically. I'm wagering it being that half the messages that can ever show up share the same colour - red. Let's change it to something unique, like blue-white, like our security is right now. 

## Dark Mode
![dreamseeker_mpSA39j1Cy](https://user-images.githubusercontent.com/77420409/167220553-29f9fca7-2598-4401-aafe-a50654604035.png)

## Light Mode
![dreamseeker_KR8Z7tQLQr](https://user-images.githubusercontent.com/77420409/167220569-c8ddac65-3704-4a4f-99d5-b46184a914f8.png)

I'm also considering the inverse of black and white on dark and light modes, respectively. 

## How This Contributes To The Skyrat Roleplay Experience

Readability improvement?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Changes the security channel colour. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
