### PR TITLE
Remove server room firedoors Delta/Meta

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -72354,7 +72354,6 @@
 /turf/open/floor/iron,
 /area/station/security/brig/upper)
 "see" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "Server Access";
 	req_access_txt = "30"

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -24866,7 +24866,6 @@
 /area/station/maintenance/port/aft)
 "hrR" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "Server Access";
 	req_access_txt = "30"


### PR DESCRIPTION
## About The Pull Request

Fire doors at the server rooms in these two maps cause the alarm to perpetually stay on. This is due to the fact that the server room is supposed to be cold and the fire door is detecting the cooler then average temp and activating.
Much like our other maps(Icebox, Tram and Blueshift), the doors are now removed.

Resolves #13730

## How This Contributes To The Skyrat Roleplay Experience

Stops everyone in science having to deal with an annoying alarm sound. 
Also, as an engineer, answers the question of "What the fuck is science doing in there?" that I always wondered while hearing an alarm while wandering in maint.

## Changelog

:cl:
fix: Removed fire doors causing perpetual fire alarms on Meta/Delta station server rooms.
/:cl: