### PR TITLE
Fixes cargodise lost's token machine

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
@@ -2770,7 +2770,7 @@
 /turf/open/floor/iron/checker,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Ul" = (
-/obj/machinery/gun_vendor,
+/obj/machinery/gun_vendor/no_alert,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "Um" = (

--- a/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/token_system/token_system.dm
@@ -12,6 +12,8 @@
 	circuit = /obj/item/circuitboard/machine/gun_vendor
 	max_integrity = 2000
 	density = TRUE
+	/// If FALSE, does not require an alert level to redeem the token.
+	var/requires_alert = TRUE
 
 /obj/item/circuitboard/machine/gun_vendor
 	name = "Weapons Dispenser (Machine Board)"
@@ -31,7 +33,7 @@
 		return
 
 /obj/machinery/gun_vendor/proc/RedeemToken(obj/item/armament_token/token, mob/redeemer)
-	if(seclevel2num(get_security_level()) < token.minimum_sec_level)
+	if((seclevel2num(get_security_level()) < token.minimum_sec_level) && requires_alert)
 		to_chat(redeemer, span_redtext("Warning, this holochip is locked to [num2seclevel(token.minimum_sec_level)]!"))
 		message_admins("ARMAMENT LOG: [redeemer] attempted to redeem a [token.name] on the incorrect security level!")
 		return
@@ -54,6 +56,9 @@
 	to_chat(redeemer, "Thank you for redeeming your token. Remember. Do NOT take lethal ammo without permission or good reasoning.")
 	SSblackbox.record_feedback("tally", "armament_token_redeemed", 1, dispensed)
 	qdel(token)
+
+/obj/machinery/gun_vendor/no_alert
+	requires_alert = FALSE
 
 ////////////////////
 //TOKENS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the alert requirement from cargodise lost's token vendor

## How This Contributes To The Skyrat Roleplay Experience
Freighter boss couldn't spend their armament token below amber.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Freighter crew gun vendor no longer alert locked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
