### PR TITLE
Fixes invisible guncargo 10mm auto boxes

### DIFF
--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/dynamics.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/dynamics.dm
@@ -90,13 +90,19 @@
 	item_type = /obj/item/ammo_box/c38/trac
 
 /datum/armament_entry/cargo_gun/dynamics/ammo/b10mm
-	item_type = /obj/item/ammo_box/b10mm
+	item_type = /obj/item/ammo_box/advanced/b10mm
+	lower_cost = CARGO_CRATE_VALUE * 0.75
+	upper_cost = CARGO_CRATE_VALUE * 1.25 //more ammo per box
 
 /datum/armament_entry/cargo_gun/dynamics/ammo/b10mm_hp
-	item_type = /obj/item/ammo_box/b10mm/hp
+	item_type = /obj/item/ammo_box/advanced/b10mm/hp
+	lower_cost = CARGO_CRATE_VALUE * 0.75
+	upper_cost = CARGO_CRATE_VALUE * 1.25
 
 /datum/armament_entry/cargo_gun/dynamics/ammo/b10mm_rub
-	item_type = /obj/item/ammo_box/b10mm/rubber
+	item_type = /obj/item/ammo_box/advanced/b10mm/rubber
+	lower_cost = CARGO_CRATE_VALUE * 0.75
+	upper_cost = CARGO_CRATE_VALUE * 1.25
 
 /datum/armament_entry/cargo_gun/dynamics/misc
 	subcategory = ARMAMENT_SUBCATEGORY_SPECIAL

--- a/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
@@ -114,17 +114,3 @@
 	new /obj/item/stock_parts/cell/microfusion/bluespace(src)
 	new /obj/item/stock_parts/cell/microfusion/bluespace(src)
 
-/obj/item/ammo_box/b10mm
-	name = "ammo box (10mm Auto)"
-	ammo_type = /obj/item/ammo_casing/b10mm
-	max_ammo = 20
-
-/obj/item/ammo_box/b10mm/hp
-	name = "ammo box (10mm Auto HP)"
-	ammo_type = /obj/item/ammo_casing/b10mm/hp
-	max_ammo = 20
-
-/obj/item/ammo_box/b10mm/rubber
-	name = "ammo box (10mm Auto Rubber)"
-	ammo_type = /obj/item/ammo_casing/b10mm/rubber
-	max_ammo = 20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Guncargo had 10mm auto ammoboxes that were invisible, i replaced them with existing ones from sec_haul.

## How This Contributes To The Skyrat Roleplay Experience
These being visible would be good

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Armament Dynamics 10mm auto ammo boxes are not invisible anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
