### PR TITLE
Loadout cleanup and improvement

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/accessories.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/accessories.dm
@@ -1,0 +1,8 @@
+/obj/item/clothing/accessory/skullcodpiece/armourless
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+
+/obj/item/clothing/accessory/talisman/armourless
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+
+/obj/item/clothing/accessory/skilt/armourless
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)

--- a/modular_skyrat/modules/customization/modules/clothing/masks/breath.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/masks/breath.dm
@@ -80,8 +80,6 @@
 	icon_state = "swatclavam"
 	inhand_icon_state = "balaclava"
 
-
-
 /obj/item/clothing/mask/gas/german
 	name = "black gas mask"
 	desc = "A black gas mask. Are you my Mummy?"

--- a/modular_skyrat/modules/loadouts/loadout_items/_loadout_datum.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/_loadout_datum.dm
@@ -52,6 +52,8 @@ GLOBAL_LIST_EMPTY(all_loadout_datums)
 	var/list/restricted_roles
 	/// Whether the item is restricted to supporters
 	var/donator_only
+	/// Whether the item requires a specific season in order to be available
+	var/required_season = null
 
 /*
  * Place our [var/item_path] into [outfit].

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_accessory.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_accessory.dm
@@ -1,4 +1,6 @@
-// --- Loadout item datums for accessories ---
+/*
+*	LOADOUT ITEM DATUMS FOR THE ACCESSORY SLOT
+*/
 
 /// Accessory Items (Moves overrided items to backpack)
 GLOBAL_LIST_INIT(loadout_accessory, generate_loadout_items(/datum/loadout_item/accessory))
