### PR TITLE
Un-panicfixes the self duplication exploit

### DIFF
--- a/modular_skyrat/modules/morenarcotics/code/blacktar.dm
+++ b/modular_skyrat/modules/morenarcotics/code/blacktar.dm
@@ -5,4 +5,4 @@
 	icon_state = "blacktar"
 	volume = 5
 	possible_transfer_amounts = list()
-	list_reagents = list(/datum/reagent/drug/opium/blacktar/freebase_blacktar = 5)
+	list_reagents = list(/datum/reagent/drug/opium/blacktar = 5)

--- a/modular_skyrat/modules/morenarcotics/code/blacktar.dm
+++ b/modular_skyrat/modules/morenarcotics/code/blacktar.dm
@@ -5,4 +5,4 @@
 	icon_state = "blacktar"
 	volume = 5
 	possible_transfer_amounts = list()
-	list_reagents = list(/datum/reagent/drug/opium/blacktar = 5)
+	list_reagents = list(/datum/reagent/drug/opium/blacktar/freebase_blacktar = 5)

--- a/modular_skyrat/modules/morenarcotics/code/cocaine.dm
+++ b/modular_skyrat/modules/morenarcotics/code/cocaine.dm
@@ -23,7 +23,7 @@
 		new /obj/item/reagent_containers/crack(location)
 
 /datum/reagent/drug/cocaine
-	name = "Cocaine"
+	name = "cocaine"
 	description = "A powerful stimulant extracted from coca leaves. Reduces stun times, but causes drowsiness and severe brain damage if overdosed."
 	reagent_state = LIQUID
 	color = "#ffffff"

--- a/modular_skyrat/modules/morenarcotics/code/opium.dm
+++ b/modular_skyrat/modules/morenarcotics/code/opium.dm
@@ -132,7 +132,7 @@
 	..()
 
 /datum/reagent/drug/opium/heroin
-	name = "Heroin"
+	name = "heroin"
 	description = "She's like heroin to me, she's like heroin to me! She cannot... miss a vein!"
 	reagent_state = LIQUID
 	color = "#ffe669"
@@ -151,7 +151,7 @@
 	..()
 
 /datum/reagent/drug/opium/blacktar
-	name = "Black Tar Heroin"
+	name = "black tar heroin"
 	description = "An impure, freebase form of heroin. Probably not a good idea to take this..."
 	reagent_state = LIQUID
 	color = "#242423"
@@ -170,6 +170,7 @@
 	..()
 
 /datum/reagent/drug/opium/blacktar/liquid //prevents self-duplication by going one step down when mixed
+	name - "liquid black tar heroin"
 
 /datum/chemical_reaction/blacktar
 	required_reagents = list(/datum/reagent/drug/opium/blacktar/liquid = 5)

--- a/modular_skyrat/modules/morenarcotics/code/opium.dm
+++ b/modular_skyrat/modules/morenarcotics/code/opium.dm
@@ -169,6 +169,19 @@
 	M.adjustToxLoss(0.5 * REM * delta_time, 0) //toxin damage
 	..()
 
+/datum/chemical_reaction/freebase_blacktar
+	required_reagents = list(/datum/reagent/drug/opium/blacktar = 5)
+	required_temp = 480
+	reaction_flags = REACTION_INSTANT
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL
+
+/datum/chemical_reaction/blacktar/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
+	var/location = get_turf(holder.my_atom)
+	for(var/i in 1 to created_volume)
+		new /obj/item/reagent_containers/blacktar(location)
+
+/datum/reagent/drug/opium/blacktar/freebase_blacktar //just prevents self-duping.
+
 //Exports
 /datum/export/heroin
 	cost = CARGO_CRATE_VALUE * 0.5
@@ -182,7 +195,7 @@
 	export_types = list(/obj/item/reagent_containers/heroinbrick)
 	include_subtypes = FALSE
 
-/datum/export/blacktar
+/datum/export/freebase_blacktar
 	cost = CARGO_CRATE_VALUE * 0.4
 	unit_name = "black tar heroin"
 	export_types = list(/obj/item/reagent_containers/blacktar)

--- a/modular_skyrat/modules/morenarcotics/code/opium.dm
+++ b/modular_skyrat/modules/morenarcotics/code/opium.dm
@@ -195,7 +195,7 @@
 	export_types = list(/obj/item/reagent_containers/heroinbrick)
 	include_subtypes = FALSE
 
-/datum/export/freebase_blacktar
+/datum/export/blacktar
 	cost = CARGO_CRATE_VALUE * 0.4
 	unit_name = "black tar heroin"
 	export_types = list(/obj/item/reagent_containers/blacktar)

--- a/modular_skyrat/modules/morenarcotics/code/opium.dm
+++ b/modular_skyrat/modules/morenarcotics/code/opium.dm
@@ -97,7 +97,7 @@
 	color = "#444444"
 
 /datum/reagent/drug/opium
-	name = "Opium"
+	name = "opium"
 	description = "A extract from opium poppies. Puts the user in a slightly euphoric state."
 	reagent_state = LIQUID
 	color = "#ffe669"
@@ -170,7 +170,7 @@
 	..()
 
 /datum/reagent/drug/opium/blacktar/liquid //prevents self-duplication by going one step down when mixed
-	name - "liquid black tar heroin"
+	name = "liquid black tar heroin"
 
 /datum/chemical_reaction/blacktar
 	required_reagents = list(/datum/reagent/drug/opium/blacktar/liquid = 5)

--- a/modular_skyrat/modules/morenarcotics/code/opium.dm
+++ b/modular_skyrat/modules/morenarcotics/code/opium.dm
@@ -140,7 +140,7 @@
 	ph = 6
 	taste_description = "flowers"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	failed_chem = /datum/reagent/drug/opium/blacktar
+	failed_chem = /datum/reagent/drug/opium/blacktar/liquid
 
 /datum/reagent/drug/opium/heroin/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	var/high_message = pick("You feel like nothing can stop you.", "You feel like God.")
@@ -169,8 +169,10 @@
 	M.adjustToxLoss(0.5 * REM * delta_time, 0) //toxin damage
 	..()
 
-/datum/chemical_reaction/freebase_blacktar
-	required_reagents = list(/datum/reagent/drug/opium/blacktar = 5)
+/datum/reagent/drug/opium/blacktar/liquid //prevents self-duplication by going one step down when mixed
+
+/datum/chemical_reaction/blacktar
+	required_reagents = list(/datum/reagent/drug/opium/blacktar/liquid = 5)
 	required_temp = 480
 	reaction_flags = REACTION_INSTANT
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL
@@ -179,8 +181,6 @@
 	var/location = get_turf(holder.my_atom)
 	for(var/i in 1 to created_volume)
 		new /obj/item/reagent_containers/blacktar(location)
-
-/datum/reagent/drug/opium/blacktar/freebase_blacktar //just prevents self-duping.
 
 //Exports
 /datum/export/heroin


### PR DESCRIPTION
# About The Pull Request

Makes a chem reaction for blacktar heroin that doesn't endlessly duplicate itself when heated.

## How This Contributes To The Skyrat Roleplay Experience

Makes the reaction work as intended instead of outright deleting it

## Changelog

:cl:
fix: Blacktar Heroin can be made into rocks again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
