### PR TITLE
Fixes elite modsuit on cargodise lost

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
@@ -1952,7 +1952,7 @@
 /obj/machinery/suit_storage_unit{
 	mask_type = /obj/item/clothing/mask/gas/explorer;
 	storage_type = /obj/item/tank/jetpack/oxygen/harness;
-	suit_type = /obj/item/mod/control/pre_equipped/elite
+	suit_type = /obj/item/mod/control/pre_equipped/traitor_elite
 	},
 /turf/open/floor/iron/dark/blue,
 /area/ruin/space/has_grav/deepstorage/lostcargo)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the elite modsuit to not have an access requirement.

## How This Contributes To The Skyrat Roleplay Experience
Formerly you'd need to hack the thing before you could use it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Elite modsuit on cargodise lost no longer requires hacking to use
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