@@ -23,7 +25,7 @@ GLOBAL_LIST_INIT(loadout_accessory, generate_loadout_items(/datum/loadout_item/a
 	item_path = /obj/item/clothing/accessory/waistcoat
 
 /datum/loadout_item/accessory/pocket_protector
-	name = "Pocket Protector"
+	name = "Pocket Protector (Empty)"
 	item_path = /obj/item/clothing/accessory/pocketprotector
 
 /datum/loadout_item/accessory/full_pocket_protector
@@ -39,6 +41,9 @@ GLOBAL_LIST_INIT(loadout_accessory, generate_loadout_items(/datum/loadout_item/a
 	name = "Pride Pin"
 	item_path = /obj/item/clothing/accessory/pride
 
+/*
+*	ARMBANDS
+*/
 
 /datum/loadout_item/accessory/armband_medblue
 	name = "Medical Armband (blue stripe)"
@@ -75,19 +80,21 @@ GLOBAL_LIST_INIT(loadout_accessory, generate_loadout_items(/datum/loadout_item/a
 	item_path = /obj/item/clothing/accessory/armband/science
 	restricted_roles = list(JOB_RESEARCH_DIRECTOR, JOB_SCIENTIST, JOB_ROBOTICIST, JOB_GENETICIST, JOB_VANGUARD_OPERATIVE, JOB_SCIENCE_GUARD)
 
-/* to do later
-/datum/loadout_item/accessory/dogtags
-	name = "Name-Inscribed Dogtags"
-	item_path = /obj/item/clothing/accessory/cosmetic_dogtag
-	additional_tooltip_contents = list("MATCHES NAME - The name inscribed on this item matches your character's name on spawn.")
+/*
+*	ARMOURLESS
+*/
 
 /datum/loadout_item/accessory/bone_charm
-	name = "Heirloom Bone Talismin"
-	item_path = /obj/item/clothing/accessory/armorless_talisman
+	name = "Heirloom Bone Talisman"
+	item_path = /obj/item/clothing/accessory/talisman/armourless
 	additional_tooltip_contents = list(TOOLTIP_NO_ARMOR)
 
 /datum/loadout_item/accessory/bone_codpiece
 	name = "Heirloom Skull Codpiece"
-	item_path = /obj/item/clothing/accessory/armorless_skullcodpiece
+	item_path = /obj/item/clothing/accessory/skullcodpiece/armourless
 	additional_tooltip_contents = list(TOOLTIP_NO_ARMOR)
-*/
+
+/datum/loadout_item/accessory/sinew_kilt
+	name = "Heirloom Sinew Skirt"
+	item_path = /obj/item/clothing/accessory/skilt/armourless
+	additional_tooltip_contents = list(TOOLTIP_NO_ARMOR)

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_belts.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_belts.dm
@@ -1,4 +1,6 @@
-// --- Loadout item datums for belts ---
+/*
+*	LOADOUT ITEM DATUMS FOR THE BELT SLOT
+*/
 
 /// Belt Slot Items (Moves overrided items to backpack)
 GLOBAL_LIST_INIT(loadout_belts, generate_loadout_items(/datum/loadout_item/belts))

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_ears.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_ears.dm
@@ -1,5 +1,6 @@
-
-// --- Loadout item datums for ears ---
+/*
+*	LOADOUT ITEM DATUMS FOR THE EAR SLOT
+*/
 
 /// Ear Slot Items (Moves overrided items to backpack)
 GLOBAL_LIST_INIT(loadout_ears, generate_loadout_items(/datum/loadout_item/ears))

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_glasses.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_glasses.dm
@@ -1,4 +1,6 @@
-// --- Loadout item datums for glasses ---
+/*
+*	LOADOUT ITEM DATUMS FOR THE EYE SLOT
+*/
 
 /// Glasses Slot Items (Moves overrided items to backpack)
 GLOBAL_LIST_INIT(loadout_glasses, generate_loadout_items(/datum/loadout_item/glasses))
@@ -30,6 +32,9 @@ GLOBAL_LIST_INIT(loadout_glasses, generate_loadout_items(/datum/loadout_item/gla
 		|| equipped_glasses.invis_view \
 		|| !isnull(equipped_glasses.lighting_alpha))
 		equipper.update_sight()
+/*
+*	PRESCRIPTION GLASSES
+*/
 
 /datum/loadout_item/glasses/prescription_glasses
 	name = "Glasses"
@@ -47,6 +52,18 @@ GLOBAL_LIST_INIT(loadout_glasses, generate_loadout_items(/datum/loadout_item/gla
 /datum/loadout_item/glasses/prescription_glasses/jamjar_glasses
 	name = "Jamjar Glasses"
 	item_path = /obj/item/clothing/glasses/regular/jamjar
+
+/datum/loadout_item/glasses/prescription_glasses/thin
+	name = "Thin Glasses"
+	item_path = /obj/item/clothing/glasses/thin
+
+/datum/loadout_item/glasses/prescription_glasses/better
+	name = "Modern Glasses"
+	item_path = /obj/item/clothing/glasses/betterunshit
+
+/*
+*	COSMETIC GLASSES
+*/
 
 /datum/loadout_item/glasses/cold_glasses
 	name = "Cold Glasses"
@@ -72,47 +89,45 @@ GLOBAL_LIST_INIT(loadout_glasses, generate_loadout_items(/datum/loadout_item/gla
 	name = "Red Glasses"
 	item_path = /obj/item/clothing/glasses/red
 
+/*
+*	MISC
+*/
+
 /datum/loadout_item/glasses/eyepatch
 	name = "Eyepatch"
 	item_path = /obj/item/clothing/glasses/eyepatch
-
-/datum/loadout_item/glasses/fakeblindfold
-	name = "Fake Blindfold"
-	item_path = /obj/item/clothing/glasses/trickblindfold
-
-/datum/loadout_item/glasses/blindfold
-	name = "Blindfold"
-	item_path = /obj/item/clothing/glasses/blindfold
-
-/datum/loadout_item/glasses/monocle
-	name = "Monocle"
-	item_path = /obj/item/clothing/glasses/monocle
-
-/datum/loadout_item/glasses/thin
-	name = "Thin Glasses"
-	item_path = /obj/item/clothing/glasses/thin
-	additional_tooltip_contents = list("PRESCRIPTION - This item functions with the 'nearsighted' quirk.")
-
-/datum/loadout_item/glasses/better
-	name = "Modern Glasses"
-	item_path = /obj/item/clothing/glasses/betterunshit
-	additional_tooltip_contents = list("PRESCRIPTION - This item functions with the 'nearsighted' quirk.")
-
-/datum/loadout_item/glasses/eyewrap
-	name = "Eyepatch Wrap"
-	item_path = /obj/item/clothing/glasses/eyepatch/wrap
 
 /datum/loadout_item/glasses/whiteeyepatch
 	name = "White Eyepatch"
 	item_path = /obj/item/clothing/glasses/eyepatch/white
 
-/datum/loadout_item/glasses/biker
-	name = "Biker Goggles"
-	item_path = /obj/item/clothing/glasses/biker
+/datum/loadout_item/glasses/blindfold
+	name = "Blindfold"
+	item_path = /obj/item/clothing/glasses/blindfold
+
+/datum/loadout_item/glasses/fakeblindfold
+	name = "Fake Blindfold"
+	item_path = /obj/item/clothing/glasses/trickblindfold
 
 /datum/loadout_item/glasses/obsoleteblindfold
 	name = "Obselete Fake Blindfold"
 	item_path = /obj/item/clothing/glasses/trickblindfold/obsolete
+
+/datum/loadout_item/glasses/eyewrap
+	name = "Eyepatch Wrap"
+	item_path = /obj/item/clothing/glasses/eyepatch/wrap
+
+/datum/loadout_item/glasses/monocle
+	name = "Monocle"
+	item_path = /obj/item/clothing/glasses/monocle
+
+/datum/loadout_item/glasses/biker
+	name = "Biker Goggles"
+	item_path = /obj/item/clothing/glasses/biker
+
+/*
+*	JOB-LOCKED
+*/
 
 /datum/loadout_item/glasses/medicpatch
 	name = "Medical Eyepatch"
@@ -135,31 +150,34 @@ GLOBAL_LIST_INIT(loadout_glasses, generate_loadout_items(/datum/loadout_item/gla
 	restricted_roles = list(JOB_QUARTERMASTER, JOB_CARGO_TECHNICIAN, JOB_SHAFT_MINER, JOB_CUSTOMS_AGENT, JOB_CHIEF_ENGINEER, JOB_STATION_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN, JOB_ENGINEERING_GUARD)
 
 /datum/loadout_item/glasses/sechud
-	name = "Security Hud"
+	name = "Security HUD"
 	item_path = /obj/item/clothing/glasses/hud/security
 	restricted_roles = list(JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_HEAD_OF_SECURITY, JOB_BOUNCER, JOB_ORDERLY, JOB_SCIENCE_GUARD, JOB_CUSTOMS_AGENT, JOB_ENGINEERING_GUARD)
 
 /datum/loadout_item/glasses/secpatch
-	name = "Security Eyepatch Hud"
+	name = "Security Eyepatch HUD"
 	item_path = /obj/item/clothing/glasses/hud/eyepatch/sec
 	restricted_roles = list(JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_HEAD_OF_SECURITY, JOB_BOUNCER, JOB_ORDERLY, JOB_SCIENCE_GUARD, JOB_CUSTOMS_AGENT, JOB_ENGINEERING_GUARD)
 
 /datum/loadout_item/glasses/sechud_glasses
-	name = "Prescription Security Hud"
+	name = "Prescription Security HUD"
 	item_path = /obj/item/clothing/glasses/hud/security/prescription
 	restricted_roles = list(JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_HEAD_OF_SECURITY, JOB_BOUNCER, JOB_ORDERLY, JOB_SCIENCE_GUARD, JOB_CUSTOMS_AGENT, JOB_ENGINEERING_GUARD)
 
 /datum/loadout_item/glasses/medhud_glasses
-	name = "Prescription Medical Hud"
+	name = "Prescription Medical HUD"
 	item_path = /obj/item/clothing/glasses/hud/health/prescription
 	restricted_roles = list(JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_GENETICIST, JOB_CHEMIST, JOB_VIROLOGIST, JOB_PARAMEDIC, JOB_SECURITY_MEDIC, JOB_ORDERLY)
 
 /datum/loadout_item/glasses/diaghud_glasses
-	name = "Prescription Diagnostic Hud"
+	name = "Prescription Diagnostic HUD"
 	item_path = /obj/item/clothing/glasses/hud/diagnostic/prescription
 	restricted_roles = list(JOB_RESEARCH_DIRECTOR,JOB_SCIENTIST, JOB_ROBOTICIST)
 
-//Families Gear
+/*
+*	FAMILIES
+*/
+
 /datum/loadout_item/glasses/osi
 	name = "OSI Glasses"
 	item_path = /obj/item/clothing/glasses/osi
@@ -167,6 +185,10 @@ GLOBAL_LIST_INIT(loadout_glasses, generate_loadout_items(/datum/loadout_item/gla
 /datum/loadout_item/glasses/phantom
 	name = "Phantom Glasses"
 	item_path = /obj/item/clothing/glasses/phantom
+
+/*
+*	DONATOR
+*/
 
 /datum/loadout_item/glasses/donator
 	donator_only = TRUE

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_gloves.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_gloves.dm
@@ -1,4 +1,6 @@
-// --- Loadout item datums for gloves ---
+/*
+*	LOADOUT ITEM DATUMS FOR THE HAND SLOT
+*/
 
 /// Glove Slot Items (Deletes overrided items)
 GLOBAL_LIST_INIT(loadout_gloves, generate_loadout_items(/datum/loadout_item/gloves))
@@ -54,10 +56,6 @@ GLOBAL_LIST_INIT(loadout_gloves, generate_loadout_items(/datum/loadout_item/glov
 	name = "Purple Gloves"
 	item_path = /obj/item/clothing/gloves/color/purple
 
-/datum/loadout_item/gloves/rainbow
-	name = "Rainbow Gloves"
-	item_path = /obj/item/clothing/gloves/color/rainbow
-
 /datum/loadout_item/gloves/red
 	name = "Red Gloves"
 	item_path = /obj/item/clothing/gloves/color/red
@@ -67,9 +65,13 @@ GLOBAL_LIST_INIT(loadout_gloves, generate_loadout_items(/datum/loadout_item/glov
 	item_path = /obj/item/clothing/gloves/color/yellow
 	additional_tooltip_contents = list("NON-INSULATING - This item is purely cosmetic and provide no shock insulation.")
 
-/datum/loadout_item/gloves/yellow
+/datum/loadout_item/gloves/white
 	name = "White Gloves"
 	item_path = /obj/item/clothing/gloves/color/white
+
+/datum/loadout_item/gloves/rainbow
+	name = "Rainbow Gloves"
+	item_path = /obj/item/clothing/gloves/color/rainbow
 
 /datum/loadout_item/gloves/evening
 	name = "Evening Gloves"
@@ -79,19 +81,25 @@ GLOBAL_LIST_INIT(loadout_gloves, generate_loadout_items(/datum/loadout_item/glov
 	name = "Maid Arm Covers"
 	item_path = /obj/item/clothing/gloves/maid
 
-/datum/loadout_item/gloves/goldring
-	name = "Gold ring"
-	item_path = /obj/item/clothing/gloves/ring
+/*
+*	RINGS
+*/
 
 /datum/loadout_item/gloves/silverring
-	name = "Silver ring"
+	name = "Silver Ring"
 	item_path = /obj/item/clothing/gloves/ring/silver
 
+/datum/loadout_item/gloves/goldring
+	name = "Gold Ring"
+	item_path = /obj/item/clothing/gloves/ring
+
 /datum/loadout_item/gloves/diamondring
-	name = "Diamond ring"
+	name = "Diamond Ring"
 	item_path = /obj/item/clothing/gloves/ring/diamond
 
-//Donator gloves down here
+/*
+*	DONATOR
+*/
 
 /datum/loadout_item/gloves/donator
 	donator_only = TRUE

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -1,4 +1,6 @@
-// --- Loadout item datums for heads ---
+/*
+*	LOADOUT ITEM DATUMS FOR THE HEAD SLOT
+*/
 
 /// Head Slot Items (Moves overrided items to backpack)
 GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/head))
@@ -18,20 +20,9 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	else
 		outfit.head = item_path
 
-
-//readd these on christmas or suffer my wrath
-/*/datum/loadout_item/head/santa
-	name = "Santa hat"
-	item_path = /obj/item/clothing/head/santa
-
-/datum/loadout_item/head/christmas
-	name = "Red Christmas hat"
-	item_path = /obj/item/clothing/head/christmas
-
-/datum/loadout_item/head/christmas/green
-	name = "Green Christmas hat"
-	item_path = /obj/item/clothing/head/christmas/green*/
-//see above, whatever
+/*
+*	BEANIES
+*/
 
 /datum/loadout_item/head/black_beanie
 	name = "Black Beanie"
@@ -65,6 +56,14 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Red Beanie"
 	item_path = /obj/item/clothing/head/beanie/red
 
+/datum/loadout_item/head/white_beanie
+	name = "White Beanie"
+	item_path = /obj/item/clothing/head/beanie
+
+/datum/loadout_item/head/yellow_beanie
+	name = "Yellow Beanie"
+	item_path = /obj/item/clothing/head/beanie/yellow
+
 /datum/loadout_item/head/striped_beanie
 	name = "Striped Beanie"
 	item_path = /obj/item/clothing/head/beanie/striped
@@ -81,13 +80,13 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Striped Green Beanie"
 	item_path = /obj/item/clothing/head/beanie/stripedgreen
 
-/datum/loadout_item/head/white_beanie
-	name = "White Beanie"
-	item_path = /obj/item/clothing/head/beanie
+/datum/loadout_item/head/rastafarian
+	name = "Rastafarian Cap"
+	item_path = /obj/item/clothing/head/beanie/rasta
 
-/datum/loadout_item/head/yellow_beanie
-	name = "Yellow Beanie"
-	item_path = /obj/item/clothing/head/beanie/yellow
+/*
+*	BERETS
+*/
 
 /datum/loadout_item/head/greyscale_beret
 	name = "Greyscale Beret"
@@ -97,6 +96,10 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Black Beret"
 	item_path = /obj/item/clothing/head/beret/black
 
+/*
+*	CAPS
+*/
+
 /datum/loadout_item/head/black_cap
 	name = "Black Cap"
 	item_path = /obj/item/clothing/head/soft/black
@@ -104,10 +107,6 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 /datum/loadout_item/head/blue_cap
 	name = "Blue Cap"
 	item_path = /obj/item/clothing/head/soft/blue
-
-/datum/loadout_item/head/delinquent_cap
-	name = "Delinquent Cap"
-	item_path = /obj/item/clothing/head/delinquent
 
 /datum/loadout_item/head/green_cap
 	name = "Green Cap"
@@ -125,10 +124,6 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Purple Cap"
 	item_path = /obj/item/clothing/head/soft/purple
 
-/datum/loadout_item/head/rainbow_cap
-	name = "Rainbow Cap"
-	item_path = /obj/item/clothing/head/soft/rainbow
-
 /datum/loadout_item/head/red_cap
 	name = "Red Cap"
 	item_path = /obj/item/clothing/head/soft/red
@@ -141,6 +136,14 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Yellow Cap"
 	item_path = /obj/item/clothing/head/soft/yellow
 
+/datum/loadout_item/head/rainbow_cap
+	name = "Rainbow Cap"
+	item_path = /obj/item/clothing/head/soft/rainbow
+
+/datum/loadout_item/head/delinquent_cap
+	name = "Delinquent Cap"
+	item_path = /obj/item/clothing/head/delinquent
+
 /datum/loadout_item/head/flatcap
 	name = "Flat Cap"
 	item_path = /obj/item/clothing/head/flatcap
@@ -149,17 +152,29 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Poly Flat cap"
 	item_path = /obj/item/clothing/head/colourable_flatcap
 
+/*
+*	FEDORAS
+*/
+
+/datum/loadout_item/head/black_fedora
+	name = "Black Fedora"
+	item_path = /obj/item/clothing/head/fedora/fedblack
+
 /datum/loadout_item/head/beige_fedora
 	name = "Beige Fedora"
 	item_path = /obj/item/clothing/head/fedora/beige
 
-/datum/loadout_item/head/black_fedora
-	name = "Black Fedora"
-	item_path = /obj/item/clothing/head/fedora
-
 /datum/loadout_item/head/white_fedora
 	name = "White Fedora"
 	item_path = /obj/item/clothing/head/fedora/white
+
+/datum/loadout_item/head/brown_fedora
+	name = "Brown Fedora"
+	item_path = /obj/item/clothing/head/fedora/fedbrown
+
+/*
+*	HARDHATS
+*/
 
 /datum/loadout_item/head/dark_blue_hardhat
 	name = "Dark Blue Hardhat"
@@ -181,13 +196,13 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Yellow Hardhat"
 	item_path = /obj/item/clothing/head/hardhat
 
+/*
+*	MISC
+*/
+
 /datum/loadout_item/head/mail_cap
 	name = "Mail Cap"
 	item_path = /obj/item/clothing/head/mailman
-
-/datum/loadout_item/head/nurse_hat
-	name = "Nurse Hat"
-	item_path = /obj/item/clothing/head/nursehat
 
 /datum/loadout_item/head/kitty_ears
 	name = "Kitty Ears"
@@ -201,10 +216,6 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Bandana"
 	item_path = /obj/item/clothing/head/bandana
 
-/datum/loadout_item/head/rastafarian
-	name = "Rastafarian Cap"
-	item_path = /obj/item/clothing/head/beanie/rasta
-
 /datum/loadout_item/head/top_hat
 	name = "Top Hat"
 	item_path = /obj/item/clothing/head/that
@@ -213,7 +224,28 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Bowler Hat"
 	item_path = /obj/item/clothing/head/bowler
 
-//HALLOWEEN
+/*
+*	CHRISTMAS
+*/
+
+/datum/loadout_item/head/santa
+	name = "Santa Hat"
+	item_path = /obj/item/clothing/head/santa
+	required_season = CHRISTMAS
+
+/datum/loadout_item/head/christmas
+	name = "Red Christmas Hat"
+	item_path = /obj/item/clothing/head/christmas
+	required_season = CHRISTMAS
+
+/datum/loadout_item/head/christmas/green
+	name = "Green Christmas Hat"
+	item_path = /obj/item/clothing/head/christmas/green
+	required_season = CHRISTMAS
+
+/*
+*	HALLOWEEN
+*/
 
 /datum/loadout_item/head/bear_pelt
 	name = "Bear Pelt"
@@ -244,7 +276,7 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	item_path = /obj/item/clothing/head/weddingveil
 
 /datum/loadout_item/head/synde
-	name = "Black Space-helmet Replica"
+	name = "Black Space-Helmet Replica"
 	item_path = /obj/item/clothing/head/syndicatefake
 
 /datum/loadout_item/head/glatiator
@@ -255,18 +287,21 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Griffon Head"
 	item_path = /obj/item/clothing/head/griffin
 
-//MISC
+/datum/loadout_item/head/wizard
+	name = "Wizard Hat"
+	item_path = /obj/item/clothing/head/wizard/fake
+
+/datum/loadout_item/head/witch
+	name = "Witch Hat"
+	item_path = /obj/item/clothing/head/wizard/marisa/fake
+
+/*
+*	MISC
+*/
+
 /datum/loadout_item/head/baseball
 	name = "Ballcap"
 	item_path = /obj/item/clothing/head/soft/mime
-
-/datum/loadout_item/head/beanie
-	name = "Beanie"
-	item_path = /obj/item/clothing/head/beanie
-
-/datum/loadout_item/head/beret
-	name = "Black beret"
-	item_path = /obj/item/clothing/head/beret/black
 
 /datum/loadout_item/head/pirate
 	name = "Pirate hat"
@@ -277,7 +312,7 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	item_path = /obj/item/clothing/head/flowerpin
 
 /datum/loadout_item/head/rice_hat
-	name = "Rice hat"
+	name = "Rice Hat"
 	item_path = /obj/item/clothing/head/rice_hat
 
 /datum/loadout_item/head/ushanka
@@ -301,35 +336,19 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	item_path = /obj/item/clothing/head/whiterussian/black
 
 /datum/loadout_item/head/slime
-	name = "Slime hat"
+	name = "Slime Hat"
 	item_path = /obj/item/clothing/head/collectable/slime
-
-/datum/loadout_item/head/fedora
-	name = "Fedora"
-	item_path = /obj/item/clothing/head/fedora
-
-/datum/loadout_item/head/that
-	name = "Top Hat"
-	item_path = /obj/item/clothing/head/that
 
 /datum/loadout_item/head/flakhelm
 	name = "Flak Helmet"
 	item_path = /obj/item/clothing/head/flakhelm
-
-/datum/loadout_item/head/bunnyears
-	name = "Bunny Ears"
-	item_path = /obj/item/clothing/head/rabbitears
-
-/datum/loadout_item/head/mailmanhat
-	name = "Mailman's Hat"
-	item_path = /obj/item/clothing/head/mailman
 
 /datum/loadout_item/head/whitekepi
 	name = "White Kepi"
 	item_path = /obj/item/clothing/head/kepi
 
 /datum/loadout_item/head/whitekepiold
-	name = "White Kepi, Old"
+	name = "White Kepi (Old)"
 	item_path = /obj/item/clothing/head/kepi/old
 
 /datum/loadout_item/head/maidhead
@@ -350,10 +369,6 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Wide Red Hat"
 	item_path = /obj/item/clothing/head/costume/widehat/red
 
-/datum/loadout_item/head/cardboard
-	name = "Cardboard Helmet"
-	item_path = /obj/item/clothing/head/cardborg
-
 /datum/loadout_item/head/wig
 	name = "Wig"
 	item_path = /obj/item/clothing/head/wig
@@ -362,29 +377,40 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Natural Wig"
 	item_path = /obj/item/clothing/head/wig/natural
 
-//Cowboy Stuff
+/datum/loadout_item/head/domina_cap
+	name = "Dominant Cap"
+	item_path = /obj/item/clothing/head/domina_cap
+
+/datum/loadout_item/head/fashionable_cap
+	name = "Fashionable Baseball Cap"
+	item_path = /obj/item/clothing/head/soft/yankee
+
+/*
+*	COWBOY
+*/
+
 /datum/loadout_item/head/cowboyhat
-	name = "Cowboy Hat, Brown"
+	name = "Cowboy Hat (Brown)"
 	item_path = /obj/item/clothing/head/cowboyhat
 
 /datum/loadout_item/head/cowboyhat_black
-	name = "Cowboy Hat, Black"
+	name = "Cowboy Hat (Black)"
 	item_path = /obj/item/clothing/head/cowboyhat/black
 
 /datum/loadout_item/head/cowboyhat_blackwide
-	name = "Wide Cowboy Hat, Black"
+	name = "Wide Cowboy Hat (Black)"
 	item_path = /obj/item/clothing/head/cowboyhat/blackwide
 
 /datum/loadout_item/head/cowboyhat_wide
-	name = "Wide Cowboy Hat, Brown"
+	name = "Wide Cowboy Hat (Brown)"
 	item_path = /obj/item/clothing/head/cowboyhat/wide
 
 /datum/loadout_item/head/cowboyhat_white
-	name = "Cowboy Hat, White"
+	name = "Cowboy Hat (White)"
 	item_path = /obj/item/clothing/head/cowboyhat/white
 
 /datum/loadout_item/head/cowboyhat_pink
-	name = "Cowboy Hat, Pink"
+	name = "Cowboy Hat (Pink)"
 	item_path = /obj/item/clothing/head/cowboyhat/pink
 
 /datum/loadout_item/head/cowboyhat_winter
@@ -399,7 +425,10 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Deputy Hat"
 	item_path = /obj/item/clothing/head/cowboyhat/deputy
 
-//Trek fancy Hats! (Job-locked too)
+/*
+*	TREK HATS (JOB-LOCKED)
+*/
+
 /datum/loadout_item/head/trekcap
 	name = "Federation Officer's Cap (White)"
 	item_path = /obj/item/clothing/head/caphat/parade/fedcap
@@ -424,7 +453,11 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Federation Officer's Cap (Red)"
 	item_path = /obj/item/clothing/head/caphat/parade/fedcap/sec
 	restricted_roles = list(JOB_CHIEF_ENGINEER,JOB_ATMOSPHERIC_TECHNICIAN,JOB_STATION_ENGINEER,JOB_SECURITY_MEDIC,JOB_WARDEN,JOB_DETECTIVE,JOB_SECURITY_OFFICER,JOB_HEAD_OF_SECURITY,JOB_CORRECTIONS_OFFICER,JOB_CARGO_TECHNICIAN, JOB_SHAFT_MINER, JOB_QUARTERMASTER, JOB_CUSTOMS_AGENT)
-//Job Locked Hats
+
+/*
+*	JOB-LOCKED
+*/
+
 /datum/loadout_item/head/imperial_cap
 	name = "Captain's Naval Cap"
 	item_path = /obj/item/clothing/head/imperial/cap
@@ -510,7 +543,10 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	item_path = /obj/item/clothing/head/imperial/red
 	restricted_roles = list(JOB_CAPTAIN, JOB_HEAD_OF_PERSONNEL, JOB_BLUESHIELD, JOB_HEAD_OF_SECURITY, JOB_RESEARCH_DIRECTOR, JOB_QUARTERMASTER, JOB_CHIEF_MEDICAL_OFFICER, JOB_CHIEF_ENGINEER)
 
-// JOB - Berets
+/*
+*	JOB BERETS
+*/
+
 /datum/loadout_item/head/atmos_beret
 	name = "Atmospherics Beret"
 	item_path = /obj/item/clothing/head/beret/atmos
@@ -520,6 +556,7 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Engineering Beret"
 	item_path = /obj/item/clothing/head/beret/engi
 	restricted_roles = list(JOB_STATION_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN, JOB_CHIEF_ENGINEER, JOB_ENGINEERING_GUARD)
+
 /datum/loadout_item/head/beret_med
 	name = "Medical Beret"
 	item_path = /obj/item/clothing/head/beret/medical
@@ -541,32 +578,19 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	restricted_roles = list(JOB_CHEMIST, JOB_CHIEF_MEDICAL_OFFICER)
 
 /datum/loadout_item/head/beret_sci
-	name = "Scientist's Beret"
+	name = "Scientist Beret"
 	item_path = /obj/item/clothing/head/beret/science
 	restricted_roles = list(JOB_SCIENTIST, JOB_ROBOTICIST, JOB_GENETICIST, JOB_RESEARCH_DIRECTOR, JOB_VANGUARD_OPERATIVE, JOB_SCIENCE_GUARD)
 
 /datum/loadout_item/head/beret_robo
-	name = "Roboticist's Beret"
+	name = "Roboticist Beret"
 	item_path = /obj/item/clothing/head/beret/science/fancy/robo
 	restricted_roles = list(JOB_ROBOTICIST, JOB_RESEARCH_DIRECTOR)
 
-/datum/loadout_item/head/brfed
-	name = "Brown Fedora"
-	item_path = /obj/item/clothing/head/fedora/fedbrown
+/*
+*	FAMILIES
+*/
 
-/datum/loadout_item/head/blfed
-	name = "Black Fedora"
-	item_path = /obj/item/clothing/head/fedora/fedblack
-
-/datum/loadout_item/head/dominacap
-	name = "Dominant cap"
-	item_path = /obj/item/clothing/head/domina_cap
-
-/datum/loadout_item/head/fashionable_cap
-	name = "Fashionable baseball cap"
-	item_path = /obj/item/clothing/head/soft/yankee
-
-//Families Gear
 /datum/loadout_item/head/tmc
 	name = "TMC Hat"
 	item_path = /obj/item/clothing/head/tmc
@@ -595,9 +619,16 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Basil Hat"
 	item_path = /obj/item/clothing/head/basil_boys
 
-// Donator hats here
+/*
+*	DONATOR
+*/
+
 /datum/loadout_item/head/donator
 	donator_only = TRUE
+
+/*
+*	FLOWERS
+*/
 
 /datum/loadout_item/head/donator/poppy
 	name = "Poppy Flower"
@@ -636,10 +667,14 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	item_path = /obj/item/food/grown/rainbow_flower
 	additional_tooltip_contents = list(TOOLTIP_RANDOM_COLOR)
 
+/*
+*	ENCLAVE
+*/
+
 /datum/loadout_item/head/donator/enclave
 	name = "Enclave Cap"
 	item_path = /obj/item/clothing/head/soft/enclave
 
 /datum/loadout_item/head/donator/enclaveo
-	name = "Enclave Cap - officer"
+	name = "Enclave Cap - Officer"
 	item_path = /obj/item/clothing/head/soft/enclaveo

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_inhands.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_inhands.dm
@@ -1,4 +1,6 @@
-// --- Loadout item datums for inhand items ---
+/*
+*	LOADOUT ITEM DATUMS FOR BOTH HAND SLOTS
+*/
 
 /// Inhand items (Moves overrided items to backpack)
 GLOBAL_LIST_INIT(loadout_inhand_items, generate_loadout_items(/datum/loadout_item/inhand))
@@ -45,10 +47,6 @@ GLOBAL_LIST_INIT(loadout_inhand_items, generate_loadout_items(/datum/loadout_ite
 /datum/loadout_item/inhand/bouquet_rose
 	name = "Rose Bouquet"
 	item_path = /obj/item/bouquet/rose
-
-/datum/loadout_item/inhand/cane
-	name = "Cane"
-	item_path = /obj/item/cane
 
 /datum/loadout_item/inhand/smokingpipe
 	name = "Smoking Pipe"

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_masks.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_masks.dm
@@ -1,4 +1,6 @@
-// --- Loadout item datums for masks ---
+/*
+*	LOADOUT ITEM DATUMS FOR THE MASK SLOT
+*/
 
 /// Mask Slot Items (Deletes overrided items)
 GLOBAL_LIST_INIT(loadout_masks, generate_loadout_items(/datum/loadout_item/mask))
@@ -18,14 +20,9 @@ GLOBAL_LIST_INIT(loadout_masks, generate_loadout_items(/datum/loadout_item/mask)
 	else
 		outfit.mask = item_path
 
-
-/datum/loadout_item/mask/balaclava
-	name = "Balaclava"
-	item_path = /obj/item/clothing/mask/balaclava
-
-/datum/loadout_item/mask/gas_mask
-	name = "Gas Mask"
-	item_path = /obj/item/clothing/mask/gas
+/*
+*	BANDANAS
+*/
 
 /datum/loadout_item/mask/black_bandana
 	name = "Black Bandana"
@@ -51,9 +48,55 @@ GLOBAL_LIST_INIT(loadout_masks, generate_loadout_items(/datum/loadout_item/mask)
 	name = "Skull Bandana"
 	item_path = /obj/item/clothing/mask/bandana/color/skull
 
-/datum/loadout_item/mask/surgical_mask
-	name = "Face Mask"
+/*
+*	BALACLAVAS
+*/
+
+/datum/loadout_item/mask/balaclavaadj
+	name = "Adjustable Balaclava"
+	item_path = /obj/item/clothing/mask/balaclavaadjust
+
+/datum/loadout_item/mask/balaclavathree
+	name = "Three-Hole Balaclava (Black)"
+	item_path = /obj/item/clothing/mask/balaclava/threehole
+
+/datum/loadout_item/mask/balaclavagreen
+	name = "Three-Hole Balaclava (Green)"
+	item_path = /obj/item/clothing/mask/balaclava/threehole/green
+
+/*
+*	GAS MASKS
+*/
+
+/datum/loadout_item/mask/gas_mask
+	name = "Gas Mask"
+	item_path = /obj/item/clothing/mask/gas
+
+/datum/loadout_item/mask/gas_glass
+	name = "Glass Gas Mask"
+	item_path = /obj/item/clothing/mask/gas/glass
+
+/*
+*	JOB-LOCKED
+*/
+
+/datum/loadout_item/mask/surgical
+	name = "Sterile Mask"
 	item_path = /obj/item/clothing/mask/surgical
+	restricted_roles = list(JOB_CHIEF_MEDICAL_OFFICER, JOB_MEDICAL_DOCTOR, JOB_VIROLOGIST, JOB_CHEMIST, JOB_GENETICIST, JOB_PARAMEDIC, JOB_PSYCHOLOGIST, JOB_SECURITY_MEDIC, JOB_ORDERLY)
+
+
+/*
+*	FAMILIES
+*/
+
+/datum/loadout_item/mask/driscoll
+	name = "Driscoll Mask"
+	item_path = /obj/item/clothing/mask/gas/driscoll
+
+/*
+*	MISC
+*/
 
 /datum/loadout_item/mask/fake_mustache
 	name = "Fake Moustache"
@@ -90,34 +133,3 @@ GLOBAL_LIST_INIT(loadout_masks, generate_loadout_items(/datum/loadout_item/mask)
 /datum/loadout_item/mask/balaclava
 	name = "Balaclava"
 	item_path = /obj/item/clothing/mask/balaclava
-
-/datum/loadout_item/mask/balaclavaadj
-	name = "Adjustable Balaclava"
-	item_path = /obj/item/clothing/mask/balaclavaadjust
-
-/datum/loadout_item/mask/balaclavathree
-	name = "Three Hole Balaclava"
-	item_path = /obj/item/clothing/mask/balaclava/threehole
-
-/datum/loadout_item/mask/balaclavagreen
-	name = "Three Hole Green Balaclava"
-	item_path = /obj/item/clothing/mask/balaclava/threehole/green
-
-/datum/loadout_item/mask/moustache
-	name = "Fake moustache"
-	item_path = /obj/item/clothing/mask/fakemoustache
-
-
-/datum/loadout_item/mask/gas_glass
-	name = "Glass Gas Mask"
-	item_path = /obj/item/clothing/mask/gas/glass
-
-/datum/loadout_item/mask/surgical
-	name = "Sterile Mask"
-	item_path = /obj/item/clothing/mask/surgical
-	restricted_roles = list(JOB_CHIEF_MEDICAL_OFFICER, JOB_MEDICAL_DOCTOR, JOB_VIROLOGIST, JOB_CHEMIST, JOB_GENETICIST, JOB_PARAMEDIC, JOB_PSYCHOLOGIST, JOB_SECURITY_MEDIC, JOB_ORDERLY)
-
-//Families Gear
-/datum/loadout_item/mask/driscoll
-	name = "Driscoll Mask"
-	item_path = /obj/item/clothing/mask/gas/driscoll

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_neck.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_neck.dm
@@ -1,4 +1,6 @@
-// --- Loadout item datums for neck items ---
+/*
+*	LOADOUT ITEM DATUMS FOR THE NECK SLOT
+*/
 
 /// Neck Slot Items (Deletes overrided items)
 GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck))
@@ -15,6 +17,10 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 		outfit.neck = item_path
 
 
+/*
+*	SCARVES
+*/
+
 /datum/loadout_item/neck/scarf_black
 	name = "Black Scarf"
 	item_path = /obj/item/clothing/neck/scarf/black
@@ -28,7 +34,7 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 	item_path = /obj/item/clothing/neck/scarf/cyan
 
 /datum/loadout_item/neck/scarf_dark_blue
-	name = "Darkblue Scarf"
+	name = "Dark Blue Scarf"
 	item_path = /obj/item/clothing/neck/scarf/darkblue
 
 /datum/loadout_item/neck/scarf_green
@@ -75,6 +81,10 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 	name = "Zebra Scarf"
 	item_path = /obj/item/clothing/neck/scarf/zebra
 
+/*
+*	NECKTIES
+*/
+
 /datum/loadout_item/neck/necktie_black
 	name = "Black Necktie"
 	item_path = /obj/item/clothing/neck/tie/black
@@ -100,14 +110,9 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 	item_path = /obj/item/clothing/neck/tie/disco
 	restricted_roles = list(JOB_DETECTIVE)
 
-/datum/loadout_item/neck/stethoscope
-	name = "Stethoscope"
-	item_path = /obj/item/clothing/neck/stethoscope
-	restricted_roles = list(JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER,JOB_SECURITY_MEDIC)
-
-/datum/loadout_item/neck/maid
-	name = "Maid Neck Cover"
-	item_path = /obj/item/clothing/neck/maid
+/*
+*	COLLARS
+*/
 
 /datum/loadout_item/neck/choker
 	name = "Choker"
@@ -141,6 +146,14 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 	name = "Cross Collar"
 	item_path = /obj/item/clothing/neck/human_petcollar/locked/cross
 
+/datum/loadout_item/neck/kinkycollar
+	name = "Kinky Collar"
+	item_path = /obj/item/clothing/neck/kink_collar
+
+/*
+*	PONCHOS
+*/
+
 /datum/loadout_item/neck/ponchocowboy
 	name = "Green cowboy poncho"
 	item_path = /obj/item/clothing/neck/cowboylea
@@ -148,6 +161,10 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 /datum/loadout_item/neck/ranger_poncho_greyscale
 	name = "Greyscale ranger poncho"
 	item_path = /obj/item/clothing/neck/ranger_poncho
+
+/*
+*	GAGS
+*/
 
 /datum/loadout_item/neck/gags_cloak
 	name = "Colourable Cloak"
@@ -164,6 +181,10 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 /datum/loadout_item/neck/gags_boat
 	name = "Colourable Boatcloak"
 	item_path = /obj/item/clothing/neck/cloak/colourable/boat
+
+/*
+*	MANTLES
+*/
 
 /datum/loadout_item/neck/mantle
 	name = "Mantle"
@@ -204,11 +225,23 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 	item_path = /obj/item/clothing/neck/mantle/capmantle
 	restricted_roles = list(JOB_CAPTAIN)
 
-/datum/loadout_item/neck/kinkycollar
-	name = "Kinky collar"
-	item_path = /obj/item/clothing/neck/kink_collar
+/*
+*	MISC
+*/
 
-//Donator neck items here
+/datum/loadout_item/neck/stethoscope
+	name = "Stethoscope"
+	item_path = /obj/item/clothing/neck/stethoscope
+	restricted_roles = list(JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER,JOB_SECURITY_MEDIC)
+
+/datum/loadout_item/neck/maid
+	name = "Maid Neck Cover"
+	item_path = /obj/item/clothing/neck/maid
+
+/*
+*	DONATOR
+*/
+
 /datum/loadout_item/neck/donator
 	donator_only = TRUE
 

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -1,4 +1,6 @@
-// --- Loadout item datums for backpack / pocket items ---
+/*
+*	LOADOUT ITEM DATUMS FOR BACKPACK/POCKET SLOTS
+*/
 
 /// Pocket items (Moved to backpack)
 GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_item/pocket_items))
@@ -44,9 +46,9 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 		if(!equipper.equip_to_slot_if_possible(wallet, slot = ITEM_SLOT_BACKPACK, initial = TRUE))
 			wallet.forceMove(equipper.drop_location())
 
-/datum/loadout_item/pocket_items/rag
-	name = "Rag"
-	item_path = /obj/item/reagent_containers/glass/rag
+/*
+*	GUM
+*/
 
 /datum/loadout_item/pocket_items/gum_pack
 	name = "Pack of Gum"
@@ -59,6 +61,10 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 /datum/loadout_item/pocket_items/gum_pack_hp
 	name = "Pack of HP+ Gum"
 	item_path = /obj/item/storage/box/gum/happiness
+
+/*
+*	LIPSTICK
+*/
 
 /datum/loadout_item/pocket_items/lipstick_black
 	name = "Black Lipstick"
@@ -76,20 +82,24 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 	name = "Red Lipstick"
 	item_path = /obj/item/lipstick
 
+/*
+*	MISC
+*/
+
+/datum/loadout_item/pocket_items/rag
+	name = "Rag"
+	item_path = /obj/item/reagent_containers/glass/rag
+
 /datum/loadout_item/pocket_items/razor
 	name = "Razor"
 	item_path = /obj/item/razor
-
-/datum/loadout_item/pocket_items/lighter
-	name = "Lighter"
-	item_path = /obj/item/lighter
 
 /datum/loadout_item/pocket_items/matches
 	name = "Matchbox"
 	item_path = /obj/item/storage/box/matches
 
 /datum/loadout_item/pocket_items/cheaplighter
-	name = "Cheap lighter"
+	name = "Cheap Lighter"
 	item_path = /obj/item/lighter/greyscale
 
 /datum/loadout_item/pocket_items/zippolighter
@@ -101,21 +111,16 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 	item_path = /obj/item/ttsdevice
 
 /datum/loadout_item/pocket_items/paicard
-	name = "Personal AI device"
+	name = "Personal AI Device"
 	item_path = /obj/item/paicard
 
-/datum/loadout_item/pocket_items/cigar
-	name = "Cigar"
-	item_path = /obj/item/clothing/mask/cigarette/cigar
-	 //smoking is bad mkay
-
 /datum/loadout_item/pocket_items/cigarettes
-	name = "Cigarette pack"
+	name = "Cigarette Pack"
 	item_path = /obj/item/storage/fancy/cigarettes
 
-/datum/loadout_item/pocket_items/wallet
-	name = "Wallet"
-	item_path = /obj/item/storage/wallet
+/datum/loadout_item/pocket_items/cigar //smoking is bad mkay
+	name = "Cigar"
+	item_path = /obj/item/clothing/mask/cigarette/cigar
 
 /datum/loadout_item/pocket_items/flask
 	name = "Flask"
@@ -126,43 +131,39 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 	item_path = /obj/item/skub
 
 /datum/loadout_item/pocket_items/multipen
-	name = "Multicolored pen"
+	name = "Multicolored Pen"
 	item_path = /obj/item/pen/fourcolor
 
 /datum/loadout_item/pocket_items/fountainpen
-	name = "Fancy pen"
+	name = "Fancy Pen"
 	item_path = /obj/item/pen/fountain
 
 /datum/loadout_item/pocket_items/modular_tablet
-	name = "Modular tablet"
+	name = "Modular Tablet"
 	item_path = /obj/item/modular_computer/tablet/preset/cheap/
 
-
 /datum/loadout_item/pocket_items/modular_laptop
-	name = "Modular laptop"
+	name = "Modular Laptop"
 	item_path = /obj/item/modular_computer/laptop/preset/civilian/closed
 
-
 /datum/loadout_item/pocket_items/ringbox_gold
-	name = "Gold ring box"
+	name = "Gold Ring Box"
 	item_path = /obj/item/storage/fancy/ringbox
 
-
 /datum/loadout_item/pocket_items/ringbox_silver
-	name = "Silver ring box"
+	name = "Silver Ring Box"
 	item_path = /obj/item/storage/fancy/ringbox/silver
 
-
 /datum/loadout_item/pocket_items/ringbox_diamond
-	name = "Diamond ring box"
+	name = "Diamond Ring Box"
 	item_path = /obj/item/storage/fancy/ringbox/diamond
 
 /datum/loadout_item/pocket_items/tapeplayer
-	name = "Taperecorder"
+	name = "Universal Recorder"
 	item_path = /obj/item/taperecorder
 
 /datum/loadout_item/pocket_items/tape
-	name = "Spare cassette tape"
+	name = "Spare Cassette Tape"
 	item_path = /obj/item/tape/random
 
 /datum/loadout_item/pocket_items/newspaper
@@ -177,6 +178,10 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 	name = "Ornate Cross"
 	item_path = /obj/item/crucifix
 	restricted_roles = list(JOB_CHAPLAIN)
+
+/*
+*	FRAGRANCES
+*/
 
 /datum/loadout_item/pocket_items/fragrance_cologne
 	name = "Cologne Bottle"
@@ -218,21 +223,22 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 	name = "Amber Perfume"
 	item_path = /obj/item/perfume/amber
 
-//Donator stuffs down here
+
+/*
+*	DONATOR
+*/
+
 /datum/loadout_item/pocket_items/donator
 	donator_only = TRUE
 
 /datum/loadout_item/pocket_items/donator/coin
 	name = "Iron Coin"
 	item_path = /obj/item/coin/iron
-	donator_only = TRUE
 
 /datum/loadout_item/pocket_items/donator/havana_cigar_case
 	name = "Havanian Cigars"
 	item_path = /obj/item/storage/fancy/cigarettes/cigars/havana
-	donator_only = TRUE
 
 /datum/loadout_item/pocket_items/donator/vape
 	name = "E-Cigarette"
 	item_path = /obj/item/clothing/mask/vape
-	donator_only = TRUE

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_shoes.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_shoes.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 	item_path = /obj/item/clothing/shoes/jackboots/timbs
 
 /datum/loadout_item/shoes/jungle
-	name = "Brown Jackboots"
+	name = "Jungle Boots"
 	item_path = /obj/item/clothing/shoes/jungleboots
 
 /datum/loadout_item/shoes/winter_boots

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_shoes.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_shoes.dm
@@ -1,4 +1,6 @@
-// --- Loadout item datums for shoes items ---
+/*
+*	LOADOUT ITEM DATUMS FOR THE SHOE SLOT
+*/
 
 /// Shoe Slot Items (Deletes overrided items)
 GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes))
@@ -14,16 +16,9 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 	else
 		outfit.shoes = item_path
 
-
-//christmas, readd them round december
-/*/datum/loadout_item/shoes/christmas
-	name = "Red Christmas Boots"
-	item_path = /obj/item/clothing/shoes/winterboots/christmas
-
-/datum/loadout_item/shoes/christmas/green
-	name = "Green Christmas Boots"
-	item_path = /obj/item/clothing/shoes/winterboots/christmas/green */
-//every christmas is last christmas
+/*
+*	JACKBOOTS
+*/
 
 /datum/loadout_item/shoes/jackboots
 	name = "Jackboots"
@@ -31,12 +26,8 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 
 // Thedragmeme's donator reward, they've decided to make them available to everybody.
 /datum/loadout_item/shoes/jackboots/heel
-	name = "High-heel Jackboots"
+	name = "High-Heel Jackboots"
 	item_path = /obj/item/clothing/shoes/jackboots/heel
-
-/datum/loadout_item/shoes/junhle
-	name = "Brown Jackboots"
-	item_path = /obj/item/clothing/shoes/jungleboots
 
 /datum/loadout_item/shoes/thighboot
 	name = "Thigh Boots"
@@ -46,9 +37,17 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 	name = "Knee Boots"
 	item_path = /obj/item/clothing/shoes/jackboots/knee
 
+/*
+*	MISC BOOTS
+*/
+
 /datum/loadout_item/shoes/timbs
 	name = "Fashionable Boots"
 	item_path = /obj/item/clothing/shoes/jackboots/timbs
+
+/datum/loadout_item/shoes/jungle
+	name = "Brown Jackboots"
+	item_path = /obj/item/clothing/shoes/jungleboots
 
 /datum/loadout_item/shoes/winter_boots
 	name = "Winter Boots"
@@ -62,28 +61,40 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 	name = "Mining Boots"
 	item_path = /obj/item/clothing/shoes/workboots/mining
 
-/datum/loadout_item/shoes/laceup
-	name = "Laceup Shoes"
-	item_path = /obj/item/clothing/shoes/laceup
-
 /datum/loadout_item/shoes/russian_boots
 	name = "Russian Boots"
 	item_path = /obj/item/clothing/shoes/russian
 
-/datum/loadout_item/shoes/black_cowboy_boots
-	name = "Black Cowboy Boots"
-	item_path = /obj/item/clothing/shoes/cowboy/black
+/*
+*	COWBOY
+*/
 
 /datum/loadout_item/shoes/brown_cowboy_boots
 	name = "Brown Cowboy Boots"
 	item_path = /obj/item/clothing/shoes/cowboy
 
+/datum/loadout_item/shoes/black_cowboy_boots
+	name = "Black Cowboy Boots"
+	item_path = /obj/item/clothing/shoes/cowboy/black
+
 /datum/loadout_item/shoes/white_cowboy_boots
 	name = "White Cowboy Boots"
 	item_path = /obj/item/clothing/shoes/cowboy/white
 
+/datum/loadout_item/shoes/cowboyboots
+	name = "Cowboy Boots (Brown)"
+	item_path = /obj/item/clothing/shoes/cowboyboots
+
+/datum/loadout_item/shoes/cowboyboots_black
+	name = "Cowboy Boots (Black)"
+	item_path = /obj/item/clothing/shoes/cowboyboots/black
+
+/*
+*	SNEAKERS
+*/
+
 /datum/loadout_item/shoes/greyscale_sneakers
-	name = "Greyscale Sneakers"
+	name = "Colorable Sneakers"
 	item_path = /obj/item/clothing/shoes/sneakers
 
 /datum/loadout_item/shoes/black_sneakers
@@ -110,10 +121,6 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 	name = "Orange Sneakers"
 	item_path = /obj/item/clothing/shoes/sneakers/orange
 
-/datum/loadout_item/shoes/rainbow_sneakers
-	name = "Rainbow Sneakers"
-	item_path = /obj/item/clothing/shoes/sneakers/rainbow
-
 /datum/loadout_item/shoes/yellow_sneakers
 	name = "Yellow Sneakers"
 	item_path = /obj/item/clothing/shoes/sneakers/yellow
@@ -121,6 +128,50 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 /datum/loadout_item/shoes/white_sneakers
 	name = "White Sneakers"
 	item_path = /obj/item/clothing/shoes/sneakers/white
+
+/*
+*	LEG WRAPS
+*/
+
+/datum/loadout_item/shoes/gildedcuffs
+	name = "Gilded Leg Wraps"
+	item_path = /obj/item/clothing/shoes/wraps
+
+/datum/loadout_item/shoes/silvercuffs
+	name = "Silver Leg Wraps"
+	item_path = /obj/item/clothing/shoes/wraps/silver
+
+/datum/loadout_item/shoes/redcuffs
+	name = "Red Leg Wraps"
+	item_path = /obj/item/clothing/shoes/wraps/red
+
+/datum/loadout_item/shoes/bluecuffs
+	name = "Blue Leg Wraps"
+	item_path = /obj/item/clothing/shoes/wraps/blue
+
+/datum/loadout_item/shoes/clothwrap
+	name = "Colourable Cloth Wraps"
+	item_path = /obj/item/clothing/shoes/wraps/colourable
+
+/*
+*	MISC
+*/
+
+/datum/loadout_item/shoes/laceup
+	name = "Laceup Shoes"
+	item_path = /obj/item/clothing/shoes/laceup
+
+/datum/loadout_item/shoes/high_heels
+	name = "High Heels"
+	item_path = /obj/item/clothing/shoes/high_heels
+
+/datum/loadout_item/shoes/disco
+	name = "Green Snakeskin Shoes"
+	item_path = /obj/item/clothing/shoes/discoshoes
+
+/datum/loadout_item/shoes/dominaheels
+	name = "Dominant Heels"
+	item_path = /obj/item/clothing/shoes/dominaheels
 
 /datum/loadout_item/shoes/griffin
 	name = "Griffon Boots"
@@ -134,53 +185,33 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 	name = "Sport Shoes"
 	item_path = /obj/item/clothing/shoes/sports
 
-/datum/loadout_item/shoes/gildedcuffs
-	name = "Gilded leg wraps"
-	item_path = /obj/item/clothing/shoes/wraps
+/*
+*	SEASONAL
+*/
 
-/datum/loadout_item/shoes/silvercuffs
-	name = "Silver leg wraps"
-	item_path = /obj/item/clothing/shoes/wraps/silver
+/datum/loadout_item/shoes/christmas
+	name = "Red Christmas Boots"
+	item_path = /obj/item/clothing/shoes/winterboots/christmas
+	required_season = CHRISTMAS
 
-/datum/loadout_item/shoes/redcuffs
-	name = "Red leg wraps"
-	item_path = /obj/item/clothing/shoes/wraps/red
+/datum/loadout_item/shoes/christmas/green
+	name = "Green Christmas Boots"
+	item_path = /obj/item/clothing/shoes/winterboots/christmas/green
 
-/datum/loadout_item/shoes/bluecuffs
-	name = "Blue leg wraps"
-	item_path = /obj/item/clothing/shoes/wraps/blue
 
-/datum/loadout_item/shoes/clothwrap
-	name = "Colourable Cloth Wraps"
-	item_path = /obj/item/clothing/shoes/wraps/colourable
+/*
+*	JOB-RESTRICTED
+*/
 
-/datum/loadout_item/shoes/high_heels
-	name = "High Heels"
-	item_path = /obj/item/clothing/shoes/high_heels
-
-/datum/loadout_item/shoes/cowboyboots
-	name = "Cowboy Boots, Brown"
-	item_path = /obj/item/clothing/shoes/cowboyboots
-
-/datum/loadout_item/shoes/cowboyboots_black
-	name = "Cowboy Boots, Black"
-	item_path = /obj/item/clothing/shoes/cowboyboots/black
-
-/datum/loadout_item/shoes/disco
-	name = "Green Snakeskin Shoes"
-	item_path = /obj/item/clothing/shoes/discoshoes
-
-/datum/loadout_item/shoes/dominaheels
-	name = "Dominant heels"
-	item_path = /obj/item/clothing/shoes/dominaheels
-
-// Job Restricted
 /datum/loadout_item/shoes/jester
-	name = "Jester shoes"
+	name = "Jester Shoes"
 	item_path = /obj/item/clothing/shoes/clown_shoes/jester
 	restricted_roles = list(JOB_CLOWN)
 
-//Families Gear
+/*
+*	FAMILIES
+*/
+
 /datum/loadout_item/shoes/deckers
 	name = "Deckers Shoes"
 	item_path = /obj/item/clothing/shoes/deckers
@@ -205,7 +236,10 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 	name = "Basil Shoes"
 	item_path = /obj/item/clothing/shoes/basil_boys
 
-//Donator shoes here
+/*
+*	DONATOR
+*/
+
 /datum/loadout_item/shoes/donator
 	donator_only = TRUE
 

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -1,4 +1,6 @@
-// --- Loadout item datums for exosuits / suits ---
+/*
+*	LOADOUT ITEM DATUMS FOR THE (EXO/OUTER)SUIT SLOT
+*/
 
 /// Exosuit / Outersuit Slot Items (Moves items to backpack)
 GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/suit))
@@ -14,16 +16,9 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	else
 		outfit.suit = item_path
 
-//santa's coming, coming to throw your mother down a staircase and leave you for years then cry about you not loving him
-/*/datum/loadout_item/suit/winter_coat/christmas
-	name = "Christmas Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/christmas
-
-/datum/loadout_item/suit/winter_coat/christmas/green
-	name = "Green Christmas Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/christmas/green*/
-
-//fuck santa, fuck him with every ounce of hate you have, dedicate your one reason for living to outliving that fat cunt and pissing on his grave
+/*
+*	WINTER COATS
+*/
 
 /datum/loadout_item/suit/winter_coat
 	name = "Winter Coat"
@@ -33,9 +28,29 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Greyscale Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/custom
 
-/datum/loadout_item/suit/denim_overalls
-	name = "Denim Overalls"
-	item_path = /obj/item/clothing/suit/apron/overalls
+/datum/loadout_item/suit/aformal
+	name = "Assistant's formal winter coat"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/aformal
+
+/datum/loadout_item/suit/runed
+	name = "Runed winter coat"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/narsie/fake
+
+/datum/loadout_item/suit/brass
+	name = "Brass winter coat"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/ratvar/fake
+
+/datum/loadout_item/suit/korea
+	name = "Eastern winter coat"
+	item_path = /obj/item/clothing/suit/koreacoat
+
+/datum/loadout_item/suit/czech
+	name = "Modern winter coat"
+	item_path = /obj/item/clothing/suit/modernwintercoatthing
+
+/*
+*	SUITS / SUIT JACKETS
+*/
 
 /datum/loadout_item/suit/black_suit_jacket
 	name = "Black Suit Jacket"
@@ -61,9 +76,9 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Texan Suit Jacket"
 	item_path = /obj/item/clothing/suit/texas
 
-/datum/loadout_item/suit/purple_apron
-	name = "Purple Apron"
-	item_path = /obj/item/clothing/suit/apron/purple_bartender
+/*
+*	SUSPENDERS
+*/
 
 /datum/loadout_item/suit/suspenders_blue
 	name = "Blue Suspenders"
@@ -77,9 +92,17 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Red Suspenders"
 	item_path = /obj/item/clothing/suit/toggle/suspenders
 
+/*
+*	DRESSES
+*/
+
 /datum/loadout_item/suit/white_dress
 	name = "White Dress"
 	item_path = /obj/item/clothing/suit/whitedress
+
+/*
+*	LABCOATS
+*/
 
 /datum/loadout_item/suit/labcoat
 	name = "Labcoat"
@@ -88,6 +111,10 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 /datum/loadout_item/suit/labcoat_green
 	name = "Green Labcoat"
 	item_path = /obj/item/clothing/suit/toggle/labcoat/mad
+
+/*
+*	PONCHOS
+*/
 
 /datum/loadout_item/suit/poncho
 	name = "Poncho"
@@ -101,9 +128,10 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Red Poncho"
 	item_path = /obj/item/clothing/suit/poncho/red
 
-/datum/loadout_item/suit/wawaiian_shirt
-	name = "Hawaiian Shirt"
-	item_path = /obj/item/clothing/suit/hawaiian
+
+/*
+*	JACKETS
+*/
 
 /datum/loadout_item/suit/bomber_jacket
 	name = "Bomber Jacket"
@@ -129,6 +157,10 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Leather Coat"
 	item_path = /obj/item/clothing/suit/jacket/leather/overcoat
 
+/*
+*	LETTERMAN
+*/
+
 /datum/loadout_item/suit/brown_letterman
 	name = "Brown Letterman"
 	item_path = /obj/item/clothing/suit/jacket/letterman
@@ -141,7 +173,9 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Blue Letterman"
 	item_path = /obj/item/clothing/suit/jacket/letterman_nanotrasen
 
-//HALLOWEEN
+/*
+*	COSTUMES
+*/
 
 /datum/loadout_item/suit/owl
 	name = "Owl Cloak"
@@ -171,7 +205,7 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Chicken Suit"
 	item_path = /obj/item/clothing/suit/chickensuit
 
-/datum/loadout_item/suit/monky
+/datum/loadout_item/suit/monkey
 	name = "Monkey Suit"
 	item_path = /obj/item/clothing/suit/monkeysuit
 
@@ -191,18 +225,39 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Carp Costume"
 	item_path = /obj/item/clothing/suit/hooded/carp_costume
 
-//MISC
-/datum/loadout_item/suit/poncho
-	name = "Poncho"
-	item_path = /obj/item/clothing/suit/poncho
+/datum/loadout_item/suit/wizard
+	name = "Wizard Robe"
+	item_path = /obj/item/clothing/suit/wizrobe/fake
 
-/datum/loadout_item/suit/ponchogreen
-	name = "Green poncho"
-	item_path = /obj/item/clothing/suit/poncho/green
+/datum/loadout_item/suit/witch
+	name = "Witch Robe"
+	item_path = /obj/item/clothing/suit/wizrobe/marisa/fake
 
-/datum/loadout_item/suit/ponchored
-	name = "Red poncho"
-	item_path = /obj/item/clothing/suit/poncho/red
+/*
+*	SEASONAL
+*/
+
+/datum/loadout_item/suit/winter_coat/christmas
+	name = "Christmas Coat"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/christmas
+	required_season = CHRISTMAS
+
+/datum/loadout_item/suit/winter_coat/christmas/green
+	name = "Green Christmas Coat"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/christmas/green
+
+
+/*
+*	MISC
+*/
+
+/datum/loadout_item/suit/purple_apron
+	name = "Purple Apron"
+	item_path = /obj/item/clothing/suit/apron/purple_bartender
+
+/datum/loadout_item/suit/denim_overalls
+	name = "Denim Overalls"
+	item_path = /obj/item/clothing/suit/apron/overalls
 
 /datum/loadout_item/suit/redhood
 	name = "Red cloak"
@@ -244,7 +299,10 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Black Crop Top Turtleneck"
 	item_path = /obj/item/clothing/suit/croptop
 
-/*Flannels go inside Misc*/
+/*
+*	FLANNELS
+*/
+
 /datum/loadout_item/suit/flannel_black
 	name = "Black Flannel"
 	item_path = /obj/item/clothing/suit/toggle/jacket/flannel
@@ -261,7 +319,14 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Brown Flannel"
 	item_path = /obj/item/clothing/suit/toggle/jacket/flannel/brown
 
-/*Hawaiian Shirts*/
+/*
+*	HAWAIIAN
+*/
+
+/datum/loadout_item/suit/hawaiian_shirt
+	name = "Hawaiian Shirt"
+	item_path = /obj/item/clothing/suit/hawaiian
+
 /datum/loadout_item/suit/hawaiian_blue
 	name = "Blue Hawaiian Shirt"
 	item_path = /obj/item/clothing/suit/hawaiian_blue
@@ -278,7 +343,9 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Green Hawaiian Shirt"
 	item_path = /obj/item/clothing/suit/hawaiian_green
 
-//COATS
+/*
+*	MISC
+*/
 
 /datum/loadout_item/suit/frenchtrench
 	name = "Blue Trenchcoat"
@@ -287,26 +354,6 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 /datum/loadout_item/suit/cossak
 	name = "Ukrainian Coat"
 	item_path = /obj/item/clothing/suit/cossack
-
-/datum/loadout_item/suit/aformal
-	name = "Assistant's formal winter coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/aformal
-
-/datum/loadout_item/suit/runed
-	name = "Runed winter coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/narsie/fake
-
-/datum/loadout_item/suit/brass
-	name = "Brass winter coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/ratvar/fake
-
-/datum/loadout_item/suit/korea
-	name = "Eastern winter coat"
-	item_path = /obj/item/clothing/suit/koreacoat
-
-/datum/loadout_item/suit/czech
-	name = "Modern winter coat"
-	item_path = /obj/item/clothing/suit/modernwintercoatthing
 
 /datum/loadout_item/suit/parka
 	name = "Falls Parka"
@@ -345,23 +392,43 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	item_path = /obj/item/clothing/suit/toggle/jacket
 
 /datum/loadout_item/suit/polyjacketleather
-	name = "Colorable leather jacket"
+	name = "Colorable Leather Jacket"
 	item_path = /obj/item/clothing/suit/jacket/leather/polychromic
 
 /datum/loadout_item/suit/woolcoat
-	name = "Leather overcoat"
+	name = "Leather Overcoat"
 	item_path = /obj/item/clothing/suit/woolcoat
-
-/datum/loadout_item/suit/jacketpuffer
-	name = "Puffer jacket"
-	item_path = /obj/item/clothing/suit/jacket/puffer
 
 /datum/loadout_item/suit/flakjack
 	name = "Flak Jacket"
 	item_path = /obj/item/clothing/suit/flakjack
 
+/datum/loadout_item/suit/deckard
+	name = "Runner Coat"
+	item_path = /obj/item/clothing/suit/toggle/deckard
+	restricted_roles = list(JOB_DETECTIVE)
 
-//HOODIES
+/datum/loadout_item/suit/bltrench
+	name = "Black Trenchcoat"
+	item_path = /obj/item/clothing/suit/trenchblack
+
+/datum/loadout_item/suit/brtrench
+	name = "Brown Trenchcoat"
+	item_path = /obj/item/clothing/suit/trenchbrown
+
+/datum/loadout_item/suit/discojacket
+	name = "Disco Ass Blazer"
+	item_path = /obj/item/clothing/suit/discoblazer
+	restricted_roles = list(JOB_DETECTIVE)
+
+/datum/loadout_item/suit/cardigan
+	name = "Cardigan"
+	item_path = /obj/item/clothing/suit/toggle/jacket/cardigan
+
+/*
+*	HOODIES
+*/
+
 /datum/loadout_item/suit/hoodie/greyscale
 	name = "Greyscale Hoodie"
 	item_path = /obj/item/clothing/suit/toggle/jacket/hoodie
@@ -371,7 +438,7 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	item_path = /obj/item/clothing/suit/toggle/jacket/hoodie/trim
 
 /datum/loadout_item/suit/hoodie/greyscale_trim_alt
-	name = "Greyscale Trimmed(Alt) Hoodie"
+	name = "Greyscale Trimmed Hoodie (Alt)"
 	item_path = /obj/item/clothing/suit/toggle/jacket/hoodie/trim/alt
 
 /datum/loadout_item/suit/hoodie/black
@@ -422,58 +489,62 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Mojave University Hoodie"
 	item_path = /obj/item/clothing/suit/toggle/jacket/hoodie/branded/mu
 
-//JOB RELATED
+/*
+*	JOB-LOCKED
+*/
 
+// WINTER COATS
 /datum/loadout_item/suit/coat_med
-	name = "Medical winter coat"
+	name = "Medical Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/medical
 	restricted_roles = list(JOB_CHIEF_MEDICAL_OFFICER, JOB_MEDICAL_DOCTOR, JOB_ORDERLY) // Reserve it to Medical Doctors, Orderlies, and their boss, the Chief Medical Officer
 
 /datum/loadout_item/suit/coat_paramedic
-	name = "Paramedic winter coat"
+	name = "Paramedic Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/paramedic
 	restricted_roles = list(JOB_CHIEF_MEDICAL_OFFICER, JOB_PARAMEDIC) // Reserve it to Paramedics and their boss, the Chief Medical Officer
 
 /datum/loadout_item/suit/coat_robotics
-	name = "Robotics winter coat"
+	name = "Robotics Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/robotics
 	restricted_roles = list(JOB_RESEARCH_DIRECTOR, JOB_ROBOTICIST)
 
 /datum/loadout_item/suit/coat_sci
-	name = "Science winter coat"
+	name = "Science Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/science
 	restricted_roles = list(JOB_RESEARCH_DIRECTOR, JOB_SCIENTIST, JOB_ROBOTICIST, JOB_VANGUARD_OPERATIVE, JOB_SCIENCE_GUARD) // Reserve it to the Science Departement
 
 /datum/loadout_item/suit/coat_eng
-	name = "Engineering winter coat"
+	name = "Engineering Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/engineering
 	restricted_roles = list(JOB_CHIEF_ENGINEER, JOB_STATION_ENGINEER, JOB_ENGINEERING_GUARD) // Reserve it to Station Engineers, Engineering Guards, and their boss, the Chief Engineer
 
 /datum/loadout_item/suit/coat_atmos
-	name = "Atmospherics winter coat"
+	name = "Atmospherics Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/engineering/atmos
 	restricted_roles = list(JOB_CHIEF_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN) // Reserve it to Atmos Techs and their boss, the Chief Engineer
 
 /datum/loadout_item/suit/coat_hydro
-	name = "Hydroponics winter coat"
+	name = "Hydroponics Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/hydro
 	restricted_roles = list(JOB_HEAD_OF_PERSONNEL, JOB_BOTANIST) // Reserve it to Botanists and their boss, the Head of Personnel
 
 /datum/loadout_item/suit/coat_bar
-	name = "Bartender winter coat"
+	name = "Bartender Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/bartender
 	restricted_roles = list(JOB_HEAD_OF_PERSONNEL, JOB_BARTENDER) //Reserved for Bartenders and their head-of-staff
 
 /datum/loadout_item/suit/coat_cargo
-	name = "Cargo winter coat"
+	name = "Cargo Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/cargo
 	restricted_roles = list(JOB_QUARTERMASTER, JOB_CARGO_TECHNICIAN, JOB_CUSTOMS_AGENT) // Reserve it to Cargo Techs, Customs Agentes, and their boss, the Quartermaster
 
 /datum/loadout_item/suit/coat_miner
-	name = "Mining winter coat"
+	name = "Mining Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/miner
 	restricted_roles = list(JOB_QUARTERMASTER, JOB_SHAFT_MINER) // Reserve it to Miners and their boss, the Quartermaster
 
+// JACKETS
 /datum/loadout_item/suit/navybluejacketofficer
 	name = "Security Officer's Navy Blue Jacket"
 	item_path = /obj/item/clothing/suit/armor/navyblue
@@ -529,7 +600,7 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	item_path = /obj/item/clothing/suit/gorka/supply
 	restricted_roles = list(JOB_QUARTERMASTER, JOB_CARGO_TECHNICIAN, JOB_SHAFT_MINER, JOB_CUSTOMS_AGENT)
 
-
+// LABCOATS
 /datum/loadout_item/suit/labcoat_parared
 	name = "Red Paramedic Labcoat"
 	item_path = /obj/item/clothing/suit/toggle/labcoat/para_red
@@ -540,29 +611,10 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	item_path = /obj/item/clothing/suit/toggle/labcoat/highvis
 	restricted_roles = list(JOB_CHIEF_MEDICAL_OFFICER, JOB_PARAMEDIC, JOB_ATMOSPHERIC_TECHNICIAN, JOB_DETECTIVE, JOB_SECURITY_MEDIC, JOB_CHEMIST, JOB_ORDERLY) // And now chemist and orderly get it too.
 
-/datum/loadout_item/suit/discojacket
-	name = "Disco Ass Blazer"
-	item_path = /obj/item/clothing/suit/discoblazer
-	restricted_roles = list(JOB_DETECTIVE)
+/*
+*	FAMILIES
+*/
 
-/datum/loadout_item/suit/deckard
-	name = "Runner Coat"
-	item_path = /obj/item/clothing/suit/toggle/deckard
-	restricted_roles = list(JOB_DETECTIVE)
-
-/datum/loadout_item/suit/bltrench
-	name = "Black Trenchcoat"
-	item_path = /obj/item/clothing/suit/trenchblack
-
-/datum/loadout_item/suit/brtrench
-	name = "Brown Trenchcoat"
-	item_path = /obj/item/clothing/suit/trenchbrown
-
-/datum/loadout_item/suit/cardigan
-	name = "Cardigan"
-	item_path = /obj/item/clothing/suit/toggle/jacket/cardigan
-
-//Families Gear
 /datum/loadout_item/suit/osi
 	name = "OSI Coat"
 	item_path = /obj/item/clothing/suit/osi
@@ -615,7 +667,10 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Yuri Coat"
 	item_path = /obj/item/clothing/suit/yuri
 
-//Donator sutis here
+/*
+*	DONATOR
+*/
+
 /datum/loadout_item/suit/donator
 	donator_only = TRUE
 
@@ -631,11 +686,7 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Cream Furred Jacket"
 	item_path = /obj/item/clothing/suit/brownfurrich/cream
 
-/datum/loadout_item/suit/donator/british_officer
-	name = "British Officers Coat"
-	item_path = /obj/item/clothing/suit/british_officer
-
-/datum/loadout_item/suit/donator/british_officer
+/datum/loadout_item/suit/donator/modern_winter
 	name = "Modern Winter Coat"
 	item_path = /obj/item/clothing/suit/modern_winter
 

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_toys.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_toys.dm
@@ -4,83 +4,82 @@ GLOBAL_LIST_INIT(loadout_toys, generate_loadout_items(/datum/loadout_item/toys))
 	category = LOADOUT_ITEM_TOYS
 	can_be_named = TRUE
 
+/*
+*	PLUSHIES
+*/
+
 /datum/loadout_item/toys/bee
-	name = "Bee Plush"
+	name = "Bee Plushie"
 	item_path = /obj/item/toy/plush/beeplushie
 
 /datum/loadout_item/toys/carp
-	name = "Carp Plush"
+	name = "Carp Plushie"
 	item_path = /obj/item/toy/plush/carpplushie
 
 /datum/loadout_item/toys/lizard_greyscale
-	name = "Greyscale Lizard Plush"
+	name = "Greyscale Lizard Plushie"
 	item_path = /obj/item/toy/plush/lizard_plushie
-
-/datum/loadout_item/toys/lizard_random
-	name = "Random Lizard Plush"
-	item_path = /obj/item/toy/plush/lizard_plushie
-	additional_tooltip_contents = list(TOOLTIP_RANDOM_COLOR)
 
 /datum/loadout_item/toys/moth
-	name = "Moth Plush"
+	name = "Moth Plushie"
 	item_path = /obj/item/toy/plush/moth
 
 /datum/loadout_item/toys/narsie
-	name = "Nar'sie Plush"
+	name = "Nar'sie Plushie"
 	item_path = /obj/item/toy/plush/narplush
 	restricted_roles = list(JOB_CHAPLAIN)
 
 /datum/loadout_item/toys/nukie
-	name = "Nukie Plush"
+	name = "Nukie Plushie"
 	item_path = /obj/item/toy/plush/nukeplushie
 
 /datum/loadout_item/toys/peacekeeper
-	name = "Peacekeeper Plush"
+	name = "Peacekeeper Plushie"
 	item_path = /obj/item/toy/plush/pkplush
 
 /datum/loadout_item/toys/plasmaman
-	name = "Plasmaman Plush"
+	name = "Plasmaman Plushie"
 	item_path = /obj/item/toy/plush/plasmamanplushie
 
 /datum/loadout_item/toys/ratvar
-	name = "Ratvar Plush"
+	name = "Ratvar Plushie"
 	item_path = /obj/item/toy/plush/ratplush
 	restricted_roles = list(JOB_CHAPLAIN)
 
 /datum/loadout_item/toys/rouny
-	name = "Rouny Plush"
+	name = "Rouny Plushie"
 	item_path = /obj/item/toy/plush/rouny
 
 /datum/loadout_item/toys/snake
-	name = "Snake Plush"
+	name = "Snake Plushie"
 	item_path = /obj/item/toy/plush/snakeplushie
 
 /datum/loadout_item/toys/slime
-	name = "Slime plushie"
+	name = "Slime Plushie"
 	item_path = /obj/item/toy/plush/slimeplushie
 
 /datum/loadout_item/toys/bubble
-	name = "Bubblegum plushie"
+	name = "Bubblegum Plushie"
 	item_path = /obj/item/toy/plush/bubbleplush
 
 /datum/loadout_item/toys/goat
-	name = "Strange Goat plushie"
+	name = "Strange Goat Plushie"
 	item_path = /obj/item/toy/plush/goatplushie
 
 /datum/loadout_item/toys/sechound
-	name = "Sechound plushie"
+	name = "Sechound Plushie"
 	item_path = /obj/item/toy/plush/sechound
 
 /datum/loadout_item/toys/medihound
-	name = "Medihound plushie"
+	name = "Medihound Plushie"
 	item_path = /obj/item/toy/plush/medihound
 
 /datum/loadout_item/toys/engihound
-	name = "Engihound plushie"
+	name = "Engihound Plushie"
 	item_path = /obj/item/toy/plush/engihound
 
 /datum/loadout_item/toys/scrubpuppy
-	name = "Scrubpuppy plushie"
+	name = "Scrubpuppy Plushie"
 	item_path = /obj/item/toy/plush/scrubpuppy
 
 /datum/loadout_item/toys/meddrake
@@ -92,87 +91,87 @@ GLOBAL_LIST_INIT(loadout_toys, generate_loadout_items(/datum/loadout_item/toys))
 	item_path = /obj/item/toy/plush/secdrake
 
 /datum/loadout_item/toys/borbplushie
-	name = "Borb plushie"
+	name = "Borb Plushie"
 	item_path = /obj/item/toy/plush/borbplushie
 
 /datum/loadout_item/toys/deer
-	name = "Deer plushie"
+	name = "Deer Plushie"
 	item_path = /obj/item/toy/plush/deer
 
 /datum/loadout_item/toys/fermis
-	name = "Medcat plushie"
+	name = "Medcat Plushie"
 	item_path = /obj/item/toy/plush/fermis
 
 /datum/loadout_item/toys/chen
-	name = "Securicat plushie"
+	name = "Securicat Plushie"
 	item_path = /obj/item/toy/plush/fermis/chen
 
 /datum/loadout_item/toys/fox
-	name = "Fox plushie"
+	name = "Fox Plushie"
 	item_path = /obj/item/toy/plush/fox
 
 /datum/loadout_item/toys/duffmoff
-	name = "Suspicious moth plushie"
+	name = "Suspicious Moth Plushie"
 	item_path = /obj/item/toy/plush/duffmoth
 
 /datum/loadout_item/toys/musicalduffy
-	name = "Suspicious musical moth"
+	name = "Suspicious Musical moth"
 	item_path = /obj/item/instrument/musicalduffy
 
 /datum/loadout_item/toys/leaplush
-	name = "Suspicious deer plushie"
+	name = "Suspicious Deer Plushie"
 	item_path = /obj/item/toy/plush/leaplush
 
 /datum/loadout_item/toys/sarmie
-	name = "Cosplayer plushie"
+	name = "Cosplayer Plushie"
 	item_path = /obj/item/toy/plush/sarmieplush
 
 /datum/loadout_item/toys/sharknet
-	name = "Gluttonous Shark plushie"
+	name = "Gluttonous Shark Plushie"
 	item_path = /obj/item/toy/plush/sharknet
 
 /datum/loadout_item/toys/pintaplush
-	name = "Smaller Deer plushie"
+	name = "Smaller Deer Plushie"
 	item_path = /obj/item/toy/plush/pintaplush
 
 /datum/loadout_item/toys/szaplush
-	name = "Suspicious spider plushie"
+	name = "Suspicious Spider Plushie"
 	item_path = /obj/item/toy/plush/szaplush
 
 /datum/loadout_item/toys/riffplush
-	name = "Valid plushie"
+	name = "Valid Plushie"
 	item_path = /obj/item/toy/plush/riffplush
 
 /datum/loadout_item/toys/ianbastardman
-	name = "Ian plushie"
+	name = "Ian Plushie"
 	item_path = /obj/item/toy/plush/ian
 
 /datum/loadout_item/toys/corgiman
-	name = "Corgi plushie"
+	name = "Corgi Plushie"
 	item_path = /obj/item/toy/plush/ian/small
 
 /datum/loadout_item/toys/corgiwoman
-	name = "Girly Corgi plushie"
+	name = "Girly Corgi Plushie"
 	item_path = /obj/item/toy/plush/ian/lisa
 
 /datum/loadout_item/toys/cat
-	name = "Cat plushie"
+	name = "Cat Plushie"
 	item_path = /obj/item/toy/plush/cat
 
 /datum/loadout_item/toys/tuxcat
-	name = "Tux Cat plushie"
+	name = "Tux Cat Plushie"
 	item_path = /obj/item/toy/plush/cat/tux
 
 /datum/loadout_item/toys/whitecat
-	name = "White Cat plushie"
+	name = "White Cat Plushie"
 	item_path = /obj/item/toy/plush/cat/white
 
 /datum/loadout_item/toys/seaduplush
-	name = "Sneed plushie"
+	name = "Sneed Plushie"
 	item_path = /obj/item/toy/plush/seaduplush
 
 /datum/loadout_item/toys/lizzyplush
-	name = "Odd yoga lizzy plushie"
+	name = "Odd Yoga lizzy Plushie"
 	item_path = /obj/item/toy/plush/lizzyplush
 
 /datum/loadout_item/toys/mechanic_fox
@@ -235,6 +234,10 @@ GLOBAL_LIST_INIT(loadout_toys, generate_loadout_items(/datum/loadout_item/toys))
 	name = "Huggable Bee Plushie"
 	item_path = /obj/item/toy/plush/rubi
 
+/*
+*	CARDS
+*/
+
 /datum/loadout_item/toys/card_binder
 	name = "Card Binder"
 	item_path = /obj/item/storage/card_binder
@@ -254,6 +257,10 @@ GLOBAL_LIST_INIT(loadout_toys, generate_loadout_items(/datum/loadout_item/toys))
 /datum/loadout_item/toys/tarot
 	name = "Tarot Card Deck"
 	item_path = /obj/item/toy/cards/deck/tarot
+
+/*
+*	DICE
+*/
 
 /datum/loadout_item/toys/d1
 	name = "D1"
@@ -304,45 +311,53 @@ GLOBAL_LIST_INIT(loadout_toys, generate_loadout_items(/datum/loadout_item/toys))
 	item_path = /obj/item/dice/d00
 
 /datum/loadout_item/toys/dice
-	name = "Dice bag"
+	name = "Dice Bag"
 	item_path = /obj/item/storage/dice
 
-/datum/loadout_item/toys/eightball
-	name = "Magic eightball"
-	item_path = /obj/item/toy/eightball
+/*
+*	TENNIS BALLS
+*/
 
 /datum/loadout_item/toys/tennis
-	name = "Classic Tennis Ball"
+	name = "Tennis Ball (Classic)"
 	item_path = /obj/item/toy/tennis
 
 /datum/loadout_item/toys/tennisred
-	name = "Red Tennis Ball"
+	name = "Tennis Ball (Red)"
 	item_path = /obj/item/toy/tennis/red
 
 /datum/loadout_item/toys/tennisyellow
-	name = "Yellow Tennis Ball"
+	name = "Tennis Ball (Yellow)"
 	item_path = /obj/item/toy/tennis/yellow
 
 /datum/loadout_item/toys/tennisgreen
-	name = "Green Tennis Ball"
+	name = "Tennis Ball (Green)"
 	item_path = /obj/item/toy/tennis/green
 
 /datum/loadout_item/toys/tenniscyan
-	name = "Cyan Tennis Ball"
+	name = "Tennis Ball (Cyan)"
 	item_path = /obj/item/toy/tennis/cyan
 
 /datum/loadout_item/toys/tennisblue
-	name = "Blue Tennis Ball"
+	name = "Tennis Ball (Blue)"
 	item_path = /obj/item/toy/tennis/blue
 
 /datum/loadout_item/toys/tennispurple
-	name = "Purple Tennis Ball"
+	name = "Tennis Ball (Purple)"
 	item_path = /obj/item/toy/tennis/purple
+
+/*
+*	MISC
+*/
+
+/datum/loadout_item/toys/eightball
+	name = "Magic Eightball"
+	item_path = /obj/item/toy/eightball
 
 /datum/loadout_item/toys/toykatana
 	name = "Toy Katana"
 	item_path = /obj/item/toy/katana
 
 /datum/loadout_item/toys/crayons
-	name = "Box of crayons"
+	name = "Box of Crayons"
 	item_path = /obj/item/storage/crayons

--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
@@ -318,6 +318,9 @@
 			if(!GLOB.donator_list[owner.ckey] && !is_admin(owner))
 				formatted_list.len--
 				continue
+		if(item.required_season && !(item.required_season in SSevents.holidays))
+			formatted_list.len--
+			continue
 
 		var/atom/loadout_atom = item.item_path
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4981,6 +4981,7 @@
 #include "modular_skyrat\modules\customization\modules\client\augment\implants.dm"
 #include "modular_skyrat\modules\customization\modules\client\augment\limbs.dm"
 #include "modular_skyrat\modules\customization\modules\client\augment\organs.dm"
+#include "modular_skyrat\modules\customization\modules\clothing\accessories.dm"
 #include "modular_skyrat\modules\customization\modules\clothing\toggle_base.dm"
 #include "modular_skyrat\modules\customization\modules\clothing\ears\ears.dm"
 #include "modular_skyrat\modules\customization\modules\clothing\glasses\glasses.dm"


### PR DESCRIPTION
# This PR does not remove anything from the loadout. If you're suddenly not spawning with your usual loadout item(s), check the item isn't elsewhere in the list and that yours was just the duplicate. If it's fully removed, let me know as that is not intentional.

## About The Pull Request

Cleans up and organises the loadout datums.
Much of the great big fuck-off walls of datums are now split up with comments denoting section.
Capitalises each word in the datum, unless a word like "of" or whatever. Please follow this in the future.

Removes a few duplicate items. **Some of these were meant to be job restricted and had an unrestricted duplicate. The unrestricted variants have been removed in favour of the job-restricted ones.** This includes things like the sterile mask.

Adds `required_season`, a variable that hides the datum if it's not the appropriate season (currently only used for Christmas).

Adds **armourless** versions of the sinew skirt, bone talisman, and skull codpiece.
Adds **armourless** versions of the witch and wizard robes and hats.

## How This Contributes To The Skyrat Roleplay Experience

Better code good. Worse code bad. Having to _uncomment loadout items every Christmas_ bad.

There is more I want to come back to regarding the loadout and its organisation, but my eyes started to cross by the end of doing this and I also don't massively want to do it all in one PR anyway.

## Changelog
:cl:
add: Armourless versions of the sinew skirt, bone talisman, and skull codpiece are in the loadout.
add: Armourless versions of the witch and wizard robes and hats are in the loadout.
spellcheck: (Hopefully all) the loadout options are now properly capitalised.
code: You can now restrict loadout items to specific holidays (such as Christmas).
/:cl: