### PR TITLE
Only show DNR slappers as DNR on Medhud for consistency & change the soul blurb

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -195,9 +195,7 @@ Medical HUD! Basic mode needs suit sensors on.
 	if(HAS_TRAIT(src, TRAIT_XENO_HOST))
 		holder.icon_state = "hudxeno"
 	else if(stat == DEAD || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))
-		//if((key || get_ghost(FALSE, TRUE)) && (can_defib() & DEFIB_REVIVABLE_STATES))
-		//SKYRAT EDIT CHANGE
-		if(!HAS_TRAIT(src, TRAIT_DNR) && (key || get_ghost(FALSE, TRUE)) && (can_defib() & DEFIB_REVIVABLE_STATES))
+		if((key || get_ghost(FALSE, FALSE)) && (can_defib() & DEFIB_REVIVABLE_STATES)) // SKYRAT EDIT : OG : if((key || get_ghost(FALSE, TRUE)) && (can_defib() & DEFIB_REVIVABLE_STATES))
 			holder.icon_state = "huddefib"
 		else
 			holder.icon_state = "huddead"

--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human_helpers.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human_helpers.dm
@@ -5,6 +5,6 @@
 	var/t_is = p_are()
 	//This checks to see if the body is revivable
 	if(!HAS_TRAIT(src, TRAIT_DNR) && (key || !getorgan(/obj/item/organ/brain) || ghost?.can_reenter_corpse))
-		return span_deadsay("[t_He] [t_is] limp and unresponsive... [t_his] may be some life...")
+		return span_deadsay("[t_He] [t_is] limp and unresponsive... [t_his] body is twitching slightly...")
 	else
-		return span_deadsay("[t_He] [t_is] limp and unresponsive... [t_his] soul is not with [t_his] body...")
+		return span_deadsay("[t_He] [t_is] limp and unresponsive... You do not sense [t_his] soul...")

--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human_helpers.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human_helpers.dm
@@ -5,6 +5,6 @@
 	var/t_is = p_are()
 	//This checks to see if the body is revivable
 	if(!HAS_TRAIT(src, TRAIT_DNR) && (key || !getorgan(/obj/item/organ/brain) || ghost?.can_reenter_corpse))
-		return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life...")
+		return span_deadsay("[t_He] [t_is] limp and unresponsive... [t_his] may be some life...")
 	else
-		return span_deadsay("[t_He] [t_is] limp and unresponsive. [t_his] consciousness has degraded beyond revival.")
+		return span_deadsay("[t_He] [t_is] limp and unresponsive... [t_his] soul is not with [t_his] body...")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alright. This is a weird one. So, this PR makes it so that actually unrevivable people show as unrevivable - Game closers ARE revivable and CAN and DO come back - that's the whole reason why the morgue beeps. HOWEVER, this PR changes it so DNR slappers are correctly DNR, and game returners do not become visually DNR. 

Previously, these people would show a skull. PEOPLE DO COME BACK. A brief disconnect will show you as skulls. 

## How This Contributes To The Skyrat Roleplay Experience

Less people being sent to morgue / glanced over / suffering from medical being unable to understand messages.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

oh god why did we have to not use the TG versions

:cl:
qol: tweaks medhud to not show dc'd but still linked ghosts as DNR.
qol: changes the dead example blurb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
