### PR TITLE
[MODULAR] Adds the suppressor to NT armories.

### DIFF
--- a/modular_skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield.dm
@@ -86,7 +86,7 @@
 	new /obj/item/ammo_box/magazine/multi_sprite/cmg(src)
 	new /obj/item/ammo_box/magazine/multi_sprite/cmg/lethal(src)
 	new /obj/item/ammo_box/magazine/multi_sprite/cmg/lethal(src)
-	new /obj/item/suppressor(src) //why the fuck does BS need a suppressed gun is beyond me
+	new /obj/item/suppressor/nanotrasen(src) //why the fuck does BS need a suppressed gun is beyond me
 
 /obj/item/ammo_casing/energy/laser/hellfire/bs
 	projectile_type = /obj/projectile/beam/laser/hellfire

--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/nanotrasen.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/nanotrasen.dm
@@ -66,7 +66,7 @@
 	upper_cost = CARGO_CRATE_VALUE * 16
 	interest_required = PASSED_INTEREST
 	
-/datum/armament_entry/cargo_gun/nanotrasen/part/suppressor
-	item_type = /obj/item/suppressor
+/datum/armament_entry/cargo_gun/nanotrasen/part/suppressor/NT
+	item_type = /obj/item/suppressor/NT
 	lower_cost = CARGO_CRATE_VALUE * 10
 	upper_cost = CARGO_CRATE_VALUE * 15

--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/nanotrasen.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/nanotrasen.dm
@@ -65,3 +65,8 @@
 	lower_cost = CARGO_CRATE_VALUE * 12
 	upper_cost = CARGO_CRATE_VALUE * 16
 	interest_required = PASSED_INTEREST
+	
+/datum/armament_entry/cargo_gun/nanotrasen/part/suppressor
+	item_type = /obj/item/suppressor
+	lower_cost = CARGO_CRATE_VALUE * 10
+	upper_cost = CARGO_CRATE_VALUE * 15

--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/nanotrasen.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/nanotrasen.dm
@@ -66,7 +66,7 @@
 	upper_cost = CARGO_CRATE_VALUE * 16
 	interest_required = PASSED_INTEREST
 	
-/datum/armament_entry/cargo_gun/nanotrasen/part/suppressor/NT
-	item_type = /obj/item/suppressor/NT
+/datum/armament_entry/cargo_gun/nanotrasen/part/suppressor/nanotrasen
+	item_type = /obj/item/suppressor/nanotrasen
 	lower_cost = CARGO_CRATE_VALUE * 10
 	upper_cost = CARGO_CRATE_VALUE * 15

--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/scarborough.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/scarborough.dm
@@ -52,8 +52,8 @@
 
 /datum/armament_entry/cargo_gun/scarborough/part/suppressor
 	item_type = /obj/item/suppressor
-	lower_cost = CARGO_CRATE_VALUE * 10
-	upper_cost = CARGO_CRATE_VALUE * 15
+	lower_cost = CARGO_CRATE_VALUE * 7 // Cheaper here because NT sells the same thing.
+	upper_cost = CARGO_CRATE_VALUE * 10
 
 /datum/armament_entry/cargo_gun/scarborough/ammo
 	subcategory = ARMAMENT_SUBCATEGORY_AMMO

--- a/modular_skyrat/modules/gun_cargo/code/objects/suppressor.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/suppressor.dm
@@ -1,7 +1,4 @@
-
 /obj/item/suppressor/nanotrasen
 	name = "NT-S Suppressor"
 	desc = "A Nanotrasen brand knockoff suppressor, you can almost smell abestos."
-	icon = 'icons/obj/guns/ballistic.dmi'
-	icon_state = "suppressor"
-	w_class = WEIGHT_CLASS_TINY
+	

--- a/modular_skyrat/modules/gun_cargo/code/objects/suppressor.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/suppressor.dm
@@ -1,5 +1,5 @@
 
-/obj/item/suppressor/NT
+/obj/item/suppressor/nanotrasen
 	name = "NT-S Suppressor"
 	desc = "A Nanotrasen brand knockoff suppressor, you can almost smell abestos."
 	icon = 'icons/obj/guns/ballistic.dmi'

--- a/modular_skyrat/modules/gun_cargo/code/objects/suppressor.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/suppressor.dm
@@ -1,4 +1,6 @@
 /obj/item/suppressor/nanotrasen
 	name = "NT-S Suppressor"
 	desc = "A Nanotrasen brand knockoff suppressor, you can almost smell abestos."
-	
+	icon = 'icons/obj/guns/ballistic.dmi'
+	icon_state = "suppressor"
+	w_class = WEIGHT_CLASS_TINY

--- a/modular_skyrat/modules/gun_cargo/code/objects/suppressor.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/suppressor.dm
@@ -1,0 +1,7 @@
+
+/obj/item/suppressor/NT
+	name = "NT-S Suppressor"
+	desc = "A Nanotrasen brand knockoff suppressor, you can almost smell abestos."
+	icon = 'icons/obj/guns/ballistic.dmi'
+	icon_state = "suppressor"
+	w_class = WEIGHT_CLASS_TINY

--- a/modular_skyrat/modules/projectiles/code/guns/ballistic.dm
+++ b/modular_skyrat/modules/projectiles/code/guns/ballistic.dm
@@ -1,3 +1,0 @@
-/obj/item/suppressor/nanotrasen
-	name = "NT-S Suppressor"
-	desc = "A Nanotrasen brand knockoff suppressor, you can almost smell abestos."

--- a/modular_skyrat/modules/projectiles/code/guns/ballistic.dm
+++ b/modular_skyrat/modules/projectiles/code/guns/ballistic.dm
@@ -1,0 +1,3 @@
+/obj/item/suppressor/nanotrasen
+	name = "NT-S Suppressor"
+	desc = "A Nanotrasen brand knockoff suppressor, you can almost smell abestos."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5252,6 +5252,7 @@
 #include "modular_skyrat\modules\gun_cargo\code\objects\vending.dm"
 #include "modular_skyrat\modules\gun_cargo\code\objects\guns\interdyne.dm"
 #include "modular_skyrat\modules\gun_cargo\code\objects\guns\izhevsk.dm"
+#include "modular_skyrat/modules/gun_cargo/code/objects/suppressor.dm"
 #include "modular_skyrat\modules\gunhud\code\gun_hud.dm"
 #include "modular_skyrat\modules\gunhud\code\gun_hud_component.dm"
 #include "modular_skyrat\modules\gunpoint\code\gunpoint.dm"


### PR DESCRIPTION


## About The Pull Request
Originally in Scarborough, and made non-contraband for gun cargo, just to be lost to the tides when scarborough became emag only.

## How This Contributes To The Skyrat Roleplay Experience

suppressed peacekeeper shotguns do more damage, and no one can tell me otherwise.

## Changelog


:cl:
add: NT Armories now carries suppressors, for all your indoor shooting needs.
/:cl:

