### PR TITLE
[NO GBP] [MODULAR] [BlueShift] Some BlueShift fixes

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_lower.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_lower.dmm
@@ -5643,8 +5643,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/evac_maintenance)
 "dZH" = (
-/turf/open/space/basic,
-/area/station/maintenance/department/engineering/atmos/aft_maint)
+/obj/structure/cable/layer1,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/power_room)
 "dZJ" = (
 /obj/item/bodypart/head/monkey,
 /obj/effect/decal/cleanable/blood/footprints,
@@ -7065,10 +7068,6 @@
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"fmO" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/station/maintenance/department/engineering/atmos/port_maint)
 "fmP" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -7543,6 +7542,7 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/power_room)
 "fMH" = (
@@ -8778,11 +8778,6 @@
 	dir = 8
 	},
 /area/station/engineering/atmos/office)
-"gHz" = (
-/obj/structure/shuttle/engine/huge,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/station/maintenance/department/engineering/atmos/aft_maint)
 "gHH" = (
 /obj/structure/chair{
 	dir = 4
@@ -11299,9 +11294,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"iOt" = (
-/turf/open/space/basic,
-/area/station/maintenance/department/engineering/atmos/port_maint)
 "iOv" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/cable,
@@ -12088,6 +12080,7 @@
 	req_access_txt = "10"
 	},
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/power_room)
 "jvW" = (
@@ -16143,7 +16136,7 @@
 /obj/structure/shuttle/engine/huge,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/station/maintenance/department/engineering/atmos/port_maint)
+/area/space/nearstation)
 "mHa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -18197,6 +18190,7 @@
 /area/station/maintenance/department/electrical)
 "odd" = (
 /obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engineering/atmos/port_maint)
 "odq" = (
@@ -29556,10 +29550,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"xdk" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/station/maintenance/department/engineering/atmos/aft_maint)
 "xdx" = (
 /turf/closed/wall,
 /area/station/engineering/atmos/hallway)
@@ -57722,8 +57712,8 @@ bmL
 xFR
 xFR
 cvj
-rYU
-iOt
+vYg
+yaE
 mGP
 xJs
 ylQ
@@ -57979,9 +57969,9 @@ evH
 cuO
 cuO
 lvn
-rYU
-iOt
-fmO
+vYg
+yaE
+ybD
 xJs
 ylQ
 ylQ
@@ -58236,9 +58226,9 @@ neG
 oJd
 oJd
 wAe
-rYU
-iOt
-fmO
+vYg
+yaE
+ybD
 xJs
 ylQ
 ylQ
@@ -58734,7 +58724,7 @@ xeq
 bsT
 odd
 jvI
-oxH
+dZH
 qCr
 rCB
 dld
@@ -68516,9 +68506,9 @@ haA
 cuY
 cuY
 qwu
-yhe
-dZH
-gHz
+vYg
+yaE
+mGP
 xJs
 ylQ
 ylQ
@@ -68773,9 +68763,9 @@ pYV
 oLR
 oLR
 cvP
-yhe
-dZH
-xdk
+vYg
+yaE
+ybD
 xJs
 ylQ
 ylQ
@@ -69030,9 +69020,9 @@ fgJ
 eDC
 eDC
 tWj
-yhe
-dZH
-xdk
+vYg
+yaE
+ybD
 xJs
 ylQ
 ylQ

--- a/_maps/map_files/Blueshift/BlueShift_lower.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_lower.dmm
@@ -5642,12 +5642,6 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
 /area/station/maintenance/evac_maintenance)
-"dZH" = (
-/obj/structure/cable/layer1,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/power_room)
 "dZJ" = (
 /obj/item/bodypart/head/monkey,
 /obj/effect/decal/cleanable/blood/footprints,
@@ -7036,6 +7030,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "flF" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/power_room)
 "flO" = (
@@ -7068,6 +7063,12 @@
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"fmO" = (
+/obj/structure/cable/layer1,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/power_room)
 "fmP" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -12848,6 +12849,7 @@
 /area/station/maintenance/department/engine/atmos)
 "kbY" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/power_room)
 "kcv" = (
@@ -20655,7 +20657,7 @@
 /obj/machinery/computer/monitor{
 	dir = 4
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/power_room)
 "pYV" = (
@@ -58724,7 +58726,7 @@ xeq
 bsT
 odd
 jvI
-dZH
+fmO
 qCr
 rCB
 dld

--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -6025,6 +6025,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "bvm" = (
@@ -12251,6 +12252,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/bar)
 "dxt" = (
@@ -22179,6 +22181,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "gXx" = (
@@ -28104,6 +28107,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "iTS" = (
@@ -39799,6 +39803,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "mSw" = (
@@ -40143,6 +40148,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "mZD" = (
@@ -40435,6 +40441,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "neq" = (
@@ -56555,6 +56562,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "szW" = (
@@ -69424,15 +69432,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/maintenance/rus_gambling)
-"wNy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/service)
 "wNz" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/misc/beach/sand,
@@ -70753,6 +70752,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "xiw" = (
@@ -108428,7 +108428,7 @@ cMF
 kkj
 vJL
 iEl
-wNy
+giZ
 xCF
 pfv
 sLc
@@ -111772,7 +111772,7 @@ hge
 uQl
 vVL
 dtd
-lsP
+vGc
 tik
 bcq
 kQy
@@ -112029,7 +112029,7 @@ tGT
 pFO
 vVL
 rzN
-kQS
+pwn
 sWK
 utT
 eUj

--- a/_maps/map_files/Blueshift/BlueShift_upper.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_upper.dmm
@@ -43872,11 +43872,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/maintenance/gamer_lair)
-"oGM" = (
-/obj/structure/shuttle/engine/large,
-/obj/effect/turf_decal/stripes,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/xenobio_disposals)
 "oGR" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -48382,10 +48377,6 @@
 	},
 /turf/open/openspace/airless,
 /area/space/nearstation)
-"qnD" = (
-/obj/effect/turf_decal/stripes,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/xenobio_disposals)
 "qnE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -100947,8 +100938,8 @@ vho
 ylI
 itK
 deG
-itK
-oGM
+mpz
+jas
 vZd
 vZd
 vZd
@@ -101204,8 +101195,8 @@ sVk
 ylI
 itK
 deG
-itK
-qnD
+mpz
+jLy
 vZd
 vZd
 vZd


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a few errors I did on BlueShift.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Engineers can stop panicking when one room is depowered now. Also muh immersion with the engines.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
fix: The APC in BlueShifts power bank room is connected to the right wire layer.
fix: Replaced the areas of some of BlueShifts engines with nearstation.
fix: Service area of Blueshift now has redundant wiring to prevent power issues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
