### PR TITLE
Transfer votes will no longer be available to be started by everyone

### DIFF
--- a/config/skyrat/skyrat_config.txt
+++ b/config/skyrat/skyrat_config.txt
@@ -51,8 +51,11 @@ CRYO_MIN_SSD_TIME 15
 ## log subtler emotes in game.txt
 #LOG_SUBTLER
 
-## Enables autotransfer voting.
+## Enables autotransfer system
 #AUTOTRANSFER
+
+## Enables starting transfer votes by the crew at large.
+#ALLOW_VOTE_TRANSFER
 
 ## autovote initial delay (deciseconds in real time) before first automatic transfer vote call (default 120 minutes)
 ## Set to 0 to disable the subsystem altogether.

--- a/modular_skyrat/modules/autotransfer/code/autotransfer_config.dm
+++ b/modular_skyrat/modules/autotransfer/code/autotransfer_config.dm
@@ -18,3 +18,7 @@
 
 /// Determines if the autotransfer system runs or not.
 /datum/config_entry/flag/autotransfer
+
+
+/// Determines if the transfer vote can be started by anyone or not.
+/datum/config_entry/flag/allow_vote_transfer

--- a/modular_skyrat/modules/autotransfer/code/transfer_vote.dm
+++ b/modular_skyrat/modules/autotransfer/code/transfer_vote.dm
@@ -13,18 +13,25 @@
 		CRASH("[type] wasn't passed a \"toggler\" mob to toggle_votable.")
 	if(!check_rights_for(toggler.client, R_ADMIN))
 		return FALSE
+
+
+	CONFIG_SET(flag/allow_vote_transfer, !CONFIG_GET(flag/allow_vote_transfer))
 	return TRUE
 
 /datum/vote/transfer_vote/is_config_enabled()
-	return CONFIG_GET(flag/autotransfer)
+	return CONFIG_GET(flag/autotransfer) && CONFIG_GET(flag/allow_vote_transfer)
 
 /datum/vote/transfer_vote/can_be_initiated(mob/by_who, forced)
 	. = ..()
 	if(!.)
 		return FALSE
 
-	if(!forced && !CONFIG_GET(flag/autotransfer) && !by_who && !check_rights_for(by_who.client, R_ADMIN))
-		to_chat(by_who, span_warning("Transfer voting is disabled."))
+	if(forced)
+		return TRUE
+
+	if(!CONFIG_GET(flag/autotransfer) || !CONFIG_GET(flag/allow_vote_transfer))
+		if(by_who)
+			to_chat(by_who, span_warning("Transfer voting is disabled."))
 		return FALSE
 
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
As simple as that, I'll mark it for a test-merge first because I need to be sure that it still work in automatic mode (it should, I don't see why it wouldn't, but you never know, and I didn't want to wait forever for it to fire.)

## How This Contributes To The Skyrat Roleplay Experience
Yeah, I don't think I need to explain why everyone being able to start transfer votes is a bad idea.

## Changelog

:cl: GoldenAlpharex
fix: Fixed everyone being able to start transfer votes. Now, only admins will be able to, if autotransfer is enabled.
config: Added ALLOW_VOTE_TRANSFER config flag, defaults to false.
/:cl: