### PR TITLE
Partial revert of #12310 (suit slot guns)

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -620,7 +620,6 @@
 	slowdown_inactive = 1
 	slowdown_active = 0.5
 	allowed_suit_storage = list(
-		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -677,7 +676,6 @@
 	slowdown_inactive = 0.75
 	slowdown_active = 0.25
 	allowed_suit_storage = list(
-		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -736,7 +734,6 @@
 	slowdown_inactive = 0.75
 	slowdown_active = 0.25
 	allowed_suit_storage = list(
-		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -843,7 +840,6 @@
 	ui_theme = "syndicate"
 	inbuilt_modules = list(/obj/item/mod/module/armor_booster)
 	allowed_suit_storage = list(
-		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -927,7 +923,6 @@
 	ui_theme = "syndicate"
 	inbuilt_modules = list(/obj/item/mod/module/armor_booster)
 	allowed_suit_storage = list(
-		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -1091,7 +1086,6 @@
 	slowdown_inactive = 0.5
 	slowdown_active = 0
 	allowed_suit_storage = list(
-		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -1169,7 +1163,6 @@
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 10
 	allowed_suit_storage = list(
-		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,
@@ -1225,7 +1218,6 @@
 	slowdown_inactive = 0.5
 	slowdown_active = 0
 	allowed_suit_storage = list(
-		/obj/item/gun, // SKYRAT EDIT - GUN IN SUIT SLOT
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/ammo_box,


### PR DESCRIPTION
## About The Pull Request
Partially reverts #12310 
Reverts Skyrat Edits on mod_theme.dm allowing guns to be equipped in the suit slot in most combat-oriented Modsuits as it is now redundant.

## How This Contributes To The Skyrat Roleplay Experience
These were added when we had the funny gun holster that was clunky to use. 
Holsters were replaced by the Magnetic Harness, which essentially already does what the edit tried to do, with little additional functionality. 
Being able to save 2 complexity to still carry guns, that just don't reattach when dropped (a very minor part of the functionality) would be less than ideal for balance.

## Changelog

:cl:
del: MODsuits with magnetic harnesses pre-installed no longer can carry guns on them if the harness is removed.
/:cl: