### PR TITLE
Lets you make stone brick floor tiles that actually look like stone brick, not exact copies of metal tiles, also lets them make stone walls directly out of stone without girders

### DIFF
--- a/modular_skyrat/modules/stone/code/stone.dm
+++ b/modular_skyrat/modules/stone/code/stone.dm
@@ -19,6 +19,15 @@
 	source = null
 	walltype = /turf/closed/wall/mineral/stone
 
+GLOBAL_LIST_INIT(stone_recipes, list ( \
+	new/datum/stack_recipe("stone brick wall", /turf/closed/wall/mineral/stone, 5, one_per_turf = 1, on_floor = 1, applies_mats = TRUE), \
+	new/datum/stack_recipe("stone brick tile", /obj/item/stack/tile/mineral/stone, 1, 4, 20),  \
+	))
+
+/obj/item/stack/sheet/mineral/uranium/get_main_recipes()
+	. = ..()
+	. += GLOB.stone_recipes
+
 /datum/material/stone
 	name = "stone"
 	desc = "It's stone."
@@ -41,6 +50,17 @@
 	scan_state = null
 	spreadChance = 20
 	merge_type = /obj/item/stack/ore/stone
+
+/obj/item/stack/tile/mineral/stone
+	name = "stone tile"
+	singular_name = "stone floor tile"
+	desc = "A tile made of stone bricks, for that fortress look."
+	icon_state = "tile_herringbone"
+	inhand_icon_state = "tile"
+	turf_type = /turf/open/floor/stone
+	mineralType = "stone"
+	mats_per_unit = list(/datum/material/stone=MINERAL_MATERIAL_AMOUNT*0.25)
+	merge_type = /obj/item/stack/tile/mineral/stone
 
 /turf/closed/wall/mineral/stone
 	name = "stone wall"

--- a/modular_skyrat/modules/stone/code/stone.dm
+++ b/modular_skyrat/modules/stone/code/stone.dm
@@ -22,7 +22,7 @@
 GLOBAL_LIST_INIT(stone_recipes, list ( \
 	new/datum/stack_recipe("stone brick wall", /turf/closed/wall/mineral/stone, 5, one_per_turf = 1, on_floor = 1, applies_mats = TRUE), \
 	new/datum/stack_recipe("stone brick tile", /obj/item/stack/tile/mineral/stone, 1, 4, 20),  \
-	))
+	)
 
 /obj/item/stack/sheet/mineral/uranium/get_main_recipes()
 	. = ..()

--- a/modular_skyrat/modules/stone/code/stone.dm
+++ b/modular_skyrat/modules/stone/code/stone.dm
@@ -22,7 +22,7 @@
 GLOBAL_LIST_INIT(stone_recipes, list ( \
 	new/datum/stack_recipe("stone brick wall", /turf/closed/wall/mineral/stone, 5, one_per_turf = 1, on_floor = 1, applies_mats = TRUE), \
 	new/datum/stack_recipe("stone brick tile", /obj/item/stack/tile/mineral/stone, 1, 4, 20),  \
-	)
+	))
 
 /obj/item/stack/sheet/mineral/uranium/get_main_recipes()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Part two of me discovering that stone bricks don't work as intended

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
I swear that the players having stone bricks will be useful later

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: stone walls can be made directly from stone without a girder, y'know, since stone walls usually don't have metal in them
fix: tiles made from stone will no longer just be metal tiles with no differences
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
