### PR TITLE
[NO GBP] Fixes some stupid mistakes I have done with stone and forge cooking

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/forge.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge.dm
@@ -477,8 +477,6 @@
 			to_chat(user, span_warning("You cannot do multiple things at the same time!"))
 			return FALSE
 
-		in_use = TRUE
-	
 		if(forge_temperature < MIN_FORGE_TEMP)
 			fail_message(user, "The [src] is not hot enough to start cooking [thing_to_cook]!")
 			return FALSE
@@ -490,10 +488,12 @@
 			fail_message(user, "No choice made")
 			return FALSE
 
+		in_use = TRUE
 		balloon_alert_to_viewers("cooking...")
 
 		if(!do_after(user, 10 SECONDS, target = src))
 			fail_message(user, "You stop trying to cook [thing_to_cook]!")
+			in_use = FALSE
 			return FALSE
 
 		switch(user_input)

--- a/modular_skyrat/modules/stone/code/stone.dm
+++ b/modular_skyrat/modules/stone/code/stone.dm
@@ -21,10 +21,10 @@
 
 GLOBAL_LIST_INIT(stone_recipes, list ( \
 	new/datum/stack_recipe("stone brick wall", /turf/closed/wall/mineral/stone, 5, one_per_turf = 1, on_floor = 1, applies_mats = TRUE), \
-	new/datum/stack_recipe("stone brick tile", /obj/item/stack/tile/mineral/stone, 1, 4, 20),  \
+	new/datum/stack_recipe("stone brick tile", /obj/item/stack/tile/mineral/stone, 1, 4, 20),
 	))
 
-/obj/item/stack/sheet/mineral/uranium/get_main_recipes()
+/obj/item/stack/sheet/mineral/stone/get_main_recipes()
 	. = ..()
 	. += GLOB.stone_recipes
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If someone was moved away from a forge while making a recipe selection, the forge would become unusable for everyone

I don't know about you, but being able to make stone walls and floors out of uranium, and not from stone itself, seems like a slight problem

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
I would assume the less dumb bugs we have the better

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: you can no longer make stone walls out of uranium
fix: you can now actually make stone walls with stone
fix: moving away from a forge when making a selection to cook food will no longer permanently lock everyone out of using the forge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
