### PR TITLE
Removes veteran lock from Vanguard

### DIFF
--- a/modular_skyrat/modules/exp_corps/code/expeditionary_trooper.dm
+++ b/modular_skyrat/modules/exp_corps/code/expeditionary_trooper.dm
@@ -28,8 +28,6 @@
 
 	family_heirlooms = list(/obj/item/binoculars)
 
-	veteran_only = TRUE
-
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS
 
 /datum/job/expeditionary_trooper/after_spawn(mob/living/carbon/human/H, mob/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the requirement to be veteran crew from vanguard slots.

## How This Contributes To The Skyrat Roleplay Experience
Overall, I don't see the purpose in having Vanguard be veteran locked. It's not a job that requires a high amount of trust (aside from not going valid salad on the antags when they get back on station, but the only away mission we have is Black Mesa, which i have yet to see completed without a shift extension). In addition, when I run an away mission, vanguard being vet locked usually means it takes an hour-ish for all 4 slots to fill, which I do not like.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
config: Vanguard are no longer veteran-crew locked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
