### PR TITLE
Sec Officer vest - digitigrade fix

### DIFF
--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -449,6 +449,7 @@
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
 	icon_state = "vest_warden"
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 //Security Wintercoat (and hood)
 /obj/item/clothing/head/hooded/winterhood/security

--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -410,6 +410,7 @@
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
 	icon_state = "vest_white"
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	uses_advanced_reskins = TRUE
 	unique_reskin = list(
 		"Black Variant" = list(


### PR DESCRIPTION
## About The Pull Request

Due to an improper flag these vests were showing up untextured.
No digi file is necessary as this is just upper body wear.
Fixes the thing.

Edit: Now with Warden coat fix too. 

## How This Contributes To The Skyrat Roleplay Experience

Digi security officers aren't forced to be goofy lookin' if they want protection.

Resolves #13322 
I think. Guess they can let me know if anything is found out to be missing.

## Changelog

:cl:
fix: Fixed Sec Off / Warden vests for digi.
/:cl:
