### PR TITLE
[MODULAR] Blacklists morphine and all inverses from smartdarts.

### DIFF
--- a/modular_skyrat/modules/medical/code/smartdarts.dm
+++ b/modular_skyrat/modules/medical/code/smartdarts.dm
@@ -138,7 +138,7 @@
 
 		if(!is_type_in_list(meds, allowed_medicine))
 			continue
-		if(!is_type_in_list(meds, disallowed_medicine))
+		if(is_type_in_list(meds, disallowed_medicine))
 			return
 		if(is_type_in_list(meds, allergy_list))
 			prevention_used = TRUE

--- a/modular_skyrat/modules/medical/code/smartdarts.dm
+++ b/modular_skyrat/modules/medical/code/smartdarts.dm
@@ -85,7 +85,7 @@
 	)
         ///Blacklist that contains medicines that SmartDarts are unable to inject.
 	var/list/disallowed_medicine = list(
-		/datum/reagent/inverse/healing/tirimol,
+		/datum/reagent/inverse/
 		/datum/reagent/medicine/morphine,
 	)
 

--- a/modular_skyrat/modules/medical/code/smartdarts.dm
+++ b/modular_skyrat/modules/medical/code/smartdarts.dm
@@ -83,6 +83,10 @@
 		/datum/reagent/medicine,
 		/datum/reagent/vaccine
 	)
+	var/list/disalloawed_medicine = list(
+		/datum/reagent/inverse/healing/tirimol,
+		/datum/reagent/medicine/morphine,
+	)
 
 /obj/projectile/bullet/dart/syringe/dart/on_hit(atom/target, blocked = FALSE)
 	if(!iscarbon(target))
@@ -134,6 +138,8 @@
 
 		if(!is_type_in_list(meds, allowed_medicine))
 			continue
+		if(!is_type_in_list(meds, disallowed_medicine))
+			return
 		if(is_type_in_list(meds, allergy_list))
 			prevention_used = TRUE
 		else

--- a/modular_skyrat/modules/medical/code/smartdarts.dm
+++ b/modular_skyrat/modules/medical/code/smartdarts.dm
@@ -139,7 +139,7 @@
 		if(!is_type_in_list(meds, allowed_medicine))
 			continue
 		if(is_type_in_list(meds, disallowed_medicine))
-			return
+			continue
 		if(is_type_in_list(meds, allergy_list))
 			prevention_used = TRUE
 		else

--- a/modular_skyrat/modules/medical/code/smartdarts.dm
+++ b/modular_skyrat/modules/medical/code/smartdarts.dm
@@ -85,7 +85,7 @@
 	)
         ///Blacklist that contains medicines that SmartDarts are unable to inject.
 	var/list/disallowed_medicine = list(
-		/datum/reagent/inverse/
+		/datum/reagent/inverse/,
 		/datum/reagent/medicine/morphine,
 	)
 

--- a/modular_skyrat/modules/medical/code/smartdarts.dm
+++ b/modular_skyrat/modules/medical/code/smartdarts.dm
@@ -83,7 +83,7 @@
 		/datum/reagent/medicine,
 		/datum/reagent/vaccine
 	)
-	var/list/disalloawed_medicine = list(
+	var/list/disallowed_medicine = list(
 		/datum/reagent/inverse/healing/tirimol,
 		/datum/reagent/medicine/morphine,
 	)

--- a/modular_skyrat/modules/medical/code/smartdarts.dm
+++ b/modular_skyrat/modules/medical/code/smartdarts.dm
@@ -83,6 +83,7 @@
 		/datum/reagent/medicine,
 		/datum/reagent/vaccine
 	)
+        ///Blacklist that contains medicines that SmartDarts are unable to inject.
 	var/list/disallowed_medicine = list(
 		/datum/reagent/inverse/healing/tirimol,
 		/datum/reagent/medicine/morphine,


### PR DESCRIPTION

## About The Pull Request

For the darts that are supposed to have no combat use (doing no damage when hitting someone, and letting pacifists use them), letting them load two of the more-effective 'get fucked' chems, is a 'bit' much.

## How This Contributes To The Skyrat Roleplay Experience

No more mass-printable super-melatonin/ nooartrium darts.

## Changelog



:cl:
balance: Smartdarts can no longer load super-melatonin, or morphine, relegating them back to the actual combat-oriented syringe guns.
/:cl:

