### PR TITLE
Fixes security jumpskirt loadout override

### DIFF
--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -561,23 +561,23 @@
 //
 // This code overrides security's jumpskirt preference, as we're not going to be giving them jumpskirts
 //
-/datum/outfit/job/security/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/security/pre_equip(mob/living/carbon/human/affected_mob)
+	if(affected_mob.jumpsuit_style == PREF_SKIRT)
+		to_chat(affected_mob, span_alertwarning("Lopland Peacekeeper uniforms don't include a skirt variant! You've been equipped with a jumpsuit instead."))
+		affected_mob.jumpsuit_style = PREF_SUIT
 	. = ..()
-	if(H.jumpsuit_style == PREF_SKIRT)
-		to_chat(H, span_alertwarning("Lopland Peacekeeper uniforms don't include a Skirt variant! You've been equipped with a jumpsuit instead."))
-		uniform = /obj/item/clothing/under/rank/security/officer
 
-/datum/outfit/job/hos/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/hos/pre_equip(mob/living/carbon/human/affected_mob)
+	if(affected_mob.jumpsuit_style == PREF_SKIRT)
+		to_chat(affected_mob, span_alertwarning("Lopland Peacekeeper uniforms don't include a skirt variant! You've been equipped with a jumpsuit instead."))
+		affected_mob.jumpsuit_style = PREF_SUIT
 	. = ..()
-	if(H.jumpsuit_style == PREF_SKIRT)
-		to_chat(H, span_alertwarning("Lopland Peacekeeper uniforms don't include a Skirt variant! You've been equipped with a jumpsuit instead."))
-		uniform = /obj/item/clothing/under/rank/security/head_of_security
 
-/datum/outfit/job/warden/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/warden/pre_equip(mob/living/carbon/human/affected_mob)
+	if(affected_mob.jumpsuit_style == PREF_SKIRT)
+		to_chat(affected_mob, span_alertwarning("Lopland Peacekeeper uniforms don't include a skirt variant! You've been equipped with a jumpsuit instead."))
+		affected_mob.jumpsuit_style = PREF_SUIT
 	. = ..()
-	if(H.jumpsuit_style == PREF_SKIRT)
-		to_chat(H, span_alertwarning("Lopland Peacekeeper uniforms don't include a Skirt variant! You've been equipped with a jumpsuit instead."))
-		uniform = /obj/item/clothing/under/rank/security/warden
 
 //PDA Greyscale Overrides
 /obj/item/modular_computer/tablet/pda/security

--- a/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -18,6 +18,10 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 		if(!visuals_only)
 			to_chat(equipper, "Your loadout uniform was not equipped directly due to your envirosuit.")
 			LAZYADD(outfit.backpack_contents, item_path)
+	else if(override_items == LOADOUT_OVERRIDE_BACKPACK && !visuals_only)
+		if(outfit.uniform)
+			LAZYADD(outfit.backpack_contents, outfit.uniform)
+		outfit.uniform = item_path
 	else
 		outfit.uniform = item_path
 
@@ -572,22 +576,22 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	name = "Black Cargo Uniform"
 	item_path = /obj/item/clothing/under/rank/cargo/tech/skyrat/evil
 	restricted_roles = list(JOB_CARGO_TECHNICIAN)
-	
+
 /datum/loadout_item/under/miscellaneous/cargo_turtle
 	name = "Cargo Turtleneck"
 	item_path = /obj/item/clothing/under/rank/cargo/tech/skyrat/turtleneck
 	restricted_roles = list(JOB_CARGO_TECHNICIAN)
-	
+
 /datum/loadout_item/under/miscellaneous/cargo_skirtle
 	name = "Cargo Skirtleneck"
 	item_path = /obj/item/clothing/under/rank/cargo/tech/skyrat/turtleneck/skirt
 	restricted_roles = list(JOB_CARGO_TECHNICIAN)
-	
+
 /datum/loadout_item/under/miscellaneous/qm_skirtle
 	name = "Quartermaster's Skirtleneck"
 	item_path = /obj/item/clothing/under/rank/cargo/qm/skyrat/turtleneck/skirt
 	restricted_roles = list(JOB_QUARTERMASTER)
-	
+
 /datum/loadout_item/under/miscellaneous/qm_gorka
 	name = "Quartermaster's Gorka Uniform"
 	item_path = /obj/item/clothing/under/rank/cargo/qm/skyrat/gorka


### PR DESCRIPTION
## About The Pull Request

That title barely makes sense but basically if you wear a jumpskirt as sec, it overrides that to a jumpsuit but does it in such a way that it *also* overrides your uniform chosen in your loadout if you have move job to backpack selected.

Also fixes move job to backpack pref not actually... moving your jumpsuit to your backpack, and instead just deleting it.

## How This Contributes To The Skyrat Roleplay Experience

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/12307

## Changelog
:cl:
fix: Joining sec no longer overrides your loadout with the default jumpsuit in some cases
fix: "Move job to backpack" preference now indeed moves your job jumpsuit to your backpack rather than deleting it.
/:cl: