### PR TITLE
Go good (lights) or go home.

### DIFF
--- a/modular_skyrat/modules/aesthetics/airlock/code/airlock.dm
+++ b/modular_skyrat/modules/aesthetics/airlock/code/airlock.dm
@@ -374,6 +374,7 @@
 /obj/machinery/door/airlock/glass_large
 	icon = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/multi_tile/multi_tile.dmi'
 	overlays_file = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/multi_tile/overlays.dmi'
+	multi_tile = TRUE
 
 //ASSEMBLYS
 /obj/structure/door_assembly/door_assembly_public


### PR DESCRIPTION
## About The Pull Request

Flags up that particular door(glass_large) with the multi_tile flag so it orients the door lights properly on spawn like other associated doors.

We get 
![image](https://user-images.githubusercontent.com/84706993/167247032-c80a9449-23d8-4e29-9835-b3f4a58482cc.png)
Instead of
![image](https://user-images.githubusercontent.com/84706993/167247060-3fe6a876-68d3-4f83-b697-08eb4f0a465b.png)
when the door is sideways~

Resolves #13230 

## How This Contributes To The Skyrat Roleplay Experience

Just fixes an aesthetic issue. But when you're RP'ing at the end of the day, that's what matters most, eh?

## Changelog

:cl:
fix: Fixes glass_large door lighting.
/:cl: