### PR TITLE
Adds ashwalkers to icebox

### DIFF
--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_ash_walker1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_ash_walker1_skyrat.dmm
@@ -105,8 +105,8 @@
 "fC" = (
 /obj/structure/headpike/bone,
 /obj/effect/mapping_helpers/no_lava,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/turf/template_noop,
+/area/template_noop)
 "gn" = (
 /obj/structure/stone_tile/block/burnt{
 	dir = 8
@@ -116,9 +116,6 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"hg" = (
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "hL" = (
 /obj/item/reagent_containers/glass/bucket/wooden{
 	desc = "If this bucket is used for anything other than clean water, the user is to hunt the tribes dinner, and make a new bucket.";
@@ -1375,9 +1372,6 @@
 /obj/structure/headpike/bone,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"RG" = (
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "RK" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -1637,8 +1631,8 @@
 /area/ruin/unpowered/ash_walkers)
 "XV" = (
 /obj/effect/mapping_helpers/no_lava,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/turf/template_noop,
+/area/template_noop)
 "Zi" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -1678,57 +1672,57 @@ mv
 mv
 mv
 mv
-RG
-RG
-RG
-RG
-RG
-RG
-RG
-RG
-RG
-RG
-hg
-hg
-hg
-hg
-hg
-hg
-hg
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
 "}
 (2,1,1) = {"
 mv
 mv
 mv
 mv
-RG
-RG
-RG
-RG
+bH
+bH
+bH
+bH
 JD
 JD
 JD
 JD
-RG
-RG
-RG
-RG
-hg
-hg
-hg
-hg
-hg
-hg
-hg
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
 "}
 (3,1,1) = {"
 mv
 mv
 bH
-RG
-RG
-RG
-RG
+bH
+bH
+bH
+bH
 JD
 tl
 mZ
@@ -1736,22 +1730,22 @@ mZ
 mZ
 JD
 JD
-RG
-RG
-RG
-RG
-RG
-RG
-RG
-hg
-hg
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
 "}
 (4,1,1) = {"
 mv
 bH
 bH
-RG
-RG
+bH
+bH
 Ly
 Ly
 Ly
@@ -1761,7 +1755,7 @@ mZ
 mZ
 mZ
 JD
-RG
+JD
 Vr
 Vr
 Vr
@@ -1775,7 +1769,7 @@ XV
 bH
 bH
 bH
-RG
+bH
 JD
 Ly
 uM
@@ -2344,7 +2338,7 @@ Ly
 Ly
 Ly
 XV
-hg
+bH
 "}
 (28,1,1) = {"
 bH
@@ -2369,7 +2363,7 @@ Zi
 Ny
 Ly
 XV
-hg
+bH
 "}
 (29,1,1) = {"
 bH
@@ -2394,7 +2388,7 @@ OG
 MS
 Ly
 XV
-hg
+bH
 "}
 (30,1,1) = {"
 bH
@@ -2419,16 +2413,16 @@ MF
 px
 Ly
 XV
-hg
+bH
 "}
 (31,1,1) = {"
 mv
 bH
 bH
-RG
-RG
-RG
-RG
+bH
+bH
+bH
+bH
 Ly
 PB
 dw
@@ -2450,10 +2444,10 @@ XV
 mv
 bH
 bH
-RG
-RG
-RG
-RG
+bH
+bH
+bH
+bH
 Ly
 Ly
 Ly

--- a/modular_skyrat/modules/mapping/code/icemoon.dm
+++ b/modular_skyrat/modules/mapping/code/icemoon.dm
@@ -18,3 +18,12 @@
 	description = "The Iceminer arena."
 	suffix = "icemoon_underground_mining_site_skyrat.dmm"
 	always_place = TRUE
+
+/datum/map_template/ruin/icemoon/underground/skyrat/ashwalker_nest
+	name = "Ash Walker Nest"
+	id = "ash-walker-ice"
+	description = "An ashen ruin all the way out here... There's something strange about this."
+	prefix = "_maps/RandomRuins/LavaRuins/skyrat/"
+	suffix = "lavaland_surface_ash_walker1_skyrat.dmm"
+	always_place = TRUE
+	allow_duplicates = FALSE

--- a/modular_skyrat/modules/mapping/code/mob_spawns.dm
+++ b/modular_skyrat/modules/mapping/code/mob_spawns.dm
@@ -1,4 +1,11 @@
 //SPAWNERS//
+
+/obj/effect/mob_spawn/ghost_role/human/ash_walker/special(mob/living/carbon/human/spawned_human)
+	. = ..()
+	if(SSmapping.level_trait(spawned_human.z, ZTRAIT_ICE_RUINS_UNDERGROUND) || SSmapping.level_trait(spawned_human.z, ZTRAIT_ICE_RUINS_UNDERGROUND))
+		ADD_TRAIT(spawned_human, TRAIT_NOBREATH, ROUNDSTART_TRAIT)
+		ADD_TRAIT(spawned_human, TRAIT_RESISTCOLD, ROUNDSTART_TRAIT)
+
 /obj/effect/mob_spawn/ghost_role/human/blackmarket
 	name = "cryogenics pod"
 	prompt_name = "a blackmarket dealer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Messes with the ashwalker map and adds it to icebox.

## How This Contributes To The Skyrat Roleplay Experience
Hardmode ashwalker is fun, it changes up the dynamic a lot and even if it doesn't make full sense, I think it's more fun to have ashwalkers on every map.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Ashwalkers can now appear on icebox
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
