### PR TITLE
Freighter Fix 1 (Also cargo outfit fixes)

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/clothing_variation_overrides/under.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/clothing_variation_overrides/under.dm
@@ -216,5 +216,4 @@
 /obj/item/clothing/under/costume/swagoutfit
 	supports_variations_flags = NONE
 
-/obj/item/clothing/under/rank/cargo/tech
-	supports_variations_flags = NONE
+

--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -441,6 +441,7 @@
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
 	icon_state = "vest_bulletproof"
 	body_parts_covered = CHEST|GROIN|ARMS // Our sprite has groin and arm protections, so we get it too.
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 //Warden's Vest
 /obj/item/clothing/suit/armor/vest/warden


### PR DESCRIPTION
## About The Pull Request

Friends love doing ghost role stuff. Including the freighter but a bunch of changes overtime have caused a number of issues. The first being the outfits are broken. 
Cargo outfits were flagged in a section for not having Digi variants. But we do! This fixes our cargo outfits for all the digi players in the world, including the ones used in said ghost role. 
Also does the same for the bodyarmor as it doesn't need a digi variant to begin with as it's just a top.

## How This Contributes To The Skyrat Roleplay Experience

Makes the freighter role not have such a terrible start where you're immediately hit with a bunch of broken outfits.
Plus ya know, helps cargo players RP with accurate fashion. Regardless of which outfit they choose.

## Changelog
:cl:
fix: Cargo outfits are once again digi friendly
fix: Bulletproof armor now shows up properly on Digi characters.
/:cl: