### PR TITLE
Fixes freighter boss's ammo

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
@@ -474,9 +474,6 @@
 "jR" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/gun/ballistic/automatic/cfa_rifle,
-/obj/item/ammo_box/magazine/cm762,
-/obj/item/ammo_box/magazine/cm762,
-/obj/item/ammo_box/magazine/cm762,
 /obj/item/storage/bag/ammo,
 /obj/item/clothing/suit/armor/bulletproof,
 /obj/item/storage/belt/utility/syndicate,
@@ -484,6 +481,9 @@
 /obj/item/clothing/gloves/combat,
 /obj/item/storage/backpack/duffelbag/syndie,
 /obj/item/radio,
+/obj/item/ammo_box/magazine/cm68,
+/obj/item/ammo_box/magazine/cm68,
+/obj/item/ammo_box/magazine/cm68,
 /turf/open/floor/carpet/green,
 /area/ruin/space/has_grav/deepstorage/lostcargo)
 "jX" = (

--- a/_maps/RandomZLevels/blackmesa.dmm
+++ b/_maps/RandomZLevels/blackmesa.dmm
@@ -662,9 +662,9 @@
 /area/awaymission/black_mesa/xen)
 "da" = (
 /obj/structure/rack/shelf,
-/obj/item/ammo_box/magazine/cm762,
-/obj/item/ammo_box/magazine/cm762,
-/obj/item/ammo_box/magazine/cm762,
+/obj/item/ammo_box/magazine/cm68,
+/obj/item/ammo_box/magazine/cm68,
+/obj/item/ammo_box/magazine/cm68,
 /turf/open/floor/wood/parquet,
 /area/awaymission/black_mesa)
 "db" = (

--- a/modular_skyrat/modules/modular_weapons/code/rifle.dm
+++ b/modular_skyrat/modules/modular_weapons/code/rifle.dm
@@ -160,5 +160,5 @@
 	max_ammo = 10
 	multiple_sprites = 2
 
-/obj/item/ammo_box/magazine/cm762/empty
+/obj/item/ammo_box/magazine/cm68/empty
 	start_empty = 1

--- a/modular_skyrat/modules/opposing_force/code/equipment/ammo.dm
+++ b/modular_skyrat/modules/opposing_force/code/equipment/ammo.dm
@@ -42,9 +42,9 @@
 /datum/opposing_force_equipment/ammo/mg42
 	item_type = /obj/item/ammo_box/magazine/mg42
 
-/datum/opposing_force_equipment/ammo/cm762
-	item_type = /obj/item/ammo_box/magazine/cm762
-	description = "7.62 bullets in a ten round magazine for Cantanheim 7.62 rifle."
+/datum/opposing_force_equipment/ammo/cm68
+	item_type = /obj/item/ammo_box/magazine/cm68
+	description = "6.8mm bullets in a ten round magazine for a Cantanheim 6.8 rifle."
 
 /datum/opposing_force_equipment/ammo/makarov
 	item_type = /obj/item/ammo_box/magazine/m9mm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Now spawns the correct magazine type for the freighter bosses' 6.8mm rifle

## How This Contributes To The Skyrat Roleplay Experience
It was giving them rounds that didn't exist before this

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Cargo freighter boss now gets the correct ammunition.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
