### PR TITLE
Speeds up the arrivals shuttle

### DIFF
--- a/modular_skyrat/modules/advanced_shuttles/code/shuttles.dm
+++ b/modular_skyrat/modules/advanced_shuttles/code/shuttles.dm
@@ -7,9 +7,9 @@
 	dir = WEST
 	port_direction = SOUTH
 
-	callTime = 30 SECONDS
+	callTime = 15 SECONDS
 	ignitionTime = 6 SECONDS
-	rechargeTime = 20 SECONDS
+	rechargeTime = 15 SECONDS
 
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 0)
 	can_be_called_in_transit = FALSE


### PR DESCRIPTION
## About The Pull Request

Lowers the travel time of the arrival shuttle from 30 seconds to 15.
Lowers the recharge time from 20 seconds to 15. Still plenty of time to dismount.

## How This Contributes To The Skyrat Roleplay Experience

The shuttle is cool. It's nice. The amount of time it takes to get there is not nice, and god forbid someone sends it just as you're about to get on and you have to wait the 30s travel time + 20s recharge + 30s travel time + 20s recharge + 30s travel time *just to get on station*.

In that worst-case scenario, the total time you'd spend waiting goes from 130 seconds to just 75. Still a while, but not quite as agonising.

## Changelog
:cl:
qol: The arrivals shuttle got new thrusters, cutting its travel time in half and its recharge time down by a quarter.
/:cl: