### PR TITLE
organic interface code standards cleanup

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/arousal_system.dm
@@ -78,14 +78,14 @@
 	reagent_state = LIQUID
 	overdose_threshold = 10
 
-/datum/reagent/drug/dopamine/on_mob_add(mob/living/carbon/human/M)
-	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "[type]_start", /datum/mood_event/orgasm, name)
+/datum/reagent/drug/dopamine/on_mob_add(mob/living/carbon/human/affected_mob)
+	SEND_SIGNAL(affected_mob, COMSIG_ADD_MOOD_EVENT, "[type]_start", /datum/mood_event/orgasm, name)
 	..()
 
-/datum/reagent/drug/dopamine/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.set_timed_status_effect(2 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
+/datum/reagent/drug/dopamine/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
+	affected_mob.set_timed_status_effect(2 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
 	if(prob(7))
-		M.emote(pick("shaking","moan"))
+		affected_mob.emote(pick("shaking", "moan"))
 	..()
 
 /datum/reagent/drug/dopamine/overdose_start(mob/living/carbon/human/human_mob)
@@ -94,12 +94,12 @@
 	to_chat(human_mob, span_userdanger("You don't want to cum anymore!"))
 	SEND_SIGNAL(human_mob, COMSIG_ADD_MOOD_EVENT, "[type]_overdose", /datum/mood_event/overgasm, name)
 
-/datum/reagent/drug/dopamine/overdose_process(mob/living/carbon/human/M)
-	M.adjustArousal(0.5)
-	M.adjustPleasure(0.3)
-	M.adjustPain(-0.5)
+/datum/reagent/drug/dopamine/overdose_process(mob/living/carbon/human/affected_mob)
+	affected_mob.adjustArousal(0.5)
+	affected_mob.adjustPleasure(0.3)
+	affected_mob.adjustPain(-0.5)
 	if(prob(2))
-		M.emote(pick("moan","twitch_s"))
+		affected_mob.emote(pick("moan", "twitch_s"))
 	return
 
 ///////////-----Initilaze------///////////
@@ -147,7 +147,7 @@
 
 /mob/living/carbon/human/Initialize()
 	. = ..()
-	if(!istype(src,/mob/living/carbon/human/species/monkey))
+	if(!istype(src, /mob/living/carbon/human/species/monkey))
 		apply_status_effect(/datum/status_effect/aroused)
 		apply_status_effect(/datum/status_effect/body_fluid_regen)
 
@@ -183,28 +183,28 @@
 	alert_type = null
 
 /datum/status_effect/body_fluid_regen/tick()
-	var/mob/living/carbon/human/H = owner
-	if(owner.stat != DEAD && H.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
+	var/mob/living/carbon/human/affected_mob = owner
+	if(owner.stat != DEAD && affected_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 		var/obj/item/organ/genital/testicles/balls = owner.getorganslot(ORGAN_SLOT_TESTICLES)
 		var/obj/item/organ/genital/breasts/breasts = owner.getorganslot(ORGAN_SLOT_BREASTS)
 		var/obj/item/organ/genital/vagina/vagina = owner.getorganslot(ORGAN_SLOT_VAGINA)
 
 		var/interval = 5
 		if(balls)
-			if(H.arousal >= AROUS_SYS_LITTLE)
-				var/regen = (H.arousal/25) * (balls.internal_fluids.maximum_volume/235) * interval
+			if(affected_mob.arousal >= AROUS_SYS_LITTLE)
+				var/regen = (affected_mob.arousal / 25) * (balls.internal_fluids.maximum_volume / 235) * interval
 				balls.internal_fluids.add_reagent(/datum/reagent/consumable/cum, regen)
 
 		if(breasts)
 			if(breasts.lactates == TRUE)
-				var/regen = ((owner.nutrition / (NUTRITION_LEVEL_WELL_FED/100))/100) * (breasts.internal_fluids.maximum_volume/11000) * interval
+				var/regen = ((owner.nutrition / (NUTRITION_LEVEL_WELL_FED / 100)) / 100) * (breasts.internal_fluids.maximum_volume / 11000) * interval
 				if(!breasts.internal_fluids.holder_full())
 					owner.adjust_nutrition(-regen / 2)
 					breasts.internal_fluids.add_reagent(/datum/reagent/consumable/breast_milk, regen)
 
 		if(vagina)
-			if(H.arousal >= AROUS_SYS_LITTLE)
-				var/regen = (H.arousal/25) * (vagina.internal_fluids.maximum_volume/250) * interval
+			if(affected_mob.arousal >= AROUS_SYS_LITTLE)
+				var/regen = (affected_mob.arousal / 25) * (vagina.internal_fluids.maximum_volume / 250) * interval
 				vagina.internal_fluids.add_reagent(/datum/reagent/consumable/girlcum, regen)
 				if(vagina.internal_fluids.holder_full() && regen >= 0.15)
 					regen = regen
@@ -229,19 +229,19 @@
 
 		if(arousal_status != arousal_flag) // Set organ arousal status
 			arousal_status = arousal_flag
-			if(istype(src,/mob/living/carbon/human))
-				var/mob/living/carbon/human/M = src
-				for(var/i=1,i<=M.internal_organs.len,i++)
-					if(istype(M.internal_organs[i],/obj/item/organ/genital))
-						var/obj/item/organ/genital/G = M.internal_organs[i]
-						if(!G.aroused == AROUSAL_CANT)
-							G.aroused = arousal_status
-							G.update_sprite_suffix()
-				M.update_body()
+			if(istype(src, /mob/living/carbon/human))
+				var/mob/living/carbon/human/target = src
+				for(var/i = 1, i <= target.internal_organs.len, i++)
+					if(istype(target.internal_organs[i], /obj/item/organ/genital))
+						var/obj/item/organ/genital/target_genital = target.internal_organs[i]
+						if(!target_genital.aroused == AROUSAL_CANT)
+							target_genital.aroused = arousal_status
+							target_genital.update_sprite_suffix()
+				target.update_body()
 	else
 		arousal -= abs(arous)
 
-		arousal = min(max(arousal,0),100)
+		arousal = min(max(arousal, 0), 100)
 
 /datum/status_effect/aroused
 	id = "aroused"
@@ -250,65 +250,65 @@
 	alert_type = null
 
 /datum/status_effect/aroused/tick()
-	var/mob/living/carbon/human/H = owner
+	var/mob/living/carbon/human/affected_mob = owner
 	var/temp_arousal = -0.1
 	var/temp_pleasure = -0.5
 	var/temp_pain = -0.5
-	if(H.stat != DEAD)
+	if(affected_mob.stat != DEAD)
 
-		var/obj/item/organ/genital/testicles/balls = H.getorganslot(ORGAN_SLOT_TESTICLES)
+		var/obj/item/organ/genital/testicles/balls = affected_mob.getorganslot(ORGAN_SLOT_TESTICLES)
 		if(balls)
 			if(balls.internal_fluids.holder_full())
 				temp_arousal += 0.08
 
-		if(HAS_TRAIT(H, TRAIT_MASOCHISM))
+		if(HAS_TRAIT(affected_mob, TRAIT_MASOCHISM))
 			temp_pain -= 0.5
-		if(HAS_TRAIT(H, TRAIT_NEVERBONER))
+		if(HAS_TRAIT(affected_mob, TRAIT_NEVERBONER))
 			temp_pleasure -= 50
 			temp_arousal -= 50
 
-		if(H.pain > H.pain_limit)
+		if(affected_mob.pain > affected_mob.pain_limit)
 			temp_arousal -= 0.1
-		if(H.arousal >= AROUS_SYS_STRONG && H.stat != DEAD)
+		if(affected_mob.arousal >= AROUS_SYS_STRONG && affected_mob.stat != DEAD)
 			if(prob(3))
-				H.emote(pick("moan","blush"))
+				affected_mob.emote(pick("moan", "blush"))
 			temp_pleasure += 0.1
 			//moan
-		if(H.pleasure >= PLEAS_SYS_EDGE && H.stat != DEAD)
+		if(affected_mob.pleasure >= PLEAS_SYS_EDGE && affected_mob.stat != DEAD)
 			if(prob(3))
-				H.emote(pick("moan","twitch_s"))
+				affected_mob.emote(pick("moan", "twitch_s"))
 			//moan x2
 
-	H.adjustArousal(temp_arousal)
-	H.adjustPleasure(temp_pleasure)
-	H.adjustPain(temp_pain)
+	affected_mob.adjustArousal(temp_arousal)
+	affected_mob.adjustPleasure(temp_pleasure)
+	affected_mob.adjustPain(temp_pain)
 
 ////Pain////
 /mob/living/carbon/human/proc/get_pain()
 	return pain
 
-/mob/living/carbon/human/proc/adjustPain(pn = 0)
+/mob/living/carbon/human/proc/adjustPain(change_amount = 0)
 	if(stat != DEAD && client?.prefs?.read_preference(/datum/preference/toggle/erp))
-		if(pain > pain_limit || pn > pain_limit / 10) // pain system // YOUR SYSTEM IS PAIN, WHY WE'RE GETTING AROUSED BY STEPPING ON ANTS?!
+		if(pain > pain_limit || change_amount > pain_limit / 10) // pain system // YOUR SYSTEM IS PAIN, WHY WE'RE GETTING AROUSED BY STEPPING ON ANTS?!
 			if(HAS_TRAIT(src, TRAIT_MASOCHISM))
-				var/p = pn - (pain_limit / 10)
-				if(p > 0)
-					adjustArousal(-p)
+				var/arousal_adjustment = change_amount - (pain_limit / 10)
+				if(arousal_adjustment > 0)
+					adjustArousal(-arousal_adjustment)
 			else
-				if(pn > 0)
-					adjustArousal(-pn)
-			if(prob(2) && pain > pain_limit && pn > pain_limit / 10)
-				emote(pick("scream","shiver")) //SCREAM!!!
+				if(change_amount > 0)
+					adjustArousal(-change_amount)
+			if(prob(2) && pain > pain_limit && change_amount > pain_limit / 10)
+				emote(pick("scream", "shiver")) //SCREAM!!!
 		else
-			if(pn > 0)
-				adjustArousal(pn)
+			if(change_amount > 0)
+				adjustArousal(change_amount)
 			if(HAS_TRAIT(src, TRAIT_MASOCHISM))
-				var/p = pn / 2
-				adjustPleasure(p)
-		pain += pn
+				var/pleasure_adjustment = change_amount / 2
+				adjustPleasure(pleasure_adjustment)
+		pain += change_amount
 	else
-		pain -= abs(pn)
-	pain = min(max(pain,0),100)
+		pain -= abs(change_amount)
+	pain = min(max(pain, 0), 100)
 
 ////Pleasure////
 /mob/living/carbon/human/proc/get_pleasure()
@@ -321,24 +321,24 @@
 			climax(FALSE)
 	else
 		pleasure -= abs(pleas)
-	pleasure = min(max(pleasure,0),100)
+	pleasure = min(max(pleasure, 0), 100)
 
-// get damage for pain system
-/datum/species/apply_damage(damage, damagetype, def_zone, blocked, mob/living/carbon/human/H, forced, spread_damage, wound_bonus, bare_wound_bonus, sharpness, attack_direction)
+// Get damage for pain system
+/datum/species/apply_damage(damage, damagetype, def_zone, blocked, mob/living/carbon/human/affected_mob, forced, spread_damage, wound_bonus, bare_wound_bonus, sharpness, attack_direction)
 	. = ..()
 	if(!.)
 		return
-	if(H.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
+	if(affected_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 		return
-	var/hit_percent = (100-(blocked+armor))/100
-	hit_percent = (hit_percent * (100-H.physiology.damage_resistance))/100
+	var/hit_percent = (100 - (blocked + armor)) / 100
+	hit_percent = (hit_percent * (100 - affected_mob.physiology.damage_resistance)) / 100
 	switch(damagetype)
 		if(BRUTE)
-			var/amount = forced ? damage : damage * hit_percent * brutemod * H.physiology.brute_mod
-			INVOKE_ASYNC(H, /mob/living/carbon/human/.proc/adjustPain, amount)
+			var/amount = forced ? damage : damage * hit_percent * brutemod * affected_mob.physiology.brute_mod
+			INVOKE_ASYNC(affected_mob, /mob/living/carbon/human/.proc/adjustPain, amount)
 		if(BURN)
-			var/amount = forced ? damage : damage * hit_percent * burnmod * H.physiology.burn_mod
-			INVOKE_ASYNC(H, /mob/living/carbon/human/.proc/adjustPain, amount)
+			var/amount = forced ? damage : damage * hit_percent * burnmod * affected_mob.physiology.burn_mod
+			INVOKE_ASYNC(affected_mob, /mob/living/carbon/human/.proc/adjustPain, amount)
 
 ////////////
 ///CLIMAX///
@@ -524,16 +524,16 @@
 	alert_type = null
 
 /datum/status_effect/masturbation_climax/tick() //this one should not leave decals on the floor. Used in case if character cumming on somebody's face or in beaker.
-	var/mob/living/carbon/human/H = owner
-	if(H.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
+	var/mob/living/carbon/human/affected_mob = owner
+	if(affected_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 		var/temp_arousal = -12
 		var/temp_pleasure = -12
 		var/temp_stamina = 8
 
 		owner.reagents.add_reagent(/datum/reagent/drug/dopamine, 0.3)
 		owner.adjustStaminaLoss(temp_stamina)
-		H.adjustArousal(temp_arousal)
-		H.adjustPleasure(temp_pleasure)
+		affected_mob.adjustArousal(temp_arousal)
+		affected_mob.adjustPleasure(temp_pleasure)
 
 /datum/status_effect/climax
 	id = "climax"
@@ -542,16 +542,16 @@
 	alert_type = null
 
 /datum/status_effect/climax/tick()
-	var/mob/living/carbon/human/H = owner
-	if(H.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
+	var/mob/living/carbon/human/affected_mob = owner
+	if(affected_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 		var/temp_arousal = -12
 		var/temp_pleasure = -12
 		var/temp_stamina = 15
 
 		owner.reagents.add_reagent(/datum/reagent/drug/dopamine, 0.5)
 		owner.adjustStaminaLoss(temp_stamina)
-		H.adjustArousal(temp_arousal)
-		H.adjustPleasure(temp_pleasure)
+		affected_mob.adjustArousal(temp_arousal)
+		affected_mob.adjustPleasure(temp_pleasure)
 
 ////////////////////////
 ///SPANKING PROCEDURE///
@@ -564,10 +564,9 @@
 	alert_type = null
 
 /mob/living/carbon/human/examine(mob/user)
-	.=..()
-	var/mob/living/U = user
-
-	if(stat != DEAD && !HAS_TRAIT(src, TRAIT_FAKEDEATH) && src != U)
+	. = ..()
+	var/mob/living/affected_mob = user
+	if(stat != DEAD && !HAS_TRAIT(src, TRAIT_FAKEDEATH) && src != affected_mob)
 		if(src != user)
 			if(has_status_effect(/datum/status_effect/spanked) && is_bottomless())
 				. += span_purple("[user.p_their(TRUE)] butt has a red tint to it.") + "\n"
@@ -618,7 +617,7 @@
 
 /datum/mood_event/ropebunny
 	description = span_purple("I'm tied! Cannot move! These ropes... Ah!~")
-	mood_change = 0 //I don't want to doom the station to sonic-speed perverts, but still want to keep this as mood modifier.
+	mood_change = 0 // I don't want to doom the station to sonic-speed perverts, but still want to keep this as mood modifier.
 
 ///////////////////////
 ///AROUSAL INDICATOR///
@@ -740,26 +739,26 @@
 	cumface = mutable_appearance('modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_decals/lewd_decals.dmi')
 
 	if(ishuman(parent))
-		var/mob/living/carbon/human/H = parent
-		if(H.dna.species.id == SPECIES_LIZARD)
+		var/mob/living/carbon/human/target = parent
+		if(target.dna.species.id == SPECIES_LIZARD)
 			cumface.icon_state = "cumface_lizard"
-		else if(H.dna.species.id == SPECIES_MONKEY)
+		else if(target.dna.species.id == SPECIES_MONKEY)
 			cumface.icon_state = "cumface_monkey"
-		else if(H.dna.species.id == SPECIES_VOX)
+		else if(target.dna.species.id == SPECIES_VOX)
 			cumface.icon_state = "cumface_vox"
-		else if(H.dna.species.mutant_bodyparts["snout"])
+		else if(target.dna.species.mutant_bodyparts["snout"])
 			cumface.icon_state = "cumface_lizard"
 		else
 			cumface.icon_state = "cumface_human"
 	else if(isAI(parent))
 		cumface.icon_state = "cumface_ai"
 
-	var/atom/A = parent
-	A.add_overlay(cumface)
+	var/atom/overlayed_atom = parent
+	overlayed_atom.add_overlay(cumface)
 
 /datum/component/cumfaced/Destroy(force, silent)
-	var/atom/A = parent
-	A.cut_overlay(cumface)
+	var/atom/overlayed_atom = parent
+	overlayed_atom.cut_overlay(cumface)
 	qdel(cumface)
 	return ..()
 
@@ -797,26 +796,26 @@
 	bigcumface = mutable_appearance('modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_decals/lewd_decals.dmi')
 
 	if(ishuman(parent))
-		var/mob/living/carbon/human/H = parent
-		if(H.dna.species.id == "lizard")
+		var/mob/living/carbon/human/target = parent
+		if(target.dna.species.id == "lizard")
 			bigcumface.icon_state = "bigcumface_lizard"
-		else if(H.dna.species.id == "monkey")
+		else if(target.dna.species.id == "monkey")
 			bigcumface.icon_state = "bigcumface_monkey"
-		else if(H.dna.species.id == "vox")
+		else if(target.dna.species.id == "vox")
 			bigcumface.icon_state = "bigcumface_vox"
-		else if(H.dna.species.mutant_bodyparts["snout"])
+		else if(target.dna.species.mutant_bodyparts["snout"])
 			bigcumface.icon_state = "bigcumface_lizard"
 		else
 			bigcumface.icon_state = "bigcumface_human"
 	else if(isAI(parent))
 		bigcumface.icon_state = "cumface_ai"
 
-	var/atom/A = parent
-	A.add_overlay(bigcumface)
+	var/atom/overlayed_atom = parent
+	overlayed_atom.add_overlay(bigcumface)
 
 /datum/component/cumfaced/big/Destroy(force, silent)
-	var/atom/A = parent
-	A.cut_overlay(bigcumface)
+	var/atom/overlayed_atom = parent
+	overlayed_atom.cut_overlay(bigcumface)
 	qdel(bigcumface)
 	return ..()
 
@@ -842,12 +841,12 @@
 
 
 	var/obj/item/coomer = new /obj/item/hand_item/coom(user)
-	var/mob/living/carbon/human/H = user
+	var/mob/living/carbon/human/target = user
 	var/obj/item/held = user.get_active_held_item()
 	var/obj/item/unheld = user.get_inactive_held_item()
-	if(user.put_in_hands(coomer) && H.dna.species.mutant_bodyparts["testicles"] && H.dna.species.mutant_bodyparts["penis"])
+	if(user.put_in_hands(coomer) && target.dna.species.mutant_bodyparts["testicles"] && target.dna.species.mutant_bodyparts["penis"])
 		if(held || unheld)
-			if(!((held.name=="cum" && held.item_flags == DROPDEL | ABSTRACT | HAND_ITEM) || (unheld.name=="cum" && unheld.item_flags == DROPDEL | ABSTRACT | HAND_ITEM)))
+			if(!((held.name == "cum" && held.item_flags == DROPDEL | ABSTRACT | HAND_ITEM) || (unheld.name == "cum" && unheld.item_flags == DROPDEL | ABSTRACT | HAND_ITEM)))
 				to_chat(user, span_notice("You mentally prepare yourself to masturbate."))
 			else
 				qdel(coomer)
@@ -864,51 +863,51 @@
 	icon_state = "eggplant"
 	inhand_icon_state = "nothing"
 
-/obj/item/hand_item/coom/attack(mob/living/M, mob/user, proximity)
+/obj/item/hand_item/coom/attack(mob/living/target, mob/user, proximity)
 	if (CONFIG_GET(flag/disable_erp_preferences))
 		return
 	if(!proximity)
 		return
-	if(!ishuman(M))
+	if(!ishuman(target))
 		return
 	if(user.stat == DEAD)
 		return
-	var/mob/living/carbon/human/human_cumvictim = M
+	var/mob/living/carbon/human/human_cumvictim = target
 	if(!human_cumvictim.client)
-		to_chat(user, span_warning("You can't cum onto [M]."))
+		to_chat(user, span_warning("You can't cum onto [target]."))
 		return
-	if(!(human_cumvictim.client.prefs.read_preference(/datum/preference/toggle/erp/cum_face))) //im just paranoid about runtime errors
-		to_chat(user, span_warning("You can't cum onto [M]."))
+	if(!(human_cumvictim.client.prefs.read_preference(/datum/preference/toggle/erp/cum_face))) // I'm just paranoid about runtime errors
+		to_chat(user, span_warning("You can't cum onto [target]."))
 		return
-	var/mob/living/carbon/human/H = user
-	var/obj/item/organ/genital/testicles/G = H.getorganslot(ORGAN_SLOT_TESTICLES)
-	var/obj/item/organ/genital/testicles/P = H.getorganslot(ORGAN_SLOT_PENIS)
-	var/datum/sprite_accessory/genital/spriteP = GLOB.sprite_accessories["penis"][H.dna.species.mutant_bodyparts["penis"][MUTANT_INDEX_NAME]]
-	if(spriteP.is_hidden(H))
+	var/mob/living/carbon/human/affected_human = user
+	var/obj/item/organ/genital/testicles/testicles = affected_human.getorganslot(ORGAN_SLOT_TESTICLES)
+	var/obj/item/organ/genital/penis/penis = affected_human.getorganslot(ORGAN_SLOT_PENIS)
+	var/datum/sprite_accessory/genital/penis_accessory = GLOB.sprite_accessories["penis"][affected_human.dna.species.mutant_bodyparts["penis"][MUTANT_INDEX_NAME]]
+	if(penis_accessory.is_hidden(affected_human))
 		to_chat(user, span_notice("You need to expose yourself in order to masturbate."))
 		return
-	else if(P.aroused != AROUSAL_FULL)
+	else if(penis.aroused != AROUSAL_FULL)
 		to_chat(user, span_notice("You need to be aroused in order to masturbate."))
 		return
-	var/cum_volume = G.genital_size*5+5
-	var/datum/reagents/R = new/datum/reagents(50)
-	R.add_reagent(/datum/reagent/consumable/cum, cum_volume)
-	if(M==user)
-		user.visible_message(span_warning("[user] starts masturbating onto [M.p_them()]self!"), span_danger("You start masturbating onto yourself!"))
+	var/cum_volume = testicles.genital_size * 5 + 5
+	var/datum/reagents/applied_reagents = new/datum/reagents(50)
+	applied_reagents.add_reagent(/datum/reagent/consumable/cum, cum_volume)
+	if(target == user)
+		user.visible_message(span_warning("[user] starts masturbating onto [target.p_them()]self!"), span_danger("You start masturbating onto yourself!"))
 	else
-		user.visible_message(span_warning("[user] starts masturbating onto [M]!"), span_danger("You start masturbating onto [M]!"))
-	if(do_after(user,60,M))
-		if(M==user)
-			user.visible_message(span_warning("[user] cums on [M.p_them()]self!"), span_danger("You cum on yourself!"))
+		user.visible_message(span_warning("[user] starts masturbating onto [target]!"), span_danger("You start masturbating onto [target]!"))
+	if(do_after(user, 60, target))
+		if(target == user)
+			user.visible_message(span_warning("[user] cums on [target.p_them()]self!"), span_danger("You cum on yourself!"))
 		else
-			user.visible_message(span_warning("[user] cums on [M]!"), span_danger("You cum on [M]!"))
-		R.expose(M, TOUCH)
-		log_combat(user, M, "came on")
+			user.visible_message(span_warning("[user] cums on [target]!"), span_danger("You cum on [target]!"))
+		applied_reagents.expose(target, TOUCH)
+		log_combat(user, target, "came on")
 		if(prob(40))
 			user.emote("moan")
 		qdel(src)
 
-//jerk off into bottles
+// Jerk off into bottles
 /obj/item/hand_item/coom/afterattack(obj/target, mob/user, proximity)
 	. = ..()
 	if (CONFIG_GET(flag/disable_erp_preferences))
@@ -919,38 +918,38 @@
 		return
 	if(user.stat == DEAD)
 		return
-	var/mob/living/carbon/human/H = user
-	var/obj/item/organ/genital/testicles/G = H.getorganslot(ORGAN_SLOT_TESTICLES)
-	var/obj/item/organ/genital/testicles/P = H.getorganslot(ORGAN_SLOT_PENIS)
-	var/datum/sprite_accessory/genital/spriteP = GLOB.sprite_accessories["penis"][H.dna.species.mutant_bodyparts["penis"][MUTANT_INDEX_NAME]]
-	if(spriteP.is_hidden(H))
+	var/mob/living/carbon/human/affected_human = user
+	var/obj/item/organ/genital/testicles/testicles = affected_human.getorganslot(ORGAN_SLOT_TESTICLES)
+	var/obj/item/organ/genital/penis/penis = affected_human.getorganslot(ORGAN_SLOT_PENIS)
+	var/datum/sprite_accessory/genital/spriteP = GLOB.sprite_accessories["penis"][affected_human.dna.species.mutant_bodyparts["penis"][MUTANT_INDEX_NAME]]
+	if(spriteP.is_hidden(affected_human))
 		to_chat(user, span_notice("You need to expose yourself in order to masturbate."))
 		return
-	else if(P.aroused != AROUSAL_FULL)
+	else if(penis.aroused != AROUSAL_FULL)
 		to_chat(user, span_notice("You need to be aroused in order to masturbate."))
 		return
 	if(target.is_refillable() && target.is_drainable())
-		var/cum_volume = G.genital_size*5+5
+		var/cum_volume = testicles.genital_size*5+5
 		if(target.reagents.holder_full())
 			to_chat(user, span_warning("[target] is full."))
 			return
-		var/datum/reagents/R = new/datum/reagents(50)
-		R.add_reagent(/datum/reagent/consumable/cum, cum_volume)
+		var/datum/reagents/applied_reagents = new/datum/reagents(50)
+		applied_reagents.add_reagent(/datum/reagent/consumable/cum, cum_volume)
 		user.visible_message(span_warning("[user] starts masturbating into [target]!"), span_danger("You start masturbating into [target]!"))
-		if(do_after(user,60))
+		if(do_after(user, 60))
 			user.visible_message(span_warning("[user] cums into [target]!"), span_danger("You cum into [target]!"))
 			playsound(target, SFX_DESECRATION, 50, TRUE, ignore_walls = FALSE)
-			R.trans_to(target, cum_volume)
+			applied_reagents.trans_to(target, cum_volume)
 			if(prob(40))
 				user.emote("moan")
 			qdel(src)
 	else
 		user.visible_message(span_warning("[user] starts masturbating onto [target]!"), span_danger("You start masturbating onto [target]!"))
-		if(do_after(user,60))
-			var/turf/T = get_turf(target)
+		if(do_after(user, 60))
+			var/turf/target_turf = get_turf(target)
 			user.visible_message(span_warning("[user] cums on [target]!"), span_danger("You cum on [target]!"))
 			playsound(target, SFX_DESECRATION, 50, TRUE, ignore_walls = FALSE)
-			new/obj/effect/decal/cleanable/cum(T)
+			new/obj/effect/decal/cleanable/cum(target_turf)
 			if(prob(40))
 				user.emote("moan")
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/chemistry_for_ERP.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/chemistry_for_ERP.dm
@@ -187,7 +187,7 @@
 /datum/reagent/drug/aphrodisiac/dopamine/life_effects(mob/living/carbon/human/exposed_mob)
 	exposed_mob.set_timed_status_effect(drugginess_amount, /datum/status_effect/drugginess)
 	if(prob(drugginess_chance))
-		exposed_mob.emote(pick("twitch","drool","moan","giggle","shaking"))
+		exposed_mob.emote(pick("twitch", "drool", "moan", "giggle", "shaking"))
 
 /datum/reagent/drug/aphrodisiac/dopamine/overdose_start(mob/living/carbon/human/exposed_mob)
 	. = ..()
@@ -201,7 +201,7 @@
 	exposed_mob.adjustPleasure(pleasure_adjust_amount)
 	exposed_mob.adjustPain(pain_adjust_amount)
 	if(prob(2))
-		exposed_mob.emote(pick("moan","twitch_s"))
+		exposed_mob.emote(pick("moan", "twitch_s"))
 
 /*
 * ANAPHRODISIACS
@@ -361,21 +361,21 @@
 		enlargement_amount = 0
 
 		/// Words for the breasts when huge.
-		var/static/list/words_for_bigger = list("huge", "massive", "squishy", "gigantic", "rather large", "jiggly", "hefty",)
+		var/static/list/words_for_bigger = list("huge", "massive", "squishy", "gigantic", "rather large", "jiggly", "hefty", )
 		/// Synonyms for breasts.
-		var/static/list/boob_text_list = list("boobs", "tits", "breasts",)
+		var/static/list/boob_text_list = list("boobs", "tits", "breasts", )
 		/// Synonyms for the chest.
-		var/static/list/covered_boobs_list = list("bust", "chest", "bosom",)
+		var/static/list/covered_boobs_list = list("bust", "chest", "bosom", )
 		/// Synonyms for bigger breasts.
-		var/static/list/bigger_boob_text_list = list("jigglies", "melons", "jugs", "boobies", "milkers", "boobs", "tits", "breasts",)
+		var/static/list/bigger_boob_text_list = list("jigglies", "melons", "jugs", "boobies", "milkers", "boobs", "tits", "breasts", )
 		/// Wording chosen to expand the breasts, shown only to the mob.
-		var/static/list/action_text_list = list("expand outward to ", "grow out to ", "begin to enlarge, growing to ", "suddenly expand to ", "swell out to ",)
+		var/static/list/action_text_list = list("expand outward to ", "grow out to ", "begin to enlarge, growing to ", "suddenly expand to ", "swell out to ", )
 		/// Wording chosen to be seen by other mobs, regardless of whether mob is clothed/unclothed.
-		var/static/list/public_bigger_action_text_list = list("expand and jiggle outward.", "grow a bit larger, bouncing about.", "seem a bit bigger than they were before.", "bounce and jiggle as they suddenly expand.",)
+		var/static/list/public_bigger_action_text_list = list("expand and jiggle outward.", "grow a bit larger, bouncing about.", "seem a bit bigger than they were before.", "bounce and jiggle as they suddenly expand.", )
 		/// Wording chosen to be seen by other mobs, while mob is unclothed.
-		var/static/list/public_action_text_list = list("expand outward.", "seem to grow a bit larger.", "appear a bit bigger than they were before.", "bounce and jiggle as they suddenly expand.",)
+		var/static/list/public_action_text_list = list("expand outward.", "seem to grow a bit larger.", "appear a bit bigger than they were before.", "bounce and jiggle as they suddenly expand.", )
 		/// Wording chosen to be seen by other mobs, while mob is clothed.
-		var/static/list/notice_boobs = list("seems to be a bit tighter.", "appears to be a bit bigger.", "seems to swell outward a bit.",)
+		var/static/list/notice_boobs = list("seems to be a bit tighter.", "appears to be a bit bigger.", "seems to swell outward a bit.", )
 		/// Checks for cup size.
 		var/translation = breasts_size_to_cup(mob_breasts.genital_size)
 
@@ -503,15 +503,15 @@
 		exposed_mob.update_body()
 		enlargement_amount = 0
 		/// Words for the cock when huge.
-		var/static/list/words_for_bigger_cock = list("huge", "massive", "gigantic", "rather lengthy", "colossal", "hefty",)
+		var/static/list/words_for_bigger_cock = list("huge", "massive", "gigantic", "rather lengthy", "colossal", "hefty", )
 		/// Synonyms for cock.
-		var/static/list/cock_text_list = list("cock", "penis", "dick", "member", "richard", "johnston", "johnson",)
+		var/static/list/cock_text_list = list("cock", "penis", "dick", "member", "richard", "johnston", "johnson", )
 		/// Synonyms for bigger cock.
-		var/static/list/bigger_cock_text_list = list("rod", "shaft", "cock", "penis", "dick", "member", "richard", "johnston", "johnson",)
+		var/static/list/bigger_cock_text_list = list("rod", "shaft", "cock", "penis", "dick", "member", "richard", "johnston", "johnson", )
 		/// Wording chosen to extend the cock, shown only to the mob.
-		var/static/list/cock_action_text_list = list("extends to ", "grows out to ", "begins to enlarge, growing to ", "suddenly expands to ", "lengthens out to ",)
+		var/static/list/cock_action_text_list = list("extends to ", "grows out to ", "begins to enlarge, growing to ", "suddenly expands to ", "lengthens out to ", )
 		/// Wording chosen to be seen by other mobs, while mob is unclothed.
-		var/static/list/public_cock_action_text_list = list("expands by an inch or so.", "appears to grow a bit longer.", "seems a bit bigger than it was before.", "suddenly lengthens about an inch or two.",)
+		var/static/list/public_cock_action_text_list = list("expands by an inch or so.", "appears to grow a bit longer.", "seems a bit bigger than it was before.", "suddenly lengthens about an inch or two.", )
 
 		if(mob_penis.visibility_preference == GENITAL_ALWAYS_SHOW || exposed_mob.is_bottomless())
 			if(mob_penis?.genital_size >= (penis_max_length - 2))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/ballgag.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/ballgag.dm
@@ -130,5 +130,5 @@
 		if("large")
 			wearer.adjustOxyLoss(rand(1, 4))
 	if(prob(10))
-		wearer.emote(pick("gasp","choke","moan"))
+		wearer.emote(pick("gasp", "choke", "moan"))
 	choke_timer = 0

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/bdsm_mask.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/bdsm_mask.dm
@@ -41,15 +41,15 @@
 	flags_cover = MASKCOVERSMOUTH
 
 /obj/item/clothing/mask/gas/bdsm_mask/proc/update_action_buttons_icons()
-	var/datum/action/item_action/M
+	var/datum/action/item_action/button
 
-	for(M in src.actions)
-		if(istype(M, /datum/action/item_action/toggle_breathcontrol))
-			M.button_icon_state = "[current_mask_color]_switch_[mask_on? "on" : "off"]"
-			M.icon_icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_icons.dmi'
-		if(istype(M, /datum/action/item_action/mask_inhale))
-			M.button_icon_state = "[current_mask_color]_breath"
-			M.icon_icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_icons.dmi'
+	for(button in src.actions)
+		if(istype(button, /datum/action/item_action/toggle_breathcontrol))
+			button.button_icon_state = "[current_mask_color]_switch_[mask_on? "on" : "off"]"
+			button.icon_icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_icons.dmi'
+		if(istype(button, /datum/action/item_action/mask_inhale))
+			button.button_icon_state = "[current_mask_color]_breath"
+			button.icon_icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_icons.dmi'
 	update_icon()
 
 /obj/item/clothing/mask/gas/bdsm_mask/handle_speech(datum/source, list/speech_args)
@@ -66,11 +66,11 @@
 		"cyan" = image(icon = src.icon, icon_state = "mask_cyan_off"))
 
 // Using multitool on pole
-/obj/item/clothing/mask/gas/bdsm_mask/AltClick(mob/user, obj/item/I)
+/obj/item/clothing/mask/gas/bdsm_mask/AltClick(mob/user)
 	if(color_changed == FALSE)
 		if(.)
 			return
-		var/choice = show_radial_menu(user,src, mask_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, mask_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		current_mask_color = choice
@@ -113,46 +113,46 @@
 /obj/item/clothing/mask/gas/bdsm_mask/attack_hand(mob/user)
 	if(iscarbon(user))
 		if(mask_on == TRUE)
-			var/mob/living/carbon/C = user
-			if(C.wear_mask == src)
-				if(!do_after(C, 600, target = src))
-					to_chat(C, span_warning("You fail to remove the gas mask!"))
+			var/mob/living/carbon/wearer = user
+			if(wearer.wear_mask == src)
+				if(!do_after(wearer, 600, target = src))
+					to_chat(wearer, span_warning("You fail to remove the gas mask!"))
 					return
 				else
-					to_chat(C, span_notice("You remove the gas mask."))
+					to_chat(wearer, span_notice("You remove the gas mask."))
 	add_fingerprint(usr)
 	. = ..()
 
 // To make in unremovable without helping when mask is on (for MouseDrop)
 /obj/item/clothing/mask/gas/bdsm_mask/MouseDrop(atom/over_object)
-	var/mob/M = usr
-	var/mob/living/carbon/human/C = usr
-	if(ismecha(M.loc)) // Stops inventory actions in a mech
+	var/mob/target_mob = usr
+	var/mob/living/carbon/human/target_carbon = usr
+	if(ismecha(target_mob.loc)) // Stops inventory actions in a mech
 		return
-	if(!M.incapacitated())
-		if(loc == M)
+	if(!target_mob.incapacitated())
+		if(loc == target_mob)
 			if(istype(over_object, /atom/movable/screen/inventory/hand))
-				var/atom/movable/screen/inventory/hand/H = over_object
+				var/atom/movable/screen/inventory/hand/hand = over_object
 				if(iscarbon(usr))
 					if(mask_on == TRUE)
-						if(src == C.wear_mask || . == C.wear_mask)
-							if(!do_after(C, 600, target = src))
-								to_chat(M, span_warning("You fail to remove the gas mask!"))
+						if(src == target_carbon.wear_mask || . == target_carbon.wear_mask)
+							if(!do_after(target_carbon, 600, target = src))
+								to_chat(target_mob, span_warning("You fail to remove the gas mask!"))
 								return
 							else
-								to_chat(M, span_notice("You remove the gas mask."))
-				if(M.putItemFromInventoryInHandIfPossible(src, H.held_index))
+								to_chat(target_mob, span_notice("You remove the gas mask."))
+				if(target_mob.putItemFromInventoryInHandIfPossible(src, hand.held_index))
 					add_fingerprint(usr)
 				. = ..()
 
-// Handler for clicking on a slot in a mask by hand whith a filter
-/datum/component/storage/concrete/pockets/small/bdsm_mask/attackby(datum/source, obj/item/I, mob/M, params)
-	.=..()
-	var/obj/item/clothing/mask/gas/bdsm_mask/B = M.get_item_by_slot(ITEM_SLOT_MASK)
-	if(istype(I, /obj/item/reagent_containers/glass/lewd_filter))
-		if(B) // Null check
-			if(istype(B, /obj/item/clothing/mask/gas/bdsm_mask)) // Check that the mask is of the correct type
-				if(B.mask_on == TRUE)
+// Handler for clicking on a slot in a mask by hand with a filter
+/datum/component/storage/concrete/pockets/small/bdsm_mask/attackby(datum/source, obj/item/used_item, mob/user, params)
+	. = ..()
+	var/obj/item/clothing/mask/gas/bdsm_mask/worn_mask = user.get_item_by_slot(ITEM_SLOT_MASK)
+	if(istype(used_item, /obj/item/reagent_containers/glass/lewd_filter))
+		if(worn_mask) // Null check
+			if(istype(worn_mask, /obj/item/clothing/mask/gas/bdsm_mask)) // Check that the mask is of the correct type
+				if(worn_mask.mask_on == TRUE)
 					// Place for text about the impossibility to attach a filter
 					to_chat(usr, span_warning("You can't attach a filter while the mask is locked!"))
 					return
@@ -164,9 +164,9 @@
 
 // Trigger thing for manual breath
 /datum/action/item_action/toggle_breathcontrol/Trigger(trigger_flags)
-	var/obj/item/clothing/mask/gas/bdsm_mask/H = target
-	if(istype(H))
-		H.check()
+	var/obj/item/clothing/mask/gas/bdsm_mask/mask = target
+	if(istype(mask))
+		mask.check()
 
 /datum/action/item_action/mask_inhale
     name = "Inhale oxygen"
@@ -175,29 +175,29 @@
 // Open the valve when press the button
 /datum/action/item_action/mask_inhale/Trigger(trigger_flags)
 	if(istype(target, /obj/item/clothing/mask/gas/bdsm_mask))
-		var/obj/item/clothing/mask/gas/bdsm_mask/M = target
-		if(M.breath_status == FALSE)
-			M.time_to_choke_left = M.time_to_choke
-			M.breath_status = TRUE
-			var/mob/living/carbon/C = usr
-			C.emote("inhale")
-			var/obj/item/reagent_containers/glass/lewd_filter/F = M.contents[1]
-			F.reagent_consumption(C, F.amount_per_transfer_from_this)
+		var/obj/item/clothing/mask/gas/bdsm_mask/mask = target
+		if(mask.breath_status == FALSE)
+			mask.time_to_choke_left = mask.time_to_choke
+			mask.breath_status = TRUE
+			var/mob/living/carbon/affected_mob = usr
+			affected_mob.emote("inhale")
+			var/obj/item/reagent_containers/glass/lewd_filter/filter = mask.contents[1]
+			filter.reagent_consumption(affected_mob, filter.amount_per_transfer_from_this)
 		return
 	return ..()
 
 // Adding breath_manually on equip
 /obj/item/clothing/mask/gas/bdsm_mask/equipped(/mob/user, slot)
 	. = ..()
-	var/mob/living/carbon/human/C = loc
-	var/I = C.get_item_by_slot(ITEM_SLOT_MASK)
-	if(I==src)
+	var/mob/living/carbon/human/affected_human = loc
+	var/worn_mask = affected_human.get_item_by_slot(ITEM_SLOT_MASK)
+	if(worn_mask == src)
 		if(mask_on)
 			if(breath_status == FALSE)
 				time_to_choke_left = time_to_choke
 				breath_status = TRUE
-				C.emote("inhale")
-			to_chat(C, span_purple("You suddenly find it much harder to breathe!."))
+				affected_human.emote("inhale")
+			to_chat(affected_human, span_purple("You suddenly find it much harder to breathe!."))
 			START_PROCESSING(SSobj, src)
 			time_to_choke_left = time_to_choke
 
@@ -210,11 +210,11 @@
 
 // To check if player already have this mask on and trying to change mode
 /obj/item/clothing/mask/gas/bdsm_mask/proc/check()
-	var/mob/living/carbon/C = usr
-	if(src == C.wear_mask)
+	var/mob/living/carbon/affected_carbon = usr
+	if(src == affected_carbon.wear_mask)
 		to_chat(usr, span_notice("You can't reach the air filter switch!"))
 	else
-		toggle(C)
+		toggle(affected_carbon)
 
 // Switch the mask valve to the opposite state
 /obj/item/clothing/mask/gas/bdsm_mask/proc/toggle(user)
@@ -224,9 +224,9 @@
 	update_icon_state()
 	update_action_buttons_icons()
 	update_icon()
-	var/mob/living/carbon/human/C = usr
+	var/mob/living/carbon/human/affected_human = usr
 	if(mask_on)
-		if(src == C.wear_mask && C.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
+		if(src == affected_human.wear_mask && affected_human.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 			START_PROCESSING(SSobj, src)
 			time_to_choke_left = time_to_choke
 	else
@@ -234,27 +234,27 @@
 
 // Mask choke processor
 /obj/item/clothing/mask/gas/bdsm_mask/process(delta_time)
-	var/mob/living/U = loc
+	var/mob/living/affected_mob = loc
 	if(time_to_choke_left < time_to_choke/2 && breath_status == TRUE)
-		if(temp_check == FALSE && U.stat == CONSCIOUS) //If user passed out while wearing this we should continue when he wakes up
+		if(temp_check == FALSE && affected_mob.stat == CONSCIOUS) // If user passed out while wearing this we should continue when he wakes up
 			breath_status = FALSE
 			time_to_choke_left = time_to_choke
 			temp_check = TRUE
 
-		if(U.stat == CONSCIOUS)
-			U.emote("exhale")
+		if(affected_mob.stat == CONSCIOUS)
+			affected_mob.emote("exhale")
 			breath_status = FALSE
-			if(rand(0,3) == 0)
-				U.emote("moan")
+			if(rand(0, 3) == 0)
+				affected_mob.emote("moan")
 		else
 			breath_status = TRUE
 			temp_check = FALSE
 
 	if(time_to_choke_left <= 0)
 		if(tt <= 0)
-			if(U.stat == CONSCIOUS)
-				U.adjustOxyLoss(rand(4,8)) // Oxy dmg
-				U.emote(pick("gasp","choke","moan"))
+			if(affected_mob.stat == CONSCIOUS)
+				affected_mob.adjustOxyLoss(rand(4, 8)) // Oxy dmg
+				affected_mob.emote(pick("gasp", "choke", "moan"))
 				tt = time
 			else
 				breath_status = TRUE
@@ -277,9 +277,9 @@
 	unique_reskin = list("pink" = "filter_pink",
 						"teal" = "filter_teal")
 	w_class = WEIGHT_CLASS_SMALL
-	custom_materials = list(/datum/material/glass=1500, /datum/material/plastic=2000)
+	custom_materials = list(/datum/material/glass = 1500, /datum/material/plastic = 2000)
 	volume = 50
-	possible_transfer_amounts = list(1,2,3,4,5)
+	possible_transfer_amounts = list(1, 2, 3, 4, 5)
 	list_reagents = list(/datum/reagent/drug/aphrodisiac/crocin = 50)
 
 // Standard initialize code for filter
@@ -303,11 +303,11 @@
 		reskin_obj(user)
 		return
 	// After reskin all clicks go normal, but we can't change the flow rate if mask on and equipped
-	var/obj/item/clothing/mask/gas/bdsm_mask/B = user.get_item_by_slot(ITEM_SLOT_MASK)
-	if(B)
+	var/obj/item/clothing/mask/gas/bdsm_mask/worn_mask = user.get_item_by_slot(ITEM_SLOT_MASK)
+	if(worn_mask)
 		if(iscarbon(user))
-			if(istype(B, /obj/item/clothing/mask/gas/bdsm_mask))
-				if(B.mask_on == TRUE)
+			if(istype(worn_mask, /obj/item/clothing/mask/gas/bdsm_mask))
+				if(worn_mask.mask_on == TRUE)
 					if(istype(src, /obj/item/reagent_containers/glass/lewd_filter))
 						to_chat(user, span_warning("You can't change the flow rate of the valve while the mask is on!"))
 						return
@@ -315,11 +315,11 @@
 
 // Filter click handling
 /obj/item/reagent_containers/glass/lewd_filter/attack_hand(mob/user)
-	var/obj/item/clothing/mask/gas/bdsm_mask/B = user.get_item_by_slot(ITEM_SLOT_MASK)
-	if(B)
+	var/obj/item/clothing/mask/gas/bdsm_mask/worn_mask = user.get_item_by_slot(ITEM_SLOT_MASK)
+	if(worn_mask)
 		if(iscarbon(user))
-			if(istype(B, /obj/item/clothing/mask/gas/bdsm_mask))
-				if(B.mask_on == TRUE)
+			if(istype(worn_mask, /obj/item/clothing/mask/gas/bdsm_mask))
+				if(worn_mask.mask_on == TRUE)
 					if(istype(src, /obj/item/reagent_containers/glass/lewd_filter))
 						// Place for text about the impossibility of detaching the filter
 						to_chat(user, span_warning("You can't detach the filter while the mask is locked!"))
@@ -329,22 +329,22 @@
 	add_fingerprint(usr)
 
 // Processing a click with a mask filter on the mask. Needed to intercept call at the object class level. Returns automatically to attack_hand(mob/user) method.
-/obj/item/clothing/mask/gas/bdsm_mask/attackby(obj/item/I, mob/living/user, params)
-	return ..() || ((obj_flags & CAN_BE_HIT) && I.attack_atom(src, user))
+/obj/item/clothing/mask/gas/bdsm_mask/attackby(obj/item/used_item, mob/living/user, params)
+	return ..() || ((obj_flags & CAN_BE_HIT) && used_item.attack_atom(src, user))
 
 // Mouse drop handler
 /obj/item/reagent_containers/glass/lewd_filter/MouseDrop(atom/over_object)
-	var/mob/M = usr
-	var/mob/living/carbon/human/C = usr
-	var/obj/item/clothing/mask/gas/bdsm_mask/B = C.get_item_by_slot(ITEM_SLOT_MASK)
+	var/mob/affected_mob = usr
+	var/mob/living/carbon/human/affected_human = usr
+	var/obj/item/clothing/mask/gas/bdsm_mask/worn_mask = affected_human.get_item_by_slot(ITEM_SLOT_MASK)
 
-	if(ismecha(M.loc)) // Stops inventory actions in a mech
+	if(ismecha(affected_mob.loc)) // Stops inventory actions in a mech
 		return
 
-	if(!M.incapacitated())
-		if(loc == M)
+	if(!affected_mob.incapacitated())
+		if(loc == affected_mob)
 			if(iscarbon(usr))
-				if(B.mask_on == TRUE)
+				if(worn_mask.mask_on == TRUE)
 					if(istype(over_object, /atom/movable/screen/inventory/hand))
 						// Place for text about the impossibility of detaching the filter
 						to_chat(usr, span_warning("You can't detach the filter while the mask is locked!"))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/deprivation_helmet.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/deprivation_helmet.dm
@@ -13,7 +13,7 @@
 	righthand_file = 'modular_skyrat/modules/modular_items/lewd_items/icons/mob/lewd_inhands/lewd_inhand_right.dmi'
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT|HIDEFACIALHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 25, FIRE = 20, ACID = 15)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 25, FIRE = 20, ACID = 15)
 	clothing_flags = SNUG_FIT
 	var/color_changed = FALSE
 	//these three vars needed to turn deprivation stuff on or off
@@ -49,45 +49,45 @@
 
 //Vision switcher
 /datum/action/item_action/toggle_vision/Trigger(trigger_flags)
-	var/obj/item/clothing/head/helmet/space/deprivation_helmet/H = target
-	var/mob/living/carbon/C = usr
-	if(istype(H))
-		if(H == C.head)
+	var/obj/item/clothing/head/helmet/space/deprivation_helmet/deprivation_helmet = target
+	var/mob/living/carbon/affected_carbon = usr
+	if(istype(deprivation_helmet))
+		if(deprivation_helmet == affected_carbon.head)
 			to_chat(usr, span_notice("You can't reach the deprivation helmet switch!"))
 		else
-			H.SwitchHelmet("vision")
+			deprivation_helmet.SwitchHelmet("vision")
 
 //Hearing switcher
 /datum/action/item_action/toggle_hearing/Trigger(trigger_flags)
-	var/obj/item/clothing/head/helmet/space/deprivation_helmet/H = target
-	var/mob/living/carbon/C = usr
-	if(istype(H))
-		if(H == C.head)
+	var/obj/item/clothing/head/helmet/space/deprivation_helmet/deprivation_helmet = target
+	var/mob/living/carbon/affected_carbon = usr
+	if(istype(deprivation_helmet))
+		if(deprivation_helmet == affected_carbon.head)
 			to_chat(usr, span_notice("You can't reach the deprivation helmet switch!"))
 		else
-			H.SwitchHelmet("hearing")
+			deprivation_helmet.SwitchHelmet("hearing")
 
 //Speech switcher
 /datum/action/item_action/toggle_speech/Trigger(trigger_flags)
-	var/obj/item/clothing/head/helmet/space/deprivation_helmet/H = target
-	var/mob/living/carbon/C = usr
-	if(istype(H))
-		if(H == C.head)
+	var/obj/item/clothing/head/helmet/space/deprivation_helmet/deprivation_helmet = target
+	var/mob/living/carbon/affected_carbon = usr
+	if(istype(deprivation_helmet))
+		if(deprivation_helmet == affected_carbon.head)
 			to_chat(usr, span_notice("You can't reach the deprivation helmet switch!"))
 		else
-			H.SwitchHelmet("speech")
+			deprivation_helmet.SwitchHelmet("speech")
 
 //Helmet switcher
 /obj/item/clothing/head/helmet/space/deprivation_helmet/proc/SwitchHelmet(button)
-	var/C = button
-	if(C == "speech")
+	var/user_client = button
+	if(user_client == "speech")
 		if(muzzle == TRUE)
 			muzzle = FALSE
 			playsound(usr, 'sound/weapons/magout.ogg', 40, TRUE, ignore_walls = FALSE)
 			to_chat(usr, span_notice("Speech switch off"))
 			if(usr.get_item_by_slot(ITEM_SLOT_HEAD) == src)
 				REMOVE_TRAIT(usr, TRAIT_MUTE, CLOTHING_TRAIT)
-//				to_chat(U, span_purple("Your mouth is free. you breathe out with relief."))
+				//to_chat(U, span_purple("Your mouth is free. you breathe out with relief."))
 		else
 			muzzle = TRUE
 			playsound(usr, 'sound/weapons/magin.ogg', 40, TRUE, ignore_walls = FALSE)
@@ -95,7 +95,7 @@
 			if(usr.get_item_by_slot(ITEM_SLOT_HEAD) == src)
 				ADD_TRAIT(usr, TRAIT_MUTE, CLOTHING_TRAIT)
 				to_chat(usr, span_purple("Something is gagging your mouth! You can barely make a sound..."))
-	if(C == "hearing")
+	if(user_client == "hearing")
 		if(earmuffs == TRUE)
 			earmuffs = FALSE
 			playsound(usr, 'sound/weapons/magout.ogg', 40, TRUE, ignore_walls = FALSE)
@@ -103,7 +103,7 @@
 			if(usr.get_item_by_slot(ITEM_SLOT_HEAD) == src)
 				REMOVE_TRAIT(usr, TRAIT_DEAF, CLOTHING_TRAIT)
 				Toggle_Sounds()
-//				to_chat(U, span_purple("Finally you can hear the world around again."))
+				//to_chat(U, span_purple("Finally you can hear the world around again."))
 		else
 			earmuffs = TRUE
 			playsound(usr, 'sound/weapons/magin.ogg', 40, TRUE, ignore_walls = FALSE)
@@ -113,7 +113,7 @@
 				Toggle_Sounds()
 				stop_client_sounds()
 				to_chat(usr, span_purple("You can barely hear anything! Your other senses have become more apparent..."))
-	if(C == "vision")
+	if(user_client == "vision")
 		var/mob/living/carbon/human/user = usr
 		if(prevent_vision == TRUE)
 			prevent_vision = FALSE
@@ -121,7 +121,7 @@
 			to_chat(usr, span_notice("Vision switch off"))
 			if(usr.get_item_by_slot(ITEM_SLOT_HEAD) == src)
 				user.cure_blind("deprivation_helmet_[REF(src)]")
-//				to_chat(U, span_purple("Helmet no longer restricts your vision."))
+				//to_chat(U, span_purple("Helmet no longer restricts your vision."))
 		else
 			prevent_vision = TRUE
 			playsound(usr, 'sound/weapons/magin.ogg', 40, TRUE, ignore_walls = FALSE)
@@ -130,53 +130,53 @@
 				user.become_blind("deprivation_helmet_[REF(src)]")
 				to_chat(usr, span_purple("The helmet is blocking your vision! You can't make out anything on the other side..."))
 
-//Client sound switchers for more silense! And check current state of parameters
-//Switcher agregator function
+// Client sound switchers for more silense! And check current state of parameters
+// Switcher agregator function
 /obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Sounds()
-	var/C = usr.client
+	var/user_client = usr.client
 	if(earmuffs == FALSE)
 		if(ambience_sound_state	!= 0)
-			var/T = Toggle_Soundscape_Get_checked(C)
-			if(T == 0)
+			var/soundscape_check = Toggle_Soundscape_Get_checked(user_client)
+			if(soundscape_check == 0)
 				Toggle_Soundscape()
 		if(instruments_sound_state != 0)
-			var/I = Toggle_Instruments_Get_checked(C)
-			if(I == 0)
+			var/instruments_check = Toggle_Instruments_Get_checked(user_client)
+			if(instruments_check == 0)
 				Toggle_Instruments()
 		if(combatmode_sound_state != 0)
-			var/B = Toggle_Combatmode_Sound_Get_checked(C)
-			if(B == 0)
+			var/combat_mode_sound_check = Toggle_Combatmode_Sound_Get_checked(user_client)
+			if(combat_mode_sound_check == 0)
 				Toggle_Combatmode_Sound()
 		if(midis_sound_state != 0)
-			var/M = Toggle_Midis_Get_checked(C)
-			if(M == 0)
+			var/midis_check = Toggle_Midis_Get_checked(user_client)
+			if(midis_check == 0)
 				Toggle_Midis()
 		if(announcement_sound_state	!= 0)
-			var/A = Toggle_Announcement_Sound_Get_checked(C)
-			if(A == 0)
+			var/announcement_sound_check = Toggle_Announcement_Sound_Get_checked(user_client)
+			if(announcement_sound_check == 0)
 				Toggle_Announcement_Sound()
 		if(ship_ambience_sound_state != 0)
-			var/S = Toggle_Ship_Ambience_Get_Checked(C)
-			if(S == 0)
+			var/ambience_check = Toggle_Ship_Ambience_Get_Checked(user_client)
+			if(ambience_check == 0)
 				Toggle_Ship_Ambience()
 	else
-		var/T = Toggle_Soundscape_Get_checked(C)
-		if(T != 0)
+		var/soundscape_check = Toggle_Soundscape_Get_checked(user_client)
+		if(soundscape_check != 0)
 			Toggle_Soundscape()
-		var/I = Toggle_Instruments_Get_checked(C)
-		if(I != 0)
+		var/instruments_check = Toggle_Instruments_Get_checked(user_client)
+		if(instruments_check != 0)
 			Toggle_Instruments()
-		var/B = Toggle_Combatmode_Sound_Get_checked(C)
-		if(B != 0)
+		var/combat_mode_sound_check = Toggle_Combatmode_Sound_Get_checked(user_client)
+		if(combat_mode_sound_check != 0)
 			Toggle_Combatmode_Sound()
-		var/M = Toggle_Midis_Get_checked(C)
-		if(M != 0)
+		var/midis_check = Toggle_Midis_Get_checked(user_client)
+		if(midis_check != 0)
 			Toggle_Midis()
-		var/A = Toggle_Announcement_Sound_Get_checked(C)
-		if(A != 0)
+		var/announcement_sound_check = Toggle_Announcement_Sound_Get_checked(user_client)
+		if(announcement_sound_check != 0)
 			Toggle_Announcement_Sound()
-		var/S = Toggle_Ship_Ambience_Get_Checked(C)
-		if(S != 0)
+		var/ambience_check = Toggle_Ship_Ambience_Get_Checked(user_client)
+		if(ambience_check != 0)
 			Toggle_Ship_Ambience()
 
 //Ambience sound switch function
@@ -184,58 +184,58 @@
 	usr.client.prefs.toggles ^= SOUND_AMBIENCE
 	usr.client.prefs.save_preferences()
 	if(usr.client.prefs.toggles & SOUND_AMBIENCE)
-//		to_chat(usr, "You will now hear ambient sounds.")
+		//to_chat(usr, "You will now hear ambient sounds.")
 	else
-//		to_chat(usr, "You will no longer hear ambient sounds.")
+		//to_chat(usr, "You will no longer hear ambient sounds.")
 		usr.stop_sound_channel(CHANNEL_AMBIENCE)
 		usr.stop_sound_channel(CHANNEL_BUZZ)
 	usr.client.update_ambience_pref()
 
 //Ambience sound check status function
-/obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Soundscape_Get_checked(client/C)
-	return C.prefs.toggles & SOUND_AMBIENCE
+/obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Soundscape_Get_checked(client/user_client)
+	return user_client.prefs.toggles & SOUND_AMBIENCE
 
 //Instuments sound switch function
 /obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Instruments()
 	usr.client.prefs.toggles ^= SOUND_INSTRUMENTS
 	usr.client.prefs.save_preferences()
 	if(usr.client.prefs.toggles & SOUND_INSTRUMENTS)
-//		to_chat(usr, "You will now hear people playing musical instruments.")
+		//to_chat(usr, "You will now hear people playing musical instruments.")
 	else
-//		to_chat(usr, "You will no longer hear musical instruments.")
+		//to_chat(usr, "You will no longer hear musical instruments.")
 
 //Instruments sound check status
-/obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Instruments_Get_checked(client/C)
-	return C.prefs.toggles & SOUND_INSTRUMENTS
+/obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Instruments_Get_checked(client/user_client)
+	return user_client.prefs.toggles & SOUND_INSTRUMENTS
 
 //Combat sound switch function
 /obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Combatmode_Sound()
 	usr.client.prefs.toggles ^= SOUND_COMBATMODE
 	usr.client.prefs.save_preferences()
 	if(usr.client.prefs.toggles & SOUND_COMBATMODE)
-//		to_chat(usr, "You will now hear a sound when combat mode is turned on.")
+		//to_chat(usr, "You will now hear a sound when combat mode is turned on.")
 	else
-//		to_chat(usr, "You will no longer hear a sound when combat mode is turned on.")
+		//to_chat(usr, "You will no longer hear a sound when combat mode is turned on.")
 
 //Combat sound check status function
-/obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Combatmode_Sound_Get_checked(client/C)
-	return C.prefs.toggles & SOUND_COMBATMODE
+/obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Combatmode_Sound_Get_checked(client/user_client)
+	return user_client.prefs.toggles & SOUND_COMBATMODE
 
 //Midis sound switch function
 /obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Midis()
 	usr.client.prefs.toggles ^= SOUND_MIDI
 	usr.client.prefs.save_preferences()
 	if(usr.client.prefs.toggles & SOUND_MIDI)
-//		to_chat(usr, "You will now hear any sounds uploaded by admins.")
+		//to_chat(usr, "You will now hear any sounds uploaded by admins.")
 	else
-//		to_chat(usr, "You will no longer hear sounds uploaded by admins")
+		//to_chat(usr, "You will no longer hear sounds uploaded by admins")
 		usr.stop_sound_channel(CHANNEL_ADMIN)
-		var/client/C = usr.client
-		C?.tgui_panel?.stop_music()
+		var/client/user_client = usr.client
+		user_client?.tgui_panel?.stop_music()
 
 //Midis sound check status function
-/obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Midis_Get_checked(client/C)
-	return C.prefs.toggles & SOUND_MIDI
+/obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Midis_Get_checked(client/user_client)
+	return user_client.prefs.toggles & SOUND_MIDI
 //Anounce sound switch function
 
 /obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Announcement_Sound()
@@ -243,18 +243,18 @@
 	set category = "Preferences"
 	set desc = "Hear Announcement Sound"
 	usr.client.prefs.toggles ^= SOUND_ANNOUNCEMENTS
-//	to_chat(usr, "You will now [(usr.client.prefs.toggles & SOUND_ANNOUNCEMENTS) ? "hear announcement sounds" : "no longer hear announcements"].")
+	//to_chat(usr, "You will now [(usr.client.prefs.toggles & SOUND_ANNOUNCEMENTS) ? "hear announcement sounds" : "no longer hear announcements"].")
 	usr.client.prefs.save_preferences()
 
 //Anounce sound check status function
-/obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Announcement_Sound_Get_checked(client/C)
-	return C.prefs.toggles & SOUND_ANNOUNCEMENTS
+/obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Announcement_Sound_Get_checked(client/user_client)
+	return user_client.prefs.toggles & SOUND_ANNOUNCEMENTS
 
 //Stop sound function for immediatlely silence
 /obj/item/clothing/head/helmet/space/deprivation_helmet/proc/stop_client_sounds()
 	SEND_SOUND(usr, sound(null))
-	var/client/C = usr.client
-	C?.tgui_panel?.stop_music()
+	var/client/user_client = usr.client
+	user_client?.tgui_panel?.stop_music()
 //Ship ambience switch function
 
 /obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Ship_Ambience()
@@ -264,17 +264,18 @@
 	usr.client.prefs.toggles ^= SOUND_SHIP_AMBIENCE
 	usr.client.prefs.save_preferences()
 
-//	STUFF THAT IS "//" NOT REALLY USEFUL
+	// STUFF THAT IS "//" NOT REALLY USEFUL
 	if(usr.client.prefs.toggles & SOUND_SHIP_AMBIENCE)
-//		to_chat(usr, "You will now hear ship ambience.")
+		//to_chat(usr, "You will now hear ship ambience.")
 	else
-//		to_chat(usr, "You will no longer hear ship ambience.")
+		//to_chat(usr, "You will no longer hear ship ambience.")
 		usr.stop_sound_channel(CHANNEL_BUZZ)
-//Ship ambience check status function
-/obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Ship_Ambience_Get_Checked(client/C)
-	return C.prefs.toggles & SOUND_SHIP_AMBIENCE
 
-//create radial menu
+// Ship ambience check status function
+/obj/item/clothing/head/helmet/space/deprivation_helmet/proc/Toggle_Ship_Ambience_Get_Checked(client/user_client)
+	return user_client.prefs.toggles & SOUND_SHIP_AMBIENCE
+
+// Create radial menu
 /obj/item/clothing/head/helmet/space/deprivation_helmet/proc/populate_helmet_designs()
 	helmet_designs = list(
 		"pink" = image(icon = src.icon, icon_state = "dephelmet_pink"),
@@ -282,13 +283,13 @@
 		"pinkn" = image(icon = src.icon, icon_state = "dephelmet_pinkn"),
 		"tealn" = image(icon = src.icon, icon_state = "dephelmet_tealn"))
 
-//to change model
-/obj/item/clothing/head/helmet/space/deprivation_helmet/AltClick(mob/user, obj/item/I)
+// To change model
+/obj/item/clothing/head/helmet/space/deprivation_helmet/AltClick(mob/user)
 	if(color_changed == FALSE)
 		. = ..()
 		if(.)
 			return
-		var/choice = show_radial_menu(user,src, helmet_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, helmet_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		current_helmet_color = choice
@@ -299,21 +300,21 @@
 		return
 
 /obj/item/clothing/head/helmet/space/deprivation_helmet/proc/update_action_buttons_icons()
-	var/datum/action/item_action/M
+	var/datum/action/item_action/action_button
 
-	for(M in src.actions)
-		if(istype(M, /datum/action/item_action/toggle_vision))
-			M.button_icon_state = "[current_helmet_color]_blind"
-			M.icon_icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_icons.dmi'
-		if(istype(M, /datum/action/item_action/toggle_hearing))
-			M.button_icon_state = "[current_helmet_color]_deaf"
-			M.icon_icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_icons.dmi'
-		if(istype(M, /datum/action/item_action/toggle_speech))
-			M.button_icon_state = "[current_helmet_color]_mute"
-			M.icon_icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_icons.dmi'
+	for(action_button in src.actions)
+		if(istype(action_button, /datum/action/item_action/toggle_vision))
+			action_button.button_icon_state = "[current_helmet_color]_blind"
+			action_button.icon_icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_icons.dmi'
+		if(istype(action_button, /datum/action/item_action/toggle_hearing))
+			action_button.button_icon_state = "[current_helmet_color]_deaf"
+			action_button.icon_icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_icons.dmi'
+		if(istype(action_button, /datum/action/item_action/toggle_speech))
+			action_button.button_icon_state = "[current_helmet_color]_mute"
+			action_button.icon_icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_icons.dmi'
 	update_icon()
 
-//to check if we can change helmet's model
+// To check if we can change helmet's model
 /obj/item/clothing/head/helmet/space/deprivation_helmet/proc/check_menu(mob/living/user)
 	if(!istype(user))
 		return FALSE
@@ -329,25 +330,25 @@
 	if(!length(helmet_designs))
 		populate_helmet_designs()
 
-//updating both and icon in hands and icon worn
+// Updating both and icon in hands and icon worn
 /obj/item/clothing/head/helmet/space/deprivation_helmet/update_icon_state()
 	.=..()
 	icon_state = "[initial(icon_state)]_[current_helmet_color]"
 	inhand_icon_state = "[initial(icon_state)]_[current_helmet_color]"
 
-//Here goes code that applies stuff on the wearer
+// Here goes code that applies stuff on the wearer
 /obj/item/clothing/head/helmet/space/deprivation_helmet/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(slot != ITEM_SLOT_HEAD)
 		return
 	//Save current sound states
-	var/C = usr.client
-	ambience_sound_state = Toggle_Soundscape_Get_checked(C)
-	instruments_sound_state = Toggle_Instruments_Get_checked(C)
-	combatmode_sound_state = Toggle_Combatmode_Sound_Get_checked(C)
-	midis_sound_state = Toggle_Midis_Get_checked(C)
-	announcement_sound_state = Toggle_Announcement_Sound_Get_checked(C)
-	ship_ambience_sound_state = Toggle_Ship_Ambience_Get_Checked(C)
+	var/mob_client = usr.client
+	ambience_sound_state = Toggle_Soundscape_Get_checked(mob_client)
+	instruments_sound_state = Toggle_Instruments_Get_checked(mob_client)
+	combatmode_sound_state = Toggle_Combatmode_Sound_Get_checked(mob_client)
+	midis_sound_state = Toggle_Midis_Get_checked(mob_client)
+	announcement_sound_state = Toggle_Announcement_Sound_Get_checked(mob_client)
+	ship_ambience_sound_state = Toggle_Ship_Ambience_Get_Checked(mob_client)
 	if(muzzle == TRUE)
 		ADD_TRAIT(user, TRAIT_MUTE, CLOTHING_TRAIT)
 		to_chat(usr, span_purple("Something is gagging your mouth! You can barely make a sound..."))
@@ -361,7 +362,7 @@
 		to_chat(usr, span_purple("The helmet is blocking your vision! You can't make out anything on the other side..."))
 
 
-//Here goes code that heals the wearer after unequipping helmet
+// Here goes code that heals the wearer after unequipping helmet
 /obj/item/clothing/head/helmet/space/deprivation_helmet/dropped(mob/living/carbon/human/user)
 	. = ..()
 	if(muzzle == TRUE)
@@ -374,7 +375,7 @@
 	if(prevent_vision == TRUE)
 		user.cure_blind("deprivation_helmet_[REF(src)]")
 
-	//some stuff for unequip messages
+	// Some stuff for unequip messages
 	if(src == user.head)
 		if(muzzle == TRUE)
 			to_chat(user, span_purple("Your mouth is free. You breathe out with relief."))
@@ -383,7 +384,7 @@
 		if(prevent_vision == TRUE)
 			to_chat(user, span_purple("The helmet no longer restricts your vision."))
 
-	//Let's drop sound states
+	// Let's drop sound states
 	ambience_sound_state = null
 	instruments_sound_state = null
 	combatmode_sound_state = null

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/hypnogoggles.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/hypnogoggles.dm
@@ -62,13 +62,13 @@
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 //to change model
-/obj/item/clothing/glasses/hypno/AltClick(mob/user, obj/item/I)
+/obj/item/clothing/glasses/hypno/AltClick(mob/user)
 	if(color_changed)
 		return
 	. = ..()
 	if(.)
 		return
-	var/choice = show_radial_menu(user,src, hypnogoggles_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+	var/choice = show_radial_menu(user, src, hypnogoggles_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 	if(!choice)
 		return FALSE
 	current_hypnogoggles_color = choice
@@ -111,15 +111,15 @@
 		qdel(src)
 	hypnotic_phrase = phrase
 	try
-		target_phrase = new("(\\b[REGEX_QUOTE(hypnotic_phrase)]\\b)","ig")
-	catch(var/exception/e)
-		stack_trace("[e] on [e.file]:[e.line]")
+		target_phrase = new("(\\b[REGEX_QUOTE(hypnotic_phrase)]\\b)", "ig")
+	catch(var/exception/caught_exception)
+		stack_trace("[caught_exception] on [caught_exception.file]:[caught_exception.line]")
 		qdel(src)
 	return ..()
 
 /datum/brain_trauma/induced_hypnosis/on_gain()
 	log_game("[key_name(owner)] was hypnogoggled'.")
-	to_chat(owner, "<span class='reallybig hypnophrase'>[hypnotic_phrase]</span>")
+	to_chat(owner, "<span class = 'reallybig hypnophrase'>[hypnotic_phrase]</span>")
 	to_chat(owner, span_notice(pick("You feel your thoughts focusing on this phrase... you can't seem to get it out of your head.",
 									"Your head hurts, but this is all you can think of. It must be vitally important.",
 									"You feel a part of your mind repeating this over and over. You need to follow these words.",
@@ -140,7 +140,7 @@
 	..()
 	if(!(DT_PROB(1, delta_time)))
 		return
-	switch(rand(1,2))
+	switch(rand(1, 2))
 		if(1)
 			to_chat(owner, span_hypnophrase("<i>...[lowertext(hypnotic_phrase)]...</i>"))
 		if(2)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kink_collars.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kink_collars.dm
@@ -135,7 +135,7 @@
 	if(!istype(attack_item))
 		return
 	if(attack_item.key_id == REF(src))
-		IsLocked((locked ? FALSE : TRUE),user)
+		IsLocked((locked ? FALSE : TRUE), user)
 		return
 	to_chat(user, span_warning("This isn't the correct key!"))
 
@@ -210,7 +210,7 @@
 		return
 	var/obj/item/clothing/neck/kink_collar/locked/collar = target.wear_neck
 	if(REF(collar) == src.key_id)
-		collar.IsLocked((collar.locked ? FALSE : TRUE),user)
+		collar.IsLocked((collar.locked ? FALSE : TRUE), user)
 	else
 		to_chat(user, span_warning("This isn't the correct key!"))
 
@@ -231,7 +231,7 @@
 		collar.IsLocked(FALSE, user)
 		if(prob(33)) //chance to get damage
 			to_chat(user, span_warning("You successfully cut away the lock, but gave [target.name] several cuts in the process!"))
-			target.apply_damage(rand(1,4), BRUTE, BODY_ZONE_HEAD, wound_bonus=10)
+			target.apply_damage(rand(1, 4), BRUTE, BODY_ZONE_HEAD, wound_bonus = 10)
 		else
 			to_chat(user, span_warning("You successfully cut away the lock!"))
 	else
@@ -240,11 +240,11 @@
 		if(prob(33))
 			to_chat(user, span_warning("You successfully cut away the lock, but gave yourself several cuts in the process!"))
 			collar.broken = TRUE
-			collar.IsLocked(FALSE,user)
-			target.apply_damage(rand(2,4), BRUTE, BODY_ZONE_HEAD, wound_bonus=10)
+			collar.IsLocked(FALSE, user)
+			target.apply_damage(rand(2, 4), BRUTE, BODY_ZONE_HEAD, wound_bonus = 10)
 		else
 			to_chat(user, span_warning("You fail to cut away the lock, cutting yourself in the process!"))
-			target.apply_damage(rand(3,5), BRUTE, BODY_ZONE_HEAD, wound_bonus=30)
+			target.apply_damage(rand(3, 5), BRUTE, BODY_ZONE_HEAD, wound_bonus = 30)
 
 /////////////////////////
 ///MIND CONTROL COLLAR///

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kinky_blindfold.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kinky_blindfold.dm
@@ -26,13 +26,13 @@
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 //to change model
-/obj/item/clothing/glasses/blindfold/kinky/AltClick(mob/user, obj/item/I)
+/obj/item/clothing/glasses/blindfold/kinky/AltClick(mob/user)
 	if(color_changed)
 		return
 	. = ..()
 	if(.)
 		return
-	var/choice = show_radial_menu(user,src, kinkfold_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+	var/choice = show_radial_menu(user, src, kinkfold_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 	if(!choice)
 		return FALSE
 	current_kinkfold_color = choice

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kinky_headphones.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kinky_headphones.dm
@@ -34,13 +34,13 @@
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 //to change model
-/obj/item/clothing/ears/kinky_headphones/AltClick(mob/user, obj/item/I)
+/obj/item/clothing/ears/kinky_headphones/AltClick(mob/user)
 	if(color_changed)
 		return
 	. = ..()
 	if(.)
 		return
-	var/choice = show_radial_menu(user,src, kinkphones_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+	var/choice = show_radial_menu(user, src, kinkphones_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 	if(!choice)
 		return FALSE
 	current_kinkphones_color = choice

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kinky_sleepbag.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kinky_sleepbag.dm
@@ -57,9 +57,9 @@
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 //to change model
-/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/AltClick(mob/user, obj/item/I)
-	var/mob/living/carbon/human/H = user
-	if(istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
+/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/AltClick(mob/user)
+	var/mob/living/carbon/human/clicking_human = user
+	if(istype(clicking_human.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
 		to_chat(user, span_warning("Your hands are stuck, you can't do this!"))
 		return FALSE
 	switch(color_changed)
@@ -67,7 +67,7 @@
 			. = ..()
 			if(.)
 				return
-			var/choice = show_radial_menu(user,src, bag_colors, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+			var/choice = show_radial_menu(user, src, bag_colors, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 			if(!choice)
 				return FALSE
 			bag_color = choice
@@ -106,37 +106,37 @@
 	inhand_icon_state = "[initial(icon_state)]_[bag_color]_[bag_state]_[bag_fold? "folded" : "unfolded"]"
 
 /obj/item/clothing/suit/straight_jacket/kinky_sleepbag/equipped(mob/user, slot)
-	var/mob/living/carbon/human/H = user
+	var/mob/living/carbon/human/affected_human = user
 	if(ishuman(user) && slot == ITEM_SLOT_OCLOTHING)
 		ADD_TRAIT(user, TRAIT_FLOORED, CLOTHING_TRAIT)
 
-		H.cut_overlay(H.overlays_standing[SHOES_LAYER])
-		H.cut_overlay(H.overlays_standing[BELT_LAYER])
-		H.cut_overlay(H.overlays_standing[NECK_LAYER])
-		H.cut_overlay(H.overlays_standing[BACK_LAYER])
-		H.cut_overlay(H.overlays_standing[BODY_BEHIND_LAYER])
+		affected_human.cut_overlay(affected_human.overlays_standing[SHOES_LAYER])
+		affected_human.cut_overlay(affected_human.overlays_standing[BELT_LAYER])
+		affected_human.cut_overlay(affected_human.overlays_standing[NECK_LAYER])
+		affected_human.cut_overlay(affected_human.overlays_standing[BACK_LAYER])
+		affected_human.cut_overlay(affected_human.overlays_standing[BODY_BEHIND_LAYER])
 
 		START_PROCESSING(SSobj, src)
 		time_to_sound_left = time_to_sound
 
 		if(bag_state == "inflated")
-			to_chat(H, span_purple("You realize that you can't move even an inch. The inflated sleeping bag squeezes you from all sides!"))
-			H.cut_overlay(H.overlays_standing[HEAD_LAYER])
-			H.cut_overlay(H.overlays_standing[HAIR_LAYER])
+			to_chat(affected_human, span_purple("You realize that you can't move even an inch. The inflated sleeping bag squeezes you from all sides!"))
+			affected_human.cut_overlay(affected_human.overlays_standing[HEAD_LAYER])
+			affected_human.cut_overlay(affected_human.overlays_standing[HAIR_LAYER])
 		if(bag_state == "deflated")
-			to_chat(H, span_purple("You realize that moving now is much harder. You're fully restrained, any struggling is useless!"))
+			to_chat(affected_human, span_purple("You realize that moving now is much harder. You're fully restrained, any struggling is useless!"))
 	. = ..()
 
 //to inflate/deflate that thing
-/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/attack_self(mob/user, obj/item/I)
-	var/mob/living/carbon/human/H = user
+/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/attack_self(mob/user)
+	var/mob/living/carbon/human/affected_human = user
 	if(bag_fold == FALSE)
 		toggle_mode()
-		to_chat(H, span_notice("The sleeping bag now is [bag_state? "inflated." : "deflated."]"))
+		to_chat(affected_human, span_notice("The sleeping bag now is [bag_state? "inflated." : "deflated."]"))
 		update_icon()
 		update_icon_state()
 	else
-		to_chat(H, span_notice("You need to unfold the bag before inflating it!"))
+		to_chat(affected_human, span_notice("You need to unfold the bag before inflating it!"))
 
 /obj/item/clothing/suit/straight_jacket/kinky_sleepbag/proc/fold(mob/user, src)
 	bag_fold = !bag_fold
@@ -164,26 +164,26 @@
 	// appearance_update()
 
 /obj/item/clothing/suit/straight_jacket/kinky_sleepbag/dropped(mob/user)
-	var/mob/living/carbon/human/H = user
+	var/mob/living/carbon/human/affected_human = user
 
 	if(ishuman(user))
-		if(src == H.wear_suit)
+		if(src == affected_human.wear_suit)
 			REMOVE_TRAIT(user, TRAIT_FLOORED, CLOTHING_TRAIT)
 			to_chat(user, span_purple("You are finally free! The bag is no longer constricting your movements."))
 
-			H.add_overlay(H.overlays_standing[SHOES_LAYER])
-			H.update_inv_shoes()
-			H.add_overlay(H.overlays_standing[BELT_LAYER])
-			H.add_overlay(H.overlays_standing[NECK_LAYER])
-			H.add_overlay(H.overlays_standing[BACK_LAYER])
-			H.add_overlay(H.overlays_standing[BODY_BEHIND_LAYER])
-			H.add_overlay(H.overlays_standing[BODY_FRONT_LAYER])
-			H.add_overlay(H.overlays_standing[HEAD_LAYER])
-			H.add_overlay(H.overlays_standing[HAIR_LAYER])
-			H.add_overlay(H.overlays_standing[SHOES_LAYER])
+			affected_human.add_overlay(affected_human.overlays_standing[SHOES_LAYER])
+			affected_human.update_inv_shoes()
+			affected_human.add_overlay(affected_human.overlays_standing[BELT_LAYER])
+			affected_human.add_overlay(affected_human.overlays_standing[NECK_LAYER])
+			affected_human.add_overlay(affected_human.overlays_standing[BACK_LAYER])
+			affected_human.add_overlay(affected_human.overlays_standing[BODY_BEHIND_LAYER])
+			affected_human.add_overlay(affected_human.overlays_standing[BODY_FRONT_LAYER])
+			affected_human.add_overlay(affected_human.overlays_standing[HEAD_LAYER])
+			affected_human.add_overlay(affected_human.overlays_standing[HAIR_LAYER])
+			affected_human.add_overlay(affected_human.overlays_standing[SHOES_LAYER])
 
-			H.update_inv_shoes()
-			H.regenerate_icons()
+			affected_human.update_inv_shoes()
+			affected_human.regenerate_icons()
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 
@@ -191,7 +191,7 @@
 	if(time_to_sound_left <= 0)
 		if(tt <= 0)
 			playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 100, TRUE, ignore_walls = FALSE)
-			tt = rand(15,35) //to do random funny sounds when character inside that thing.
+			tt = rand(15, 35) //to do random funny sounds when character inside that thing.
 		else
 			tt -= delta_time
 	else

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/latex_catsuit.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/latex_catsuit.dm
@@ -22,28 +22,28 @@
 //this fragment of code makes unequipping not instant
 /obj/item/clothing/under/misc/latex_catsuit/attack_hand(mob/user)
 	if(iscarbon(user))
-		var/mob/living/carbon/human/C = user
-		if(src == C.w_uniform)
-			if(!do_after(C, 60, target = src))
+		var/mob/living/carbon/human/affected_human = user
+		if(src == affected_human.w_uniform)
+			if(!do_after(affected_human, 60, target = src))
 				return
 	. = ..()
 
 // //some gender identification magic
-/obj/item/clothing/under/misc/latex_catsuit/equipped(mob/living/U, slot)
+/obj/item/clothing/under/misc/latex_catsuit/equipped(mob/living/affected_mob, slot)
 	. = ..()
-	var/mob/living/carbon/human/C = U
-	var/obj/item/organ/genital/breasts/B = C.getorganslot(ORGAN_SLOT_BREASTS)
-	if(src == C.w_uniform)
-		if(U.gender == FEMALE)
+	var/mob/living/carbon/human/affected_human = affected_mob
+	var/obj/item/organ/genital/breasts/affected_breasts = affected_human.getorganslot(ORGAN_SLOT_BREASTS)
+	if(src == affected_human.w_uniform)
+		if(affected_mob.gender == FEMALE)
 			icon_state = "latex_catsuit_female"
-			U.update_inv_w_uniform()
+			affected_mob.update_inv_w_uniform()
 
-		if(U.gender == MALE)
+		if(affected_mob.gender == MALE)
 			icon_state = "latex_catsuit_male"
-			U.update_inv_w_uniform()
+			affected_mob.update_inv_w_uniform()
 
 	//For giving taurs proper sprites
-	if(C.dna.species.mutant_bodyparts["taur"])
+	if(affected_human.dna.species.mutant_bodyparts["taur"])
 		breasts_overlay = mutable_appearance('modular_skyrat/modules/modular_items/lewd_items/icons/mob/lewd_clothing/lewd_uniform/lewd_uniform-snake.dmi', "none")
 		update_overlays()
 	else
@@ -51,40 +51,40 @@
 		update_overlays()
 
 	//Breasts overlay for catsuit
-	if(B?.genital_size >= 6 || B?.genital_type == "pair")
+	if(affected_breasts?.genital_size >= 6 || affected_breasts?.genital_type == "pair")
 		breasts_overlay.icon_state = "breasts_double"
 		breasts_icon_overlay.icon_state = "iconbreasts_double"
 		accessory_overlay = breasts_overlay
 		add_overlay(breasts_icon_overlay)
 		update_overlays()
-	if(B?.genital_type == "quad")
+	if(affected_breasts?.genital_type == "quad")
 		breasts_overlay.icon_state = "breasts_quad"
 		breasts_icon_overlay.icon_state = "iconbreasts_quad"
 		accessory_overlay = breasts_overlay
 		add_overlay(breasts_icon_overlay)
 		update_overlays()
-	if(B?.genital_type == "sextuple")
+	if(affected_breasts?.genital_type == "sextuple")
 		breasts_overlay.icon_state = "breasts_sextuple"
 		breasts_icon_overlay.icon_state = "iconbreasts_sextuple"
 		accessory_overlay = breasts_overlay
 		add_overlay(breasts_icon_overlay)
 		update_overlays()
 
-	if(C.dna.species.mutant_bodyparts["taur"] && src == C.w_uniform)
-		C.remove_overlay(BODY_BEHIND_LAYER)
-		C.remove_overlay(BODY_FRONT_LAYER)
-	C.regenerate_icons()
+	if(affected_human.dna.species.mutant_bodyparts["taur"] && src == affected_human.w_uniform)
+		affected_human.remove_overlay(BODY_BEHIND_LAYER)
+		affected_human.remove_overlay(BODY_FRONT_LAYER)
+	affected_human.regenerate_icons()
 
-/obj/item/clothing/under/misc/latex_catsuit/dropped(mob/living/U)
+/obj/item/clothing/under/misc/latex_catsuit/dropped(mob/living/affected_mob)
 	. = ..()
-	var/mob/living/carbon/human/C = U
+	var/mob/living/carbon/human/affected_human = affected_mob
 	accessory_overlay = null
 	breasts_overlay.icon_state = "none"
 	cut_overlay(breasts_icon_overlay)
 	breasts_icon_overlay.icon_state = "none"
-	if(C.dna.species.mutant_bodyparts["taur"] && src == C.w_uniform)
-		C.apply_overlay(BODY_BEHIND_LAYER)
-		C.apply_overlay(BODY_FRONT_LAYER)
+	if(affected_human.dna.species.mutant_bodyparts["taur"] && src == affected_human.w_uniform)
+		affected_human.apply_overlay(BODY_BEHIND_LAYER)
+		affected_human.apply_overlay(BODY_FRONT_LAYER)
 
 //Plug to bypass the bug with instant suit equip/drop
 /obj/item/clothing/under/misc/latex_catsuit/MouseDrop(atom/over_object)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/lewd_maid.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/lewd_maid.dm
@@ -52,13 +52,13 @@
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 //to change model
-/obj/item/clothing/accessory/lewdapron/AltClick(mob/user, obj/item/I)
+/obj/item/clothing/accessory/lewdapron/AltClick(mob/user)
 	if(color_changed)
 		return
 	. = ..()
 	if(.)
 		return
-	var/choice = show_radial_menu(user,src, apron_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+	var/choice = show_radial_menu(user, src, apron_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 	if(!choice)
 		return FALSE
 	current_color = choice

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/lewd_shoes.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/lewd_shoes.dm
@@ -20,64 +20,64 @@
 //it takes time to put them off, do not touch
 /obj/item/clothing/shoes/latexheels/attack_hand(mob/user)
 	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		if(src == C.shoes)
-			if(!do_after(C, 40, target = src))
+		var/mob/living/carbon/affected_mob = user
+		if(src == affected_mob.shoes)
+			if(!do_after(affected_mob, 40, target = src))
 				return
 	. = ..()
 
 //start processing
 /obj/item/clothing/shoes/latexheels/equipped(mob/user, slot)
 	. = ..()
-	var/mob/living/carbon/human/C = user
-	if(src == C.shoes)
+	var/mob/living/carbon/human/affected_mob = user
+	if(src == affected_mob.shoes)
 		START_PROCESSING(SSobj, src)
-	C.update_inv_shoes()
-	C.hud_used.hidden_inventory_update()
+	affected_mob.update_inv_shoes()
+	affected_mob.hud_used.hidden_inventory_update()
 	message_sent = FALSE
 
 //stop processing
 /obj/item/clothing/shoes/latexheels/dropped(mob/user)
 	. = ..()
-	var/mob/living/carbon/human/H = user
+	var/mob/living/carbon/human/affected_mob = user
 	STOP_PROCESSING(SSobj, src)
 	if(discomfort >= 80)
-		to_chat(H, span_purple("The latex heels no longer hurt your legs."))
+		to_chat(affected_mob, span_purple("The latex heels no longer hurt your legs."))
 	discomfort = 0
 	slowdown = 4
 
 // Heels pain processor
 /obj/item/clothing/shoes/latexheels/process(delta_time)
-	var/mob/living/carbon/human/U = loc
-	if(discomfort <= 100 && U.body_position != LYING_DOWN)
+	var/mob/living/carbon/human/affected_mob = loc
+	if(discomfort <= 100 && affected_mob.body_position != LYING_DOWN)
 		discomfort += 1
-	if(discomfort >= 0 && U.body_position == LYING_DOWN)
+	if(discomfort >= 0 && affected_mob.body_position == LYING_DOWN)
 		discomfort -= 2
 		message_sent = FALSE
 		slowdown = 4
 
 	//Pain effect
-	if(discomfort >= 80 && U.body_position != LYING_DOWN)
-		U.adjustPain(1)
+	if(discomfort >= 80 && affected_mob.body_position != LYING_DOWN)
+		affected_mob.adjustPain(1)
 
-	if(discomfort >=100 && U.body_position != LYING_DOWN)
-		U.adjustPain(4)
+	if(discomfort >= 100 && affected_mob.body_position != LYING_DOWN)
+		affected_mob.adjustPain(4)
 		slowdown = 6
 		if(prob(10))
-			U.Knockdown(1)
+			affected_mob.Knockdown(1)
 
 	//Discomfort milestone signalling that something is really wrong
-	if(discomfort >= 100 && U.body_position != LYING_DOWN && message_sent == FALSE)
-		if(HAS_TRAIT(U, TRAIT_MASOCHISM))
-			to_chat(U, span_notice("These heels are causing my feet incredible pain... And I kind of like it!"))
+	if(discomfort >= 100 && affected_mob.body_position != LYING_DOWN && message_sent == FALSE)
+		if(HAS_TRAIT(affected_mob, TRAIT_MASOCHISM))
+			to_chat(affected_mob, span_notice("These heels are causing my feet incredible pain... And I kind of like it!"))
 		else
-			to_chat(U, span_notice("These heels are really hurting my feet!"))
+			to_chat(affected_mob, span_notice("These heels are really hurting my feet!"))
 		message_sent = TRUE
 
 //to make sound when we walking in this
 /obj/item/clothing/shoes/latexheels/Initialize()
 	. = ..()
-	AddComponent(/datum/component/squeak, list('modular_skyrat/modules/modular_items/lewd_items/sounds/highheel1.ogg' = 1,'modular_skyrat/modules/modular_items/lewd_items/sounds/highheel2.ogg' = 1), 70)
+	AddComponent(/datum/component/squeak, list('modular_skyrat/modules/modular_items/lewd_items/sounds/highheel1.ogg' = 1, 'modular_skyrat/modules/modular_items/lewd_items/sounds/highheel2.ogg' = 1), 70)
 
 /////////////////
 ///Latex socks///
@@ -96,9 +96,9 @@
 //start processing
 /obj/item/clothing/shoes/latex_socks/equipped(mob/user, slot)
 	. = ..()
-	var/mob/living/carbon/human/C = user
-	C.update_inv_shoes()
-	C.hud_used.hidden_inventory_update()
+	var/mob/living/carbon/human/affected_mob = user
+	affected_mob.update_inv_shoes()
+	affected_mob.hud_used.hidden_inventory_update()
 
 //////////////////
 ///Domina heels///
@@ -119,13 +119,13 @@
 //it takes time to put them off, do not touch
 /obj/item/clothing/shoes/dominaheels/attack_hand(mob/user)
 	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		if(src == C.shoes)
-			if(!do_after(C, 20, target = src))
+		var/mob/living/carbon/affected_mob = user
+		if(src == affected_mob.shoes)
+			if(!do_after(affected_mob, 20, target = src))
 				return
 	. = ..()
 
 //to make sound when we walking in this
 /obj/item/clothing/shoes/dominaheels/Initialize()
 	. = ..()
-	AddComponent(/datum/component/squeak, list('modular_skyrat/modules/modular_items/lewd_items/sounds/highheel1.ogg' = 1,'modular_skyrat/modules/modular_items/lewd_items/sounds/highheel2.ogg' = 1), 70)
+	AddComponent(/datum/component/squeak, list('modular_skyrat/modules/modular_items/lewd_items/sounds/highheel1.ogg' = 1, 'modular_skyrat/modules/modular_items/lewd_items/sounds/highheel2.ogg' = 1), 70)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/neckleash.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/neckleash.dm
@@ -83,12 +83,12 @@
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 //to change color
-/obj/item/leash/AltClick(mob/user, obj/item/I)
+/obj/item/leash/AltClick(mob/user)
 	if(color_changed == FALSE)
 		. = ..()
 		if(.)
 			return
-		var/choice = show_radial_menu(user,src, leash_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, leash_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		current_color = choice
@@ -127,7 +127,7 @@
 		if(C.handcuffed)
 			leashtime = 5
 		if(do_mob(user, C, leashtime)) //do_mob adds a progress bar, but then we also check to see if they have a collar
-			log_combat(user, C, "leashed", addition="playfully")
+			log_combat(user, C, "leashed", addition = "playfully")
 			//TODO: Figure out how to make an easy breakout for leashed leash_pets
 			C.apply_status_effect(/datum/status_effect/leash_pet)//Has now been leashed
 			user.apply_status_effect(/datum/status_effect/leash_dom) //Is the leasher
@@ -136,7 +136,7 @@
 			RegisterSignal(leash_pet, COMSIG_MOVABLE_MOVED, .proc/on_pet_move)
 			RegisterSignal(leash_master, COMSIG_MOVABLE_MOVED, .proc/on_master_move)
 
-			var/datum/beam/new_leash = Beam(C, icon_state = "leash", maxdistance = 5, beam_type=/obj/effect/ebeam/leash)
+			var/datum/beam/new_leash = Beam(C, icon_state = "leash", maxdistance = 5, beam_type = /obj/effect/ebeam/leash)
 			RegisterSignal(new_leash, COMSIG_PARENT_QDELETING, .proc/remove_leash, new_leash)
 
 			if(!leash_pet.has_status_effect(/datum/status_effect/leash_dom)) //Add slowdown if the pet didn't leash themselves
@@ -500,12 +500,12 @@
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 //to change color
-/obj/item/leash/AltClick(mob/user, obj/item/I)
+/obj/item/leash/AltClick(mob/user)
 	if(color_changed == FALSE)
 		. = ..()
 		if(.)
 			return
-		var/choice = show_radial_menu(user,src, leash_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, leash_designs, custom_check = CALLBACK(src, .proc/check_menu, user, radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		current_color = choice
@@ -534,7 +534,7 @@
 	inhand_icon_state = "[initial(icon_state)]_[current_color]"
 
 //Called when someone is clicked with the leash
-/obj/item/leash/attack(mob/living/carbon/C, mob/living/user) //C is the target, user is the one with the leash
+/obj/item/leash/attack(mob/living/carbon/C, mob/living/user) // C is the target, user is the one with the leash
 	.=..()
 	if(C.has_status_effect(/datum/status_effect/leash_pet)) //If the pet is already leashed, do not leash them. For the love of god.
 		to_chat(user, span_notice("[C] has already been leashed."))
@@ -544,7 +544,7 @@
 		if(C.handcuffed)
 			leashtime = 5
 		if(do_mob(user, C, leashtime)) //do_mob adds a progress bar, but then we also check to see if they have a collar
-			log_combat(user, C, "leashed", addition="playfully")
+			log_combat(user, C, "leashed", addition = "playfully")
 			//TODO: Figure out how to make an easy breakout for leashed leash_pets
 			C.apply_status_effect(/datum/status_effect/leash_pet)//Has now been leashed
 			user.apply_status_effect(/datum/status_effect/leash_dom) //Is the leasher
@@ -553,7 +553,7 @@
 			RegisterSignal(leash_pet, COMSIG_MOVABLE_MOVED, .proc/on_pet_move)
 			RegisterSignal(leash_master, COMSIG_MOVABLE_MOVED, .proc/on_master_move)
 
-			leashrope = user.Beam(leash_pet, icon_state="leashrope", time = INFINITE, beam_type = /obj/effect/ebeam/leashrope)
+			leashrope = user.Beam(leash_pet, icon_state = "leashrope", time = INFINITE, beam_type = /obj/effect/ebeam/leashrope)
 			RegisterSignal(leashrope, COMSIG_PARENT_QDELETING)//this is a WAY better rangecheck than what was done before (process check)
 
 			leash_used = 1
@@ -645,7 +645,7 @@
 		return
 
 	//If the master moves, pull the pet in behind
-	sleep(2) //A small sleep so the pet kind of bounces back after they make the step
+	sleep(2) // A small sleep so the pet kind of bounces back after they make the step
 	//Also, the sleep means that the distance check for master happens before the pet, to prevent both from proccing.
 
 	if(leash_master == null) //Just to stop error messages
@@ -737,7 +737,7 @@
 		return
 
 	//If the pet gets too far away, they get tugged back
-	sleep(3)//A small sleep so the pet kind of bounces back after they make the step
+	sleep(3) // A small sleep so the pet kind of bounces back after they make the step
 	if(leash_master == null)
 		return
 	if(leash_pet == null)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shackles.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shackles.dm
@@ -38,12 +38,12 @@
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 //to change model
-/obj/item/clothing/suit/straight_jacket/shackles/AltClick(mob/user, obj/item/I)
+/obj/item/clothing/suit/straight_jacket/shackles/AltClick(mob/user)
 	if(color_changed == FALSE)
 		. = ..()
 		if(.)
 			return
-		var/choice = show_radial_menu(user,src, shackles_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, shackles_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		current_color = choice
@@ -75,8 +75,8 @@
 //message when equipping that thing
 /obj/item/clothing/suit/straight_jacket/shackles/equipped(mob/user, slot)
 	. = ..()
-	var/mob/living/carbon/human/C = user
-	if(src == C.wear_suit)
+	var/mob/living/carbon/human/affected_mob = user
+	if(src == affected_mob.wear_suit)
 		to_chat(user, span_purple("The shackles are restraining your body, though the lock appears to be made of... Plastic?"))
 	else
 		return
@@ -84,18 +84,18 @@
 //message when unequipping that thing
 /obj/item/clothing/suit/straight_jacket/shackles/dropped(mob/user)
 	. = ..()
-	var/mob/living/carbon/human/C = user
-	if(src == C.wear_suit)
+	var/mob/living/carbon/human/affected_mob = user
+	if(src == affected_mob.wear_suit)
 		to_chat(user, span_purple("The shackles are no longer restraining your body. It wasn't too hard, huh?"))
 
 //reinforcing normal version by using handcuffs on it.
-/obj/item/clothing/suit/straight_jacket/shackles/attackby(obj/item/I, mob/user, params) //That part allows reinforcing this item with normal straightjacket
-    if(istype(I, /obj/item/restraints/handcuffs))
-        var/obj/item/clothing/suit/straight_jacket/shackles/reinforced/W = new /obj/item/clothing/suit/straight_jacket/shackles/reinforced
+/obj/item/clothing/suit/straight_jacket/shackles/attackby(obj/item/used_item, mob/user, params) //That part allows reinforcing this item with normal straightjacket
+    if(istype(used_item, /obj/item/restraints/handcuffs))
+        var/obj/item/clothing/suit/straight_jacket/shackles/reinforced/shackles = new /obj/item/clothing/suit/straight_jacket/shackles/reinforced
         remove_item_from_storage(user)
-        user.put_in_hands(W)
-        to_chat(user, span_notice("You reinforced the locks on [src] with [I]."))
-        qdel(I)
+        user.put_in_hands(shackles)
+        to_chat(user, span_notice("You reinforced the locks on [src] with [used_item]."))
+        qdel(used_item)
         qdel(src)
         return
     . = ..()
@@ -123,15 +123,15 @@
 //message when equipping that thing
 /obj/item/clothing/suit/straight_jacket/shackles/reinforced/equipped(mob/user, slot)
 	. = ..()
-	var/mob/living/carbon/human/C = user
-	if(src == C.wear_suit)
+	var/mob/living/carbon/human/affected_mob = user
+	if(src == affected_mob.wear_suit)
 		to_chat(user, span_purple("The shackles are restraining your body!"))
 	else
 		return
 
 //message when unequipping that thing
 /obj/item/clothing/suit/straight_jacket/shackles/reinforced/dropped(mob/user)
-	var/mob/living/carbon/human/C = user
 	. = ..()
-	if(src == C.wear_suit)
+	var/mob/living/carbon/human/affected_mob = user
+	if(src == affected_mob.wear_suit)
 		to_chat(user, span_purple("The shackles are no longer restraining your body. You are free!"))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shibari_worn_uniform.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shibari_worn_uniform.dm
@@ -154,8 +154,8 @@
 	if(!hooman?.dna?.mutant_bodyparts["taur"])
 		slowdown = 0
 		return ..()
-	var/datum/sprite_accessory/taur/S = GLOB.sprite_accessories["taur"][hooman.dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME]]
-	if(S.hide_legs)
+	var/datum/sprite_accessory/taur/taur_accessory = GLOB.sprite_accessories["taur"][hooman.dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME]]
+	if(taur_accessory.hide_legs)
 		slowdown = 4
 	else
 		slowdown = 0

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shockcollar.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/shockcollar.dm
@@ -34,23 +34,23 @@
 		return
 
 	if(isliving(loc) && on) //the "on" arg is currently useless
-		var/mob/living/carbon/human/L = loc
-		if(!L.get_item_by_slot(ITEM_SLOT_NECK)) //**properly** stops pocket shockers
+		var/mob/living/carbon/human/affected_mob = loc
+		if(!affected_mob.get_item_by_slot(ITEM_SLOT_NECK)) //**properly** stops pocket shockers
 			return
 		if(shock_cooldown == TRUE)
 			return
 		shock_cooldown = TRUE
 		addtimer(VARSET_CALLBACK(src, shock_cooldown, FALSE), 100)
-		step(L, pick(GLOB.cardinals))
+		step(affected_mob, pick(GLOB.cardinals))
 
-		to_chat(L, span_danger("You feel a sharp shock from the collar!"))
-		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-		s.set_up(3, 1, L)
-		s.start()
+		to_chat(affected_mob, span_danger("You feel a sharp shock from the collar!"))
+		var/datum/effect_system/spark_spread/created_sparks = new /datum/effect_system/spark_spread
+		created_sparks.set_up(3, 1, affected_mob)
+		created_sparks.start()
 
-		L.Paralyze(30)
-		L.adjustPain(10)
-		L.adjust_timed_status_effect(30 SECONDS, /datum/status_effect/speech/stutter)
+		affected_mob.Paralyze(30)
+		affected_mob.adjustPain(10)
+		affected_mob.adjust_timed_status_effect(30 SECONDS, /datum/status_effect/speech/stutter)
 
 	if(master)
 		if(isassembly(master))
@@ -59,23 +59,23 @@
 		master.receive_signal()
 	return
 
-/obj/item/electropack/shockcollar/attackby(obj/item/W, mob/user, params) //moves it here because on_click is being bad
-	if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "Would you like to change the name on the tag?", "Name your new pet", tagname ? tagname : "Spot", MAX_NAME_LEN)
-		if(t)
-			tagname = t
-			name = "[initial(name)] - [t]"
+/obj/item/electropack/shockcollar/attackby(obj/item/used_item, mob/user, params) // Moves it here because on_click is being bad
+	if(istype(used_item, /obj/item/pen))
+		var/tag_input = stripped_input(user, "Would you like to change the name on the tag?", "Name your new pet", tagname ? tagname : "Spot", MAX_NAME_LEN)
+		if(tag_input)
+			tagname = tag_input
+			name = "[initial(name)] - [tag_input]"
 		return
-	if(istype(W, /obj/item/clothing/head/helmet))
+	if(istype(used_item, /obj/item/clothing/head/helmet))
 		return
 	else
 		return ..()
 
 /obj/item/electropack/shockcollar/Initialize()
 	if(random)
-		code = rand(1,100)
+		code = rand(1, 100)
 		frequency = rand(MIN_FREE_FREQ, MAX_FREE_FREQ)
-		if(ISMULTIPLE(frequency, 2))//signaller frequencies are always uneven!
+		if(ISMULTIPLE(frequency, 2)) // Signaller frequencies are always uneven!
 			frequency++
 	if(freq_in_name)
 		name = initial(name) + " - freq: [frequency/10] code: [code]"

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/strapon.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/strapon.dm
@@ -8,7 +8,7 @@
 	var/in_hands = FALSE
 	var/type_changed = FALSE
 	var/strapon_type = "human"
-	var/obj/item/strapon_dildo/W
+	var/obj/item/strapon_dildo/strapon_item
 	var/static/list/strapon_types
 	actions_types = list(/datum/action/item_action/take_strapon)
 
@@ -27,12 +27,12 @@
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 //to change model
-/obj/item/clothing/strapon/AltClick(mob/user, obj/item/I)
+/obj/item/clothing/strapon/AltClick(mob/user)
 	if(type_changed == FALSE)
 		. = ..()
 		if(.)
 			return
-		var/choice = show_radial_menu(user,src, strapon_types, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, strapon_types, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		strapon_type = choice
@@ -61,39 +61,39 @@
 
 /obj/item/clothing/strapon/equipped(mob/user, slot)
 	. = ..()
-	var/mob/living/carbon/human/H = user
-	var/obj/item/organ/genital/vagina/V = H.getorganslot(ORGAN_SLOT_VAGINA)
-	var/obj/item/organ/genital/womb/W = H.getorganslot(ORGAN_SLOT_WOMB)
-	var/obj/item/organ/genital/penis/P = H.getorganslot(ORGAN_SLOT_PENIS)
-	var/obj/item/organ/genital/testicles/T = H.getorganslot(ORGAN_SLOT_TESTICLES)
+	var/mob/living/carbon/human/affected_mob = user
+	var/obj/item/organ/genital/vagina/affected_vagina = affected_mob.getorganslot(ORGAN_SLOT_VAGINA)
+	var/obj/item/organ/genital/womb/affected_womb = affected_mob.getorganslot(ORGAN_SLOT_WOMB)
+	var/obj/item/organ/genital/penis/affected_penis = affected_mob.getorganslot(ORGAN_SLOT_PENIS)
+	var/obj/item/organ/genital/testicles/affected_testicles = affected_mob.getorganslot(ORGAN_SLOT_TESTICLES)
 
-	if(src == H.belt)
-		V?.visibility_preference = GENITAL_NEVER_SHOW
-		W?.visibility_preference = GENITAL_NEVER_SHOW
-		P?.visibility_preference = GENITAL_NEVER_SHOW
-		T?.visibility_preference = GENITAL_NEVER_SHOW
-		H.update_body()
+	if(src == affected_mob.belt)
+		affected_vagina?.visibility_preference = GENITAL_NEVER_SHOW
+		affected_womb?.visibility_preference = GENITAL_NEVER_SHOW
+		affected_penis?.visibility_preference = GENITAL_NEVER_SHOW
+		affected_testicles?.visibility_preference = GENITAL_NEVER_SHOW
+		affected_mob.update_body()
 	else
 		return
 
 /obj/item/clothing/strapon/dropped(mob/living/user)
 	. = ..()
-	var/mob/living/carbon/human/H = user
-	var/obj/item/organ/genital/vagina/Vagene = H.getorganslot(ORGAN_SLOT_VAGINA)
-	var/obj/item/organ/genital/womb/Wombo = H.getorganslot(ORGAN_SLOT_WOMB)
-	var/obj/item/organ/genital/penis/Penus = H.getorganslot(ORGAN_SLOT_PENIS)
-	var/obj/item/organ/genital/testicles/Testes = H.getorganslot(ORGAN_SLOT_TESTICLES)
+	var/mob/living/carbon/human/affected_mob = user
+	var/obj/item/organ/genital/vagina/affected_vagina = affected_mob.getorganslot(ORGAN_SLOT_VAGINA)
+	var/obj/item/organ/genital/womb/affected_womb = affected_mob.getorganslot(ORGAN_SLOT_WOMB)
+	var/obj/item/organ/genital/penis/affected_penis = affected_mob.getorganslot(ORGAN_SLOT_PENIS)
+	var/obj/item/organ/genital/testicles/affected_testicles = affected_mob.getorganslot(ORGAN_SLOT_TESTICLES)
 
-	if(W && !ismob(loc) && in_hands == TRUE && src != H.belt)
-		qdel(W)
+	if(strapon_item && !ismob(loc) && in_hands == TRUE && src != affected_mob.belt)
+		qdel(strapon_item)
 		in_hands = FALSE
 
-	if(src == H.belt)
-		Vagene?.visibility_preference = GENITAL_HIDDEN_BY_CLOTHES
-		Wombo?.visibility_preference = GENITAL_HIDDEN_BY_CLOTHES
-		Penus?.visibility_preference = GENITAL_HIDDEN_BY_CLOTHES
-		Testes?.visibility_preference = GENITAL_HIDDEN_BY_CLOTHES
-		H.update_body()
+	if(src == affected_mob.belt)
+		affected_vagina?.visibility_preference = GENITAL_HIDDEN_BY_CLOTHES
+		affected_womb?.visibility_preference = GENITAL_HIDDEN_BY_CLOTHES
+		affected_penis?.visibility_preference = GENITAL_HIDDEN_BY_CLOTHES
+		affected_testicles?.visibility_preference = GENITAL_HIDDEN_BY_CLOTHES
+		affected_mob.update_body()
 	else
 		return
 
@@ -103,9 +103,9 @@
 
 //Functionality stuff
 /obj/item/clothing/strapon/proc/update_action_buttons_icons()
-	for(var/datum/action/item_action/take_strapon/M in actions_types)
-		M.button_icon_state = "dildo_[strapon_type]"
-		M.icon_icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_items.dmi'
+	for(var/datum/action/item_action/take_strapon/action_button in actions_types)
+		action_button.button_icon_state = "dildo_[strapon_type]"
+		action_button.icon_icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_items.dmi'
 	update_icon()
 
 //button stuff
@@ -114,59 +114,58 @@
     desc = "Put the strapon in your hand in order to use it properly."
 
 /datum/action/item_action/take_strapon/Trigger(trigger_flags)
-	var/obj/item/clothing/strapon/H = target
-	if(istype(H))
-		H.check()
+	var/obj/item/clothing/strapon/affected_item = target
+	if(istype(affected_item))
+		affected_item.check()
 
 /obj/item/clothing/strapon/proc/check()
-	var/mob/living/carbon/human/C = usr
-	if(src == C.belt)
-		toggle(C)
+	var/mob/living/carbon/human/user = usr
+	if(src == user.belt)
+		toggle(user)
 	else
-		to_chat(C, span_warning("You need to put the strapon around your waist before you can use it!"))
+		to_chat(user, span_warning("You need to put the strapon around your waist before you can use it!"))
 
-/obj/item/clothing/strapon/proc/toggle(user)
-	var/mob/living/carbon/human/C = usr
-	playsound(C, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 40, TRUE, ignore_walls = FALSE)
-	var/obj/item/held = C.get_active_held_item()
-	var/obj/item/unheld = C.get_inactive_held_item()
+/obj/item/clothing/strapon/proc/toggle(mob/living/carbon/human/user)
+	playsound(user, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 40, TRUE, ignore_walls = FALSE)
+	var/obj/item/held = user.get_active_held_item()
+	var/obj/item/unheld = user.get_inactive_held_item()
 
 	if(in_hands == TRUE)
 		if(istype(held, /obj/item/strapon_dildo))
 			qdel(held)
-			C.visible_message(span_notice("[user] puts the strapon back."))
+			user.visible_message(span_notice("[user] puts the strapon back."))
 			in_hands = FALSE
 			return
 
 		else if(istype(unheld, /obj/item/strapon_dildo))
 			qdel(unheld)
-			C.visible_message(span_notice("[user] puts the strapon back."))
+			user.visible_message(span_notice("[user] puts the strapon back."))
 			in_hands = FALSE
 			return
 
 		else if(held == null)
 			if(unheld.name =="strapon" && unheld.item_flags == ABSTRACT | HAND_ITEM)
-				if(src == C.belt)
+				if(src == user.belt)
 					qdel(unheld)
 					//CODE FOR PUTTING STRAPON IN HANDS
-					W = new()
-					C.put_in_hands(W)
-					W.strapon_type = strapon_type
-					W.update_icon_state()
-					W.update_icon()
-					C.visible_message(span_notice("[user] holds the strapon in their hand menacingly."))
+					strapon_item = new()
+					user.put_in_hands(strapon_item)
+					strapon_item.strapon_type = strapon_type
+					strapon_item.update_icon_state()
+					strapon_item.update_icon()
+					user.visible_message(span_notice("[user] holds the strapon in their hand menacingly."))
 					in_hands = TRUE
 					return
 		else
-			C.visible_message(span_notice("[user] tries to hold the strapon in their hand, but their hand isn't empty!"))
+			user.visible_message(span_notice("[user] tries to hold the strapon in their hand, but their hand isn't empty!"))
 			return
 	else
-		W = new()
-		C.put_in_hands(W)
-		W.strapon_type = strapon_type
-		W.update_icon_state()
-		W.update_icon()
-		C.visible_message(span_notice("[user] holds the strapon in their hand menacingly."))
+		strapon_item = new()
+		user.put_in_hands(strapon_item)
+		strapon_item.strapon_type = strapon_type
+		strapon_item.update_icon_state()
+		strapon_item.update_icon()
+		user.visible_message(span_notice("[user] holds the strapon in their hand menacingly."))
 		in_hands = TRUE
 		return
 
@@ -191,25 +190,25 @@
 	.=..()
 	icon_state = "[initial(icon_state)]_[strapon_type]"
 
-/obj/item/strapon_dildo/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
-	if(M == user)
+/obj/item/strapon_dildo/attack(mob/living/carbon/human/hit_mob, mob/living/carbon/human/user)
+	if(hit_mob == user)
 		return
 	. = ..()
-	if(!istype(M, /mob/living/carbon/human))
+	if(!istype(hit_mob, /mob/living/carbon/human))
 		return
 
 	var/message = ""
-	var/obj/item/organ/genital/vagina = M.getorganslot(ORGAN_SLOT_VAGINA)
-	if(M.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
+	var/obj/item/organ/genital/vagina = hit_mob.getorganslot(ORGAN_SLOT_VAGINA)
+	if(hit_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 		switch(user.zone_selected) //to let code know what part of body we gonna fuck
 			if(BODY_ZONE_PRECISE_GROIN)
 				if(vagina)
-					if(M.is_bottomless() || vagina.visibility_preference == GENITAL_ALWAYS_SHOW)
-						message = pick("delicately rubs [M]'s vagina with [src]", "uses [src] to fuck [M]'s vagina","jams [M]'s pussy with [src]", "teases [M]'s pussy with [src]")
-						M.adjustArousal(6)
-						M.adjustPleasure(8)
+					if(hit_mob.is_bottomless() || vagina.visibility_preference == GENITAL_ALWAYS_SHOW)
+						message = pick("delicately rubs [hit_mob]'s vagina with [src]", "uses [src] to fuck [hit_mob]'s vagina", "jams [hit_mob]'s pussy with [src]", "teases [hit_mob]'s pussy with [src]")
+						hit_mob.adjustArousal(6)
+						hit_mob.adjustPleasure(8)
 						if(prob(40))
-							M.emote(pick("twitch_s","moan"))
+							hit_mob.emote(pick("twitch_s", "moan"))
 						user.visible_message(span_purple("[user] [message]!"))
 						playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
 											'modular_skyrat/modules/modular_items/lewd_items/sounds/bang2.ogg',
@@ -218,20 +217,20 @@
 											'modular_skyrat/modules/modular_items/lewd_items/sounds/bang5.ogg',
 											'modular_skyrat/modules/modular_items/lewd_items/sounds/bang6.ogg'), 60, TRUE, ignore_walls = FALSE)
 					else
-						to_chat(user, span_danger("[M]'s groin is covered!"))
+						to_chat(user, span_danger("[hit_mob]'s groin is covered!"))
 						return
 				else
-					to_chat(user, span_danger("[M] doesn't have suitable genitalia for that!"))
+					to_chat(user, span_danger("[hit_mob] doesn't have suitable genitalia for that!"))
 					return
 
 			if(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_PRECISE_EYES) //Mouth only. Sorry, perverts. No eye/ear penetration for you today.
-				if(!M.is_mouth_covered())
-					message = pick("fucks [M]'s mouth with [src]", "chokes [M] by inserting [src] into [M.p_their()] throat", "forces [M] to suck [src]", "inserts [src] into [M]'s throat")
-					M.adjustArousal(4)
-					M.adjustPleasure(1)
-					M.adjustOxyLoss(1.5)
+				if(!hit_mob.is_mouth_covered())
+					message = pick("fucks [hit_mob]'s mouth with [src]", "chokes [hit_mob] by inserting [src] into [hit_mob.p_their()] throat", "forces [hit_mob] to suck [src]", "inserts [src] into [hit_mob]'s throat")
+					hit_mob.adjustArousal(4)
+					hit_mob.adjustPleasure(1)
+					hit_mob.adjustOxyLoss(1.5)
 					if(prob(70))
-						M.emote(pick("gasp","moan"))
+						hit_mob.emote(pick("gasp", "moan"))
 					user.visible_message(span_purple("[user] [message]!"))
 					playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/bang2.ogg',
@@ -241,16 +240,16 @@
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/bang6.ogg'), 40, TRUE, ignore_walls = FALSE)
 
 				else
-					to_chat(user, span_danger("[M]'s mouth is covered!"))
+					to_chat(user, span_danger("[hit_mob]'s mouth is covered!"))
 					return
 
 			else
-				if(M.is_bottomless())
-					message = pick("fucks [M]'s ass with [src]", "uses [src] to fuck [M]'s anus", "jams [M]'s ass with [src]", "roughly fucks [M]'s ass with [src], causing their eyes to roll back")
-					M.adjustArousal(5)
-					M.adjustPleasure(5)
+				if(hit_mob.is_bottomless())
+					message = pick("fucks [hit_mob]'s ass with [src]", "uses [src] to fuck [hit_mob]'s anus", "jams [hit_mob]'s ass with [src]", "roughly fucks [hit_mob]'s ass with [src], causing their eyes to roll back")
+					hit_mob.adjustArousal(5)
+					hit_mob.adjustPleasure(5)
 					if(prob(60))
-						M.emote(pick("twitch_s","moan","shiver"))
+						hit_mob.emote(pick("twitch_s", "moan", "shiver"))
 					user.visible_message(span_purple("[user] [message]!"))
 					playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/bang2.ogg',
@@ -260,8 +259,8 @@
 										'modular_skyrat/modules/modular_items/lewd_items/sounds/bang6.ogg'), 100, TRUE, ignore_walls = FALSE)
 
 				else
-					to_chat(user, span_danger("[M]'s anus is covered!"))
+					to_chat(user, span_danger("[hit_mob]'s anus is covered!"))
 					return
 	else
-		to_chat(user, span_danger("[M] doesn't want you to do that."))
+		to_chat(user, span_danger("[hit_mob] doesn't want you to do that."))
 		return

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/attachable_vibrator.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/attachable_vibrator.dm
@@ -38,12 +38,12 @@
 		"pink" = image(icon = src.icon, icon_state = "[initial(icon_state)]_pink_low[(istype(src, /obj/item/clothing/sextoy/eggvib/signalvib)) ? "_on" : ""]"),
 		"teal" = image(icon = src.icon, icon_state = "[initial(icon_state)]_teal_low[(istype(src, /obj/item/clothing/sextoy/eggvib/signalvib)) ? "_on" : ""]"))
 
-/obj/item/clothing/sextoy/eggvib/AltClick(mob/user, obj/item/object)
+/obj/item/clothing/sextoy/eggvib/AltClick(mob/user)
 	if(!color_changed)
 		. = ..()
 		if(.)
 			return
-		var/choice = show_radial_menu(user,src, vib_designs, custom_check = CALLBACK(src, .proc/check_menu, user, object), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, vib_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		current_color = choice
@@ -157,7 +157,7 @@
 
 /obj/item/clothing/sextoy/eggvib/signalvib/Initialize()
 	if(random)
-		code = rand(1,100)
+		code = rand(1, 100)
 		frequency = rand(MIN_FREE_FREQ, MAX_FREE_FREQ)
 		if(ISMULTIPLE(frequency, 2))//signaller frequencies are always uneven!
 			frequency++
@@ -170,7 +170,7 @@
 	SSradio.remove_object(src, frequency)
 	. = ..()
 
-//A moment for the `attackby()` proc that used to lie here, letting you turn a vibrator into an electric chair.
+// A moment for the `attackby()` proc that used to lie here, letting you turn a vibrator into an electric chair.
 
 /obj/item/clothing/sextoy/eggvib/signalvib/update_icon_state()
 	. = ..()
@@ -187,9 +187,9 @@
 
 //arousal stuff
 
-/obj/item/clothing/sextoy/eggvib/signalvib/AltClick(mob/user, obj/item/I)
+/obj/item/clothing/sextoy/eggvib/signalvib/AltClick(mob/user)
 	if(!color_changed)
-		var/choice = show_radial_menu(user,src, vib_designs, custom_check = CALLBACK(src, /obj/item/clothing/sextoy/proc/check_menu, user, I), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, vib_designs, custom_check = CALLBACK(src, /obj/item/clothing/sextoy/proc/check_menu, user), radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		current_color = choice

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/buttplug.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/buttplug.dm
@@ -43,12 +43,12 @@
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 
-/obj/item/clothing/sextoy/buttplug/AltClick(mob/user, obj/item/object)
+/obj/item/clothing/sextoy/buttplug/AltClick(mob/user)
 	if(!color_changed)
 		. = ..()
 		if(.)
 			return
-		var/choice = show_radial_menu(user,src, buttplug_designs, custom_check = CALLBACK(src, .proc/check_menu, user, object), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, buttplug_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		current_color = choice
@@ -62,7 +62,7 @@
 			. = ..()
 			if(.)
 				return
-			var/choice = show_radial_menu(user,src, buttplug_forms, custom_check = CALLBACK(src, .proc/check_menu, user, object), radius = 36, require_near = TRUE)
+			var/choice = show_radial_menu(user, src, buttplug_forms, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 			if(!choice)
 				return FALSE
 			current_size = choice
@@ -107,7 +107,7 @@
 	var/mob/living/carbon/human/target = loc
 	if(!istype(target))
 		return
-	//i tried using switch here, but it need static value, and u.arousal can't be it. So fuck switches. Reject it, embrace the IFs
+	// I tried using switch here, but it need static value, and u.arousal can't be it. So fuck switches. Reject it, embrace the IFs
 	if(current_size == "small" && target.arousal < 30)
 		target.adjustArousal(0.6 * delta_time)
 		target.adjustPleasure(0.7 * delta_time)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/condom.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/condom.dm
@@ -31,16 +31,16 @@
 	if(!do_after(user, 1.5 SECONDS, target = user))
 		return
 	playsound(src.loc, 'sound/items/poster_ripped.ogg', 50, TRUE)
-	var/obj/item/clothing/sextoy/condom/C = new /obj/item/clothing/sextoy/condom
+	var/obj/item/clothing/sextoy/condom/removed_condom = new /obj/item/clothing/sextoy/condom
 
-	user.put_in_hands(C)
+	user.put_in_hands(removed_condom)
 	switch(current_color)
 		if("pink")
-			C.current_color = "pink"
+			removed_condom.current_color = "pink"
 		if("teal")
-			C.current_color = "teal"
-	C.update_icon_state()
-	C.update_icon()
+			removed_condom.current_color = "teal"
+	removed_condom.update_icon_state()
+	removed_condom.update_icon()
 	qdel(src)
 
 //Opened condom

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
@@ -39,13 +39,13 @@
 		"human" = image(icon = src.icon, icon_state = "[initial(icon_state)]_human"),
 		"tentacle" = image(icon = src.icon, icon_state = "[initial(icon_state)]_tentacle"))
 
-/obj/item/clothing/sextoy/dildo/AltClick(mob/user, obj/item/object)
+/obj/item/clothing/sextoy/dildo/AltClick(mob/user)
 	if(color_changed)
 		return
 	. = ..()
 	if(.)
 		return
-	var/choice = show_radial_menu(user,src, dildo_designs, custom_check = CALLBACK(src, .proc/check_menu, user, object), radius = 36, require_near = TRUE)
+	var/choice = show_radial_menu(user, src, dildo_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 	if(!choice)
 		return FALSE
 	current_color = choice
@@ -107,7 +107,7 @@
 			if(!(target.is_bottomless() || vagina.visibility_preference == GENITAL_ALWAYS_SHOW))
 				to_chat(user, span_danger("[target]'s groin is covered!"))
 				return
-			message = (user == target) ? pick("rubs [target.p_their()] vagina with [src]","gently jams [target.p_their()] pussy with [src]","fucks [target.p_their()] vagina with a [src]") : pick("delicately rubs [target]'s vagina with [src]", "uses [src] to fuck [target]'s vagina","jams [target]'s pussy with [src]", "teasing [target]'s pussy with [src]")
+			message = (user == target) ? pick("rubs [target.p_their()] vagina with [src]", "gently jams [target.p_their()] pussy with [src]", "fucks [target.p_their()] vagina with a [src]") : pick("delicately rubs [target]'s vagina with [src]", "uses [src] to fuck [target]'s vagina", "jams [target]'s pussy with [src]", "teasing [target]'s pussy with [src]")
 			if(poly_size == "small")
 				target.adjustArousal(4)
 				target.adjustPleasure(5)
@@ -117,13 +117,13 @@
 				target.adjustArousal(6)
 				target.adjustPleasure(8)
 				if(prob(40) && (target.stat != DEAD))
-					target.emote(pick("twitch_s","moan"))
+					target.emote(pick("twitch_s", "moan"))
 			else if(poly_size == "big")
 				target.adjustArousal(8)
 				target.adjustPleasure(10)
 				target.adjustPain(2)
 				if(prob(60) && (target.stat != DEAD))
-					target.emote(pick("twitch_s","moan","gasp"))
+					target.emote(pick("twitch_s", "moan", "gasp"))
 			if(side_double)
 				user.adjustArousal(6)
 				user.adjustPleasure(8)
@@ -132,22 +132,22 @@
 			if(!target.is_mouth_covered())
 				to_chat(user, span_danger("Looks like [target]'s mouth is covered!"))
 				return
-			message = (user == target) ? pick("licks [src] erotically","sucks on [src], slowly inserting it into [target.p_their()] throat") : pick("fucks [target]'s mouth with [src]", "inserts [src] into [target]'s throat, choking [target.p_them()]", "forces [target] to suck [src]", "inserts [src] into [target]'s throat")
+			message = (user == target) ? pick("licks [src] erotically", "sucks on [src], slowly inserting it into [target.p_their()] throat") : pick("fucks [target]'s mouth with [src]", "inserts [src] into [target]'s throat, choking [target.p_them()]", "forces [target] to suck [src]", "inserts [src] into [target]'s throat")
 			target.adjustArousal(4)
 			target.adjustPleasure(1)
 			if(prob(70) && (target.stat != DEAD))
-				target.emote(pick("gasp","moan"))
+				target.emote(pick("gasp", "moan"))
 
 
 		else
 			if(!target.is_bottomless())
 				to_chat(user, span_danger("[target]'s anus is covered!"))
 				return
-			message = (user == target) ? pick("puts [src] into [target.p_their()] anus","slowly inserts [src] into [target.p_their()] ass") : pick("fucks [target]'s ass with [src]", "uses [src] to fuck [target]'s anus", "jams [target]'s ass with [src]", "roughly fucks [target]'s ass with [src], making [target.p_their()] eyes roll back")
+			message = (user == target) ? pick("puts [src] into [target.p_their()] anus", "slowly inserts [src] into [target.p_their()] ass") : pick("fucks [target]'s ass with [src]", "uses [src] to fuck [target]'s anus", "jams [target]'s ass with [src]", "roughly fucks [target]'s ass with [src], making [target.p_their()] eyes roll back")
 			target.adjustArousal(5)
 			target.adjustPleasure(5)
 			if(prob(60) && (target.stat != DEAD))
-				target.emote(pick("twitch_s","moan","shiver"))
+				target.emote(pick("twitch_s", "moan", "shiver"))
 
 	user.visible_message(span_purple("[user] [message]!"))
 	playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/bang1.ogg',
@@ -162,17 +162,17 @@
 ///////////////////////
 
 GLOBAL_LIST_INIT(dildo_colors, list(//mostly neon colors
-		"Cyan"		= "#00f9ff",//cyan
-		"Green"		= "#49ff00",//green
-		"Pink"		= "#ff4adc",//pink
-		"Yellow"	= "#fdff00",//yellow
-		"Blue"		= "#00d2ff",//blue
-		"Lime"		= "#89ff00",//lime
-		"Black"		= "#101010",//black
-		"Red"		= "#ff0000",//red
-		"Orange"	= "#ff9a00",//orange
-		"Purple"	= "#e300ff",//purple
-		"White"		= "#c0c0c0",//white
+		"Cyan"		= "#00f9ff", //cyan
+		"Green"		= "#49ff00", //green
+		"Pink"		= "#ff4adc", //pink
+		"Yellow"	= "#fdff00", //yellow
+		"Blue"		= "#00d2ff", //blue
+		"Lime"		= "#89ff00", //lime
+		"Black"		= "#101010", //black
+		"Red"		= "#ff0000", //red
+		"Orange"	= "#ff9a00", //orange
+		"Purple"	= "#e300ff", //purple
+		"White"		= "#c0c0c0", //white
 		))
 
 /obj/item/clothing/sextoy/dildo/custom_dildo
@@ -198,9 +198,9 @@ GLOBAL_LIST_INIT(dildo_colors, list(//mostly neon colors
 		"medium" = image(icon = src.icon, icon_state = "[initial(icon_state)]_medium"),
 		"big" = image(icon = src.icon, icon_state = "[initial(icon_state)]_big"))
 
-/obj/item/clothing/sextoy/dildo/custom_dildo/AltClick(mob/living/user, obj/item/I)
+/obj/item/clothing/sextoy/dildo/custom_dildo/AltClick(mob/living/user)
 	if(!size_changed)
-		var/choice = show_radial_menu(user, src, dildo_sizes, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, dildo_sizes, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		poly_size = choice
@@ -218,15 +218,15 @@ GLOBAL_LIST_INIT(dildo_colors, list(//mostly neon colors
 
 /// Choose a color and transparency level for the toy
 /obj/item/clothing/sextoy/dildo/custom_dildo/proc/customize(mob/living/user)
-	if(src && !user.incapacitated() && in_range(user,src))
+	if(src && !user.incapacitated() && in_range(user, src))
 		var/color_choice = tgui_input_list(user, "Choose a color for your dildo.", "Dildo Color", GLOB.dildo_colors)
-		if(src && color_choice && !user.incapacitated() && in_range(user,src))
+		if(src && color_choice && !user.incapacitated() && in_range(user, src))
 			sanitize_inlist(color_choice, GLOB.dildo_colors, "Red")
 			color = GLOB.dildo_colors[color_choice]
 	update_icon_state()
-	if(src && !user.incapacitated() && in_range(user,src))
+	if(src && !user.incapacitated() && in_range(user, src))
 		var/transparency_choice = tgui_input_number(user, "Choose the transparency of your dildo. Lower is more transparent! (192-255)", "Dildo Transparency", 255, 255, 192)
-		if(src && transparency_choice && !user.incapacitated() && in_range(user,src))
+		if(src && transparency_choice && !user.incapacitated() && in_range(user, src))
 			sanitize_integer(transparency_choice, 191, 255, 192)
 			alpha = transparency_choice
 	update_icon_state()
@@ -277,7 +277,7 @@ GLOBAL_LIST_INIT(dildo_colors, list(//mostly neon colors
 /obj/item/clothing/sextoy/dildo/double_dildo/populate_dildo_designs()
 	return
 
-/obj/item/clothing/sextoy/dildo/double_dildo/AltClick(mob/user, obj/item/object)
+/obj/item/clothing/sextoy/dildo/double_dildo/AltClick(mob/user)
 	return
 
 /// Proc to update the actionbutton icon

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/feather.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/feather.dm
@@ -21,11 +21,11 @@
 			if(!(target.is_bottomless()))
 				to_chat(user, span_danger("[target]'s groin is covered!"))
 				return
-			message = (user == target) ? pick("tickles [target.p_them()]self with [src]","gently teases [target.p_their()] belly with [src]") : pick("teases [target]'s belly with [src]", "uses [src] to tickle [target]'s belly","tickles [target] with [src]")
+			message = (user == target) ? pick("tickles [target.p_them()]self with [src]", "gently teases [target.p_their()] belly with [src]") : pick("teases [target]'s belly with [src]", "uses [src] to tickle [target]'s belly", "tickles [target] with [src]")
 			if(target.stat == DEAD)
 				return
 			if(prob(70))
-				target.emote(pick("laugh","giggle","twitch","twitch_s"))
+				target.emote(pick("laugh", "giggle", "twitch", "twitch_s"))
 
 		if(BODY_ZONE_CHEST)
 			targetedsomewhere = TRUE
@@ -33,11 +33,11 @@
 			if(!(target.is_topless() || badonkers.visibility_preference == GENITAL_ALWAYS_SHOW))
 				to_chat(user, span_danger("[target]'s chest is covered!"))
 				return
-			message = (user == target) ? pick("tickles [target.p_them()]self with [src]","gently teases [target.p_their()] own nipples with [src]") : pick("teases [target]'s nipples with [src]", "uses [src] to tickle [target]'s left nipple", "uses [src] to tickle [target]'s right nipple")
+			message = (user == target) ? pick("tickles [target.p_them()]self with [src]", "gently teases [target.p_their()] own nipples with [src]") : pick("teases [target]'s nipples with [src]", "uses [src] to tickle [target]'s left nipple", "uses [src] to tickle [target]'s right nipple")
 			if(target.stat == DEAD)
 				return
 			if(prob(70))
-				target.emote(pick("laugh","giggle","twitch","twitch_s","moan",))
+				target.emote(pick("laugh", "giggle", "twitch", "twitch_s", "moan", ))
 
 		if(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 			targetedsomewhere = TRUE
@@ -48,22 +48,22 @@
 			if(!target.is_barefoot())
 				to_chat(user, span_danger("[target]'s feet are covered!"))
 				return
-			message = (user == target) ? pick("tickles [target.p_them()]self with [src]","gently teases [target.p_their()] own feet with [src]") : pick("teases [target]'s feet with [src]", "uses [src] to tickle [target]'s [user.zone_selected == BODY_ZONE_L_LEG ? "left" : "right"] foot", "uses [src] to tickle [target]'s toes")
+			message = (user == target) ? pick("tickles [target.p_them()]self with [src]", "gently teases [target.p_their()] own feet with [src]") : pick("teases [target]'s feet with [src]", "uses [src] to tickle [target]'s [user.zone_selected == BODY_ZONE_L_LEG ? "left" : "right"] foot", "uses [src] to tickle [target]'s toes")
 			if(target.stat == DEAD)
 				return
 			if(prob(70))
-				target.emote(pick("laugh","giggle","twitch","twitch_s","moan",))
+				target.emote(pick("laugh", "giggle", "twitch", "twitch_s", "moan", ))
 
 		if(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
 			targetedsomewhere = TRUE
 			if(!target.is_topless())
 				to_chat(user, span_danger("[target]'s armpits are covered!"))
 				return
-			message = (user == target) ? pick("tickles [target.p_them()]self with [src]","gently teases [target.p_their()] own armpit with [src]") : pick("teases [target]'s right armpit with [src]", "uses [src] to tickle [target]'s [user.zone_selected == BODY_ZONE_L_ARM ? "left" : "right"] armpit", "uses [src] to tickle [target]'s underarm")
+			message = (user == target) ? pick("tickles [target.p_them()]self with [src]", "gently teases [target.p_their()] own armpit with [src]") : pick("teases [target]'s right armpit with [src]", "uses [src] to tickle [target]'s [user.zone_selected == BODY_ZONE_L_ARM ? "left" : "right"] armpit", "uses [src] to tickle [target]'s underarm")
 			if(target.stat == DEAD)
 				return
 			if(prob(70))
-				target.emote(pick("laugh","giggle","twitch","twitch_s","moan",))
+				target.emote(pick("laugh", "giggle", "twitch", "twitch_s", "moan", ))
 	if(!targetedsomewhere)
 		return
 	target.do_jitter_animation()
@@ -71,9 +71,9 @@
 	SEND_SIGNAL(target, COMSIG_ADD_MOOD_EVENT, "tickled", /datum/mood_event/tickled)
 	target.adjustArousal(3)
 	user.visible_message(span_purple("[user] [message]!"))
-	playsound(loc, pick('sound/items/handling/cloth_drop.ogg', 					//i duplicate this part of code because im useless shitcoder that can't make it work properly without tons of repeating code blocks
-            			'sound/items/handling/cloth_pickup.ogg',				//if you can make it better - go ahead, modify it, please.
-        	       	    'sound/items/handling/cloth_pickup.ogg'), 70, 1, -1, ignore_walls = FALSE)	//selfdestruction - 100
+	playsound(loc, pick('sound/items/handling/cloth_drop.ogg', // I duplicate this part of code because im useless shitcoder that can't make it work properly without tons of repeating code blocks
+            			'sound/items/handling/cloth_pickup.ogg', // If you can make it better - go ahead, modify it, please.
+        	       	    'sound/items/handling/cloth_pickup.ogg'), 70, 1, -1, ignore_walls = FALSE)
 
 //Mood boost
 /datum/mood_event/tickled

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/fleshlight.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/fleshlight.dm
@@ -37,13 +37,13 @@
 	icon_state = "[initial(icon_state)]_[current_color]"
 	inhand_icon_state = "[initial(icon_state)]_[current_color]"
 
-/obj/item/clothing/sextoy/fleshlight/AltClick(mob/user, obj/item/object)
+/obj/item/clothing/sextoy/fleshlight/AltClick(mob/user)
 	if(color_changed)
 		return
 	. = ..()
 	if(.)
 		return
-	var/choice = show_radial_menu(user, src, fleshlight_designs, custom_check = CALLBACK(src, .proc/check_menu, user, object), radius = 36, require_near = TRUE)
+	var/choice = show_radial_menu(user, src, fleshlight_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 	if(!choice)
 		return FALSE
 	current_color = choice
@@ -68,10 +68,10 @@
 			if(!(target.is_bottomless() || penis.visibility_preference == GENITAL_ALWAYS_SHOW))
 				to_chat(user, span_danger("[target]'s groin is covered!"))
 				return
-			message = (user == target) ? pick("moans in ecstasy as [target.p_they()] use the [src]","slowly moves [src] up and down on [target]'s penis, causing [target.p_them()] to bend in pleasure","slightly shivers in pleasure as [target.p_they()] use [src]") : pick("uses [src] on [target]'s penis","fucks [target] with [src]","masturbates [target] with [src], causing [target.p_them()] to moan in ecstasy")
+			message = (user == target) ? pick("moans in ecstasy as [target.p_they()] use the [src]", "slowly moves [src] up and down on [target]'s penis, causing [target.p_them()] to bend in pleasure", "slightly shivers in pleasure as [target.p_they()] use [src]") : pick("uses [src] on [target]'s penis", "fucks [target] with [src]", "masturbates [target] with [src], causing [target.p_them()] to moan in ecstasy")
 			if(!(prob(40) && (target.stat != DEAD)))
 				return
-			target.emote(pick("twitch_s","moan","blush"))
+			target.emote(pick("twitch_s", "moan", "blush"))
 			target.adjustArousal(6)
 			target.adjustPleasure(9)
 			user.visible_message(span_purple("[user] [message]!"))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/kinky_shocker.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/kinky_shocker.dm
@@ -276,11 +276,11 @@
 	if(!targetedsomewhere)
 		return
 	user.visible_message(span_purple("[user] [message]!"))
-	playsound(loc,'sound/weapons/taserhit.ogg')
+	playsound(loc, 'sound/weapons/taserhit.ogg')
 	if(target.stat == DEAD)
 		return
 	if(prob(80))
-		target.emote(pick("twitch","twitch_s","shiver","scream"))
+		target.emote(pick("twitch", "twitch_s", "shiver", "scream"))
 	target.do_jitter_animation()
 	target.adjustStaminaLoss(3)
 	target.adjustPain(9)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/leather_whip.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/leather_whip.dm
@@ -94,12 +94,12 @@
 	update_overlays()
 
 //to change color
-/obj/item/clothing/mask/leatherwhip/AltClick(mob/user, obj/item/I)
+/obj/item/clothing/mask/leatherwhip/AltClick(mob/user)
 	if(!color_changed)
 		. = ..()
 		if(.)
 			return
-		var/choice = show_radial_menu(user,src, whip_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, whip_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		current_whip_color = choice
@@ -113,7 +113,7 @@
 		. = ..()
 		if(.)
 			return
-		var/choice = show_radial_menu(user,src, whip_forms, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, whip_forms, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		current_whip_form = choice
@@ -176,7 +176,7 @@
 				message = (user == target) ? pick("Knocks [target.p_them()]self down with [src]", "Uses [src] to knock [target.p_them()]self on the ground") : pick("drops [target] to the ground with [src]", "uses [src] to put [target] on [target.p_their()] knees")
 				if(target.stat != DEAD)
 					if(prob(60))
-						target.emote(pick("gasp","shiver"))
+						target.emote(pick("gasp", "shiver"))
 					if(prob(10))
 						target.apply_status_effect(/datum/status_effect/subspace)
 				target.Paralyze(1)//don't touch it. It's domination tool, it should have ability to put someone on kneels. I already inserted check for PREF YOU CAN'T ABUSE THIS ITEM
@@ -186,7 +186,7 @@
 				message = (user == target) ? pick("knocks [target.p_them()]self down with [src]", "gently uses [src] to knock [target.p_them()]self on the ground") : pick("drops [target] to the ground with [src]", "uses [src] to put [target] on [target.p_their()] knees")
 				if(target.stat != DEAD)
 					if(prob(30))
-						target.emote(pick("gasp","shiver"))
+						target.emote(pick("gasp", "shiver"))
 					if(prob(10))
 						target.apply_status_effect(/datum/status_effect/subspace)
 				target.Paralyze(1)
@@ -202,7 +202,7 @@
 				message = (user == target) ? pick("knocks [target.p_them()]self down with [src]", "uses [src] to knock [target.p_them()]self on the ground") : pick("Hardly drops [target] on the ground with [src]", "uses [src] to put [target] on [target.p_their()] knees")
 				if(target.stat != DEAD)
 					if(prob(60))
-						target.emote(pick("gasp","shiver"))
+						target.emote(pick("gasp", "shiver"))
 					if(prob(10))
 						target.apply_status_effect(/datum/status_effect/subspace)
 				target.Paralyze(1)//don't touch it. It's domination tool, it should have ability to put someone on kneels. I already inserted check for PREF YOU CAN'T ABUSE THIS ITEM
@@ -212,7 +212,7 @@
 				message = (user == target) ? pick("Knocks [target.p_them()]self down with [src]", "gently uses [src] to knock [target.p_them()]self on the ground") : pick("drops [target] to the ground with [src]", "uses [src] to put [target] on [target.p_their()] knees")
 				if(target.stat != DEAD)
 					if(prob(30))
-						target.emote(pick("gasp","shiver"))
+						target.emote(pick("gasp", "shiver"))
 					if(prob(10))
 						target.apply_status_effect(/datum/status_effect/subspace)
 				target.Paralyze(1)
@@ -223,7 +223,7 @@
 			targetedsomewhere = TRUE
 			message = (user == target) ? pick("wraps [src] around [target.p_their()] neck, choking [target.p_them()]self", "chokes [target.p_them()]self with [src]") : pick("chokes [target] with [src]", "twines [src] around [target]'s neck!")
 			if(prob(70) && (target.stat != DEAD))
-				target.emote(pick("gasp","choke", "moan"))
+				target.emote(pick("gasp", "choke", "moan"))
 			target.adjustArousal(3)
 			target.adjustPain(5)
 			playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/latex.ogg', 80)
@@ -234,10 +234,10 @@
 				to_chat(user, span_danger("[target]'s butt is covered!"))
 				return
 			if(current_whip_type == "weak")
-				message = (user == target) ? pick("whips [target.p_them()]self with [src]", "flogs [target.p_them()]self with [src]") :pick("playfully flogs [target]'s thighs with [src]","flogs [target] with [src]","mercilessly flogs [target] with [src]")
+				message = (user == target) ? pick("whips [target.p_them()]self with [src]", "flogs [target.p_them()]self with [src]") :pick("playfully flogs [target]'s thighs with [src]", "flogs [target] with [src]", "mercilessly flogs [target] with [src]")
 				if(target.stat != DEAD)
 					if(prob(70))
-						target.emote(pick("moan","twitch"))
+						target.emote(pick("moan", "twitch"))
 					if(prob(10))
 						target.apply_status_effect(/datum/status_effect/subspace)
 				target.adjustArousal(5)
@@ -248,10 +248,10 @@
 				playsound(loc, 'sound/weapons/whip.ogg', 60)
 
 			if(current_whip_type == "hard")
-				message = (user == target) ? pick("roughly flogs [target.p_them()]self with [src]", "flogs [target.p_them()]self with [src]") : pick("playfully flogs [target]'s thighs with [src]","flogs [target] with [src]","mercilessly flogs [target] with [src]")
+				message = (user == target) ? pick("roughly flogs [target.p_them()]self with [src]", "flogs [target.p_them()]self with [src]") : pick("playfully flogs [target]'s thighs with [src]", "flogs [target] with [src]", "mercilessly flogs [target] with [src]")
 				if(target.stat != DEAD)
 					if(prob(70))
-						target.emote(pick("moan","twitch","twitch_s","scream"))
+						target.emote(pick("moan", "twitch", "twitch_s", "scream"))
 					if(prob(10))
 						target.apply_status_effect(/datum/status_effect/subspace)
 				target.adjustArousal(3)
@@ -262,10 +262,10 @@
 				playsound(loc, 'sound/weapons/whip.ogg', 100)
 		else
 			if(current_whip_type == "hard")
-				message = (user == target) ? pick("disciplines [target.p_them()]self with [src]","lashes [target.p_them()]self with [src]") : pick("lashes [target] with [src]","Uses [src] to discipline [target]", "disciplines [target] with [src]")
+				message = (user == target) ? pick("disciplines [target.p_them()]self with [src]", "lashes [target.p_them()]self with [src]") : pick("lashes [target] with [src]", "Uses [src] to discipline [target]", "disciplines [target] with [src]")
 				if(target.stat != DEAD)
 					if(prob(50))
-						target.emote(pick("moan","twitch","twitch_s","scream"))
+						target.emote(pick("moan", "twitch", "twitch_s", "scream"))
 					if(prob(10))
 						target.apply_status_effect(/datum/status_effect/subspace)
 					target.do_jitter_animation()
@@ -273,10 +273,10 @@
 				playsound(loc, 'sound/weapons/whip.ogg', 100)
 
 			else
-				message = (user == target) ? pick("whips [target.p_them()]self with [src]","lashes [target.p_them()]self with [src]") : pick("playfully lashes [target] with [src]","disciplines [target] with [src]", "gently lashes [target] with [src]")
+				message = (user == target) ? pick("whips [target.p_them()]self with [src]", "lashes [target.p_them()]self with [src]") : pick("playfully lashes [target] with [src]", "disciplines [target] with [src]", "gently lashes [target] with [src]")
 				if(target.stat != DEAD)
 					if(prob(30))
-						target.emote(pick("moan","twitch"))
+						target.emote(pick("moan", "twitch"))
 					if(prob(10))
 						target.apply_status_effect(/datum/status_effect/subspace)
 					target.do_jitter_animation()

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/magic_wand.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/magic_wand.dm
@@ -72,7 +72,7 @@
 	var/mob/living/carbon/human/vibrated = loc
 	if(!istype(vibrated))
 		return
-	//i tried using switch here, but it need static value, and u.arousal can't be it. So fuck switches. Reject it, embrace the IFs
+	// I tried using switch here, but it need static value, and u.arousal can't be it. So fuck switches. Reject it, embrace the IFs
 	if(vibration_mode == "low" && vibrated.arousal < 30)
 		vibrated.adjustArousal(0.6 * delta_time)
 		vibrated.adjustPleasure(0.7 * delta_time)
@@ -101,13 +101,13 @@
 			var/obj/item/organ/genital/vagina = target.getorganslot(ORGAN_SLOT_VAGINA)
 			if(vagina && penis)
 				if(target.is_bottomless() || vagina.visibility_preference == GENITAL_ALWAYS_SHOW && penis.visibility_preference == GENITAL_ALWAYS_SHOW)
-					message = (user == target) ? pick("massages their penis with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their penis with [src]","massages their pussy with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their pussy with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s penis with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s penis","leans the vibrator against [target]'s penis","[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s pussy with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s pussy","leans the vibrator against [target]'s pussy")
+					message = (user == target) ? pick("massages their penis with the [src]", "[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their penis with [src]", "massages their pussy with the [src]", "[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their pussy with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s penis with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s penis", "leans the vibrator against [target]'s penis", "[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s pussy with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s pussy", "leans the vibrator against [target]'s pussy")
 
 				else if(target.is_bottomless() || penis.visibility_preference == GENITAL_ALWAYS_SHOW)
-					message = (user == target) ? pick("massages their penis with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their penis with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s penis with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s penis","leans the vibrator against [target]'s penis")
+					message = (user == target) ? pick("massages their penis with the [src]", "[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their penis with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s penis with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s penis", "leans the vibrator against [target]'s penis")
 
 				else if(target.is_bottomless() || vagina.visibility_preference == GENITAL_ALWAYS_SHOW)
-					message = (user == target) ? pick("massages their pussy with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their pussy with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s pussy with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s pussy","leans the vibrator against [target]'s pussy")
+					message = (user == target) ? pick("massages their pussy with the [src]", "[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their pussy with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s pussy with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s pussy", "leans the vibrator against [target]'s pussy")
 
 				else
 					to_chat(user, span_danger("Looks like [target]'s groin is covered!"))
@@ -117,13 +117,13 @@
 				if(!(target.is_bottomless() || penis.visibility_preference == GENITAL_ALWAYS_SHOW))
 					to_chat(user, span_danger("Looks like [target]'s groin is covered!"))
 					return
-				message = (user == target) ? pick("massages their penis with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their penis with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s penis with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s penis","leans the vibrator against [target]'s penis")
+				message = (user == target) ? pick("massages their penis with the [src]", "[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their penis with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s penis with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s penis", "leans the vibrator against [target]'s penis")
 
 			else if(vagina)
 				if(!(target.is_bottomless() || vagina.visibility_preference == GENITAL_ALWAYS_SHOW))
 					to_chat(user, span_danger("Looks like [target]'s groin is covered!"))
 					return
-				message = (user == target) ? pick("massages their pussy with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their pussy with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s pussy with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s pussy","leans the vibrator against [target]'s pussy")
+				message = (user == target) ? pick("massages their pussy with the [src]", "[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their pussy with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s pussy with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s pussy", "leans the vibrator against [target]'s pussy")
 			target.adjustArousal((vibration_mode == "low" ? 4 : (vibration_mode == "hard" ? 8 : 5)))
 			target.adjustPleasure((vibration_mode == "low" ? 2 : (vibration_mode == "hard" ? 10 : 5)))
 
@@ -132,16 +132,16 @@
 			if(!(target.is_topless() || breasts.visibility_preference == GENITAL_ALWAYS_SHOW))
 				to_chat(user, span_danger("Looks like [target]'s chest is covered!"))
 				return
-			message = (user == target) ? pick("massages their [breasts ? "breasts" : "nipples"] with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their [breasts ? "tits" : "nipples"] with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] teases [target]'s [breasts ? "breasts" : "nipples"] with [src]", "uses [src] to[vibration_mode == "low" ? " slowly" : ""] massage [target]'s [breasts ? "tits" : "nipples"]", "uses [src] to tease [target]'s [breasts ? "boobs" : "nipples"]")
+			message = (user == target) ? pick("massages their [breasts ? "breasts" : "nipples"] with the [src]", "[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their [breasts ? "tits" : "nipples"] with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] teases [target]'s [breasts ? "breasts" : "nipples"] with [src]", "uses [src] to[vibration_mode == "low" ? " slowly" : ""] massage [target]'s [breasts ? "tits" : "nipples"]", "uses [src] to tease [target]'s [breasts ? "boobs" : "nipples"]")
 			target.adjustArousal((vibration_mode == "low" ? 3 : (vibration_mode == "hard" ? 7 : 4)))
 			target.adjustPleasure((vibration_mode == "low" ? 1 : (vibration_mode == "hard" ? 9 : 4)))
 
 	if(prob(30) && (target.stat != DEAD))
-		target.emote(pick("twitch_s","moan"))
+		target.emote(pick("twitch_s", "moan"))
 	user.visible_message(span_purple("[user] [message]!"))
 	playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/vibrate.ogg', (vibration_mode == "low" ? 10 : (vibration_mode == "hard" ? 30 : 20)), TRUE, ignore_walls = FALSE)
 
-/obj/item/clothing/sextoy/magic_wand/attack_self(mob/user, obj/item/I)
+/obj/item/clothing/sextoy/magic_wand/attack_self(mob/user)
 	toggle_mode()
 	switch(vibration_mode)
 		if("low")

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/serviette.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/serviette.dm
@@ -28,7 +28,7 @@
 		return
 	var/clean_speedies = 1 * cleanspeed
 	if(user.mind)
-		clean_speedies = cleanspeed * min(user.mind.get_skill_modifier(/datum/skill/cleaning, SKILL_SPEED_MODIFIER)+0.1,1) //less scaling for soapies
+		clean_speedies = cleanspeed * min(user.mind.get_skill_modifier(/datum/skill/cleaning, SKILL_SPEED_MODIFIER)+0.1, 1) //less scaling for soapies
 
 	if((target in user?.client.screen) && !user.is_holding(target))
 		to_chat(user, span_warning("You need to take \the [target.name] off before cleaning it!"))
@@ -38,7 +38,7 @@
 		if(do_after(user, clean_speedies, target = target))
 			to_chat(user, span_notice("You clean \the [target.name] out."))
 			var/obj/effect/decal/cleanable/cleanies = target
-			user.mind?.adjust_experience(/datum/skill/cleaning, max(round(cleanies.beauty/CLEAN_SKILL_BEAUTY_ADJUSTMENT),0)) //again, intentional that this does NOT round but mops do.
+			user.mind?.adjust_experience(/datum/skill/cleaning, max(round(cleanies.beauty/CLEAN_SKILL_BEAUTY_ADJUSTMENT), 0)) //again, intentional that this does NOT round but mops do.
 			qdel(target)
 			qdel(src)
 			var/obj/item/serviette_used/used_serviette = new /obj/item/serviette_used
@@ -81,23 +81,23 @@
 	desc = "I wonder why LustWish makes them..."
 	icon_state = "serviettepack"
 	icon = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_items.dmi'
-	///A count of how many serviettes are left in the pack
-	var/servleft = 4
+	/// A count of how many serviettes are left in the pack
+	var/number_remaining = 4
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/serviette_pack/update_icon_state()
 	. = ..()
-	icon_state = "[initial(icon_state)]_[servleft]"
+	icon_state = "[initial(icon_state)]_[number_remaining]"
 
 /obj/item/serviette_pack/Initialize()
 	. = ..()
 	update_icon_state()
 	update_icon()
 
-/obj/item/serviette_pack/attack_self(mob/user, obj/item/I)
-	if(servleft)
+/obj/item/serviette_pack/attack_self(mob/user)
+	if(number_remaining)
 		to_chat(user, span_notice("You take a serviette from [src]."))
-		servleft--
+		number_remaining--
 		var/obj/item/serviette/used_serviette = new /obj/item/serviette
 		user.put_in_hands(used_serviette)
 		update_icon()

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/shibari.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/shibari.dm
@@ -77,8 +77,8 @@
 /obj/item/stack/shibari_rope/split_stack(mob/user, amount)
 	. = ..()
 	if(.)
-		var/obj/item/stack/F = .
-		F.set_greyscale(greyscale_colors)
+		var/obj/item/stack/current_stack = .
+		current_stack.set_greyscale(greyscale_colors)
 
 /obj/item/stack/shibari_rope/can_merge(obj/item/stack/check, inhand = TRUE)
 	if(check.greyscale_colors == greyscale_colors)
@@ -145,8 +145,8 @@
 	var/obj/item/stack/shibari_rope/split_rope = null
 	var/slow = 0
 	if(them?.dna?.mutant_bodyparts["taur"])
-		var/datum/sprite_accessory/taur/S = GLOB.sprite_accessories["taur"][them.dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME]]
-		if(S.hide_legs)
+		var/datum/sprite_accessory/taur/taur_accessory = GLOB.sprite_accessories["taur"][them.dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME]]
+		if(taur_accessory.hide_legs)
 			split_rope = split_stack(null, 2)
 			slow = 4
 		else
@@ -159,7 +159,7 @@
 		shibari_groin.set_greyscale(greyscale_colors)
 		shibari_groin.glow = glow
 		split_rope.forceMove(shibari_groin)
-		if(them.equip_to_slot_if_possible(shibari_groin,ITEM_SLOT_ICLOTHING,TRUE,FALSE,TRUE))
+		if(them.equip_to_slot_if_possible(shibari_groin, ITEM_SLOT_ICLOTHING, TRUE, FALSE, TRUE))
 			shibari_groin.tightness = tightness
 			shibari_groin = null
 			them.visible_message(span_warning("[user] tied [them]'s groin!"),\
@@ -188,7 +188,7 @@
 		shibari_body.set_greyscale(greyscale_colors)
 		shibari_body.glow = glow
 		split_rope.forceMove(shibari_body)
-		if(them.equip_to_slot_if_possible(shibari_body,ITEM_SLOT_ICLOTHING,TRUE,FALSE,TRUE))
+		if(them.equip_to_slot_if_possible(shibari_body, ITEM_SLOT_ICLOTHING, TRUE, FALSE, TRUE))
 			shibari_body.tightness = tightness
 			shibari_body = null
 			them.visible_message(span_warning("[user] tied [them]'s chest!"),\
@@ -212,7 +212,7 @@
 		shibari_hands.set_greyscale(greyscale_colors)
 		shibari_hands.glow = glow
 		split_rope.forceMove(shibari_hands)
-		if(them.equip_to_slot_if_possible(shibari_hands,ITEM_SLOT_GLOVES,TRUE,FALSE,TRUE))
+		if(them.equip_to_slot_if_possible(shibari_hands, ITEM_SLOT_GLOVES, TRUE, FALSE, TRUE))
 			shibari_hands = null
 			them.visible_message(span_warning("[user] tied [them]'s hands!"),\
 				span_userdanger("[user] tied your hands!"),\
@@ -226,8 +226,8 @@
 		to_chat(user, span_warning("They're already wearing something on this slot!"))
 		return
 	if(them?.dna?.mutant_bodyparts["taur"])
-		var/datum/sprite_accessory/taur/S = GLOB.sprite_accessories["taur"][them.dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME]]
-		if(S.hide_legs)
+		var/datum/sprite_accessory/taur/taur_accessory = GLOB.sprite_accessories["taur"][them.dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME]]
+		if(taur_accessory.hide_legs)
 			to_chat(user, span_warning("You can't tie their feet, they're a taur!"))
 			return
 	them.visible_message(span_warning("[user] starts tying [them]'s feet!"),\
@@ -241,7 +241,7 @@
 		shibari_legs.set_greyscale(greyscale_colors)
 		shibari_legs.glow = glow
 		split_rope.forceMove(shibari_legs)
-		if(them.equip_to_slot_if_possible(shibari_legs,ITEM_SLOT_FEET,TRUE,FALSE,TRUE))
+		if(them.equip_to_slot_if_possible(shibari_legs, ITEM_SLOT_FEET, TRUE, FALSE, TRUE))
 			shibari_legs = null
 			them.visible_message(span_warning("[user] tied [them]'s feet!"),\
 				span_userdanger("[user] tied your feet!"),\
@@ -260,8 +260,8 @@
 				return
 			var/slow = 0
 			if(them?.dna?.mutant_bodyparts["taur"])
-				var/datum/sprite_accessory/taur/S = GLOB.sprite_accessories["taur"][them.dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME]]
-				if(S.hide_legs)
+				var/datum/sprite_accessory/taur/taur_accessory = GLOB.sprite_accessories["taur"][them.dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME]]
+				if(taur_accessory.hide_legs)
 					slow = 4
 			var/obj/item/stack/shibari_rope/split_rope = split_stack(null, 1)
 			if(split_rope)
@@ -275,7 +275,7 @@
 						thing.forceMove(shibari_fullbody)
 					shibari_fullbody.set_greyscale(list(greyscale_colors, body_rope.greyscale_colors))
 					qdel(them.w_uniform)
-					if(them.equip_to_slot_if_possible(shibari_fullbody,ITEM_SLOT_ICLOTHING,TRUE,FALSE,TRUE))
+					if(them.equip_to_slot_if_possible(shibari_fullbody, ITEM_SLOT_ICLOTHING, TRUE, FALSE, TRUE))
 						shibari_fullbody.tightness = tightness
 						shibari_fullbody = null
 						them.visible_message(span_warning("[user] tied [them]'s chest!"),\
@@ -295,8 +295,8 @@
 			var/obj/item/stack/shibari_rope/split_rope = null
 			var/slow = 0
 			if(them?.dna?.mutant_bodyparts["taur"])
-				var/datum/sprite_accessory/taur/S = GLOB.sprite_accessories["taur"][them.dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME]]
-				if(S.hide_legs)
+				var/datum/sprite_accessory/taur/taur_accessory = GLOB.sprite_accessories["taur"][them.dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME]]
+				if(taur_accessory.hide_legs)
 					split_rope = split_stack(null, 2)
 					slow = 4
 				else
@@ -314,7 +314,7 @@
 						thing.forceMove(shibari_fullbody)
 					shibari_fullbody.set_greyscale(list(body_rope.greyscale_colors, greyscale_colors))
 					qdel(them.w_uniform)
-					if(them.equip_to_slot_if_possible(shibari_fullbody,ITEM_SLOT_ICLOTHING,TRUE,FALSE,TRUE))
+					if(them.equip_to_slot_if_possible(shibari_fullbody, ITEM_SLOT_ICLOTHING, TRUE, FALSE, TRUE))
 						shibari_fullbody.tightness = tightness
 						shibari_fullbody = null
 						them.visible_message(span_warning("[user] tied [them]'s groin!"),\
@@ -328,7 +328,7 @@
 
 ///This part of code required for tightness adjustment. You can change tightness of future shibari bondage on character by clicking on ropes.
 
-/obj/item/stack/shibari_rope/attack_self(mob/user, obj/item/I)
+/obj/item/stack/shibari_rope/attack_self(mob/user)
 	switch(tightness)
 		if(ROPE_TIGHTNESS_HIGH)
 			tightness = ROPE_TIGHTNESS_LOW

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/shibari_stand.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/shibari_stand.dm
@@ -202,13 +202,13 @@
 /obj/item/shibari_stand_kit/screwdriver_act(mob/living/user, obj/item/tool)
 	var/list/allowed_configs = list()
 	allowed_configs += "[greyscale_config]"
-	if(!tool.use_tool(src, user, 0, volume=40))
+	if(!tool.use_tool(src, user, 0, volume = 40))
 		return FALSE
 	var/datum/greyscale_modify_menu/menu = new(
 		src, usr, allowed_configs, null, \
-		starting_icon_state=icon_state, \
-		starting_config=greyscale_config, \
-		starting_colors=greyscale_colors
+		starting_icon_state = icon_state, \
+		starting_config = greyscale_config, \
+		starting_colors = greyscale_colors
 	)
 	menu.ui_interact(usr)
 	to_chat(user, span_notice("You switch the frame's plastic fittings color."))
@@ -217,7 +217,7 @@
 //Assembling shibari stand
 /obj/item/shibari_stand_kit/wrench_act(mob/living/user, obj/item/tool)
 	to_chat(user, span_notice("You begin fastening the frame to the floor."))
-	if(!tool.use_tool(src, user, 8 SECONDS, volume=50))
+	if(!tool.use_tool(src, user, 8 SECONDS, volume = 50))
 		return FALSE
 	to_chat(user, span_notice("You assemble the frame."))
 	var/obj/structure/chair/shibari_stand/stand = new(get_turf(src))
@@ -228,7 +228,7 @@
 //Disassembling shibari stand
 /obj/structure/chair/shibari_stand/wrench_act(mob/living/user, obj/item/tool)
 	to_chat(user, span_notice("You begin unfastening the frame of \the [src]..."))
-	if(!tool.use_tool(src, user, 8 SECONDS, volume=50))
+	if(!tool.use_tool(src, user, 8 SECONDS, volume = 50))
 		return FALSE
 	to_chat(user, span_notice("You disassemble \the [src]."))
 	var/obj/item/shibari_stand_kit/kit = new(get_turf(src))
@@ -241,13 +241,13 @@
 /obj/structure/chair/shibari_stand/screwdriver_act(mob/living/user, obj/item/tool)
 	var/list/allowed_configs = list()
 	allowed_configs += "[greyscale_config]"
-	if(!tool.use_tool(src, user, 0, volume=40))
+	if(!tool.use_tool(src, user, 0, volume = 40))
 		return FALSE
 	var/datum/greyscale_modify_menu/menu = new(
 		src, usr, allowed_configs, null, \
-		starting_icon_state=icon_state, \
-		starting_config=greyscale_config, \
-		starting_colors=greyscale_colors
+		starting_icon_state = icon_state, \
+		starting_config = greyscale_config, \
+		starting_colors = greyscale_colors
 	)
 	menu.ui_interact(usr)
 	to_chat(user, span_notice("You switch the frame's plastic fittings color."))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/spanking_pad.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/spanking_pad.dm
@@ -44,13 +44,13 @@
 	icon_state = "[initial(icon_state)]_[current_color]"
 	inhand_icon_state = "[initial(icon_state)]_[current_color]"
 
-/obj/item/spanking_pad/AltClick(mob/user, obj/item/I)
+/obj/item/spanking_pad/AltClick(mob/user)
 	if(color_changed)
 		return
 	. = ..()
 	if(.)
 		return
-	var/choice = show_radial_menu(user,src, spankpad_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+	var/choice = show_radial_menu(user, src, spankpad_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 	if(!choice)
 		return FALSE
 	current_color = choice
@@ -72,9 +72,9 @@
 			if(!target.is_bottomless())
 				to_chat(user, span_danger("[target]'s butt is covered!"))
 				return
-			message = (user == target) ? pick("spanks themselves with [src]","uses [src] to slap their hips") : pick("slaps [target]'s hips with [src]", "uses [src] to slap [target]'s butt","spanks [target] with [src], making a loud slapping noise","slaps [target]'s thighs with [src]")
+			message = (user == target) ? pick("spanks themselves with [src]", "uses [src] to slap their hips") : pick("slaps [target]'s hips with [src]", "uses [src] to slap [target]'s butt", "spanks [target] with [src], making a loud slapping noise", "slaps [target]'s thighs with [src]")
 			if(prob(40) && (target.stat != DEAD))
-				target.emote(pick("twitch_s","moan","blush","gasp"))
+				target.emote(pick("twitch_s", "moan", "blush", "gasp"))
 			target.adjustArousal(2)
 			target.adjustPain(4)
 			target.apply_status_effect(/datum/status_effect/spanked)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/torture_candle.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/torture_candle.dm
@@ -105,12 +105,12 @@
 	open_flame()
 	update_brightness()
 
-/obj/item/bdsm_candle/AltClick(mob/user, obj/item/item)
+/obj/item/bdsm_candle/AltClick(mob/user)
 	. = ..()
 	if(!lit)
 		if(color_changed)
 			return
-		var/choice = show_radial_menu(user,src, candle_designs, custom_check = CALLBACK(src, .proc/check_menu, user, item), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, candle_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		current_color = choice
@@ -163,11 +163,11 @@
 				attacked.adjustPain(PAIN_DEFAULT)
 
 			else if(vagina && (attacked.is_bottomless() || vagina.visibility_preference == GENITAL_ALWAYS_SHOW))
-				message = (user == attacked) ? pick("drips some wax on themselves, letting it reach his vagina. He moans in pleasure.","drips some wax on the [attacked]'s pussy, he moans in pleasure") : pick("drips some wax on the [attacked]'s vagina, he moans in pleasure","tilts the candle. Wax slowly goes down, reaching the [attacked]'s vagina.","tilts the candle. Drops of wax, dripping right from [src] right on the [attacked]'s pussy, made him moan.")
+				message = (user == attacked) ? pick("drips some wax on themselves, letting it reach his vagina. He moans in pleasure.", "drips some wax on the [attacked]'s pussy, he moans in pleasure") : pick("drips some wax on the [attacked]'s vagina, he moans in pleasure", "tilts the candle. Wax slowly goes down, reaching the [attacked]'s vagina.", "tilts the candle. Drops of wax, dripping right from [src] right on the [attacked]'s pussy, made him moan.")
 				attacked.adjustPain(PAIN_DEFAULT)
 
 			else if(attacked.is_bottomless())
-				message = (user == attacked) ? pick("drips some wax on themselves, letting it reach his belly. He moans in pleasure.","drips some wax on the [attacked]'s tummy, he moans in pleasure") : pick("drips some wax on the [attacked]'s belly, he moans in pleasure","tilts the candle. Wax slowly goes down, reaching the [attacked]'s tummy.","tilts the candle. Drops of wax, dripping right from [src] right on the [attacked]'s groin, made him moan.")
+				message = (user == attacked) ? pick("drips some wax on themselves, letting it reach his belly. He moans in pleasure.", "drips some wax on the [attacked]'s tummy, he moans in pleasure") : pick("drips some wax on the [attacked]'s belly, he moans in pleasure", "tilts the candle. Wax slowly goes down, reaching the [attacked]'s tummy.", "tilts the candle. Drops of wax, dripping right from [src] right on the [attacked]'s groin, made him moan.")
 				attacked.adjustPain(PAIN_DEFAULT)
 
 			else
@@ -178,7 +178,7 @@
 			targeted_somewhere = TRUE
 			var/obj/item/organ/genital/breasts = attacked.getorganslot(ORGAN_SLOT_BREASTS)
 			if(attacked.is_topless() || breasts.visibility_preference == GENITAL_ALWAYS_SHOW)
-				message = (user == attacked) ? pick("drips some wax on [attacked.p_their()] [breasts ? "breasts" : "nipples"], releasing all [attacked.p_their()] lustness","drips some wax right on [attacked.p_their()] [breasts ? "tits" : "chest"], making [attacked.p_their()] feel faint.") : pick("pours the wax that is slowly dripping from [src] onto [attacked]'s [breasts ? "breasts" : "nipples"], [attacked.p_they()] shows pure enjoyment.","tilts the candle. Right in the moment when wax drips on [attacked]'s [breasts ? "breasts" : "nipples"], [attacked.p_they()] shivers","tilts the candle. Just when hot drops of wax fell on [attacked]'s [breasts ? "breasts" : "nipples"], [attacked.p_they()] quietly moans in pleasure")
+				message = (user == attacked) ? pick("drips some wax on [attacked.p_their()] [breasts ? "breasts" : "nipples"], releasing all [attacked.p_their()] lustness", "drips some wax right on [attacked.p_their()] [breasts ? "tits" : "chest"], making [attacked.p_their()] feel faint.") : pick("pours the wax that is slowly dripping from [src] onto [attacked]'s [breasts ? "breasts" : "nipples"], [attacked.p_they()] shows pure enjoyment.", "tilts the candle. Right in the moment when wax drips on [attacked]'s [breasts ? "breasts" : "nipples"], [attacked.p_they()] shivers", "tilts the candle. Just when hot drops of wax fell on [attacked]'s [breasts ? "breasts" : "nipples"], [attacked.p_they()] quietly moans in pleasure")
 				attacked.adjustPain(PAIN_DEFAULT * 0.66)
 
 			else
@@ -190,7 +190,7 @@
 	if(attacked.stat != DEAD)
 		attacked.do_jitter_animation()
 		if(prob(50))
-			attacked.emote(pick("twitch_s" ,"gasp","shiver"))
+			attacked.emote(pick("twitch_s" , "gasp", "shiver"))
 	user.visible_message(span_purple("[user] [message]!"))
 	playsound(loc, pick('modular_skyrat/modules/modular_items/lewd_items/sounds/vax1.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/vax2.ogg'), 70, TRUE, ignore_walls = FALSE)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibrator.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibrator.dm
@@ -41,13 +41,13 @@
 		"yellow" = image(icon = src.icon, icon_state = "vibrator_yellow_low"),
 		"green" = image(icon = src.icon, icon_state = "vibrator_green_low"))
 
-/obj/item/clothing/sextoy/vibrator/AltClick(mob/user, obj/item/object)
+/obj/item/clothing/sextoy/vibrator/AltClick(mob/user)
 	if(color_changed)
 		return
 	. = ..()
 	if(.)
 		return
-	var/choice = show_radial_menu(user, src, vibrator_designs, custom_check = CALLBACK(src, .proc/check_menu, user, object), radius = 36, require_near = TRUE)
+	var/choice = show_radial_menu(user, src, vibrator_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 	if(!choice)
 		return FALSE
 	current_color = choice
@@ -127,17 +127,17 @@
 			var/obj/item/organ/genital/penis = target.getorganslot(ORGAN_SLOT_PENIS)
 			var/obj/item/organ/genital/vagina = target.getorganslot(ORGAN_SLOT_VAGINA)
 			if((vagina && penis) && (vagina.visibility_preference == GENITAL_ALWAYS_SHOW && penis.visibility_preference == GENITAL_ALWAYS_SHOW || target.is_bottomless()))
-				message = (user == target) ? pick("massages their vagina with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their pussy with [src]","massages their penis with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their penis with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s vagina with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s crotch","leans the massager against [target]'s pussy","[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s penis with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s penis","leans the massager against [target]'s penis")
+				message = (user == target) ? pick("massages their vagina with the [src]", "[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their pussy with [src]", "massages their penis with the [src]", "[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their penis with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s vagina with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s crotch", "leans the massager against [target]'s pussy", "[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s penis with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s penis", "leans the massager against [target]'s penis")
 				target.adjustArousal(DEFAULT_AROUSAL_INCREASE)
 				target.adjustPleasure(DEFAULT_PLEASURE_INCREASE)
 
 			else if(vagina && (vagina.visibility_preference == GENITAL_ALWAYS_SHOW || target.is_bottomless()))
-				message = (user == target) ? pick("massages their vagina with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their pussy with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s vagina with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s crotch","leans the massager against [target]'s pussy")
+				message = (user == target) ? pick("massages their vagina with the [src]", "[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their pussy with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s vagina with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s crotch", "leans the massager against [target]'s pussy")
 				target.adjustArousal(DEFAULT_AROUSAL_INCREASE)
 				target.adjustPleasure(DEFAULT_PLEASURE_INCREASE)
 
 			else if(penis && (penis.visibility_preference == GENITAL_ALWAYS_SHOW || target.is_bottomless()))
-				message = (user == target) ? pick("massages their penis with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their penis with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s penis with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s penis","leans the massager against [target]'s penis")
+				message = (user == target) ? pick("massages their penis with the [src]", "[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their penis with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] massages [target]'s penis with [src]", "uses [src] to [vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] massage [target]'s penis", "leans the massager against [target]'s penis")
 				target.adjustArousal(DEFAULT_AROUSAL_INCREASE)
 				target.adjustPleasure(DEFAULT_PLEASURE_INCREASE)
 
@@ -146,17 +146,17 @@
 				return
 
 			if(prob(50) && (target.stat != DEAD))
-				target.emote(pick("twitch_s","moan","blush"))
+				target.emote(pick("twitch_s", "moan", "blush"))
 
 		if(BODY_ZONE_CHEST)
 			targetedsomewhere = TRUE
 			var/obj/item/organ/genital/breasts = target.getorganslot(ORGAN_SLOT_BREASTS)
 			if(target.is_topless() || breasts.visibility_preference == GENITAL_ALWAYS_SHOW)
-				message = (user == target) ? pick("massages their [breasts ? "breasts" : "nipples"] with the [src]","[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their tits with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] teases [target]'s [breasts ? "breasts" : "nipples"] with [src]", "uses [src] to[vibration_mode == "low" ? " slowly" : ""] massage [target]'s [breasts ? "tits" : "nipples"]", "uses [src] to tease [target]'s [breasts ? "boobs" : "nipples"]", "rubs [target]'s [breasts ? "tits" : "nipples"] with [src]")
+				message = (user == target) ? pick("massages their [breasts ? "breasts" : "nipples"] with the [src]", "[vibration_mode == "low" ? "gently" : ""][vibration_mode = "hard" ? "roughly" : ""] teases their tits with [src]") : pick("[vibration_mode == "low" ? "delicately" : ""][vibration_mode = "hard" ? "aggressively" : ""] teases [target]'s [breasts ? "breasts" : "nipples"] with [src]", "uses [src] to[vibration_mode == "low" ? " slowly" : ""] massage [target]'s [breasts ? "tits" : "nipples"]", "uses [src] to tease [target]'s [breasts ? "boobs" : "nipples"]", "rubs [target]'s [breasts ? "tits" : "nipples"] with [src]")
 				target.adjustArousal(DEFAULT_AROUSAL_INCREASE)
 				target.adjustPleasure(DEFAULT_PLEASURE_INCREASE * 0.5)
 				if(prob(30) && (target.stat != DEAD))
-					target.emote(pick("twitch_s","moan"))
+					target.emote(pick("twitch_s", "moan"))
 
 			else
 				to_chat(user, span_danger("Looks like [target]'s chest is covered!"))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibroring.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/vibroring.dm
@@ -39,13 +39,13 @@
 		"pink" = image(icon = src.icon, icon_state = "vibroring_pink_off"),
 		"teal" = image(icon = src.icon, icon_state = "vibroring_teal_off"))
 
-/obj/item/clothing/sextoy/vibroring/AltClick(mob/user, obj/item/object)
+/obj/item/clothing/sextoy/vibroring/AltClick(mob/user)
 	if(color_changed)
 		return
 	. = ..()
 	if(.)
 		return
-	var/choice = show_radial_menu(user, src, vibroring_designs, custom_check = CALLBACK(src, .proc/check_menu, user, object), radius = 36, require_near = TRUE)
+	var/choice = show_radial_menu(user, src, vibroring_designs, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 	if(!choice)
 		return FALSE
 	current_color = choice

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/milking_machine.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/milking_machine.dm
@@ -22,26 +22,26 @@
 	/////////////////////////////
 	// Machine operating modes //
 	/////////////////////////////
-	var/pump_state_list = list("pump_off","pump_on")
+	var/pump_state_list = list("pump_off", "pump_on")
 	var/pump_state
-	var/mode_list = list("off","low","medium","hard")
+	var/mode_list = list("off", "low", "medium", "hard")
 	var/current_mode
 
 	/////////////////////////////////
 	// Return sensation parameters //
 	/////////////////////////////////
 	// Values are returned every tick, without additional modifiers
-	var/arousal_amounts = list("off" = 0, "low" = 1,"medium" = 2,"hard" = 3)
-	var/pleasure_amounts = list("off" = 0, "low" = 0.2,"medium" = 1,"hard" = 1.5)
-	var/pain_amounts = list("off" = 0, "low" = 0,"medium" = 0.2,"hard" = 0.5)
+	var/arousal_amounts = list("off" = 0, "low" = 1, "medium" = 2, "hard" = 3)
+	var/pleasure_amounts = list("off" = 0, "low" = 0.2, "medium" = 1, "hard" = 1.5)
+	var/pain_amounts = list("off" = 0, "low" = 0, "medium" = 0.2, "hard" = 0.5)
 
 	//////////////////////
 	// Fluid management //
 	//////////////////////
 	// Liquids are taken every tick, no additional modifiers
-	var/milk_retrive_amount = list("off" = 0, "low" = 1,"medium" = 2,"hard" = 3)
-	var/girlcum_retrive_amount = list("off" = 0, "low" = 1,"medium" = 2,"hard" = 3)
-	var/semen_retrive_amount = list("off" = 0, "low" = 1,"medium" = 2,"hard" = 3)
+	var/milk_retrive_amount = list("off" = 0, "low" = 1, "medium" = 2, "hard" = 3)
+	var/girlcum_retrive_amount = list("off" = 0, "low" = 1, "medium" = 2, "hard" = 3)
+	var/semen_retrive_amount = list("off" = 0, "low" = 1, "medium" = 2, "hard" = 3)
 	var/climax_retrive_multiplier = 2 // Climax intake volume multiplier
 
 	//////////////////////////
@@ -70,17 +70,17 @@
 	var/testicles_size = null
 
 	// Machine colors
-	var/machine_color_list = list("pink","teal") // Применить ссылки на список везде, где можно
+	var/machine_color_list = list("pink", "teal") // Применить ссылки на список везде, где можно
 	var/machine_color
 
 	//////////////////////////////////////////
 	// Stuff for visualizing machine states //
 	//////////////////////////////////////////
 	// Cell power capacity indicator
-	var/indicator_state_list = list("indicator_off","indicator_low","indicator_medium","indicator_high")
+	var/indicator_state_list = list("indicator_off", "indicator_low", "indicator_medium", "indicator_high")
 	var/indicator_state
 	// Vessel capacity indicator
-	var/vessel_state_list = list("liquid_empty","liquid_low","liquid_medium","liquid_high","liquid_full")
+	var/vessel_state_list = list("liquid_empty", "liquid_low", "liquid_medium", "liquid_high", "liquid_full")
 	var/vessel_state
 	// Organ types and sizes
 	var/organ_types = list()
@@ -167,11 +167,11 @@
 		"teal" = image(icon = src.icon, icon_state = "milking_teal_off"))
 
 // Radial menu handler for color selection by using multitool
-/obj/structure/chair/milking_machine/multitool_act(mob/living/user, obj/item/I)
+/obj/structure/chair/milking_machine/multitool_act(mob/living/user, obj/item/used_item)
 	. = ..()
 	if(.)
 		return FALSE
-	var/choice = show_radial_menu(user,src, milkingmachine_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+	var/choice = show_radial_menu(user, src, milkingmachine_designs, custom_check = CALLBACK(src, .proc/check_menu, user, used_item), radius = 36, require_near = TRUE)
 	if(!choice)
 		return TRUE
 	machine_color = choice
@@ -196,18 +196,18 @@
 	return FALSE
 
 // Get the organs of the mob and visualize the change in machine
-/obj/structure/chair/milking_machine/post_buckle_mob(mob/living/M)
-	current_mob = M
+/obj/structure/chair/milking_machine/post_buckle_mob(mob/living/affected_mob)
+	current_mob = affected_mob
 
-	current_breasts = M.getorganslot(ORGAN_SLOT_BREASTS)
+	current_breasts = affected_mob.getorganslot(ORGAN_SLOT_BREASTS)
 	if(current_breasts)
 		breasts_size = current_breasts.genital_size
 
-	current_testicles = M.getorganslot(ORGAN_SLOT_TESTICLES)
+	current_testicles = affected_mob.getorganslot(ORGAN_SLOT_TESTICLES)
 	if(current_testicles)
 		testicles_size = current_testicles.genital_size
 
-	current_vagina = M.getorganslot(ORGAN_SLOT_VAGINA)
+	current_vagina = affected_mob.getorganslot(ORGAN_SLOT_VAGINA)
 	if(current_vagina)
 		vagina_size = current_vagina.genital_size
 
@@ -227,16 +227,16 @@
 		current_mob.update_abstract_handcuffed()
 
 	update_overlays()
-	M.layer = BELOW_MOB_LAYER
+	affected_mob.layer = BELOW_MOB_LAYER
 	update_all_visuals()
 
-	if(SStgui.try_update_ui(M, src))
-		var/datum/tgui/ui = SStgui.try_update_ui(M, src)
+	if(SStgui.try_update_ui(affected_mob, src))
+		var/datum/tgui/ui = SStgui.try_update_ui(affected_mob, src)
 		ui.close()
 	return
 
 // Clear the cache of the organs of the mob and update the state of the machine
-/obj/structure/chair/milking_machine/post_unbuckle_mob(mob/living/M)
+/obj/structure/chair/milking_machine/post_unbuckle_mob(mob/living/affected_mob)
 	cut_overlay(organ_overlay)
 	organ_overlay.icon_state = "none"
 
@@ -349,26 +349,26 @@
 	if(parented_struct)
 		parented_struct.unbuckle_all_mobs()
 
-/obj/structure/chair/milking_machine/user_unbuckle_mob(mob/living/carbon/human/M, mob/user)
+/obj/structure/chair/milking_machine/user_unbuckle_mob(mob/living/carbon/human/affected_mob, mob/user)
 
-	if(M)
-		if(M == user)
+	if(affected_mob)
+		if(affected_mob == user)
 			// Have difficulty unbuckling if overly aroused
-			if(M.arousal >= 60)
+			if(affected_mob.arousal >= 60)
 				if((current_mode != mode_list[1]) && (current_mode != mode_list[2]))
-					to_chat(M, span_purple("You are too horny to try to get out!"))
+					to_chat(affected_mob, span_purple("You are too horny to try to get out!"))
 					return
 				else
-					M.visible_message(span_notice("[M] unbuckles [M.p_them()]self from [src]."),\
+					affected_mob.visible_message(span_notice("[affected_mob] unbuckles [affected_mob.p_them()]self from [src]."),\
 						span_notice("You unbuckle yourself from [src]."),\
 						span_hear("You hear metal clanking."))
-					unbuckle_mob(M)
+					unbuckle_mob(affected_mob)
 					return
 			else
-				M.visible_message(span_notice("[M] unbuckles [M.p_them()]self from [src]."),\
+				affected_mob.visible_message(span_notice("[affected_mob] unbuckles [affected_mob.p_them()]self from [src]."),\
 					span_notice("You unbuckle yourself from [src]."),\
 					span_hear("You hear metal clanking."))
-				unbuckle_mob(M)
+				unbuckle_mob(affected_mob)
 				return
 	else
 		. = ..()
@@ -390,7 +390,7 @@
 	// Block the ability to open the interface of the machine if we are attached to it
 	if(LAZYLEN(buckled_mobs))
 		if(user == buckled_mobs[1])
-			user_unbuckle_mob(user,user)
+			user_unbuckle_mob(user, user)
 			return
 	// Standard processing, open the machine interface
 	. = ..()
@@ -399,22 +399,22 @@
 	return
 
 // Attack handler for various item
-/obj/structure/chair/milking_machine/attackby(obj/item/W, mob/user)
+/obj/structure/chair/milking_machine/attackby(obj/item/used_item, mob/user)
 	// Beaker attack check
-	if(istype(W, /obj/item/reagent_containers) && !(W.item_flags & ABSTRACT) && W.is_open_container())
+	if(istype(used_item, /obj/item/reagent_containers) && !(used_item.item_flags & ABSTRACT) && used_item.is_open_container())
 		. = TRUE // No afterattack
 		if(panel_open)
 			to_chat(user, span_warning("You can't use [src] while its panel is opened!"))
 			return
-		var/obj/item/reagent_containers/B = W
+		var/obj/item/reagent_containers/used_container = used_item
 		. = TRUE // No afterattack
-		if(!user.transferItemToLoc(B, src))
+		if(!user.transferItemToLoc(used_container, src))
 			return
-		replace_beaker(user, B)
+		replace_beaker(user, used_container)
 		updateUsrDialog()
 		return
 	// Cell attack check
-	if(istype(W, /obj/item/stock_parts/cell))
+	if(istype(used_item, /obj/item/stock_parts/cell))
 		if(panel_open)
 			if(!anchored)
 				to_chat(user, span_warning("[src] isn't attached to the ground!"))
@@ -423,16 +423,16 @@
 				to_chat(user, span_warning("There is already a cell in [src]!"))
 				return
 			else
-				var/area/a = loc.loc // Gets our locations location, like a dream within a dream
-				if(!isarea(a))
+				var/area/current_area = loc.loc // Gets our locations location, like a dream within a dream
+				if(!isarea(current_area))
 					return
-				if(!user.transferItemToLoc(W,src))
+				if(!user.transferItemToLoc(used_item, src))
 					cut_overlay(cell_overlay)
 					cell_overlay.icon_state = "milking_cell_empty"
 					update_all_visuals()
 					return
 
-				cell = W
+				cell = used_item
 				cut_overlay(cell_overlay)
 				cell_overlay.icon_state = "milking_cell"
 				add_overlay(cell_overlay)
@@ -443,11 +443,11 @@
 			to_chat(user, span_warning("[src]'s maintenance panel isn't opened!"))
 			return
 	else
-		if(screwdriver_action(user, icon_state, icon_state, W))
+		if(screwdriver_action(user, icon_state, icon_state, used_item))
 			return
-		if(crowbar_action(W))
+		if(crowbar_action(used_item))
 			return
-		if(!cell && wrench_act(user, W))
+		if(!cell && wrench_act(user, used_item))
 			return
 		return ..()
 
@@ -483,9 +483,9 @@
 		object.forceMove(drop_location())
 
 // Handler for opening the panel with a screwdriver for maintenance
-/obj/structure/chair/milking_machine/proc/screwdriver_action(mob/user, icon_state_open, icon_state_closed, obj/item/I)
-	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		I.play_tool_sound(src, 50)
+/obj/structure/chair/milking_machine/proc/screwdriver_action(mob/user, icon_state_open, icon_state_closed, obj/item/used_item)
+	if(used_item.tool_behaviour == TOOL_SCREWDRIVER)
+		used_item.play_tool_sound(src, 50)
 		if(!panel_open)
 			panel_open = TRUE
 			cut_overlay(indicator_overlay)
@@ -513,18 +513,18 @@
 	return FALSE
 
 // Object disassembly handler by crowbar
-/obj/structure/chair/milking_machine/proc/crowbar_action(obj/item/I, ignore_panel = 0)
+/obj/structure/chair/milking_machine/proc/crowbar_action(obj/item/used_item, ignore_panel = 0)
 
-	. = (panel_open || ignore_panel) && !(flags_1 & NODECONSTRUCT_1) && I.tool_behaviour == TOOL_CROWBAR
+	. = (panel_open || ignore_panel) && !(flags_1 & NODECONSTRUCT_1) && used_item.tool_behaviour == TOOL_CROWBAR
 	if(.)
-		I.play_tool_sound(src, 50)
+		used_item.play_tool_sound(src, 50)
 		deconstruct(TRUE)
 
 // // Object disassembly handler by wrench
-// /obj/structure/chair/milking_machine/default_unfasten_wrench(mob/user, obj/item/I, time = 20)
-// 	. = !(flags_1 & NODECONSTRUCT_1) && I.tool_behaviour == TOOL_WRENCH
+// /obj/structure/chair/milking_machine/default_unfasten_wrench(mob/user, obj/item/used_item, time = 20)
+// 	. = !(flags_1 & NODECONSTRUCT_1) && used_item.tool_behaviour == TOOL_WRENCH
 // 	if(.)
-// 		I.play_tool_sound(src, 50)
+// 		used_item.play_tool_sound(src, 50)
 // 		deconstruct(TRUE)
 
 // Machine Workflow Processor
@@ -546,19 +546,19 @@
 	if(current_selected_organ == null || current_mode == mode_list[1])
 		update_all_visuals()
 		return // Does not work if an organ is not connected OR the machine is not switched to On
-	if(istype(current_selected_organ,/obj/item/organ/genital/breasts))
+	if(istype(current_selected_organ, /obj/item/organ/genital/breasts))
 		if(milk_vessel.reagents.total_volume == max_vessel_capacity)
 			current_mode = mode_list[1]
 			pump_state = pump_state_list[1]
 			update_all_visuals()
 			return
-	if(istype(current_selected_organ,/obj/item/organ/genital/vagina))
+	if(istype(current_selected_organ, /obj/item/organ/genital/vagina))
 		if(girlcum_vessel.reagents.total_volume == max_vessel_capacity)
 			current_mode = mode_list[1]
 			pump_state = pump_state_list[1]
 			update_all_visuals()
 			return
-	if(istype(current_selected_organ,/obj/item/organ/genital/testicles))
+	if(istype(current_selected_organ, /obj/item/organ/genital/testicles))
 		if(semen_vessel.reagents.total_volume == max_vessel_capacity)
 			current_mode = mode_list[1]
 			pump_state = pump_state_list[1]
@@ -583,24 +583,24 @@
 // Liquid intake handler
 /obj/structure/chair/milking_machine/proc/retrive_liquids_from_selected_organ(delta_time)
 	// Climax check
-	var/X = 1
+	var/fluid_multiplier = 1
 	if(current_mob != null)
 		if(current_mob.has_status_effect(/datum/status_effect/climax))
-			X = climax_retrive_multiplier
+			fluid_multiplier = climax_retrive_multiplier
 
 	if(istype(current_selected_organ, /obj/item/organ/genital/breasts))
 		if(current_selected_organ.reagents.total_volume > 0)
-			current_selected_organ.internal_fluids.trans_to(milk_vessel, milk_retrive_amount[current_mode] * X * delta_time)
+			current_selected_organ.internal_fluids.trans_to(milk_vessel, milk_retrive_amount[current_mode] * fluid_multiplier * delta_time)
 		else
 			return
 	else if (istype(current_selected_organ, /obj/item/organ/genital/vagina))
 		if(current_selected_organ.reagents.total_volume > 0)
-			current_selected_organ.internal_fluids.trans_to(girlcum_vessel, girlcum_retrive_amount[current_mode] * X * delta_time)
+			current_selected_organ.internal_fluids.trans_to(girlcum_vessel, girlcum_retrive_amount[current_mode] * fluid_multiplier * delta_time)
 		else
 			return
 	else if (istype(current_selected_organ, /obj/item/organ/genital/testicles))
 		if(current_selected_organ.reagents.total_volume > 0)
-			current_selected_organ.internal_fluids.trans_to(semen_vessel, semen_retrive_amount[current_mode] * X * delta_time)
+			current_selected_organ.internal_fluids.trans_to(semen_vessel, semen_retrive_amount[current_mode] * fluid_multiplier * delta_time)
 		else
 			return
 	else
@@ -635,14 +635,14 @@
 	. = ..()
 	if(.)
 		if(istype(src, /mob/living/) && istype(over_object, /obj/structure/chair/milking_machine))
-			var/mob/living/M = src
-			var/obj/structure/chair/milking_machine/MM = over_object
-			if(M.getorganslot(ORGAN_SLOT_TESTICLES))
-				MM.current_testicles = M.getorganslot(ORGAN_SLOT_TESTICLES)
-			if(M.getorganslot(ORGAN_SLOT_VAGINA))
-				MM.current_vagina = M.getorganslot(ORGAN_SLOT_VAGINA)
-			if(M.getorganslot(ORGAN_SLOT_BREASTS))
-				MM.current_breasts = M.getorganslot(ORGAN_SLOT_BREASTS)
+			var/mob/living/affected_mob = src
+			var/obj/structure/chair/milking_machine/milking_machine = over_object
+			if(affected_mob.getorganslot(ORGAN_SLOT_TESTICLES))
+				milking_machine.current_testicles = affected_mob.getorganslot(ORGAN_SLOT_TESTICLES)
+			if(affected_mob.getorganslot(ORGAN_SLOT_VAGINA))
+				milking_machine.current_vagina = affected_mob.getorganslot(ORGAN_SLOT_VAGINA)
+			if(affected_mob.getorganslot(ORGAN_SLOT_BREASTS))
+				milking_machine.current_breasts = affected_mob.getorganslot(ORGAN_SLOT_BREASTS)
 			else
 				// A place for the handler when the mob doesn't have the genitals it needs
 				return
@@ -653,11 +653,11 @@
 		// The mob for some reason did not get buckled, we do nothing
 		return
 
-/obj/structure/chair/milking_machine/wrench_act(mob/living/user, obj/item/I)
-	if((flags_1 & NODECONSTRUCT_1) && I.tool_behaviour == TOOL_WRENCH)
+/obj/structure/chair/milking_machine/wrench_act(mob/living/user, obj/item/used_item)
+	if((flags_1 & NODECONSTRUCT_1) && used_item.tool_behaviour == TOOL_WRENCH)
 		to_chat(user, span_notice("You being to deconstruct [src]..."))
-		if(I.use_tool(src, user, 8 SECONDS, volume=50))
-			I.play_tool_sound(src, 50)
+		if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
+			used_item.play_tool_sound(src, 50)
 			deconstruct(TRUE)
 			to_chat(user, span_notice("You disassemble [src]."))
 		return TRUE
@@ -788,24 +788,24 @@
 
 	// Processing changes in the capacity overlay
 	cut_overlay(vessel_overlay)
-	var/T = (milk_vessel.reagents.total_volume + girlcum_vessel.reagents.total_volume + semen_vessel.reagents.total_volume)
-	if(T == 0 && T < 1)
+	var/total_reagents_volume = (milk_vessel.reagents.total_volume + girlcum_vessel.reagents.total_volume + semen_vessel.reagents.total_volume)
+	if(total_reagents_volume == 0 && total_reagents_volume < 1)
 		if(vessel_state != vessel_state_list[1])
 			vessel_overlay.icon_state = vessel_state_list[1]
 			vessel_state = vessel_state_list[1]
-	if((T >= 1) && (T < (max_vessel_capacity / 3)))
+	if((total_reagents_volume >= 1) && (total_reagents_volume < (max_vessel_capacity / 3)))
 		if(vessel_state != vessel_state_list[2])
 			vessel_overlay.icon_state = vessel_state_list[2]
 			vessel_state = vessel_state_list[2]
-	if((T >= (max_vessel_capacity / 3)) && (T < (2 * max_vessel_capacity / 3)))
+	if((total_reagents_volume >= (max_vessel_capacity / 3)) && (total_reagents_volume < (2 * max_vessel_capacity / 3)))
 		if(vessel_state != vessel_state_list[3])
 			vessel_overlay.icon_state = vessel_state_list[3]
 			vessel_state = vessel_state_list[3]
-	if((T >= (2 * max_vessel_capacity / 3)) && (T < max_vessel_capacity))
+	if((total_reagents_volume >= (2 * max_vessel_capacity / 3)) && (total_reagents_volume < max_vessel_capacity))
 		if(vessel_state != vessel_state_list[4])
 			vessel_overlay.icon_state = vessel_state_list[4]
 			vessel_state = vessel_state_list[4]
-	if(T == max_vessel_capacity)
+	if(total_reagents_volume == max_vessel_capacity)
 		if(vessel_state != vessel_state_list[5])
 			vessel_overlay.icon_state = vessel_state_list[5]
 			vessel_state = vessel_state_list[5]
@@ -813,20 +813,20 @@
 
 	// Indicator state control
 	if(cell != null)
-		var/X = round(cell.charge / cell.maxcharge, 0.01)*100
-		if(X >= 0 && X < 25)
+		var/charge_percentage = round(cell.charge / cell.maxcharge, 0.01)*100
+		if(charge_percentage >= 0 && charge_percentage < 25)
 			if(indicator_overlay.icon_state != indicator_state_list[2])
 				cut_overlay(indicator_overlay)
 				indicator_overlay.icon_state = indicator_state_list[2]
 				if(!panel_open)
 					add_overlay(indicator_overlay)
-		if(X >= 25 && X < 75)
+		if(charge_percentage >= 25 && charge_percentage < 75)
 			if(indicator_overlay.icon_state != indicator_state_list[3])
 				cut_overlay(indicator_overlay)
 				indicator_overlay.icon_state = indicator_state_list[3]
 				if(!panel_open)
 					add_overlay(indicator_overlay)
-		if(X >= 75 && X <= 100)
+		if(charge_percentage >= 75 && charge_percentage <= 100)
 			if(indicator_overlay.icon_state != indicator_state_list[4])
 				cut_overlay(indicator_overlay)
 				indicator_overlay.icon_state = indicator_state_list[4]
@@ -919,7 +919,7 @@
 		return
 	if(action == "ejectCreature")
 		unbuckle_mob(current_mob)
-		to_chat(usr,span_notice("You eject [current_mob] from [src]"))
+		to_chat(usr, span_notice("You eject [current_mob] from [src]"))
 		return TRUE
 
 	if(action == "ejectBeaker")
@@ -931,28 +931,28 @@
 		current_mode = mode_list[1]
 		pump_state = pump_state_list[1]
 		update_all_visuals()
-		to_chat(usr,span_notice("You turn off [src]"))
+		to_chat(usr, span_notice("You turn off [src]"))
 		return TRUE
 
 	if(action == "setLowMode")
 		current_mode = mode_list[2]
 		pump_state = pump_state_list[2]
 		update_all_visuals()
-		to_chat(usr,span_notice("You switch [src] onto low mode"))
+		to_chat(usr, span_notice("You switch [src] onto low mode"))
 		return TRUE
 
 	if(action == "setMediumMode")
 		current_mode = mode_list[3]
 		pump_state = pump_state_list[2]
 		update_all_visuals()
-		to_chat(usr,span_notice("You switch [src] onto medium mode"))
+		to_chat(usr, span_notice("You switch [src] onto medium mode"))
 		return TRUE
 
 	if(action == "setHardMode")
 		current_mode = mode_list[4]
 		pump_state = pump_state_list[2]
 		update_all_visuals()
-		to_chat(usr,span_notice("You switch [src] onto hard mode"))
+		to_chat(usr, span_notice("You switch [src] onto hard mode"))
 		return TRUE
 
 	if(action == "unplug")
@@ -961,25 +961,25 @@
 		pump_state = pump_state_list[1]
 		current_selected_organ = null
 		update_all_visuals()
-		to_chat(usr,span_notice("You detach the liner."))
+		to_chat(usr, span_notice("You detach the liner."))
 		return TRUE
 
 	if(action == "setBreasts")
 		current_selected_organ = current_breasts
 		update_all_visuals()
-		to_chat(usr,span_notice("You attach the liner to [current_selected_organ]."))
+		to_chat(usr, span_notice("You attach the liner to [current_selected_organ]."))
 		return TRUE
 
 	if(action == "setVagina")
 		current_selected_organ = current_vagina
 		update_all_visuals()
-		to_chat(usr,span_notice("You attach the liner to [current_selected_organ]."))
+		to_chat(usr, span_notice("You attach the liner to [current_selected_organ]."))
 		return TRUE
 
 	if(action == "setTesticles")
 		current_selected_organ = current_testicles
 		update_all_visuals()
-		to_chat(usr,span_notice("You attach the liner to [current_selected_organ]."))
+		to_chat(usr, span_notice("You attach the liner to [current_selected_organ]."))
 		return TRUE
 
 	if(action == "setMilk")
@@ -1005,7 +1005,7 @@
 		current_vessel.reagents?.trans_to(beaker, amount)
 		current_vessel.reagents?.reagent_list[1].name
 		update_all_visuals()
-		to_chat(usr,span_notice("You transfer [amount] of [current_vessel.reagents?.reagent_list[1].name] to [beaker.name]"))
+		to_chat(usr, span_notice("You transfer [amount] of [current_vessel.reagents?.reagent_list[1].name] to [beaker.name]"))
 		return TRUE
 
 // Milking machine construction kit
@@ -1027,15 +1027,15 @@
 	icon_state = "[initial(icon_state)]_[current_color]"
 
 // Processor of the process of assembling a kit into a machine
-/obj/item/milking_machine/constructionkit/attackby(obj/item/I, mob/living/carbon/user, params)
+/obj/item/milking_machine/constructionkit/attackby(obj/item/used_item, mob/living/carbon/user, params)
 	if((item_flags & IN_INVENTORY) || (item_flags & IN_STORAGE))
 		return
-	if(I.tool_behaviour == TOOL_WRENCH)
+	if(used_item.tool_behaviour == TOOL_WRENCH)
 		if(user.get_held_items_for_side(LEFT_HANDS) == src || user.get_held_items_for_side(RIGHT_HANDS) == src)
 			return
 		if(get_turf(user) == get_turf(src))
 			return
-		else if(I.use_tool(src, user, 8 SECONDS, volume=50))
+		else if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
 			var/obj/structure/chair/milking_machine/new_milker = new(get_turf(user))
 			if(istype(src, /obj/item/milking_machine/constructionkit))
 				if(current_color == "pink")

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -165,7 +165,7 @@
 /datum/brain_trauma/special/bimbo/on_lose()
 	SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "bimbo", /datum/mood_event/bimbo)
 	if(HAS_TRAIT_FROM(owner, TRAIT_BIMBO, LEWDCHEM_TRAIT))
-		REMOVE_TRAIT(owner,TRAIT_BIMBO, LEWDCHEM_TRAIT)
+		REMOVE_TRAIT(owner, TRAIT_BIMBO, LEWDCHEM_TRAIT)
 	UnregisterSignal(owner, COMSIG_MOB_SAY)
 	if(HAS_TRAIT_FROM(owner, TRAIT_MASOCHISM, APHRO_TRAIT))
 		REMOVE_TRAIT(owner, TRAIT_MASOCHISM, APHRO_TRAIT)
@@ -256,9 +256,9 @@
 	resilience = TRAUMA_RESILIENCE_ABSOLUTE
 
 /datum/brain_trauma/special/sadism/on_life(delta_time, times_fired)
-	var/mob/living/carbon/human/H = owner
-	if(someone_suffering() && H.client?.prefs?.read_preference(/datum/preference/toggle/erp))
-		H.adjustArousal(2)
+	var/mob/living/carbon/human/affected_mob = owner
+	if(someone_suffering() && affected_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp))
+		affected_mob.adjustArousal(2)
 		SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "sadistic", /datum/mood_event/sadistic)
 	else
 		SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "sadistic", /datum/mood_event/sadistic)
@@ -266,10 +266,10 @@
 /datum/brain_trauma/special/sadism/proc/someone_suffering()
 	if(HAS_TRAIT(owner, TRAIT_BLIND))
 		return FALSE
-	for(var/mob/living/carbon/human/M in oview(owner, 4))
-		if(!isliving(M)) //ghosts ain't people
+	for(var/mob/living/carbon/human/iterated_mob in oview(owner, 4))
+		if(!isliving(iterated_mob)) //ghosts ain't people
 			continue
-		if(istype(M) && M.pain >= 10)
+		if(istype(iterated_mob) && iterated_mob.pain >= 10)
 			return TRUE
 	return FALSE
 
@@ -286,13 +286,13 @@
 
 /datum/quirk/ropebunny/post_add()
 	. = ..()
-	var/mob/living/carbon/human/H = quirk_holder
-	ADD_TRAIT(H,TRAIT_ROPEBUNNY, LEWDQUIRK_TRAIT)
+	var/mob/living/carbon/human/affected_mob = quirk_holder
+	ADD_TRAIT(affected_mob, TRAIT_ROPEBUNNY, LEWDQUIRK_TRAIT)
 
 /datum/quirk/ropebunny/remove()
 	. = ..()
-	var/mob/living/carbon/human/H = quirk_holder
-	REMOVE_TRAIT(H,TRAIT_ROPEBUNNY, LEWDQUIRK_TRAIT)
+	var/mob/living/carbon/human/affected_mob = quirk_holder
+	REMOVE_TRAIT(affected_mob, TRAIT_ROPEBUNNY, LEWDQUIRK_TRAIT)
 
 //Rigger code
 /datum/quirk/rigger
@@ -306,13 +306,13 @@
 
 /datum/quirk/rigger/post_add()
 	. = ..()
-	var/mob/living/carbon/human/H = quirk_holder
-	ADD_TRAIT(H,TRAIT_RIGGER, LEWDQUIRK_TRAIT)
+	var/mob/living/carbon/human/affected_mob = quirk_holder
+	ADD_TRAIT(affected_mob, TRAIT_RIGGER, LEWDQUIRK_TRAIT)
 
 /datum/quirk/rigger/remove()
 	. = ..()
-	var/mob/living/carbon/human/H = quirk_holder
-	REMOVE_TRAIT(H,TRAIT_RIGGER, LEWDQUIRK_TRAIT)
+	var/mob/living/carbon/human/affected_mob = quirk_holder
+	REMOVE_TRAIT(affected_mob, TRAIT_RIGGER, LEWDQUIRK_TRAIT)
 /datum/mood_event/sadistic
 	description = span_purple("Others' suffering makes me happier\n")
 
@@ -320,12 +320,11 @@
 ///EMPATH BOUNS///
 //////////////////
 /mob/living/carbon/human/examine(mob/user)
-	.=..()
-	var/mob/living/U = user
-
-	if(stat != DEAD && !HAS_TRAIT(src, TRAIT_FAKEDEATH) && src != U)
+	. = ..()
+	var/mob/living/examiner = user
+	if(stat != DEAD && !HAS_TRAIT(src, TRAIT_FAKEDEATH) && src != examiner)
 		if(src != user)
-			if(HAS_TRAIT(U, TRAIT_EMPATH))
+			if(HAS_TRAIT(examiner, TRAIT_EMPATH))
 				switch(arousal)
 					if(11 to 21)
 						. += span_purple("[p_they()] [p_are()] excited.") + "\n"

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/bdsm_furniture.dm
@@ -14,38 +14,38 @@
 	var/unwrapped = 0
 	w_class = WEIGHT_CLASS_HUGE
 
-/obj/item/bdsm_bed_kit/attackby(obj/item/P, mob/user, params) //constructing a bed here.
+/obj/item/bdsm_bed_kit/attackby(obj/item/used_item, mob/user, params) //constructing a bed here.
 	add_fingerprint(user)
-	if(istype(P, /obj/item/wrench))
+	if(istype(used_item, /obj/item/wrench))
 		if (!(item_flags & IN_INVENTORY) && !(item_flags & IN_STORAGE))
 			to_chat(user, span_notice("You fasten the frame to the floor and begin to inflate the latex pillows..."))
-			if(P.use_tool(src, user, 8 SECONDS, volume=50))
+			if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
 				to_chat(user, span_notice("You assemble the bdsm bed."))
-				var/obj/structure/bed/bdsm_bed/C = new
-				C.loc = loc
+				var/obj/structure/bed/bdsm_bed/assembled_bed = new
+				assembled_bed.loc = loc
 				qdel(src)
 			return
 	else
 		return ..()
 
-/obj/structure/bed/bdsm_bed/post_buckle_mob(mob/living/M)
+/obj/structure/bed/bdsm_bed/post_buckle_mob(mob/living/affected_mob)
 	density = TRUE
 	//Push them up from the normal lying position
-	M.pixel_y = M.base_pixel_y
+	affected_mob.pixel_y = affected_mob.base_pixel_y
 
-/obj/structure/bed/bdsm_bed/post_unbuckle_mob(mob/living/M)
+/obj/structure/bed/bdsm_bed/post_unbuckle_mob(mob/living/affected_mob)
 	density = FALSE
 	//Set them back down to the normal lying position
-	M.pixel_y = M.base_pixel_y + M.body_position_pixel_y_offset
+	affected_mob.pixel_y = affected_mob.base_pixel_y + affected_mob.body_position_pixel_y_offset
 
-/obj/structure/bed/bdsm_bed/attackby(obj/item/P, mob/user, params) //deconstructing a bed. Aww(
+/obj/structure/bed/bdsm_bed/attackby(obj/item/used_item, mob/user, params) //deconstructing a bed. Aww(
 	add_fingerprint(user)
-	if(istype(P, /obj/item/wrench))
+	if(istype(used_item, /obj/item/wrench))
 		to_chat(user, span_notice("You begin unfastening the frame of bdsm bed and deflating the latex pillows..."))
-		if(P.use_tool(src, user, 8 SECONDS, volume=50))
+		if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
 			to_chat(user, span_notice("You disassemble the BDSM bed."))
-			var/obj/item/bdsm_bed_kit/C = new
-			C.loc = loc
+			var/obj/item/bdsm_bed_kit/created_kit = new
+			created_kit.loc = loc
 			unbuckle_all_mobs()
 			qdel(src)
 		return
@@ -95,14 +95,14 @@
 
 //X-Stand LBM interaction handler
 /obj/structure/chair/x_stand/attack_hand(mob/living/user)
-	var/mob/living/M = locate() in src.loc
+	var/mob/living/affected_mob = locate() in src.loc
 	// X-Stand is empty?
 	if(!has_buckled_mobs())
 		// Is there someone on the X-Stand tile?
-		if(M)
+		if(affected_mob)
 			// Can a mob in a X-Stand tile be buckled?
-			if(M.can_buckle_to)
-				user_buckle_mob(M, user, check_loc = TRUE)
+			if(affected_mob.can_buckle_to)
+				user_buckle_mob(affected_mob, user, check_loc = TRUE)
 			else
 				// The X-Stand is empty, but there is a mob in the X-Stand tile that cannot be buckled
 				// A place to report the impossibility to buckle the current mob in X-Stand
@@ -119,19 +119,19 @@
 /obj/structure/chair/x_stand/attack_tk(mob/user)
 	return FALSE
 
-// Handler for attempting to unbukle a mob from a X-Stand
+// Handler for attempting to unbuckle a mob from a X-Stand
 /obj/structure/chair/x_stand/user_unbuckle_mob(mob/living/buckled_mob, mob/living/user)
 	// Let's make sure that the X-Stand is in the correct state
 	if(stand_state == "open")
 		toggle_mode(user)
-	var/mob/living/M = unbuckle_mob(buckled_mob)
-	if(M)
-		if(M != user)
-			if(!do_after(user, 5 SECONDS, M)) // Timer for unbuckling one mob with another mob
+	var/mob/living/affected_mob = unbuckle_mob(buckled_mob)
+	if(affected_mob)
+		if(affected_mob != user)
+			if(!do_after(user, 5 SECONDS, affected_mob)) // Timer for unbuckling one mob with another mob
 				// Place to describe failed attempt
 				return FALSE
 			// Description of a successful attempt
-			M.visible_message(span_notice("[user] unbuckles [M] from [src]."),\
+			affected_mob.visible_message(span_notice("[user] unbuckles [affected_mob] from [src]."),\
 				span_notice("[user] unbuckles you from [src]."),\
 				span_hear("You hear metal clanking."))
 			// Description of a successful mob attempt to unbuckle one mob with another mob
@@ -140,62 +140,62 @@
 			user.visible_message(span_notice("You unbuckle yourself from [src]."),\
 				span_hear("You hear metal clanking."))
 		add_fingerprint(user)
-		if(isliving(M.pulledby))
-			var/mob/living/L = M.pulledby
-			L.set_pull_offsets(M, L.grab_state)
+		if(isliving(affected_mob.pulledby))
+			var/mob/living/pulling_mob = affected_mob.pulledby
+			pulling_mob.set_pull_offsets(affected_mob, pulling_mob.grab_state)
 		toggle_mode(user)
-	return M
+	return affected_mob
 
 // Handler for attempting to buckle a mob into a X-Stand
-/obj/structure/chair/x_stand/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
+/obj/structure/chair/x_stand/user_buckle_mob(mob/living/affected_mob, mob/user, check_loc = TRUE)
 	// Let's make sure that the X-Stand is in the correct state
 	if(stand_state == "close")
 		toggle_mode(user)
 		//return  // Uncomment if it is necessary to "open" the X-Stand as a separate action before buckling
 
 	// Is buckling even possible? Do a full suite of checks.
-	if(!is_user_buckle_possible(M, user, check_loc))
+	if(!is_user_buckle_possible(affected_mob, user, check_loc))
 		return FALSE
 	add_fingerprint(user)
 
 	// If the mob we're attempting to buckle is not stood on this atom's turf and it isn't the user buckling themselves,
 	// we'll try it with a 2 second do_after delay.
-	if(M != user)
+	if(affected_mob != user)
 		// Place to describe an attempt to buckle a mob
-		M.visible_message(span_warning("[user] starts buckling [M] to [src]!"),\
+		affected_mob.visible_message(span_warning("[user] starts buckling [affected_mob] to [src]!"),\
 			span_userdanger("[user] starts buckling you to [src]!"),\
 			span_hear("You hear metal clanking."))
-		if(!do_after(user, 5 SECONDS, M)) // Timer to buckle one mob by another
+		if(!do_after(user, 5 SECONDS, affected_mob)) // Timer to buckle one mob by another
 			// Place to describe a failed buckling attempt
 			return FALSE
 
 		// Sanity check before we attempt to buckle. Is everything still in a kosher state for buckling after the 3 seconds have elapsed?
 		// Covers situations where, for example, the chair was moved or there's some other issue.
-		if(!is_user_buckle_possible(M, user, check_loc))
+		if(!is_user_buckle_possible(affected_mob, user, check_loc))
 			// A place to report the inability to buckle a mob
 			return FALSE
 
 
 		// Place to insert a description of a successful attempt for a user mob
-		if(buckle_mob(M, check_loc = check_loc))
+		if(buckle_mob(affected_mob, check_loc = check_loc))
 			// Description of a successful attempt to buckle a mob by another mob
-			M.visible_message(span_warning("[user] starts buckling [M] to [src]!"),\
+			affected_mob.visible_message(span_warning("[user] starts buckling [affected_mob] to [src]!"),\
 				span_userdanger("[user] starts buckling you to [src]!"),\
 				span_hear("You hear metal clanking."))
 		toggle_mode(user)
 
 	else
-		if(!do_after(user, 10 SECONDS, M)) // Timer to buckle the mob itself
+		if(!do_after(user, 10 SECONDS, affected_mob)) // Timer to buckle the mob itself
 			// Place to describe failed attempt
 			return FALSE
 
 		// Sanity check before we attempt to buckle. Is everything still in a kosher state for buckling after the 3 seconds have elapsed?
 		// Covers situations where, for example, the chair was moved or there's some other issue.
-		if(!is_user_buckle_possible(M, user, check_loc))
+		if(!is_user_buckle_possible(affected_mob, user, check_loc))
 			// Place to report the inability to buckle
 			return FALSE
 
-		if(buckle_mob(M, check_loc = check_loc))
+		if(buckle_mob(affected_mob, check_loc = check_loc))
 			user.visible_message(span_warning("You buckles yourself to [src]!"),\
 				span_hear("You hear metal clanking."))
 		toggle_mode(user)
@@ -217,10 +217,10 @@
 
 
 //Place the mob in the desired position after buckling
-/obj/structure/chair/x_stand/post_buckle_mob(mob/living/M)
-	M.pixel_y = M.base_pixel_y
-	M.pixel_x = M.base_pixel_x
-	M.layer = BELOW_MOB_LAYER
+/obj/structure/chair/x_stand/post_buckle_mob(mob/living/affected_mob)
+	affected_mob.pixel_y = affected_mob.base_pixel_y
+	affected_mob.pixel_x = affected_mob.base_pixel_x
+	affected_mob.layer = BELOW_MOB_LAYER
 
 	if(LAZYLEN(buckled_mobs))
 		if(ishuman(buckled_mobs[1]))
@@ -237,10 +237,10 @@
 		current_mob.update_abstract_handcuffed()
 
 //Restore the position of the mob after unbuckling.
-/obj/structure/chair/x_stand/post_unbuckle_mob(mob/living/M)
-	M.pixel_x = M.base_pixel_x + M.body_position_pixel_x_offset
-	M.pixel_y = M.base_pixel_y + M.body_position_pixel_y_offset
-	M.layer = initial(M.layer)
+/obj/structure/chair/x_stand/post_unbuckle_mob(mob/living/affected_mob)
+	affected_mob.pixel_x = affected_mob.base_pixel_x + affected_mob.body_position_pixel_x_offset
+	affected_mob.pixel_y = affected_mob.base_pixel_y + affected_mob.body_position_pixel_y_offset
+	affected_mob.layer = initial(affected_mob.layer)
 
 	if(current_mob)
 		if(current_mob.handcuffed)
@@ -262,12 +262,12 @@
 	var/unwrapped = 0
 	w_class = WEIGHT_CLASS_HUGE
 
-/obj/item/x_stand_kit/attackby(obj/item/P, mob/user, params) //constructing a bed here.
+/obj/item/x_stand_kit/attackby(obj/item/used_item, mob/user, params) //constructing a bed here.
 	add_fingerprint(user)
-	if(istype(P, /obj/item/wrench))
+	if(istype(used_item, /obj/item/wrench))
 		if (!(item_flags & IN_INVENTORY) && !(item_flags & IN_STORAGE))
 			to_chat(user, span_notice("You begin fastening the frame to the floor."))
-			if(P.use_tool(src, user, 8 SECONDS, volume=50))
+			if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
 				to_chat(user, span_notice("You assemble the x-stand."))
 				new /obj/structure/chair/x_stand(get_turf(user))
 				qdel(src)
@@ -275,11 +275,11 @@
 	else
 		return ..()
 
-/obj/structure/chair/x_stand/attackby(obj/item/P, mob/user, params) //deconstructing a bed. Aww(
+/obj/structure/chair/x_stand/attackby(obj/item/used_item, mob/user, params) //deconstructing a bed. Aww(
 	add_fingerprint(user)
-	if(istype(P, /obj/item/wrench))
+	if(istype(used_item, /obj/item/wrench))
 		to_chat(user, span_notice("You begin unfastening the frame of x-stand..."))
-		if(P.use_tool(src, user, 8 SECONDS, volume=50))
+		if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
 			to_chat(user, span_notice("You disassemble the x-stand."))
 			new /obj/item/x_stand_kit(get_turf(user))
 			unbuckle_all_mobs()

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
@@ -39,11 +39,11 @@
         "white" = image(icon = src.icon, icon_state = "pole_white_on"))
 
 //using multitool on pole
-/obj/structure/pole/multitool_act(mob/living/user, obj/item/I)
+/obj/structure/pole/multitool_act(mob/living/user, obj/item/used_item)
     . = ..()
     if(.)
         return
-    var/choice = show_radial_menu(user,src, pole_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 50, require_near = TRUE)
+    var/choice = show_radial_menu(user, src, pole_designs, custom_check = CALLBACK(src, .proc/check_menu, user, used_item), radius = 50, require_near = TRUE)
     if(!choice)
         return FALSE
     current_pole_color = choice
@@ -113,25 +113,25 @@
 	if(user.loc != src.loc)
 		return
 	if(!QDELETED(src))
-		animate(user,pixel_x = -6, pixel_y = 0, time = 10)
+		animate(user, pixel_x = -6, pixel_y = 0, time = 10)
 		sleep(20)
 		user.dir = 4
 	if(!QDELETED(src))
-		animate(user,pixel_x = -6,pixel_y = 24, time = 10)
+		animate(user, pixel_x = -6, pixel_y = 24, time = 10)
 		sleep(12)
 		src.layer = 4.01 //move the pole infront for now. better to move the pole, because the character moved behind people sitting above otherwise
 	if(!QDELETED(src))
-		animate(user,pixel_x = 6,pixel_y = 12, time = 5)
+		animate(user, pixel_x = 6, pixel_y = 12, time = 5)
 		user.dir = 8
 		sleep(6)
 	if(!QDELETED(src))
-		animate(user,pixel_x = -6,pixel_y = 4, time = 5)
+		animate(user, pixel_x = -6, pixel_y = 4, time = 5)
 		user.dir = 4
 		src.layer = 4 // move it back.
 		sleep(6)
 	if(!QDELETED(src))
 		user.dir = 1
-		animate(user,pixel_x = 0, pixel_y = 0, time = 3)
+		animate(user, pixel_x = 0, pixel_y = 0, time = 3)
 		sleep(6)
 	if(!QDELETED(src))
 		user.do_jitter_animation()
@@ -156,12 +156,12 @@
 	var/unwrapped = 0
 	w_class = WEIGHT_CLASS_HUGE
 
-/obj/item/polepack/attackby(obj/item/P, mob/user, params) //erecting a pole here.
+/obj/item/polepack/attackby(obj/item/used_item, mob/user, params) //erecting a pole here.
 	add_fingerprint(user)
-	if(istype(P, /obj/item/wrench))
+	if(istype(used_item, /obj/item/wrench))
 		if (!(item_flags & IN_INVENTORY) && !(item_flags & IN_STORAGE))
 			to_chat(user, span_notice("You begin fastening the frame to the floor and ceiling..."))
-			if(P.use_tool(src, user, 8 SECONDS, volume=50))
+			if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
 				to_chat(user, span_notice("You assemble the stripper pole."))
 				new /obj/structure/pole(get_turf(user))
 				qdel(src)
@@ -169,11 +169,11 @@
 	else
 		return ..()
 
-/obj/structure/pole/attackby(obj/item/P, mob/user, params) //un-erecting a pole. :(
+/obj/structure/pole/attackby(obj/item/used_item, mob/user, params) //un-erecting a pole. :(
 	add_fingerprint(user)
-	if(istype(P, /obj/item/wrench))
+	if(istype(used_item, /obj/item/wrench))
 		to_chat(user, span_notice("You begin unfastening the frame from the floor and ceiling..."))
-		if(P.use_tool(src, user, 8 SECONDS, volume=50))
+		if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
 			to_chat(user, span_notice("You disassemble the stripper pole."))
 			new /obj/item/polepack(get_turf(user))
 			qdel(src)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/lustwish.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/lustwish.dm
@@ -138,8 +138,8 @@
         "teal" = image(icon = src.icon, icon_state = "lustwish_teal"))
 
 //Changing special secret var
-/obj/machinery/vending/dorms/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, /obj/item/lustwish_discount))
+/obj/machinery/vending/dorms/attackby(obj/item/used_item, mob/living/user, params)
+	if(istype(used_item, /obj/item/lustwish_discount))
 		user.visible_message(span_boldnotice("Something changes in [src] with a loud clunk."))
 		card_used = !card_used
 		switch(card_used)
@@ -153,12 +153,12 @@
 		return ..()
 
 //using multitool on pole
-/obj/machinery/vending/dorms/multitool_act(mob/living/user, obj/item/I)
+/obj/machinery/vending/dorms/multitool_act(mob/living/user, obj/item/used_item)
 	. = ..()
 	if(.)
 		return
 	if(card_used == TRUE)
-		var/choice = show_radial_menu(user,src, vend_designs, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 50, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, vend_designs, custom_check = CALLBACK(src, .proc/check_menu, user, used_item), radius = 50, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		current_color = choice

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/pillow.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/pillow.dm
@@ -1,8 +1,8 @@
-//WARNING - Lot's of shitcode here. I'm not the best coder but this stuff works and i'm happy. Improve it if you want, but don't break anything.
+//WARNING - Lot's of shitcode here. I'm not the best coder but this stuff works and I'm happy. Improve it if you want, but don't break anything.
 
-//////////////////////////
-///CODE FOR PILLOW ITEM///
-//////////////////////////
+/*
+*	CODE FOR PILLOW ITEM
+*/
 
 /obj/item/pillow
 	name = "pillow"
@@ -21,29 +21,29 @@
 	var/static/list/pillow_forms
 	w_class = WEIGHT_CLASS_SMALL
 
-//to update model
+// To update model
 /obj/item/pillow/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 
-//create radial menu
+// Create radial menu
 /obj/item/pillow/proc/populate_pillow_colors()
 	pillow_colors = list(
 		"pink" = image (icon = src.icon, icon_state = "pillow_pink_round"),
 		"teal" = image(icon = src.icon, icon_state = "pillow_teal_round"))
 
-//create radial menu, BUT for forms. I'm smort
+// Create radial menu, BUT for forms. I'm smort
 /obj/item/pillow/proc/populate_pillow_forms()
 	pillow_forms = list(
 		"square" = image (icon = src.icon, icon_state = "pillow_pink_square"),
 		"round" = image(icon = src.icon, icon_state = "pillow_pink_round"))
 
-/obj/item/pillow/AltClick(mob/user, obj/item/I)
+/obj/item/pillow/AltClick(mob/user)
 	if(color_changed == FALSE)
 		. = ..()
 		if(.)
 			return
-		var/choice = show_radial_menu(user,src, pillow_colors, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, pillow_colors, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 		if(!choice)
 			return FALSE
 		current_color = choice
@@ -55,7 +55,7 @@
 			. = ..()
 			if(.)
 				return
-			var/choice = show_radial_menu(user,src, pillow_forms, custom_check = CALLBACK(src, .proc/check_menu, user, I), radius = 36, require_near = TRUE)
+			var/choice = show_radial_menu(user, src, pillow_forms, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 36, require_near = TRUE)
 			if(!choice)
 				return FALSE
 			current_form = choice
@@ -108,9 +108,9 @@
 /datum/effect_system/feathers
 	effect_type = /obj/effect/temp_visual/feathers
 
-/obj/item/pillow/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
+/obj/item/pillow/attack(mob/living/carbon/human/affected_mob, mob/living/carbon/human/user)
 	. = ..()
-	if(!istype(M, /mob/living/carbon/human))
+	if(!istype(affected_mob, /mob/living/carbon/human))
 		return
 
 	if(prob(1.5)) // 1.5% chance of special tickling feather spawning. No idea why, i was thinking that this is funny idea. Do not erase it plz
@@ -122,40 +122,40 @@
 
 		if(BODY_ZONE_HEAD)
 			var/message = ""
-			message = (user == M) ? pick("hits [M.p_them()]self with [src]", "hits [M.p_their()] head with [src]") : pick("hits [M] with [src]", "hits [M] over the head with [src]! Luckily, [src] is soft.")
+			message = (user == affected_mob) ? pick("hits [affected_mob.p_them()]self with [src]", "hits [affected_mob.p_their()] head with [src]") : pick("hits [affected_mob] with [src]", "hits [affected_mob] over the head with [src]! Luckily, [src] is soft.")
 			if(prob(30))
-				M.emote(pick("laugh","giggle"))
+				affected_mob.emote(pick("laugh", "giggle"))
 			user.visible_message(span_notice("[user] [message]!"))
-			playsound(loc,'modular_skyrat/modules/modular_items/lewd_items/sounds/hug.ogg', 50, 1, -1)
+			playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/hug.ogg', 50, 1, -1)
 
 		if(BODY_ZONE_CHEST)
 			var/message = ""
-			message = (user == M) ? pick("has a solo pillow fight, hitting [M.p_them()]self with [src]","hits [M.p_them()]self with [src]") : pick("hits [M] in the chest with [src]", "playfully hits [M]'s chest with [src]")
+			message = (user == affected_mob) ? pick("has a solo pillow fight, hitting [affected_mob.p_them()]self with [src]", "hits [affected_mob.p_them()]self with [src]") : pick("hits [affected_mob] in the chest with [src]", "playfully hits [affected_mob]'s chest with [src]")
 			if(prob(30))
-				M.emote(pick("laugh","giggle"))
+				affected_mob.emote(pick("laugh", "giggle"))
 			user.visible_message(span_notice("[user] [message]!"))
-			playsound(loc,'modular_skyrat/modules/modular_items/lewd_items/sounds/hug.ogg', 50, 1, -1)
+			playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/hug.ogg', 50, 1, -1)
 
 		else
 			var/message = ""
-			message = (user == M) ? pick("hits [M.p_them()]self with [src]","playfully hits [M.p_them()]self with a [src]", "grabs [src], hitting [M.p_them()]self with it") : pick("hits [M] with [src]", "playfully hits [M] with [src].","hits [M] with [src]. Looks like fun")
+			message = (user == affected_mob) ? pick("hits [affected_mob.p_them()]self with [src]", "playfully hits [affected_mob.p_them()]self with a [src]", "grabs [src], hitting [affected_mob.p_them()]self with it") : pick("hits [affected_mob] with [src]", "playfully hits [affected_mob] with [src].", "hits [affected_mob] with [src]. Looks like fun")
 			if(prob(30))
-				M.emote(pick("laugh","giggle"))
+				affected_mob.emote(pick("laugh", "giggle"))
 			user.visible_message(span_notice("[user] [message]!"))
-			playsound(loc,'modular_skyrat/modules/modular_items/lewd_items/sounds/hug.ogg', 50, 1, -1)
+			playsound(loc, 'modular_skyrat/modules/modular_items/lewd_items/sounds/hug.ogg', 50, 1, -1)
 
 //spawning pillow on the ground when clicking on pillow	by LBM
 
 /obj/item/pillow/attack_self(mob/user)
 	if(IN_INVENTORY)
 		to_chat(user, span_notice("You set [src] down on the floor."))
-		var/obj/structure/bed/pillow_tiny/C = new(get_turf(src))
-		C.current_color = current_color
-		C.current_form = current_form
-		C.color_changed = color_changed
-		C.form_changed = form_changed
-		C.update_icon_state()
-		C.update_icon()
+		var/obj/structure/bed/pillow_tiny/pillow_pile = new(get_turf(src))
+		pillow_pile.current_color = current_color
+		pillow_pile.current_form = current_form
+		pillow_pile.color_changed = color_changed
+		pillow_pile.form_changed = form_changed
+		pillow_pile.update_icon_state()
+		pillow_pile.update_icon()
 		qdel(src)
 	return
 
@@ -189,55 +189,55 @@
 
 /obj/structure/bed/pillow_tiny/AltClick(mob/user)
 	to_chat(user, span_notice("You pick up [src]."))
-	var/obj/item/pillow/W = new()
-	user.put_in_hands(W)
+	var/obj/item/pillow/taken_pillow = new()
+	user.put_in_hands(taken_pillow)
 
-	W.current_form = current_form
-	W.current_color = current_color
-	W.color_changed = color_changed
-	W.form_changed = form_changed
+	taken_pillow.current_form = current_form
+	taken_pillow.current_color = current_color
+	taken_pillow.color_changed = color_changed
+	taken_pillow.form_changed = form_changed
 
-	W.update_icon_state()
-	W.update_icon()
+	taken_pillow.update_icon_state()
+	taken_pillow.update_icon()
 	qdel(src)
 
 //when we lay on it
 
-/obj/structure/bed/pillow_tiny/post_buckle_mob(mob/living/M)
+/obj/structure/bed/pillow_tiny/post_buckle_mob(mob/living/affected_mob)
 	. = ..()
 	density = TRUE
 	//Push them up from the normal lying position
-	M.pixel_y = M.base_pixel_y + 2
+	affected_mob.pixel_y = affected_mob.base_pixel_y + 2
 
-/obj/structure/bed/pillow_tiny/post_unbuckle_mob(mob/living/M)
+/obj/structure/bed/pillow_tiny/post_unbuckle_mob(mob/living/affected_mob)
 	. = ..()
 	density = FALSE
 	//Set them back down to the normal lying position
-	M.pixel_y = M.base_pixel_y
+	affected_mob.pixel_y = affected_mob.base_pixel_y
 
 //"Upgrading" pillow
-/obj/structure/bed/pillow_tiny/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, /obj/item/pillow))
-		var/obj/item/pillow/P = I
-		var/obj/structure/chair/pillow_small/C
-		if(P.current_color == current_color)
+/obj/structure/bed/pillow_tiny/attackby(obj/item/used_item, mob/living/user, params)
+	if(istype(used_item, /obj/item/pillow))
+		var/obj/item/pillow/used_pillow = used_item
+		var/obj/structure/chair/pillow_small/pillow_pile
+		if(used_pillow.current_color == current_color)
 			to_chat(user, span_notice("You add [src] to a pile."))
-			C = new(get_turf(src))
-			C.current_color = current_color
-			C.pillow2_color = P.current_color
-			C.pillow1_color = current_color
-			C.pillow1_form = current_form
-			C.pillow2_form = P.current_form
+			pillow_pile = new(get_turf(src))
+			pillow_pile.current_color = current_color
+			pillow_pile.pillow2_color = used_pillow.current_color
+			pillow_pile.pillow1_color = current_color
+			pillow_pile.pillow1_form = current_form
+			pillow_pile.pillow2_form = used_pillow.current_form
 
-			C.pillow1_color_changed = color_changed
-			C.pillow1_form_changed = color_changed
-			C.pillow2_color_changed = P.color_changed
-			C.pillow2_form_changed = P.color_changed
+			pillow_pile.pillow1_color_changed = color_changed
+			pillow_pile.pillow1_form_changed = color_changed
+			pillow_pile.pillow2_color_changed = used_pillow.color_changed
+			pillow_pile.pillow2_form_changed = used_pillow.color_changed
 
-			C.update_icon_state()
-			C.update_icon()
+			pillow_pile.update_icon_state()
+			pillow_pile.update_icon()
 			qdel(src)
-			qdel(P)
+			qdel(used_pillow)
 		else
 			to_chat(user, span_notice("You feel that those colours would clash...")) //Too lazy to add multicolor pillow pile sprites.
 			return
@@ -286,23 +286,23 @@
 	QDEL_NULL(armrest)
 	return ..()
 
-/obj/structure/chair/pillow_small/post_buckle_mob(mob/living/M)
+/obj/structure/chair/pillow_small/post_buckle_mob(mob/living/affected_mob)
     . = ..()
     update_icon()
     density = TRUE
     //Push them up from the normal lying position
-    M.pixel_y = M.base_pixel_y + 2
+    affected_mob.pixel_y = affected_mob.base_pixel_y + 2
 
 /obj/structure/chair/pillow_small/update_overlays()
     . = ..()
     if(has_buckled_mobs())
         . += mutable_appearance('modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_structures/pillows.dmi', "pillowpile_small_[current_color]_overlay", layer = ABOVE_MOB_LAYER + 0.2)
 
-/obj/structure/chair/pillow_small/post_unbuckle_mob(mob/living/M)
+/obj/structure/chair/pillow_small/post_unbuckle_mob(mob/living/affected_mob)
 	. = ..()
 	density = FALSE
 	//Set them back down to the normal lying position
-	M.pixel_y = M.base_pixel_y
+	affected_mob.pixel_y = affected_mob.base_pixel_y
 
 /obj/structure/chair/pillow_small/update_icon_state()
 	. = ..()
@@ -311,54 +311,54 @@
 //Removing pillow from a pile
 /obj/structure/chair/pillow_small/AltClick(mob/user)
 	to_chat(user, span_notice("You take [src] from the pile."))
-	var/obj/item/pillow/W = new()
-	var/obj/structure/bed/pillow_tiny/C = new(get_turf(src))
-	user.put_in_hands(W)
+	var/obj/item/pillow/taken_pillow = new()
+	var/obj/structure/bed/pillow_tiny/pillow_pile = new(get_turf(src))
+	user.put_in_hands(taken_pillow)
 	//magic
-	W.current_color = pillow2_color
-	W.current_form = pillow2_form
-	C.current_color = pillow1_color
-	C.current_form = pillow1_form
+	taken_pillow.current_color = pillow2_color
+	taken_pillow.current_form = pillow2_form
+	pillow_pile.current_color = pillow1_color
+	pillow_pile.current_form = pillow1_form
 
-	C.color_changed = pillow1_color_changed
-	C.form_changed = pillow1_form_changed
-	W.color_changed = pillow2_color_changed
-	W.form_changed = pillow2_form_changed
+	pillow_pile.color_changed = pillow1_color_changed
+	pillow_pile.form_changed = pillow1_form_changed
+	taken_pillow.color_changed = pillow2_color_changed
+	taken_pillow.form_changed = pillow2_form_changed
 
 	//magic
-	W.update_icon_state()
-	W.update_icon()
-	C.update_icon_state()
-	C.update_icon()
+	taken_pillow.update_icon_state()
+	taken_pillow.update_icon()
+	pillow_pile.update_icon_state()
+	pillow_pile.update_icon()
 	qdel(src)
 
 //Upgrading pillow pile to a PILLOW PILE!
-/obj/structure/chair/pillow_small/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, /obj/item/pillow))
-		var/obj/item/pillow/P = I
-		var/obj/structure/bed/pillow_large/C
-		if(P.current_color == current_color)
+/obj/structure/chair/pillow_small/attackby(obj/item/used_item, mob/living/user, params)
+	if(istype(used_item, /obj/item/pillow))
+		var/obj/item/pillow/used_pillow = used_item
+		var/obj/structure/bed/pillow_large/pillow_pile
+		if(used_pillow.current_color == current_color)
 			to_chat(user, span_notice("You add [src] to the pile."))
-			C = new(get_turf(src))
-			C.current_color = current_color
-			C.pillow3_color = P.current_color
-			C.pillow2_color = pillow2_color
-			C.pillow1_color = pillow1_color
-			C.pillow3_form = P.current_form
-			C.pillow1_form = pillow1_form
-			C.pillow2_form = pillow2_form
+			pillow_pile = new(get_turf(src))
+			pillow_pile.current_color = current_color
+			pillow_pile.pillow3_color = used_pillow.current_color
+			pillow_pile.pillow2_color = pillow2_color
+			pillow_pile.pillow1_color = pillow1_color
+			pillow_pile.pillow3_form = used_pillow.current_form
+			pillow_pile.pillow1_form = pillow1_form
+			pillow_pile.pillow2_form = pillow2_form
 
-			C.pillow1_color_changed = pillow1_color_changed
-			C.pillow1_form_changed = pillow1_form_changed
-			C.pillow2_color_changed = pillow2_color_changed
-			C.pillow2_form_changed = pillow2_form_changed
-			C.pillow3_color_changed = P.color_changed
-			C.pillow3_form_changed = P.form_changed
+			pillow_pile.pillow1_color_changed = pillow1_color_changed
+			pillow_pile.pillow1_form_changed = pillow1_form_changed
+			pillow_pile.pillow2_color_changed = pillow2_color_changed
+			pillow_pile.pillow2_form_changed = pillow2_form_changed
+			pillow_pile.pillow3_color_changed = used_pillow.color_changed
+			pillow_pile.pillow3_form_changed = used_pillow.form_changed
 
-			C.update_icon_state()
-			C.update_icon()
+			pillow_pile.update_icon_state()
+			pillow_pile.update_icon()
 			qdel(src)
-			qdel(P)
+			qdel(used_pillow)
 		else
 			to_chat(user, span_notice("You feel that those colours would clash...")) //Too lazy to add multicolor pillow pile sprites.
 			return
@@ -414,23 +414,23 @@
 	QDEL_NULL(armrest)
 	return ..()
 
-/obj/structure/bed/pillow_large/post_buckle_mob(mob/living/M)
+/obj/structure/bed/pillow_large/post_buckle_mob(mob/living/affected_mob)
     . = ..()
     update_icon()
     density = TRUE
     //Push them up from the normal lying position
-    M.pixel_y = M.base_pixel_y + 0.5
+    affected_mob.pixel_y = affected_mob.base_pixel_y + 0.5
 
 /obj/structure/bed/pillow_large/update_overlays()
     . = ..()
     if(has_buckled_mobs())
         . += mutable_appearance('modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_structures/pillows.dmi', "pillowpile_large_[current_color]_overlay", layer = ABOVE_MOB_LAYER + 0.2)
 
-/obj/structure/bed/pillow_large/post_unbuckle_mob(mob/living/M)
+/obj/structure/bed/pillow_large/post_unbuckle_mob(mob/living/affected_mob)
 	. = ..()
 	density = FALSE
 	//Set them back down to the normal lying position
-	M.pixel_y = M.base_pixel_y
+	affected_mob.pixel_y = affected_mob.base_pixel_y
 
 /obj/structure/bed/pillow_large/update_icon_state()
 	. = ..()
@@ -439,28 +439,28 @@
 //Removing pillow from a pile
 /obj/structure/bed/pillow_large/AltClick(mob/user)
 	to_chat(user, span_notice("You take [src] from the pile."))
-	var/obj/item/pillow/W = new()
-	var/obj/structure/chair/pillow_small/C = new(get_turf(src))
-	user.put_in_hands(W)
+	var/obj/item/pillow/taken_pillow = new()
+	var/obj/structure/chair/pillow_small/pillow_pile = new(get_turf(src))
+	user.put_in_hands(taken_pillow)
 	//magic
-	C.current_color = current_color
-	W.current_color = pillow3_color
-	W.current_form = pillow3_form
-	C.pillow2_form = pillow2_form
-	C.pillow2_color = pillow2_color
-	C.pillow1_form = pillow1_form
-	C.pillow1_color = pillow1_color
+	pillow_pile.current_color = current_color
+	taken_pillow.current_color = pillow3_color
+	taken_pillow.current_form = pillow3_form
+	pillow_pile.pillow2_form = pillow2_form
+	pillow_pile.pillow2_color = pillow2_color
+	pillow_pile.pillow1_form = pillow1_form
+	pillow_pile.pillow1_color = pillow1_color
 
-	C.pillow1_color_changed = pillow1_color_changed
-	C.pillow2_color_changed = pillow2_color_changed
-	C.pillow1_form_changed = pillow1_form_changed
-	C.pillow2_form_changed = pillow2_form_changed
-	W.color_changed = pillow3_color_changed
-	W.form_changed = pillow3_form_changed
+	pillow_pile.pillow1_color_changed = pillow1_color_changed
+	pillow_pile.pillow2_color_changed = pillow2_color_changed
+	pillow_pile.pillow1_form_changed = pillow1_form_changed
+	pillow_pile.pillow2_form_changed = pillow2_form_changed
+	taken_pillow.color_changed = pillow3_color_changed
+	taken_pillow.form_changed = pillow3_form_changed
 
 	//magic
-	W.update_icon_state()
-	W.update_icon()
-	C.update_icon_state()
-	C.update_icon()
+	taken_pillow.update_icon_state()
+	taken_pillow.update_icon()
+	pillow_pile.update_icon_state()
+	pillow_pile.update_icon()
 	qdel(src)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/technical_stuff_for_lewd.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/technical_stuff_for_lewd.dm
@@ -1,9 +1,4 @@
-//////////////////////////////////////////////////////////////////////////
-//THIS IS NOT HERESY, DO NOT TOUCH IT IN THE NAME OF GOD//////////////////
-//I made this file to prevent myself from touching normal files///////////
-//////////////////////////////////////////////////////////////////////////
-
-//moved from my old interactions file 'cause skyrats already did interactions
+// Moved from my old interactions file 'cause skyrats already did interactions
 
 #define REQUIRE_NONE 0
 #define REQUIRE_EXPOSED 1
@@ -16,9 +11,9 @@
 	var/has_breasts = FALSE
 	var/has_anus = FALSE
 
-/////////////////////////////////////
-//Looping sound for vibrating stuff//
-/////////////////////////////////////
+/*
+*	Looping sound for vibrating stuff
+*/
 
 /datum/looping_sound/vibrator
 	start_sound = 'modular_skyrat/modules/modular_items/lewd_items/sounds/bzzz-loop-1.ogg'
@@ -40,11 +35,11 @@
 /datum/looping_sound/vibrator/high
 	volume = 100
 
-////////////////////////////////////////////////////////////////////////////////
-//Boxes for vending machine, to spawn stuff with important cheap tools in pack//
-////////////////////////////////////////////////////////////////////////////////
+/*
+*	Boxes for vending machine, to spawn stuff with important cheap tools in pack
+*/
 
-//milking machine
+// Milking machine
 /obj/item/storage/box/milking_kit
 	name = "DIY Milking machine kit"
 	desc = "Contains everything you need to build your own milking machine!"
@@ -52,9 +47,9 @@
 /obj/item/storage/box/milking_kit/PopulateContents()
 	var/static/items_inside = list(
 		/obj/item/milking_machine/constructionkit = 1)
-	generate_items_inside(items_inside,src)
+	generate_items_inside(items_inside, src)
 
-//X-Stand
+// X-Stand
 /obj/item/storage/box/xstand_kit
 	name = "DIY X-Stand kit"
 	desc = "Contains everything you need to build your own X-stand!"
@@ -62,9 +57,9 @@
 /obj/item/storage/box/xstand_kit/PopulateContents()
 	var/static/items_inside = list(
 		/obj/item/x_stand_kit = 1)
-	generate_items_inside(items_inside,src)
+	generate_items_inside(items_inside, src)
 
-//BDSM bed
+// BDSM bed
 /obj/item/storage/box/bdsmbed_kit
 	name = "DIY BDSM bed kit"
 	desc = "Contains everything you need to build your own BDSM bed!"
@@ -72,9 +67,9 @@
 /obj/item/storage/box/bdsmbed_kit/PopulateContents()
 	var/static/items_inside = list(
 		/obj/item/bdsm_bed_kit = 1)
-	generate_items_inside(items_inside,src)
+	generate_items_inside(items_inside, src)
 
-//Striptease pole
+// Striptease pole
 /obj/item/storage/box/strippole_kit
 	name = "DIY stripper pole kit"
 	desc = "Contains everything you need to build your own stripper pole!"
@@ -82,9 +77,9 @@
 /obj/item/storage/box/strippole_kit/PopulateContents()
 	var/static/items_inside = list(
 		/obj/item/polepack = 1)
-	generate_items_inside(items_inside,src)
+	generate_items_inside(items_inside, src)
 
-//Shibari stand
+// Shibari stand
 /obj/item/storage/box/shibari_stand
 	name = "DIY Shibari stand kit"
 	desc = "Contains everything you need to build your own shibari stand!"
@@ -93,17 +88,17 @@
 	var/static/items_inside = list(
 		/obj/item/shibari_stand_kit = 1,
 		/obj/item/paper/shibari_kit_instructions = 1)
-	generate_items_inside(items_inside,src)
+	generate_items_inside(items_inside, src)
 
-//Paper instructions for shibari kit
+// Paper instructions for shibari kit
 
 /obj/item/paper/shibari_kit_instructions
 	info = "Hello! Congratulations on your purchase of the shibari kit by LustWish! Some newbies may get confused by our ropes, so we prepared a small instructions for you! First of all, you have to have a wrench to construct the stand itself. Secondly, you can use screwdrivers to change the color of your shibari stand. Just replace the plastic fittings! Thirdly, if you want to tie somebody to a bondage stand you need to fully tie their body, on both groin and chest!. To do that you need to use rope on body and then on groin of character, then you can just buckle them to the stand like any chair. Don't forget to have some ropes on your hand to actually tie them to the stand, as there's no ropes included with it! And that's it!"
-////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////This code is supposed to be placed in "code/modules/mob/living/carbon/human/inventory.dm"/////////////
-//If you are nice person you can transfer this part of code to it, but i didn't for modularisation reasons//
-//////////////////////////////////////////for ball mittens//////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/*
+*	This code is supposed to be placed in "code/modules/mob/living/carbon/human/inventory.dm"
+*	If you are nice person you can transfer this part of code to it, but i didn't for modularisation reasons
+*/
 
 /mob/living/carbon/human/resist_restraints()
 	if(gloves?.breakouttime)
@@ -113,18 +108,16 @@
 	else
 		..()
 
-////////////////////////////////////////////////////////////////////////////////////////
-///////i needed this code for ballgag, because it doesn't muzzle, it kinda voxbox///////
-//wearer for moaning. So i really need it, don't touch or whole ballgag will be broken//
-/////////////////////////for ballgag mute audible emotes////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////////
-
-//adding is_ballgagged() proc here. Hope won't break anything important.
-//This is kinda shitcode, but they said don't touch main code or they will break my knees.
-//i love my knees, please merge.
-
-//more shitcode can be found in code/datums/emotes.dm
-//in /datum/emote/proc/select_message_type(mob/user, intentional) proc. Sorry for that, i had no other choise.
+/*
+*	I needed this code for ballgag, because it doesn't muzzle, it kinda voxbox
+*	wearer for moaning. So i really need it, don't touch or whole ballgag will be broken
+*	for ballgag mute audible emotes
+*	adding is_ballgagged() proc here. Hope won't break anything important.
+*	This is kinda shitcode, but they said don't touch main code or they will break my knees.
+*	i love my knees, please merge.
+*	more shitcode can be found in code/datums/emotes.dm
+*	in /datum/emote/proc/select_message_type(mob/user, intentional) proc. Sorry for that, i had no other choise.
+*/
 
 //false for default
 /mob/proc/is_ballgagged()
@@ -145,10 +138,10 @@
 		return TRUE
 	return FALSE
 
-//////////////////////////////////////////////////////////////////////////////////
-/////////this shouldn't be put anywhere, get your dirty hands off!////////////////
-/////////////////////////////for dancing pole/////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////
+/*
+*	This shouldn't be put anywhere, get your dirty hands off!
+*	For dancing pole
+*/
 
 /atom
 	var/pseudo_z_axis
@@ -175,21 +168,21 @@
 		pseudo_z_axis = newloc.get_fake_z()
 		pixel_z = pseudo_z_axis
 
-//////////////////////////////////////////////////////////////////////////////////
-//this code needed to determine if human/m is naked in that part of body or not///
-//////////////You can you for your own stuff if you want, haha.///////////////////
-//////////////////////////////////////////////////////////////////////////////////
+/*
+*	This code needed to determine if the human is naked in that part of body or not
+*	You can you for your own stuff if you want, haha.
+*/
 
 
-///Are we wearing something that covers our chest?
+/// Are we wearing something that covers our chest?
 /mob/living/carbon/human/proc/is_topless()
 	return (!(wear_suit) || !(wear_suit.body_parts_covered & CHEST)) && (!(w_uniform) || !(w_uniform.body_parts_covered & CHEST))
 
-///Are we wearing something that covers our groin?
+/// Are we wearing something that covers our groin?
 /mob/living/carbon/human/proc/is_bottomless()
 	return (!(wear_suit) || !(wear_suit.body_parts_covered & GROIN)) && (!(w_uniform) || !(w_uniform.body_parts_covered & GROIN))
 
-///Are we wearing something that covers our shoes?
+/// Are we wearing something that covers our shoes?
 /mob/living/carbon/human/proc/is_barefoot()
 	return (!(wear_suit) || !(wear_suit.body_parts_covered & GROIN)) && (!(shoes) || !(shoes.body_parts_covered & FEET))
 
@@ -199,12 +192,12 @@
 /mob/living/carbon/human/proc/is_head_uncovered()
     return (head?.body_parts_covered & HEAD)
 
-/mob/living/carbon/human/proc/has_penis(nintendo = REQUIRE_ANY)
+/mob/living/carbon/human/proc/has_penis(required_state = REQUIRE_ANY)
 	if(issilicon(src) && has_penis)
 		return TRUE
 	var/obj/item/organ/genital/peepee = getorganslot(ORGAN_SLOT_PENIS)
 	if(peepee)
-		switch(nintendo)
+		switch(required_state)
 			if(REQUIRE_ANY)
 				return TRUE
 			if(REQUIRE_EXPOSED)
@@ -221,10 +214,10 @@
 				return TRUE
 	return FALSE
 
-/mob/living/carbon/human/proc/has_balls(nintendo = REQUIRE_ANY)
+/mob/living/carbon/human/proc/has_balls(required_state = REQUIRE_ANY)
 	var/obj/item/organ/genital/peepee = getorganslot(ORGAN_SLOT_TESTICLES)
 	if(peepee)
-		switch(nintendo)
+		switch(required_state)
 			if(REQUIRE_ANY)
 				return TRUE
 			if(REQUIRE_EXPOSED)
@@ -241,12 +234,12 @@
 				return TRUE
 	return FALSE
 
-/mob/living/carbon/human/proc/has_vagina(nintendo = REQUIRE_ANY)
+/mob/living/carbon/human/proc/has_vagina(required_state = REQUIRE_ANY)
 	if(issilicon(src) && has_vagina)
 		return TRUE
 	var/obj/item/organ/genital/peepee = getorganslot(ORGAN_SLOT_VAGINA)
 	if(peepee)
-		switch(nintendo)
+		switch(required_state)
 			if(REQUIRE_ANY)
 				return TRUE
 			if(REQUIRE_EXPOSED)
@@ -263,10 +256,10 @@
 				return TRUE
 	return FALSE
 
-/mob/living/carbon/human/proc/has_breasts(var/nintendo = REQUIRE_ANY)
+/mob/living/carbon/human/proc/has_breasts(required_state = REQUIRE_ANY)
 	var/obj/item/organ/genital/peepee = getorganslot(ORGAN_SLOT_BREASTS)
 	if(peepee)
-		switch(nintendo)
+		switch(required_state)
 			if(REQUIRE_ANY)
 				return TRUE
 			if(REQUIRE_EXPOSED)
@@ -283,12 +276,12 @@
 				return TRUE
 	return FALSE
 
-/mob/living/carbon/human/proc/has_anus(nintendo = REQUIRE_ANY)
+/mob/living/carbon/human/proc/has_anus(required_state = REQUIRE_ANY)
 	if(issilicon(src))
 		return TRUE
 	var/obj/item/organ/genital/peepee = getorganslot(ORGAN_SLOT_ANUS)
 	if(peepee)
-		switch(nintendo)
+		switch(required_state)
 			if(REQUIRE_ANY)
 				return TRUE
 			if(REQUIRE_EXPOSED)
@@ -304,71 +297,71 @@
 			else
 				return TRUE
 
-/mob/living/carbon/human/proc/has_arms(nintendo = REQUIRE_ANY)
-	var/handcount = 0
+/mob/living/carbon/human/proc/has_arms(required_state = REQUIRE_ANY)
+	var/hand_count = 0
 	var/covered = 0
-	var/iscovered = FALSE
-	for(var/obj/item/bodypart/l_arm/L in bodyparts)
-		handcount++
-	for(var/obj/item/bodypart/r_arm/R in bodyparts)
-		handcount++
+	var/is_covered = FALSE
+	for(var/obj/item/bodypart/l_arm/left_arm in bodyparts)
+		hand_count++
+	for(var/obj/item/bodypart/r_arm/right_arm in bodyparts)
+		hand_count++
 	if(get_item_by_slot(ITEM_SLOT_HANDS))
-		var/obj/item/clothing/gloves/G = get_item_by_slot(ITEM_SLOT_HANDS)
-		covered = G.body_parts_covered
+		var/obj/item/clothing/gloves/worn_gloves = get_item_by_slot(ITEM_SLOT_HANDS)
+		covered = worn_gloves.body_parts_covered
 	if(covered & HANDS)
-		iscovered = TRUE
-	switch(nintendo)
+		is_covered = TRUE
+	switch(required_state)
 		if(REQUIRE_ANY)
-			return handcount
+			return hand_count
 		if(REQUIRE_EXPOSED)
-			if(iscovered)
+			if(is_covered)
 				return FALSE
 			else
-				return handcount
+				return hand_count
 		if(REQUIRE_UNEXPOSED)
-			if(!iscovered)
+			if(!is_covered)
 				return FALSE
 			else
-				return handcount
+				return hand_count
 		else
-			return handcount
+			return hand_count
 
-/mob/living/carbon/human/proc/has_feet(nintendo = REQUIRE_ANY)
-	var/feetcount = 0
+/mob/living/carbon/human/proc/has_feet(required_state = REQUIRE_ANY)
+	var/feet_count = 0
 	var/covered = 0
-	var/iscovered = FALSE
-	for(var/obj/item/bodypart/l_leg/L in bodyparts)
-		feetcount++
-	for(var/obj/item/bodypart/r_leg/R in bodyparts)
-		feetcount++
+	var/is_covered = FALSE
+	for(var/obj/item/bodypart/l_leg/left_leg in bodyparts)
+		feet_count++
+	for(var/obj/item/bodypart/r_leg/right_leg in bodyparts)
+		feet_count++
 	if(!is_barefoot())
 		covered = TRUE
 	if(covered)
-		iscovered = TRUE
-	switch(nintendo)
+		is_covered = TRUE
+	switch(required_state)
 		if(REQUIRE_ANY)
-			return feetcount
+			return feet_count
 		if(REQUIRE_EXPOSED)
-			if(iscovered)
+			if(is_covered)
 				return FALSE
 			else
-				return feetcount
+				return feet_count
 		if(REQUIRE_UNEXPOSED)
-			if(!iscovered)
+			if(!is_covered)
 				return FALSE
 			else
-				return feetcount
+				return feet_count
 		else
-			return feetcount
+			return feet_count
 
 /mob/living/carbon/human/proc/get_num_feet()
 	return has_feet(REQUIRE_ANY)
 
-//weird procs go here
-/mob/living/carbon/human/proc/has_ears(nintendo = REQUIRE_ANY)
+// Weird procs go here
+/mob/living/carbon/human/proc/has_ears(required_state = REQUIRE_ANY)
 	var/obj/item/organ/peepee = getorganslot(ORGAN_SLOT_EARS)
 	if(peepee)
-		switch(nintendo)
+		switch(required_state)
 			if(REQUIRE_ANY)
 				return TRUE
 			if(REQUIRE_EXPOSED)
@@ -385,10 +378,10 @@
 				return TRUE
 	return FALSE
 
-/mob/living/carbon/human/proc/has_earsockets(nintendo = REQUIRE_ANY)
+/mob/living/carbon/human/proc/has_earsockets(required_state = REQUIRE_ANY)
 	var/obj/item/organ/peepee = getorganslot(ORGAN_SLOT_EARS)
 	if(!peepee)
-		switch(nintendo)
+		switch(required_state)
 			if(REQUIRE_ANY)
 				return TRUE
 			if(REQUIRE_EXPOSED)
@@ -405,10 +398,10 @@
 				return TRUE
 	return FALSE
 
-/mob/living/carbon/human/proc/has_eyes(nintendo = REQUIRE_ANY)
+/mob/living/carbon/human/proc/has_eyes(required_state = REQUIRE_ANY)
 	var/obj/item/organ/peepee = getorganslot(ORGAN_SLOT_EYES)
 	if(peepee)
-		switch(nintendo)
+		switch(required_state)
 			if(REQUIRE_ANY)
 				return TRUE
 			if(REQUIRE_EXPOSED)
@@ -425,10 +418,10 @@
 				return TRUE
 	return FALSE
 
-/mob/living/carbon/human/proc/has_eyesockets(nintendo = REQUIRE_ANY)
+/mob/living/carbon/human/proc/has_eyesockets(required_state = REQUIRE_ANY)
 	var/obj/item/organ/peepee = getorganslot(ORGAN_SLOT_EYES)
 	if(!peepee)
-		switch(nintendo)
+		switch(required_state)
 			if(REQUIRE_ANY)
 				return TRUE
 			if(REQUIRE_EXPOSED)
@@ -445,16 +438,16 @@
 				return TRUE
 	return FALSE
 
-//////////////////////////////////////////////////////////////////////////////////
-//////////////////////////This code needed for neckleash//////////////////////////
-//////////////////////////////////////////////////////////////////////////////////
+/*
+*	This code needed for neckleash
+*/
 
 /datum/component/redirect
 	dupe_mode = COMPONENT_DUPE_ALLOWED
 	var/list/signals
 	var/datum/callback/turfchangeCB
 
-/datum/component/redirect/Initialize(list/_signals, flags=NONE)
+/datum/component/redirect/Initialize(list/_signals, flags = NONE)
 	//It's not our job to verify the right signals are registered here, just do it.
 	if(!LAZYLEN(_signals))
 		return COMPONENT_INCOMPATIBLE
@@ -480,9 +473,9 @@
 	transfers += src
 	return turfchangeCB?.InvokeAsync(arglist(args))
 
-///////////////////////////////////////////////////////////////
-///This code needed for changing character's gender by chems///
-///////////////////////////////////////////////////////////////
+/*
+*	This code needed for changing character's gender by chems
+*/
 
 /mob/living/carbon/human/proc/set_gender(ngender = NEUTER, silent = FALSE, update_icon = TRUE, forced = FALSE)
 	if(forced || (!ckey || client?.prefs.read_preference(/datum/preference/toggle/erp/gender_change)))
@@ -506,24 +499,29 @@
 	if(update_icon)
 		update_body()
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////// INVENTORY SYSTEM EXTENTION //////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/*
+*	INVENTORY SYSTEM EXTENTION
+*/
 
-//////////////////////////////
-// ERP INVENTORY ITEM SLOTS //
-//////////////////////////////
+/*
+*	ERP INVENTORY ITEM SLOTS
+*/
 
-// /// Vagina slot
-// #define ITEM_SLOT_VAGINA (1<<21)
-// /// Anus slot
-// #define ITEM_SLOT_ANUS (1<<22)
-// /// Nipples slot
-// #define ITEM_SLOT_NIPPLES (1<<23)
-// /// Penis slot
-// #define ITEM_SLOT_PENIS (1<<20)
+/*
+/// Vagina slot
+#define ITEM_SLOT_VAGINA (1<<21)
 
-//SLOT GROUP HELPERS
+/// Anus slot
+#define ITEM_SLOT_ANUS (1<<22)
+
+/// Nipples slot
+#define ITEM_SLOT_NIPPLES (1<<23)
+
+/// Penis slot
+#define ITEM_SLOT_PENIS (1<<20)
+*/
+
+// SLOT GROUP HELPERS
 #define ITEM_SLOT_ERP_INSERTABLE (ITEM_SLOT_VAGINA|ITEM_SLOT_ANUS)
 #define ITEM_SLOT_ERP_ATTACHABLE (ITEM_SLOT_NIPPLES|ITEM_SLOT_PENIS)
 
@@ -535,9 +533,9 @@
 #define STRIPPABLE_ITEM_NIPPLES "nipples"
 #define STRIPPABLE_ITEM_PEINS "penis"
 
-////////////////////////////////////
-// OUTFIT SYSTEM ERP SLOT SUPPORT //
-////////////////////////////////////
+/*
+*	OUTFIT SYSTEM ERP SLOT SUPPORT
+*/
 
 // Variables for ERP slots
 /datum/outfit
@@ -551,48 +549,48 @@
 	var/penis = null
 
 // Complementing the equipment procedure
-/datum/outfit/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/equip(mob/living/carbon/human/target, visualsOnly = FALSE)
 	. = ..()
 	if(.)
-		pre_equip(H, visualsOnly)
+		pre_equip(target, visualsOnly)
 		if(vagina)
-			H.equip_to_slot_or_del(new vagina(H),ITEM_SLOT_VAGINA, TRUE)
+			target.equip_to_slot_or_del(new vagina(target), ITEM_SLOT_VAGINA, TRUE)
 		if(anus)
-			H.equip_to_slot_or_del(new anus(H),ITEM_SLOT_ANUS, TRUE)
+			target.equip_to_slot_or_del(new anus(target), ITEM_SLOT_ANUS, TRUE)
 		if(nipples)
-			H.equip_to_slot_or_del(new nipples(H),ITEM_SLOT_NIPPLES, TRUE)
+			target.equip_to_slot_or_del(new nipples(target), ITEM_SLOT_NIPPLES, TRUE)
 		if(penis)
-			H.equip_to_slot_or_del(new penis(H),ITEM_SLOT_PENIS, TRUE)
-		post_equip(H, visualsOnly)
-		H.update_body()
-		H?.hud_used?.hidden_inventory_update(H)
+			target.equip_to_slot_or_del(new penis(target), ITEM_SLOT_PENIS, TRUE)
+		post_equip(target, visualsOnly)
+		target.update_body()
+		target?.hud_used?.hidden_inventory_update(target)
 	return TRUE
 
 
 // Support fingerprints when working with ERP slots
-/datum/outfit/apply_fingerprints(mob/living/carbon/human/H)
+/datum/outfit/apply_fingerprints(mob/living/carbon/human/target)
 	. = ..()
 	if(.)
-		if(!istype(H))
+		if(!istype(target))
 			return
-		if(H.vagina)
-			H.vagina.add_fingerprint(H,1)
-		if(H.anus)
-			H.anus.add_fingerprint(H,1)
-		if(H.nipples)
-			H.nipples.add_fingerprint(H,1)
-		if(H.penis)
-			H.penis.add_fingerprint(H,1)
+		if(target.vagina)
+			target.vagina.add_fingerprint(target, 1)
+		if(target.anus)
+			target.anus.add_fingerprint(target, 1)
+		if(target.nipples)
+			target.nipples.add_fingerprint(target, 1)
+		if(target.penis)
+			target.penis.add_fingerprint(target, 1)
 	return 1
 
 // Supplementing the data structure with ERP slot data
 /datum/outfit/get_json_data()
-	var/list/L = ..()
+	var/list/genital_list = ..()
 
-	L["vagina"] = vagina
-	L["anus"] = anus
-	L["nipples"] = nipples
-	L["penis"] = penis
+	genital_list["vagina"] = vagina
+	genital_list["anus"] = anus
+	genital_list["nipples"] = nipples
+	genital_list["penis"] = penis
 
 // Supplementing the data structure with ERP slot data
 /datum/outfit/load_from(list/outfit_data)
@@ -619,9 +617,9 @@
 	var/obj/item/nipples = null
 	var/obj/item/penis = null
 
-/////////////////////////////
-//    SEXTOY CLOTH TYPE    //
-/////////////////////////////
+/*
+* SEXTOY CLOTH TYPE
+*/
 
 /obj/item/clothing/sextoy
 	name = "sextoy"
@@ -654,9 +652,9 @@
 		return FALSE
 	return TRUE
 
-/////////////////////////////
-// ICON UPDATING EXTENTION //
-/////////////////////////////
+/*
+*	ICON UPDATING EXTENTION
+*/
 
 // Regenerate ERP icons to
 /mob/living/carbon/human/regenerate_icons()
@@ -683,19 +681,19 @@
 			update_observer_view(vagina)
 			hud_used.hidden_inventory_update(src)
 
-	//on_mob stuff
+	// on_mob stuff
 	remove_overlay(VAGINA_LAYER)
 
-	var/obj/item/clothing/sextoy/U = vagina
+	var/obj/item/clothing/sextoy/sex_toy = vagina
 
-	if(wear_suit && (wear_suit.flags_inv & HIDESEXTOY)) //you can add proper flags here if required
+	if(wear_suit && (wear_suit.flags_inv & HIDESEXTOY)) // You can add proper flags here if required
 		return
 
 	var/icon_file = vagina?.worn_icon
 	var/mutable_appearance/vagina_overlay
 
 	if(!vagina_overlay)
-		vagina_overlay = U?.build_worn_icon(default_layer = VAGINA_LAYER, default_icon_file = 'icons/mob/clothing/under/default.dmi', isinhands = FALSE, override_file = icon_file)
+		vagina_overlay = sex_toy?.build_worn_icon(default_layer = VAGINA_LAYER, default_icon_file = 'icons/mob/clothing/under/default.dmi', isinhands = FALSE, override_file = icon_file)
 
 	if(OFFSET_UNIFORM in dna.species.offset_features)
 		vagina_overlay?.pixel_x += dna.species.offset_features[OFFSET_UNIFORM][1]
@@ -722,19 +720,19 @@
 			update_observer_view(anus)
 			hud_used.hidden_inventory_update(src)
 
-	//on_mob stuff
+	// on_mob stuff
 	remove_overlay(ANUS_LAYER)
 
-	var/obj/item/clothing/sextoy/U = anus
+	var/obj/item/clothing/sextoy/sex_toy = anus
 
-	if(wear_suit && (wear_suit.flags_inv & HIDESEXTOY)) //you can add proper flags here if required
+	if(wear_suit && (wear_suit.flags_inv & HIDESEXTOY)) // You can add proper flags here if required
 		return
 
 	var/icon_file = anus?.worn_icon
 	var/mutable_appearance/anus_overlay
 
 	if(!anus_overlay)
-		anus_overlay = U?.build_worn_icon(default_layer = ANUS_LAYER, default_icon_file = 'icons/mob/clothing/under/default.dmi', isinhands = FALSE, override_file = icon_file)
+		anus_overlay = sex_toy?.build_worn_icon(default_layer = ANUS_LAYER, default_icon_file = 'icons/mob/clothing/under/default.dmi', isinhands = FALSE, override_file = icon_file)
 
 	if(OFFSET_UNIFORM in dna.species.offset_features)
 		anus_overlay?.pixel_x += dna.species.offset_features[OFFSET_UNIFORM][1]
@@ -761,19 +759,19 @@
 			update_observer_view(nipples)
 			hud_used.hidden_inventory_update(src)
 
-	//on_mob stuff
+	// on_mob stuff
 	remove_overlay(NIPPLES_LAYER)
 
-	var/obj/item/clothing/sextoy/U = nipples
+	var/obj/item/clothing/sextoy/sex_toy = nipples
 
-	if(wear_suit && (wear_suit.flags_inv & HIDESEXTOY)) //you can add proper flags here if required
+	if(wear_suit && (wear_suit.flags_inv & HIDESEXTOY)) // You can add proper flags here if required
 		return
 
 	var/icon_file = nipples?.worn_icon
 	var/mutable_appearance/nipples_overlay
 
 	if(!nipples_overlay)
-		nipples_overlay = U?.build_worn_icon(default_layer = NIPPLES_LAYER, default_icon_file = 'icons/mob/clothing/under/default.dmi', isinhands = FALSE, override_file = icon_file)
+		nipples_overlay = sex_toy?.build_worn_icon(default_layer = NIPPLES_LAYER, default_icon_file = 'icons/mob/clothing/under/default.dmi', isinhands = FALSE, override_file = icon_file)
 
 	if(OFFSET_UNIFORM in dna.species.offset_features)
 		nipples_overlay?.pixel_x += dna.species.offset_features[OFFSET_UNIFORM][1]
@@ -800,19 +798,19 @@
 			update_observer_view(penis)
 			hud_used.hidden_inventory_update(src)
 
-	//on_mob stuff
+	// on_mob stuff
 	remove_overlay(PENIS_LAYER)
 
-	var/obj/item/clothing/sextoy/U = penis
+	var/obj/item/clothing/sextoy/sex_toy = penis
 
-	if(wear_suit && (wear_suit.flags_inv & HIDESEXTOY)) //you can add proper flags here if required
+	if(wear_suit && (wear_suit.flags_inv & HIDESEXTOY)) // You can add proper flags here if required
 		return
 
 	var/icon_file = penis?.worn_icon
 	var/mutable_appearance/penis_overlay
 
 	if(!penis_overlay)
-		penis_overlay = U?.build_worn_icon(default_layer = PENIS_LAYER, default_icon_file = 'icons/mob/clothing/under/default.dmi', isinhands = FALSE, override_file = icon_file)
+		penis_overlay = sex_toy?.build_worn_icon(default_layer = PENIS_LAYER, default_icon_file = 'icons/mob/clothing/under/default.dmi', isinhands = FALSE, override_file = icon_file)
 
 	if(OFFSET_UNIFORM in dna.species.offset_features)
 		penis_overlay?.pixel_x += dna.species.offset_features[OFFSET_UNIFORM][1]
@@ -823,15 +821,15 @@
 	update_mutant_bodyparts()
 
 /*
-// Shoes update extention for supporting correctt removing shoe in sleepbag
+// Shoes update extention for supporting correct removing shoe in sleepbag
 /mob/living/carbon/human/update_inv_shoes()
 
 	if(istype(src.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
 		remove_overlay(SHOES_LAYER)
 
 		if(dna.species.mutant_bodyparts["taur"])
-			var/datum/sprite_accessory/taur/S = GLOB.sprite_accessories["taur"][dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME]]
-			if(S.hide_legs)
+			var/datum/sprite_accessory/taur/taur_accessory = GLOB.sprite_accessories["taur"][dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME]]
+			if(taur_accessory.hide_legs)
 				return
 
 		if(num_legs<2)
@@ -846,7 +844,7 @@
 			if(client && hud_used && hud_used.hud_shown)
 				if(hud_used.inventory_shown)			//if the inventory is open
 					client.screen += shoes					//add it to client's screen
-			update_observer_view(shoes,1)
+			update_observer_view(shoes, 1)
 			var/icon_file = shoes.worn_icon
 			if((shoes.supports_variations_flags & CLOTHING_DIGITIGRADE_VARIATION) && (shoes.supports_variations_flags & CLOTHING_DIGITIGRADE_VARIATION))
 				icon_file = shoes.worn_icon_digi || 'modular_skyrat/master_files/icons/mob/clothing/feet_digi.dmi'
@@ -864,62 +862,65 @@
 	else
 		..()
 */
+
 // Updating vagina hud slot
-/mob/living/carbon/human/update_hud_vagina(obj/item/I)
-	I.screen_loc = ui_vagina
+/mob/living/carbon/human/update_hud_vagina(obj/item/contained_item)
+	contained_item.screen_loc = ui_vagina
 	if(client && src.hud_used?.hud_shown)
 		if(src.hud_used.inventory_shown)
-			client.screen += I
-	update_observer_view(I,1)
+			client.screen += contained_item
+	update_observer_view(contained_item, 1)
 
 // Updating anus hud slot
-/mob/living/carbon/human/update_hud_anus(obj/item/I)
-	I.screen_loc = ui_anus
+/mob/living/carbon/human/update_hud_anus(obj/item/contained_item)
+	contained_item.screen_loc = ui_anus
 	if(client && src.hud_used?.hud_shown)
 		if(src.hud_used.inventory_shown)
-			client.screen += I
-	update_observer_view(I,1)
+			client.screen += contained_item
+	update_observer_view(contained_item, 1)
 
 // Updating nipples hud slot
-/mob/living/carbon/human/update_hud_nipples(obj/item/I)
-	I.screen_loc = ui_nipples
+/mob/living/carbon/human/update_hud_nipples(obj/item/contained_item)
+	contained_item.screen_loc = ui_nipples
 	if(client && src.hud_used?.hud_shown)
 		if(src.hud_used.inventory_shown)
-			client.screen += I
-	update_observer_view(I,1)
+			client.screen += contained_item
+	update_observer_view(contained_item, 1)
 
 // Updating penis hud slot
-/mob/living/carbon/human/update_hud_penis(obj/item/I)
-	I.screen_loc = ui_penis
+/mob/living/carbon/human/update_hud_penis(obj/item/contained_item)
+	contained_item.screen_loc = ui_penis
 	if(client && src.hud_used?.hud_shown)
 		if(src.hud_used.inventory_shown)
-			client.screen += I
-	update_observer_view(I,1)
+			client.screen += contained_item
+	update_observer_view(contained_item, 1)
 
 // Update whether our back item appears on our hud.
-/mob/living/carbon/proc/update_hud_vagina(obj/item/I)
+/mob/living/carbon/proc/update_hud_vagina(obj/item/contained_item)
 	return
 
 // Update whether our back item appears on our hud.
-/mob/living/carbon/proc/update_hud_anus(obj/item/I)
+/mob/living/carbon/proc/update_hud_anus(obj/item/contained_item)
 	return
 
 // Update whether our back item appears on our hud.
-/mob/living/carbon/proc/update_hud_nipples(obj/item/I)
+/mob/living/carbon/proc/update_hud_nipples(obj/item/contained_item)
 	return
 
 // Update whether our back item appears on our hud.
-/mob/living/carbon/proc/update_hud_penis(obj/item/I)
+/mob/living/carbon/proc/update_hud_penis(obj/item/contained_item)
 	return
 
-//////////////////////////////////
-// UI CONSTRUCTION AND HANDLING //
-//////////////////////////////////
+/*
+*	UI CONSTRUCTION AND HANDLING
+*/
 
 // Add to hud class additional ERP variable boolean for check inventiry status (equipped or not)
 /datum/hud
-	var/list/erp_toggleable_inventory = list() //the screen ERP objects which can be hidden
-	var/ERP_inventory_shown = FALSE //Equipped item ERP inventory
+	/// The screen ERP objects which can be hidden
+	var/list/erp_toggleable_inventory = list()
+	/// Equipped item ERP inventory
+	var/ERP_inventory_shown = FALSE
 
 // Define additional button for ERP hud slots for expand/collapse like default inventory
 /atom/movable/screen/human/erp_toggle
@@ -929,25 +930,25 @@
 // ERP inventory button logic. Just expand/collapse
 /atom/movable/screen/human/erp_toggle/Click()
 
-	var/mob/targetmob = usr
+	var/mob/target_mob = usr
 
 	if(isobserver(usr))
 		if(ishuman(usr.client.eye) && (usr.client.eye != usr))
-			var/mob/M = usr.client.eye
-			targetmob = M
+			var/mob/target_eye = usr.client.eye
+			target_mob = target_eye
 
-	if(usr.hud_used.ERP_inventory_shown && targetmob.hud_used)
+	if(usr.hud_used.ERP_inventory_shown && target_mob.hud_used)
 		usr.hud_used.ERP_inventory_shown = FALSE
-		usr.client.screen -= targetmob.hud_used.erp_toggleable_inventory
+		usr.client.screen -= target_mob.hud_used.erp_toggleable_inventory
 	else
 		usr.hud_used.ERP_inventory_shown = TRUE
-		usr.client.screen += targetmob.hud_used.erp_toggleable_inventory
+		usr.client.screen += target_mob.hud_used.erp_toggleable_inventory
 
-	targetmob.hud_used.hidden_inventory_update(usr)
+	target_mob.hud_used.hidden_inventory_update(usr)
 
-////////////////////////////////////
-// STRIPPING ERP SYSTEM EXTENTION //
-////////////////////////////////////
+/*
+*	STRIPPING ERP SYSTEM EXTENTION
+*/
 
 // Extend stripping menus with ERP slots
 /datum/strippable_item/mob_item_slot/vagina
@@ -968,8 +969,8 @@
 
 // Obscuring for ERP slots
 /datum/strippable_item/mob_item_slot/vagina/get_obscuring(atom/source)
-	var/mob/M = source
-	if(M.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
+	var/mob/source_mob = source
+	if(source_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 		return isnull(get_item(source)) \
 			? STRIPPABLE_OBSCURING_NONE \
 			: STRIPPABLE_OBSCURING_HIDDEN
@@ -977,8 +978,8 @@
 		return STRIPPABLE_OBSCURING_COMPLETELY
 // Obscuring for ERP slots
 /datum/strippable_item/mob_item_slot/anus/get_obscuring(atom/source)
-	var/mob/M = source
-	if(M.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
+	var/mob/source_mob = source
+	if(source_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 		return isnull(get_item(source)) \
 			? STRIPPABLE_OBSCURING_NONE \
 			: STRIPPABLE_OBSCURING_HIDDEN
@@ -986,8 +987,8 @@
 		return STRIPPABLE_OBSCURING_COMPLETELY
 // Obscuring for ERP slots
 /datum/strippable_item/mob_item_slot/nipples/get_obscuring(atom/source)
-	var/mob/M = source
-	if(M.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
+	var/mob/source_mob = source
+	if(source_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 		return isnull(get_item(source)) \
 			? STRIPPABLE_OBSCURING_NONE \
 			: STRIPPABLE_OBSCURING_HIDDEN
@@ -995,8 +996,8 @@
 		return STRIPPABLE_OBSCURING_COMPLETELY
 // Obscuring for ERP slots
 /datum/strippable_item/mob_item_slot/penis/get_obscuring(atom/source)
-	var/mob/M = source
-	if(M.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
+	var/mob/source_mob = source
+	if(source_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 		return isnull(get_item(source)) \
 			? STRIPPABLE_OBSCURING_NONE \
 			: STRIPPABLE_OBSCURING_HIDDEN
@@ -1027,165 +1028,179 @@ GLOBAL_LIST_INIT(strippable_human_erp_items, create_erp_strippable_list(list(
 	if(CONFIG_GET(flag/disable_erp_preferences))
 		src.items -= GLOB.strippable_human_erp_items
 
-////////////////////////////////////////////////////////////////////
-// EXTENTIONS FOR SPRITE_ACCESSORY IS_HIDDEN CHECKS FOR ERP STUFF //
-////////////////////////////////////////////////////////////////////
+/*
+*	EXTENTIONS FOR SPRITE_ACCESSORY IS_HIDDEN CHECKS FOR ERP STUFF
+*/
 
 // Extends default proc check for hidden ears for supporting our sleepbag and catsuit to
-/datum/sprite_accessory/ears/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	// // Default proc code
-	// if(H.head && (H.head.flags_inv & HIDEHAIR) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR)) || !HD)
-	// 	return TRUE
-	// return FALSE
+/datum/sprite_accessory/ears/is_hidden(mob/living/carbon/human/target_human, obj/item/bodypart/HD)
+	/*
+	// Default proc code
+	if(target_human.head && (target_human.head.flags_inv & HIDEHAIR) || (target_human.wear_mask && (target_human.wear_mask.flags_inv & HIDEHAIR)) || !HD)
+		//return TRUE
+	return FALSE
+	*/
 
 	// First lets proc default code
 	. = ..()
 	if(!.) // If true, ears already hidden
-		if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
-			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/S = H.wear_suit
-			if(S.state_thing == "inflated")
+		if(target_human.wear_suit && istype(target_human.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
+			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/sleeping_bag = target_human.wear_suit
+			if(sleeping_bag.state_thing == "inflated")
 				return TRUE
 			return FALSE
-		else if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
+		else if(target_human.w_uniform && istype(target_human.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
 			return FALSE
 		return FALSE
 	return TRUE // Return TRUE if superfuncitons already retuns TRUE
 
 // Extends default proc check for hidden frills for supporting our sleepbag and catsuit to
-/datum/sprite_accessory/frills/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	// // Default proc code
-	// if(H.head && (H.try_hide_mutant_parts || (H.head.flags_inv & HIDEEARS) || !HD || HD.status == BODYPART_ROBOTIC))
-	// 	return TRUE
-	// return FALSE
+/datum/sprite_accessory/frills/is_hidden(mob/living/carbon/human/target_human, obj/item/bodypart/HD)
+	/*
+	// Default proc code
+	if(target_human.head && (target_human.try_hide_mutant_parts || (target_human.head.flags_inv & HIDEEARS) || !HD || HD.status == BODYPART_ROBOTIC))
+		//return TRUE
+	return FALSE
+	*/
 
 	. = ..()
 	if(!.) // If true, frills already hidden
-		if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
-			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/S = H.wear_suit
-			if(S.state_thing == "inflated")
+		if(target_human.wear_suit && istype(target_human.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
+			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/sleeping_bag = target_human.wear_suit
+			if(sleeping_bag.state_thing == "inflated")
 				return TRUE
 			return FALSE
-		else if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
+		else if(target_human.w_uniform && istype(target_human.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
 			return FALSE
 		return FALSE
 	return TRUE // Return TRUE if superfuncitons already retuns TRUE
 
 // Extends default proc check for hidden head accessory for supporting our sleepbag and catsuit to
-/datum/sprite_accessory/head_accessory/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	// // Default proc code
-	// if(H.head && (H.head.flags_inv & HIDEHAIR) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR)))
-	// 	return TRUE
-	// return FALSE
+/datum/sprite_accessory/head_accessory/is_hidden(mob/living/carbon/human/target_human, obj/item/bodypart/HD)
+	/*
+	// Default proc code
+	if(target_human.head && (target_human.head.flags_inv & HIDEHAIR) || (target_human.wear_mask && (target_human.wear_mask.flags_inv & HIDEHAIR)))
+		//return TRUE
+	return FALSE
+	*/
 
 	. = ..()
 	if(!.) // If true, head accessory already hidden
-		if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
-			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/S = H.wear_suit
-			if(S.state_thing == "inflated")
+		if(target_human.wear_suit && istype(target_human.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
+			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/sleeping_bag = target_human.wear_suit
+			if(sleeping_bag.state_thing == "inflated")
 				return TRUE
 			return FALSE
-		else if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
+		else if(target_human.w_uniform && istype(target_human.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
 			return FALSE
 		return FALSE
 	return TRUE // Return TRUE if superfuncitons already retuns TRUE
 
 // Extends default proc check for hidden horns for supporting our sleepbag and catsuit to
-/datum/sprite_accessory/horns/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	// // Default proc code
-	// if(H.head && (H.head.flags_inv & HIDEHAIR) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR)) || !HD)
-	// 	return TRUE
-	// return FALSE
+/datum/sprite_accessory/horns/is_hidden(mob/living/carbon/human/target_human, obj/item/bodypart/HD)
+	/*
+	// Default proc code
+	if(target_human.head && (target_human.head.flags_inv & HIDEHAIR) || (target_human.wear_mask && (target_human.wear_mask.flags_inv & HIDEHAIR)) || !HD)
+		return TRUE
+	return FALSE
+	*/
 
 	. = ..()
 	if(!.) // If true, horns already hidden
-		if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
-			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/S = H.wear_suit
-			if(S.state_thing == "inflated")
+		if(target_human.wear_suit && istype(target_human.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
+			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/sleeping_bag = target_human.wear_suit
+			if(sleeping_bag.state_thing == "inflated")
 				return TRUE
 			return FALSE
-		else if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
+		else if(target_human.w_uniform && istype(target_human.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
 			return FALSE
 		return FALSE
 	return TRUE // Return TRUE if superfuncitons already retuns TRUE
 
 // Extends default proc check for hidden antenna for supporting our sleepbag and catsuit to
-/datum/sprite_accessory/antenna/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	// // Default proc code
-	// if(H.head && (H.head.flags_inv & HIDEHAIR) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR)) || !HD)
-	// 	return TRUE
-	// return FALSE
+/datum/sprite_accessory/antenna/is_hidden(mob/living/carbon/human/target_human, obj/item/bodypart/HD)
+	/*
+	// Default proc code
+	if(target_human.head && (target_human.head.flags_inv & HIDEHAIR) || (target_human.wear_mask && (target_human.wear_mask.flags_inv & HIDEHAIR)) || !HD)
+		//return TRUE
+	return FALSE
+	*/
 
 	. = ..()
 	if(!.) // If true, antenna already hidden
-		if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
-			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/S = H.wear_suit
-			if(S.state_thing == "inflated")
+		if(target_human.wear_suit && istype(target_human.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
+			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/sleeping_bag = target_human.wear_suit
+			if(sleeping_bag.state_thing == "inflated")
 				return TRUE
 			return FALSE
-		else if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
+		else if(target_human.w_uniform && istype(target_human.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
 			return FALSE
 		return FALSE
 	return TRUE // Return TRUE if superfuncitons already retuns TRUE
 
 // Extends default proc check for hidden moth antenna for supporting our sleepbag and catsuit to
-/datum/sprite_accessory/moth_antennae/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	// // Default proc code
-	// if(H.head && (H.head.flags_inv & HIDEHAIR) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR)) || !HD)
-	// 	return TRUE
-	// return FALSE
+/datum/sprite_accessory/moth_antennae/is_hidden(mob/living/carbon/human/target_human, obj/item/bodypart/HD)
+	/*
+	// Default proc code
+	if(target_human.head && (target_human.head.flags_inv & HIDEHAIR) || (target_human.wear_mask && (target_human.wear_mask.flags_inv & HIDEHAIR)) || !HD)
+		//return TRUE
+	return FALSE
+	*/
 
 	. = ..()
 	if(!.) // If true, moth antenna already hidden
-		if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
-			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/S = H.wear_suit
-			if(S.state_thing == "inflated")
+		if(target_human.wear_suit && istype(target_human.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
+			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/sleeping_bag = target_human.wear_suit
+			if(sleeping_bag.state_thing == "inflated")
 				return TRUE
 			return FALSE
-		else if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
+		else if(target_human.w_uniform && istype(target_human.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
 			return FALSE
 		return FALSE
 	return TRUE // Return TRUE if superfuncitons already retuns TRUE
 
 // Extends default proc check for hidden skrell hair for supporting our sleepbag and catsuit to
-/datum/sprite_accessory/skrell_hair/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	// // Default proc code
-	// if(H.head && (H.head.flags_inv & HIDEHAIR) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR)))
-	// 	return TRUE
-	// return FALSE
+/datum/sprite_accessory/skrell_hair/is_hidden(mob/living/carbon/human/target_human, obj/item/bodypart/HD)
+	/*
+	// Default proc code
+	if(target_human.head && (target_human.head.flags_inv & HIDEHAIR) || (target_human.wear_mask && (target_human.wear_mask.flags_inv & HIDEHAIR)))
+		return TRUE
+	return FALSE
+	*/
 
 	. = ..()
 	if(!.) // If true, skrell hair already hidden
-		if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
-			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/S = H.wear_suit
-			if(S.state_thing == "inflated")
+		if(target_human.wear_suit && istype(target_human.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
+			var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/sleeping_bag = target_human.wear_suit
+			if(sleeping_bag.state_thing == "inflated")
 				return TRUE
 			return FALSE
-		else if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
+		else if(target_human.w_uniform && istype(target_human.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
 			return FALSE
 		return FALSE
 	return TRUE // Return TRUE if superfuncitons already retuns TRUE
 
 // Extends default proc check for hidden skrell hair for supporting our sleepbag and catsuit to
-/datum/sprite_accessory/tails/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
+/datum/sprite_accessory/tails/is_hidden(mob/living/carbon/human/target_human, obj/item/bodypart/HD)
 
 	. = ..()
 	if(!.) // If true, tail already hidden
-		if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
-			// var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/S = H.wear_suit
-			// if(S.state_thing == "inflated")
+		if(target_human.wear_suit && istype(target_human.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
+			// var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/sleeping_bag = target_human.wear_suit
+			// if(sleeping_bag.state_thing == "inflated")
 			// 	return TRUE
 			return TRUE /* return FALSE */
-		else if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
+		else if(target_human.w_uniform && istype(target_human.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
 			return TRUE
 		return FALSE
 	return TRUE // Return TRUE if superfuncitons already retuns TRUE
 
 // Extends default proc check for hidden wings for supporting our sleepbag and catsuit to
-/datum/sprite_accessory/wings/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
+/datum/sprite_accessory/wings/is_hidden(mob/living/carbon/human/target_human, obj/item/bodypart/HD)
 	. = ..()
 	if(.)
 		return TRUE
-	if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
+	if(target_human.wear_suit && istype(target_human.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
 		return TRUE
 	return FALSE
 
@@ -1194,22 +1209,20 @@ GLOBAL_LIST_INIT(strippable_human_erp_items, create_erp_strippable_list(list(
 		return FALSE
 	..()
 
-//asdasda
-/datum/sprite_accessory/xenodorsal/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
+/datum/sprite_accessory/xenodorsal/is_hidden(mob/living/carbon/human/target_human, obj/item/bodypart/HD)
+	if(target_human.wear_suit && istype(target_human.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
 		return TRUE
-	else if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
+	else if(target_human.w_uniform && istype(target_human.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
 		return TRUE
 	return FALSE
 
-//asdfasdfdasf
-/datum/sprite_accessory/xenohead/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
-		var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/S = H.wear_suit
-		if(S.state_thing == "inflated")
+/datum/sprite_accessory/xenohead/is_hidden(mob/living/carbon/human/target_human, obj/item/bodypart/HD)
+	if(target_human.wear_suit && istype(target_human.wear_suit, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag))
+		var/obj/item/clothing/suit/straight_jacket/kinky_sleepbag/sleeping_bag = target_human.wear_suit
+		if(sleeping_bag.state_thing == "inflated")
 			return TRUE
 		return FALSE
-	else if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
+	else if(target_human.w_uniform && istype(target_human.w_uniform, /obj/item/clothing/under/misc/latex_catsuit/))
 		return FALSE
 	return FALSE
 
@@ -1217,28 +1230,28 @@ GLOBAL_LIST_INIT(strippable_human_erp_items, create_erp_strippable_list(list(
 	. = ..()
 	if(client?.prefs?.read_preference(/datum/preference/toggle/erp/sex_toy))
 		if(client.mob.hud_used)
-			for(var/atom/movable/screen/human/erp_toggle/E in client.mob.hud_used.static_inventory)
-				if(istype(E, /atom/movable/screen/human/erp_toggle))
-					E.invisibility = 0
+			for(var/atom/movable/screen/human/erp_toggle/toggle in client.mob.hud_used.static_inventory)
+				if(istype(toggle, /atom/movable/screen/human/erp_toggle))
+					toggle.invisibility = 0
 	else
 		if(ishuman(client.mob))
-			var/mob/living/carbon/human/M = client.mob
-			if(M.vagina != null)
-				M.dropItemToGround(M.vagina, TRUE, M.loc, TRUE, FALSE, TRUE)
-			if(M.anus != null)
-				M.dropItemToGround(M.anus, TRUE, M.loc, TRUE, FALSE, TRUE)
-			if(M.nipples != null)
-				M.dropItemToGround(M.nipples, TRUE, M.loc, TRUE, FALSE, TRUE)
-			if(M.penis != null)
-				M.dropItemToGround(M.penis, TRUE, M.loc, TRUE, FALSE, TRUE)
+			var/mob/living/carbon/human/target = client.mob
+			if(target.vagina != null)
+				target.dropItemToGround(target.vagina, TRUE, target.loc, TRUE, FALSE, TRUE)
+			if(target.anus != null)
+				target.dropItemToGround(target.anus, TRUE, target.loc, TRUE, FALSE, TRUE)
+			if(target.nipples != null)
+				target.dropItemToGround(target.nipples, TRUE, target.loc, TRUE, FALSE, TRUE)
+			if(target.penis != null)
+				target.dropItemToGround(target.penis, TRUE, target.loc, TRUE, FALSE, TRUE)
 		if(client.mob.hud_used)
 			if(client.mob.hud_used.ERP_inventory_shown)
 				client.mob.hud_used.ERP_inventory_shown = FALSE
 				client.screen -= client.mob.hud_used.erp_toggleable_inventory
 
-			for(var/atom/movable/screen/human/erp_toggle/E in client.mob.hud_used.static_inventory)
-				if(istype(E, /atom/movable/screen/human/erp_toggle))
-					E.invisibility = 100
+			for(var/atom/movable/screen/human/erp_toggle/erp_button in client.mob.hud_used.static_inventory)
+				if(istype(erp_button, /atom/movable/screen/human/erp_toggle))
+					erp_button.invisibility = 100
 
 
 	client.mob.hud_used.hidden_inventory_update(client.mob)


### PR DESCRIPTION
## About The Pull Request

Oh boy. Doing this reminded me of the sheer volume of work still needed in this module.

Anyway.
Used these to;

add spaces after commas,
`,([^ \\])` : `, $1`

add spaces between ='s,
`([^ +/*-=])=([^ =])` : `$1 = $2`

and remove EVERY single letter variable...
`/[A-Za-z]([, )]|$)`

Also changed some comment blocks from
```
///////////////////
// this bullshit //
///////////////////
```
```
/*
* to this
*/
```
## Changelog
No player-facing changes