### PR TITLE
[MODULAR] SmartDart Pistols now show the inserted SmartDarts inside of them.

### DIFF
--- a/modular_skyrat/modules/gun_cargo/code/objects/guns/interdyne.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/guns/interdyne.dm
@@ -31,6 +31,9 @@
 	. += "<br>You can fire the underbarrel device with [span_bold("right click")]."
 	. += "<br>You can unload the underbarrel device by [span_bold("right clicking with an empty hand")]."
 
+	for(var/obj/item/reagent_containers/syringe/dart in underbarrel.syringes)
+		. += "There is a [dart] loaded"
+
 /obj/item/gun/syringe/smartdart/underbarrel
 	name = "SmartDart underbarrel device"
 	desc = "An underbarrel attachment for a pistol that fits a SmartDart."

--- a/modular_skyrat/modules/gun_cargo/code/objects/guns/interdyne.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/guns/interdyne.dm
@@ -32,7 +32,7 @@
 	. += "<br>You can unload the underbarrel device by [span_bold("right clicking with an empty hand")]."
 
 	for(var/obj/item/reagent_containers/syringe/dart in underbarrel.syringes)
-		. += "There is a [dart] loaded"
+		. += "There is a [dart] loaded."
 
 /obj/item/gun/syringe/smartdart/underbarrel
 	name = "SmartDart underbarrel device"

--- a/modular_skyrat/modules/gun_cargo/code/objects/guns/interdyne.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/guns/interdyne.dm
@@ -31,7 +31,7 @@
 	. += "<br>You can fire the underbarrel device with [span_bold("right click")]."
 	. += "<br>You can unload the underbarrel device by [span_bold("right clicking with an empty hand")]."
 
-	for(var/obj/item/reagent_containers/syringe/dart in underbarrel.syringes)
+	for(var/obj/item/reagent_containers/syringe/dart as anything in underbarrel.syringes)
 		. += "There is a [dart] loaded."
 
 /obj/item/gun/syringe/smartdart/underbarrel

--- a/modular_skyrat/modules/medical/code/smartdarts.dm
+++ b/modular_skyrat/modules/medical/code/smartdarts.dm
@@ -62,6 +62,7 @@
 
 /obj/item/gun/syringe/smartdart/examine(mob/user)
 	. = ..()
+
 	for(var/obj/item/reagent_containers/syringe/dart in syringes)
 		. += "There is a [dart] loaded"
 

--- a/modular_skyrat/modules/medical/code/smartdarts.dm
+++ b/modular_skyrat/modules/medical/code/smartdarts.dm
@@ -63,7 +63,7 @@
 /obj/item/gun/syringe/smartdart/examine(mob/user)
 	. = ..()
 
-	for(var/obj/item/reagent_containers/syringe/dart in syringes)
+	for(var/obj/item/reagent_containers/syringe/dart as anything in syringes)
 		. += "There is a [dart] loaded."
 
 //Smartdart projectiles

--- a/modular_skyrat/modules/medical/code/smartdarts.dm
+++ b/modular_skyrat/modules/medical/code/smartdarts.dm
@@ -64,7 +64,7 @@
 	. = ..()
 
 	for(var/obj/item/reagent_containers/syringe/dart in syringes)
-		. += "There is a [dart] loaded"
+		. += "There is a [dart] loaded."
 
 //Smartdart projectiles
 /obj/item/ammo_casing/syringegun/dart

--- a/modular_skyrat/modules/medical/code/smartdarts.dm
+++ b/modular_skyrat/modules/medical/code/smartdarts.dm
@@ -60,6 +60,11 @@
 		to_chat(user, span_notice("The [container] is unable to fit inside of the [src]! Try using a <b>SmartDart</b> instead."))
 		return FALSE
 
+/obj/item/gun/syringe/smartdart/examine(mob/user)
+	. = ..()
+	for(var/obj/item/reagent_containers/syringe/dart in syringes)
+		. += "There is a [dart] loaded"
+
 //Smartdart projectiles
 /obj/item/ammo_casing/syringegun/dart
 	harmful = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When examining a SmartDart pistol, it will now show what SmartDart(s) are loaded inside of the chamber.
![image](https://user-images.githubusercontent.com/68373373/167314313-2323088b-df35-48be-8c92-bac4eb16eaf6.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
This helps contribute to the idea of the SmartDart gun being a Smart version of the syringe gun, while providing useful QoL for medical players. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: SmartDart Pistols now show the inserted SmartDarts inside of them when examined.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
