### PR TITLE
[MODULAR] Various guncargo 'fixes'

### DIFF
--- a/modular_skyrat/modules/aesthetics/guns/code/magazine.dm
+++ b/modular_skyrat/modules/aesthetics/guns/code/magazine.dm
@@ -1,4 +1,4 @@
 /obj/item/ammo_box/magazine/m9mm
-	name = "pistol magazine (10mm Magnum)"
+	name = "pistol magazine (9x25mm)"
 	multiple_sprites = AMMO_BOX_PER_BULLET
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/magazine.dmi'

--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/dynamics.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/dynamics.dm
@@ -23,6 +23,15 @@
 /datum/armament_entry/cargo_gun/dynamics/ammo/c9mm_in
 	item_type = /obj/item/ammo_box/c9mm/fire
 
+/datum/armament_entry/cargo_gun/dynamics/ammo/b9mm
+	item_type = /obj/item/ammo_box/advanced/b9mm
+	
+/datum/armament_entry/cargo_gun/dynamics/ammo/b9mm_hp
+	item_type = /obj/item/ammo_box/advanced/b9mm/hp
+	
+/datum/armament_entry/cargo_gun/dynamics/ammo/b9mm_rub
+	item_type = /obj/item/ammo_box/advanced/b9mm/rubber
+
 /datum/armament_entry/cargo_gun/dynamics/ammo/c10mm
 	item_type = /obj/item/ammo_box/c10mm
 
@@ -97,6 +106,12 @@
 
 /datum/armament_entry/cargo_gun/dynamics/ammo/b10mm_rub
 	item_type = /obj/item/ammo_box/b10mm/rubber
+
+/datum/armament_entry/cargo_gun/dynamics/ammo/b6mm	
+	item_type = /obj/item/ammo_box/advanced/b6mm
+	
+/datum/armament_entry/cargo_gun/dynamics/ammo/b6mm_rub	
+	item_type = /obj/item/ammo_box/advanced/b6mm/rubber
 
 /datum/armament_entry/cargo_gun/dynamics/misc
 	subcategory = ARMAMENT_SUBCATEGORY_SPECIAL

--- a/modular_skyrat/modules/gunsgalore/code/guns/luger.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/luger.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/ballistic/automatic/pistol/luger
 	name = "\improper Armadyne P-09X"
-	desc = "A small, light-weight reproduction of the Luger P08 from the 20th century, manufactured by the Oldarms division of the Armadyne Corporation. Chambered in 9mm."
+	desc = "A small, light-weight reproduction of the Luger P08 from the 20th century, manufactured by the Oldarms division of the Armadyne Corporation. Chambered in 9x25mm."
 	icon_state = "luger"
 	inhand_icon_state = "luger"
 	icon = 'modular_skyrat/modules/gunsgalore/icons/guns/gunsgalore_guns.dmi'

--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -277,7 +277,7 @@
 /////////////////////MAKAROV
 /obj/item/gun/ballistic/automatic/pistol/makarov
 	name = "\improper R-C 'Makarov'"
-	desc = "A mediocre pocket-sized handgun of seemingly Russian origin, chambered in 10mm."
+	desc = "A mediocre pocket-sized handgun of seemingly Russian origin, chambered in 10mm Auto."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/makarov.dmi'
 	icon_state = "makarov"
 	w_class = WEIGHT_CLASS_SMALL
@@ -354,7 +354,7 @@
 //////////////////////FIREFLY
 /obj/item/gun/ballistic/automatic/pistol/firefly
 	name = "\improper P-92 'Firefly'"
-	desc = "A 9mm sidearm made by Armadyne's Medical Directive, with a heavy front for weak wrists. A small warning label on the back says it's not fit for surgical work."
+	desc = "A 9mm (Peacekeeper) sidearm made by Armadyne's Medical Directive, with a heavy front for weak wrists. A small warning label on the back says it's not fit for surgical work."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/firefly.dmi'
 	righthand_file = 'modular_skyrat/modules/sec_haul/icons/guns/inhands/righthand.dmi'
 	lefthand_file = 'modular_skyrat/modules/sec_haul/icons/guns/inhands/lefthand.dmi'

--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -728,7 +728,7 @@
 
 /obj/item/gun/ballistic/shotgun/m23
 	name = "\improper Model 23-37"
-	desc = "An outdated police shotgun sporting an eight-round tube."
+	desc = "An outdated police shotgun sporting an eight-round tube, chambered in twelve-gauge."
 	icon_state = "riotshotgun"
 	inhand_icon_state = "shotgun"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/m23
@@ -744,7 +744,7 @@
 
 /obj/item/gun/ballistic/shotgun/automatic/as2
 	name = "\improper M2 Auto-Shotgun"
-	desc = "A semi-automatic shotgun with a four-round internal tube."
+	desc = "A semi-automatic twelve-gauge shotgun with a four-round internal tube."
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/guns.dmi'
 	icon_state = "as2"
 	worn_icon = 'modular_skyrat/modules/aesthetics/guns/icons/guns_back.dmi'

--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -17,7 +17,7 @@
 //////////////////GLOCK
 /obj/item/gun/ballistic/automatic/pistol/g17
 	name = "\improper GK-17"
-	desc = "A weapon from bygone times, this has been made to look like an old, blocky firearm from the 21st century. Let's hope it's more reliable. Chambered in 9x19mm."
+	desc = "A weapon from bygone times, this has been made to look like an old, blocky firearm from the 21st century. Let's hope it's more reliable. Chambered in 9x19mm Peacekeeper."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/glock.dmi'
 	icon_state = "glock"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -34,7 +34,7 @@
 	company_flag = COMPANY_CANTALAN
 
 /obj/item/ammo_box/magazine/multi_sprite/g17
-	name = "9x19mm double stack magazine"
+	name = "9x19mm peacekeeper double stack magazine"
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'
 	icon_state = "g17"
 	ammo_type = /obj/item/ammo_casing/b9mm
@@ -56,7 +56,7 @@
 
 /obj/item/gun/ballistic/automatic/pistol/g18
 	name = "\improper GK-18"
-	desc = "A CFA-made burst firing cheap polymer pistol chambered in 9x19mm. Its heavy duty barrel affects firerate."
+	desc = "A CFA-made burst firing cheap polymer pistol chambered in 9x19mm Peacekeeper. Its heavy duty barrel affects firerate."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/glock.dmi'
 	icon_state = "glock_spec"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -98,7 +98,7 @@
 
 /obj/item/gun/ballistic/automatic/pistol/g17/mesa
 	name = "\improper Glock-17"
-	desc = "A weapon from bygone times, and this is the exact 21st century version. In fact, even more reliable. Chambered in 9x19mm."
+	desc = "A weapon from bygone times, and this is the exact 21st century version. In fact, even more reliable. Chambered in 9x19mm Peacekeeper."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/glock.dmi'
 	icon_state = "glock_mesa"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -118,7 +118,7 @@
 ////////////////PDH 40x32
 /obj/item/gun/ballistic/automatic/pistol/pdh
 	name = "\improper PDH-6H 'Osprey'"
-	desc = "A modern ballistics sidearm, used primarily by the military, however this one has had a paintjob to match command. It's chambered in 12mm."
+	desc = "A modern ballistics sidearm, used primarily by the military, however this one has had a paintjob to match command. It's chambered in 12.7x30mm."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/pdh.dmi'
 	righthand_file = 'modular_skyrat/modules/sec_haul/icons/guns/inhands/righthand40x32.dmi'
 	lefthand_file = 'modular_skyrat/modules/sec_haul/icons/guns/inhands/lefthand40x32.dmi'
@@ -200,7 +200,7 @@
 ///////////////////////////PDH PEACEKEEPER
 /obj/item/gun/ballistic/automatic/pistol/pdh/peacekeeper
 	name = "\improper PDH-6B"
-	desc = "A modern ballistic sidearm, used primarily by law enforcement."
+	desc = "A modern ballistic sidearm, used primarily by law enforcement, chambered in 9x19mm Peacekeeper."
 	fire_delay = 1.95
 	icon_state = "pdh_peacekeeper"
 	mag_type = /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper
@@ -210,7 +210,7 @@
 	company_flag = COMPANY_ARMADYNE
 
 /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper
-	name = "9x19mm polymer magazine"
+	name = "9x19mm PDH-6B polymer magazine"
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mags.dmi'
 	icon_state = "pdh"
 	ammo_type = /obj/item/ammo_casing/b9mm
@@ -233,7 +233,7 @@
 ///////////////////////LADON 40x32
 /obj/item/gun/ballistic/automatic/pistol/ladon
 	name = "\improper Ladon pistol"
-	desc = "Modern handgun based off the PDH series, chambered in 10mm."
+	desc = "Modern handgun based off the PDH series, chambered in 10mm Auto."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/ladon.dmi'
 	righthand_file = 'modular_skyrat/modules/sec_haul/icons/guns/inhands/righthand40x32.dmi'
 	lefthand_file = 'modular_skyrat/modules/sec_haul/icons/guns/inhands/lefthand40x32.dmi'
@@ -315,7 +315,7 @@
 
 /obj/item/gun/ballistic/automatic/pistol/mk58
 	name = "\improper MK-58"
-	desc = "A modern 9mm handgun with an olive polymer lower frame. Looks like a generic 21st century military sidearm."
+	desc = "A modern 9mm Peacekeeper handgun with an olive polymer lower frame. Looks like a generic 21st century military sidearm."
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/mk58.dmi'
 	icon_state = "mk58"
 	w_class = WEIGHT_CLASS_NORMAL


### PR DESCRIPTION
## About The Pull Request
Adds missing bullets to the ammo vendor, fixes the makarov magazines ammo name, and clarifies ammo type on a few guns that weren't specific about it.

### ping me on discord if you notice anything else amiss

## How This Contributes To The Skyrat Roleplay Experience
![image](https://user-images.githubusercontent.com/62520989/169439417-3a3c5410-e2fd-496e-bdfa-01ad237cbfe5.png)


clarity.
## Changelog



:cl:
qol: Made the Makarov (traitor) magazine actually say the actual ammo, and clarified the desc on a few previously 14 gauge shotguns, as well as clarifying auto and peacekeeper ammo types on the R-C makarov.
fix: Added a few bullets that were just whole-ass unobtainable for the guns that used them.
qol: All guns in the armadyne tab now clarify which ammotype they use,
/:cl:

