### PR TITLE
There goes them Dupe Bois - Map Fix for a known bug

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -723,6 +723,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
+"gu" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "gy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/vehicle/ridden/atv/snowmobile/syndicate{
@@ -926,6 +932,9 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
+"iM" = (
+/turf/open/chasm/icemoon,
+/area/icemoon/underground/explored)
 "iQ" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -1417,6 +1426,10 @@
 /obj/structure/chair/sofa/bench/right,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
+"oj" = (
+/obj/structure/railing,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "ol" = (
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
@@ -2095,7 +2108,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
-/turf/open/misc/asteroid/basalt,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/ruin/syndicate_lava_base/cargo)
 "wP" = (
 /obj/machinery/processor/slime,
@@ -2377,6 +2390,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/bar)
+"AQ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "Bf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/east,
@@ -2401,7 +2420,7 @@
 	dir = 1
 	},
 /obj/structure/flora/rock,
-/turf/open/misc/asteroid/basalt,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/ruin/syndicate_lava_base/cargo)
 "BA" = (
 /turf/open/floor/engine,
@@ -3395,7 +3414,7 @@
 	dir = 1
 	},
 /obj/structure/flora/rock/pile,
-/turf/open/misc/asteroid/basalt,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/ruin/syndicate_lava_base/cargo)
 "Na" = (
 /obj/structure/window/reinforced/survival_pod{
@@ -3676,6 +3695,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/testlab)
+"QD" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "QK" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -6999,10 +7024,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+Iy
+gu
+gu
+Iy
 dJ
 uA
 st
@@ -7058,10 +7083,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-Iy
+oj
+iM
+iM
+QD
 dJ
 ZR
 Lm
@@ -7117,9 +7142,9 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+oj
+iM
+iM
 bz
 VO
 kh
@@ -7176,10 +7201,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-Iy
+oj
+iM
+iM
+QD
 yQ
 yQ
 yQ
@@ -7235,10 +7260,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+Iy
+AQ
+AQ
+Iy
 ab
 ab
 ab

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -2872,6 +2872,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
+"IX" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "IY" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -3070,6 +3076,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
+"KZ" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "La" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3560,6 +3572,12 @@
 /obj/structure/table,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/syndicate_lava_base/cargo)
+"Rd" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Rf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3873,6 +3891,10 @@
 	},
 /turf/open/floor/plating/lavaland_atmos,
 /area/ruin/syndicate_lava_base/testlab)
+"Vf" = (
+/obj/structure/railing,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Vi" = (
 /obj/machinery/smartfridge/food,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -4014,6 +4036,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
+"WT" = (
+/turf/open/chasm/lavaland,
+/area/lavaland/surface/outdoors)
 "WU" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 4
@@ -6972,10 +6997,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+Sy
+KZ
+KZ
+Sy
 kD
 cy
 pM
@@ -7031,10 +7056,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-Sy
+Vf
+WT
+WT
+Rd
 kD
 RP
 Vt
@@ -7090,9 +7115,9 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+Vf
+WT
+WT
 wn
 TJ
 Sk
@@ -7149,10 +7174,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-Sy
+Vf
+WT
+WT
+Rd
 ZX
 ZX
 ZX
@@ -7208,10 +7233,10 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+Sy
+IX
+IX
+Sy
 ab
 ab
 ab


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Edit to our syndicate maps to add a chasm at the viro chute, this is a map fix for a duplication bug that crashes the server.
## How This Contributes To The Skyrat Roleplay Experience

Removes the accidental chance to duplicate drugs, drugs are bad mmkay
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Chasm on Icebox/standard Viro exit for Interdyne
fix: Fixes the accidental chance for the server to rapidly replicate 
admin: solves the 'accident' part of the duplicate bug
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
![image_2022-05-09_114050345](https://user-images.githubusercontent.com/22140677/167457152-a01287b1-20c3-465b-ae63-0965741237e7.png)
