### PR TITLE
[De-NonModular'd] Resets disabler stamina damage 

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -87,7 +87,7 @@
 /obj/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 41 // SKYRAT EDIT: 30
+	damage = 30
 	damage_type = STAMINA
 	armor_flag = ENERGY
 	hitsound = 'sound/weapons/tap.ogg'


### PR DESCRIPTION
## About The Pull Request

Knocks disablers back down to 30 damage, because they were buffed to 41 for the reason of 'more effective' ( https://github.com/Skyrat-SS13/Skyrat-tg/pull/8524) but, coincidentally, it made them non-comparably the single best option on any gun that has them (see: most energy guns), being able to disable any limb in two shots, or both arms in just four shots, leaving you just two shots from stamcritting them, for comparison, the 'strong' 9mm IHDF, only does 20 stamina, for another reference, the 'supposed to be rediculously strong' shotgun beanbags, only do 50.

## How This Contributes To The Skyrat Roleplay Experience





:cl:

balance: Disablers have been dropped in stamina damage from 41>30. 
/:cl:


