### PR TITLE
Fixing the Phantom Rods in Forging Tongs

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/forge.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge.dm
@@ -569,6 +569,9 @@
 		forge_item.in_use = FALSE
 		user.mind.adjust_experience(/datum/skill/smithing, 10) //creating an item gives you some experience, not a lot
 		to_chat(user, span_notice("You successfully heat up [search_rods], ready to forge a [user_choice]."))
+		search_rods = locate(/obj/item/stack/rods) in forge_item.contents
+		if(!search_rods)
+			forge_item.icon_state = "tong_empty"
 		return FALSE
 	in_use = FALSE
 	forge_item.in_use = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a small visual bug with the forging tongs, when the tongs have only 1 rod in them, and thus are using the sprite to show that the tongs are full, they do not switch to the empty tongs sprite when forging their final rod into an item. This was just a visual bug, the tongs were still empty and could still pick up other objects. This resolves that, meaning the forging tongs revert to their empty sprite when their final rod is forged.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Resolves a minor bug increasing visual clarity.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Forging tongs now display as being empty when their final rod is forged into an item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
