### PR TITLE
Replaces the space turfs under the resin walls at the ghost cafe with dirt

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -1785,7 +1785,7 @@
 /area/centcom/interlink)
 "atp" = (
 /obj/structure/alien/resin/wall/immovable,
-/turf/open/space/basic,
+/turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "atq" = (
 /obj/machinery/oven,


### PR DESCRIPTION
## About The Pull Request
Title. Whoever mapped the area thought resin walls were turfs and not objects that can be whacked into inexistence. 

## How This Contributes To The Skyrat Roleplay Experience
Removes a potential source of depressurization of that area (it'd take a lot of time to sensibly affect the whole area anyway).

## Changelog

:cl:
fix: Replaces the space turfs under the resin walls at the ghost cafe with dirt.
/:cl:
