### PR TITLE
[s] Removes black-tar self-duplication

### DIFF
--- a/modular_skyrat/modules/morenarcotics/code/opium.dm
+++ b/modular_skyrat/modules/morenarcotics/code/opium.dm
@@ -93,17 +93,6 @@
 	time = 20
 	category = CAT_CHEMISTRY
 
-/datum/chemical_reaction/blacktar
-	required_reagents = list(/datum/reagent/drug/opium/blacktar = 5)
-	required_temp = 480
-	reaction_flags = REACTION_INSTANT
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL
-
-/datum/chemical_reaction/blacktar/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	var/location = get_turf(holder.my_atom)
-	for(var/i in 1 to created_volume)
-		new /obj/item/reagent_containers/blacktar(location)
-
 /atom/movable/screen/fullscreen/color_vision/heroin_color
 	color = "#444444"
 


### PR DESCRIPTION
## About The Pull Request

HAHAHAHAHAHAHA

## How This Contributes To The Skyrat Roleplay Experience

It probably crashed the server, also _self-duplication_

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Black Tar doesn't multiply itself while on fire.
server: Stops heroin from crashing the server
/:cl:
