### PR TITLE
Revert "https://github.com/tgstation/tgstation/pull/66386" (PACMAN nerfs)

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -187,22 +187,16 @@
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/power/port_gen/pacman
 	req_components = list(
-		/obj/item/stack/cable_coil = 5,
-		/obj/item/stack/sheet/iron = 5
-	)
+		/obj/item/stock_parts/matter_bin = 1,
+		/obj/item/stock_parts/micro_laser = 1,
+		/obj/item/stack/cable_coil = 2,
+		/obj/item/stock_parts/capacitor = 1)
 	needs_anchored = FALSE
-	var/high_production_profile = FALSE
 
-/obj/item/circuitboard/machine/pacman/examine(mob/user)
-	. = ..()
-	var/message = high_production_profile ? "high production - high consumption" : "low production - low consumption"
-	. += span_notice("It's set to [message].")
-	. += span_notice("You can switch the mode by using a screwdriver on [src].")
-
-/obj/item/circuitboard/machine/pacman/screwdriver_act(mob/living/user, obj/item/tool)
-	high_production_profile = !high_production_profile
-	var/message = high_production_profile ? "high production - high consumption" : "low production - low consumption"
-	to_chat(user, span_notice("You set the board for [message]"))
+/obj/item/circuitboard/machine/pacman/super
+	name = "SUPERPACMAN-type Generator (Machine Board)"
+	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
+	build_path = /obj/machinery/power/port_gen/pacman/super
 
 /obj/item/circuitboard/machine/turbine_compressor
 	name = "Turbine - Inlet Compressor (Machine Board)"

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -81,13 +81,12 @@
 /obj/machinery/power/port_gen/pacman
 	name = "\improper P.A.C.M.A.N.-type portable generator"
 	circuit = /obj/item/circuitboard/machine/pacman
-	power_gen = 2500
 	var/sheets = 0
-	var/max_sheets = 10
+	var/max_sheets = 100
 	var/sheet_name = ""
 	var/sheet_path = /obj/item/stack/sheet/mineral/plasma
 	var/sheet_left = 0 // How much is left of the sheet
-	var/time_per_sheet = 50
+	var/time_per_sheet = 260
 	var/current_heat = 0
 
 /obj/machinery/power/port_gen/pacman/Initialize(mapload)
@@ -102,21 +101,27 @@
 	DropFuel()
 	return ..()
 
-/obj/machinery/power/port_gen/pacman/on_construction()
-	var/obj/item/circuitboard/machine/pacman/our_board = circuit
-	if(our_board.high_production_profile)
-		icon_state = "portgen1_0"
-		base_icon = "portgen1"
-		max_sheets = 5
-		time_per_sheet = 20
-		power_gen = 15000
-		sheet_path = /obj/item/stack/sheet/mineral/uranium
+/obj/machinery/power/port_gen/pacman/RefreshParts()
+	. = ..()
+	var/temp_rating = 0
+	var/consumption_coeff = 0
+	for(var/obj/item/stock_parts/SP in component_parts)
+		if(istype(SP, /obj/item/stock_parts/matter_bin))
+			max_sheets = SP.rating * SP.rating * 50
+		else if(istype(SP, /obj/item/stock_parts/capacitor))
+			temp_rating += SP.rating
+		else
+			consumption_coeff += SP.rating
+	power_gen = round(initial(power_gen) * temp_rating * 2)
+	consumption = consumption_coeff
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)
 	. = ..()
 	. += span_notice("The generator has [sheets] units of [sheet_name] fuel left, producing [display_power(power_gen)] per cycle.")
 	if(anchored)
 		. += span_notice("It is anchored to the ground.")
+	if(in_range(user, src) || isobserver(user))
+		. += span_notice("The status display reads: Fuel efficiency increased by <b>[(consumption*100)-100]%</b>.")
 
 /obj/machinery/power/port_gen/pacman/HasFuel()
 	if(sheets >= 1 / (time_per_sheet / power_output) - sheet_left)
@@ -129,7 +134,7 @@
 		sheets = 0
 
 /obj/machinery/power/port_gen/pacman/UseFuel()
-	var/needed_sheets = 1 / (time_per_sheet / power_output)
+	var/needed_sheets = 1 / (time_per_sheet * consumption / power_output)
 	var/temp = min(needed_sheets, sheet_left)
 	needed_sheets -= temp
 	sheet_left -= temp
