### PR TITLE
[MODULAR] [Interlink/Ghost Cafe] Rotates some chairs, nuking their var edits, plus a tweak

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -436,7 +436,7 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "ahI" = (
-/obj/machinery/computer/arcade/orion_trail,
+/obj/effect/spawner/random/entertainment/arcade,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafedorms)
 "ahK" = (
@@ -800,9 +800,9 @@
 	},
 /area/centcom/holding/cafedorms)
 "alc" = (
-/obj/machinery/computer/arcade/battle,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafe)
+/obj/structure/chair/stool/bar/directional/east,
+/turf/open/floor/eighties,
+/area/centcom/interlink)
 "ald" = (
 /turf/open/indestructible/cobble/corner{
 	dir = 4
@@ -2461,7 +2461,7 @@
 /turf/open/misc/grass/planet,
 /area/centcom/holding/cafepark)
 "aAd" = (
-/obj/machinery/computer/arcade/orion_trail,
+/obj/effect/spawner/random/entertainment/arcade,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -2990,7 +2990,7 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafedorms)
 "aDn" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/eighties,
 /area/centcom/interlink)
 "aDp" = (
@@ -4252,7 +4252,7 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafedorms)
 "aOw" = (
-/obj/machinery/computer/arcade/orion_trail,
+/obj/effect/spawner/random/entertainment/arcade,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aOz" = (
@@ -5260,7 +5260,7 @@
 	},
 /area/centcom/holding/cafepark)
 "aWa" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "aWb" = (
@@ -6495,7 +6495,9 @@
 /turf/open/floor/carpet/red,
 /area/centcom/holding/cafedorms)
 "ehN" = (
-/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "ejQ" = (
@@ -7345,7 +7347,7 @@
 /turf/open/misc/asteroid,
 /area/centcom/interlink)
 "hFE" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/directional/west,
 /obj/effect/landmark/latejoin,
 /turf/open/floor/eighties,
 /area/centcom/interlink)
@@ -8665,9 +8667,7 @@
 /turf/open/floor/plating/abductor,
 /area/centcom/holding/cafepark)
 "ngg" = (
-/obj/structure/chair/stool/bar{
-	dir = 8
-	},
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "ngD" = (
@@ -11224,9 +11224,7 @@
 	},
 /area/centcom/holding/cafedorms)
 "wDG" = (
-/obj/structure/chair/stool/bar{
-	dir = 1
-	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "wFJ" = (
@@ -11419,6 +11417,11 @@
 /obj/effect/turf_decal/sand,
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafepark)
+"xGy" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/landmark/latejoin,
+/turf/open/floor/eighties,
+/area/centcom/interlink)
 "xMG" = (
 /obj/machinery/light{
 	dir = 1
@@ -23987,13 +23990,13 @@ hvQ
 hvQ
 mih
 aNb
-aDn
-aDn
-aDn
+alc
+alc
+alc
 aKj
-aDn
-hFE
-aDn
+alc
+xGy
+alc
 xNb
 hvQ
 jKu
@@ -54312,7 +54315,7 @@ amH
 aDY
 aUT
 aqf
-alc
+aOw
 aUo
 aUo
 aqf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Destroys the var edited stools in favor of the directionals. Also changes the game cabinets out in the ghost cafe for random spawners.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Code stuff (chairs). Arcade machines are now no longer static in the ghost cafe.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
add: Replaced the current arcade machines in the ghost cafe with random spawners.
fix: Stools in the Interlink have been edited to not be var-edited anymore.
fix: Stools in the Ghost Cafe have been edited to not be var-edited anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
