### PR TITLE
Fixes synths errantly getting inherent armor

### DIFF
--- a/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/robotic/_mutant_robotic_bodyparts.dm
+++ b/modular_skyrat/master_files/code/modules/surgery/bodyparts/species_parts/robotic/_mutant_robotic_bodyparts.dm
@@ -6,6 +6,8 @@
 	should_draw_greyscale = TRUE
 	uses_mutcolor = TRUE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
+	brute_reduction = 0
+	burn_reduction = 0
 
 /obj/item/bodypart/chest/robot/mutant
 	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/synthmammal_parts_greyscale.dmi'
@@ -13,22 +15,30 @@
 	should_draw_greyscale = TRUE
 	limb_id = SPECIES_SYNTHMAMMAL
 	is_dimorphic = TRUE
+	brute_reduction = 0
+	burn_reduction = 0
 
 /obj/item/bodypart/l_arm/robot/mutant
 	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/synthmammal_parts_greyscale.dmi'
 	limb_id = SPECIES_SYNTHMAMMAL
 	should_draw_greyscale = TRUE
+	brute_reduction = 0
+	burn_reduction = 0
 
 /obj/item/bodypart/r_arm/robot/mutant
 	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/synthmammal_parts_greyscale.dmi'
 	limb_id = SPECIES_SYNTHMAMMAL
 	should_draw_greyscale = TRUE
+	brute_reduction = 0
+	burn_reduction = 0
 
 /obj/item/bodypart/l_leg/robot/mutant
 	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/synthmammal_parts_greyscale.dmi'
 	limb_id = SPECIES_SYNTHMAMMAL
 	should_draw_greyscale = TRUE
 	digitigrade_type = /obj/item/bodypart/l_leg/robot/digitigrade
+	brute_reduction = 0
+	burn_reduction = 0
 
 /obj/item/bodypart/r_leg/robot/mutant
 	icon_greyscale = 'modular_skyrat/master_files/icons/mob/species/synthmammal_parts_greyscale.dmi'
@@ -36,6 +46,8 @@
 	should_draw_greyscale = TRUE
 	limb_id = SPECIES_SYNTHMAMMAL
 	digitigrade_type = /obj/item/bodypart/r_leg/robot/digitigrade
+	brute_reduction = 0
+	burn_reduction = 0
 
 /obj/item/bodypart/l_leg/robot/digitigrade
 	icon = 'modular_skyrat/master_files/icons/mob/species/synthmammal_parts_greyscale.dmi'
@@ -46,6 +58,8 @@
 	limb_id = "digitigrade"
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC | BODYTYPE_DIGITIGRADE
 	base_limb_id = SPECIES_SYNTHMAMMAL
+	brute_reduction = 0
+	burn_reduction = 0
 
 /obj/item/bodypart/l_leg/robot/digitigrade/update_limb(dropping_limb = FALSE, is_creating = FALSE)
 	. = ..()
@@ -60,6 +74,8 @@
 	limb_id = "digitigrade"
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC | BODYTYPE_DIGITIGRADE
 	base_limb_id = SPECIES_SYNTHMAMMAL
+	brute_reduction = 0
+	burn_reduction = 0
 
 /obj/item/bodypart/r_leg/robot/digitigrade/update_limb(dropping_limb = FALSE, is_creating = FALSE)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turns out limb subtypes of `robot/` got an inherent 4 brute / 5 burn protection. Not intended to my knowledge.

## How This Contributes To The Skyrat Roleplay Experience
This isn't mentioned anywhere and is absolutely a buff.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Synths no longer get inherent armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