@@ -144,9 +149,9 @@
 	var/bias = 0
 	if (power_output > 4)
 		upper_limit = 400
-		bias = power_output - 3
+		bias = power_output - consumption * (4 - consumption)
 	if (current_heat < lower_limit)
-		current_heat += 3
+		current_heat += 4 - consumption
 	else
 		current_heat += rand(-7 + bias, 7 + bias)
 		if (current_heat < lower_limit)
@@ -270,12 +275,13 @@
 				. = TRUE
 
 /obj/machinery/power/port_gen/pacman/super
+	name = "\improper S.U.P.E.R.P.A.C.M.A.N.-type portable generator"
 	icon_state = "portgen1_0"
 	base_icon = "portgen1"
-	max_sheets = 5
-	time_per_sheet = 20
-	power_gen = 15000
+	circuit = /obj/item/circuitboard/machine/pacman/super
 	sheet_path = /obj/item/stack/sheet/mineral/uranium
+	power_gen = 15000
+	time_per_sheet = 85
 
-/obj/machinery/power/port_gen/pacman/pre_loaded
-	sheets = 10
+/obj/machinery/power/port_gen/pacman/super/overheat()
+	explosion(src, devastation_range = 3, heavy_impact_range = 3, light_impact_range = 3, flash_range = -1)

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -86,7 +86,7 @@
 	var/sheet_name = ""
 	var/sheet_path = /obj/item/stack/sheet/mineral/plasma
 	var/sheet_left = 0 // How much is left of the sheet
-	var/time_per_sheet = 260
+	var/time_per_sheet = 50
 	var/current_heat = 0
 
 /obj/machinery/power/port_gen/pacman/Initialize(mapload)

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -74,6 +74,13 @@
 	category = list("Engineering Machinery")
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
 
+/datum/design/board/pacman/super
+	name = "Machine Design (SUPERPACMAN-type Generator Board)"
+	desc = "The circuit board that for a SUPERPACMAN-type portable generator."
+	id = "superpacman"
+	build_path = /obj/item/circuitboard/machine/pacman/super
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
 /datum/design/turbine_part_compressor
 	name = "Turbine Part - Compressor"
 	desc = "The basic tier of a compressor blade."

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -79,7 +79,7 @@
 	desc = "The circuit board that for a SUPERPACMAN-type portable generator."
 	id = "superpacman"
 	build_path = /obj/item/circuitboard/machine/pacman/super
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_BITFLAG_ENGINEERING
 
 /datum/design/turbine_part_compressor
 	name = "Turbine Part - Compressor"

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -79,7 +79,7 @@
 	desc = "The circuit board that for a SUPERPACMAN-type portable generator."
 	id = "superpacman"
 	build_path = /obj/item/circuitboard/machine/pacman/super
-	departmental_flags = DEPARTMENTAL_BITFLAG_ENGINEERING
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
 
 /datum/design/turbine_part_compressor
 	name = "Turbine Part - Compressor"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -630,6 +630,7 @@
 		"smes",
 		"super_capacitor",
 		"super_cell",
+		"superpacman",
 		"turbine_compressor",
 		"turbine_rotor",
 		"turbine_stator",


### PR DESCRIPTION
This reverts commit 42674e1d2559dfb137a55f7611d70fee79009220.

## About The Pull Request

Reverts Portable Generator (PACMAN) nerfs.
Portable generators consume fuel at a highly increased rate, roughly five times faster than their previous rate.

## How This Contributes To The Skyrat Roleplay Experience

These machines are both very important to ghost roles and space ruins, but are extremely important here for round health in general. If the supermatter explodes, there is basically no way to power the station anymore now. A shuttle call is practically required. I have never seen any engineering team come back and completely rebuild a supermatter from an exploded one and with this there was no real ways left to keep the station on life support for probably hours.
I have kept the part where they consume fuel extremely fast. I saw this as a good thing, since when fully upgraded you could leave it and forget about it for the rest of the round.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: PACMAN generators have been reverted to their old behaviour
balance: PACMAN generators now guzzle sheets at a highly increased rate, meaning you can no longer fully upgrade them and have them still running for hours at max power.
/:cl:

