### PR TITLE
re-adds gas miners to icebox and tram

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -2587,6 +2587,7 @@
 /area/station/science/xenobiology)
 "aRj" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "aRk" = (
@@ -15409,6 +15410,7 @@
 /area/station/engineering/storage/tech)
 "eWj" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/atmospherics/miner/plasma,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "eWn" = (
@@ -15456,6 +15458,7 @@
 /area/station/command/bridge)
 "eWQ" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
 "eWT" = (
@@ -15626,6 +15629,7 @@
 /area/station/service/hydroponics)
 "eZc" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "eZi" = (
@@ -59416,6 +59420,7 @@
 /area/station/engineering/storage_shared)
 "tln" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "tlr" = (

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -35956,6 +35956,7 @@
 /area/station/engineering/atmos)
 "lpr" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "lpw" = (
@@ -43872,6 +43873,7 @@
 /area/station/cargo/office)
 "olj" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/atmospherics/miner/plasma,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "olk" = (
@@ -50403,6 +50405,7 @@
 /area/station/hallway/primary/tram/center)
 "qEi" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "qEv" = (
@@ -70687,6 +70690,7 @@
 /area/station/engineering/atmos)
 "xFX" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "xGb" = (
@@ -71260,6 +71264,7 @@
 /area/station/security/office)
 "xPD" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
 "xPV" = (


### PR DESCRIPTION
## About The Pull Request

they got lost at some point I guess
I care not for your opinion on whether they should be added. This is a PR to fix a consistency issue.

## Changelog
:cl:
fix: Tram and Icebox once again have gas miners.
/:cl: