### PR TITLE
Fixes bad global used by turf emote

### DIFF
--- a/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
+++ b/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
@@ -1,5 +1,3 @@
-var/current_turf
-
 /mob/living
 	var/obj/owned_turf
 	var/list/allowed_turfs = list()
@@ -8,6 +6,7 @@ var/current_turf
 	key = "turf"
 	key_third_person = "turf"
 	cooldown = 4 SECONDS
+	var/current_turf
 
 /datum/emote/living/mark_turf/run_emote(mob/living/user, params, type_override, intentional)
 	. = ..()
@@ -94,8 +93,7 @@ var/current_turf
 	if(do_after(user,10))
 		current_turf = chosen_turf
 
-		var/obj/turf_icon = /obj/structure/mark_turf
-		user.owned_turf = new turf_icon(get_turf(user))
+		user.owned_turf = new /obj/structure/mark_turf(get_turf(user), current_turf)
 		user.owned_turf.dir = user.dir
 
 		if(ishuman(user))

--- a/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
+++ b/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
@@ -91,7 +91,7 @@
 	if(QDELETED(src) || QDELETED(user) || !chosen_turf)
 		return FALSE
 
-	if(do_after(user,10))
+	if(do_after(user, 1 SECONDS))
 		current_turf = chosen_turf
 
 		user.owned_turf = new /obj/structure/mark_turf(get_turf(user), current_turf)

--- a/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
+++ b/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
@@ -6,6 +6,7 @@
 	key = "turf"
 	key_third_person = "turf"
 	cooldown = 4 SECONDS
+	/// The current turf ID that the user selected in the radial menu.
 	var/current_turf
 
 /datum/emote/living/mark_turf/run_emote(mob/living/user, params, type_override, intentional)

--- a/modular_skyrat/modules/emotes/code/additionalemotes/turf_list.dm
+++ b/modular_skyrat/modules/emotes/code/additionalemotes/turf_list.dm
@@ -9,7 +9,7 @@
 	density = FALSE
 	max_integrity = 15
 
-/obj/structure/mark_turf/Initialize()
+/obj/structure/mark_turf/Initialize(mapload, current_turf)
 	. = ..()
 
 	switch(current_turf)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The turf emote was using an unmanaged global to track which turf was picked, making it entirely luck that a given user spawned the correct object if 2 people were using *turf at once.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Unmanaged globals violate code standards anyway, but this shouldn't be global in any form.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed possible edge case issues with multiple uses of turf emote at the same time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
