### PR TITLE
Fix: public airlock assembly icon

### DIFF
--- a/modular_skyrat/modules/aesthetics/airlock/code/airlock.dm
+++ b/modular_skyrat/modules/aesthetics/airlock/code/airlock.dm
@@ -546,6 +546,10 @@
 /obj/structure/door_assembly/door_assembly_hydro
 	icon = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/station/botany.dmi'
 
+/obj/structure/door_assembly/
+	icon = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/station/public.dmi'
+	overlays_file = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/station/overlays.dmi'
+
 //SKYRAT EDIT ADDITION BEGIN - AESTHETICS
 #undef AIRLOCK_LIGHT_POWER
 #undef AIRLOCK_LIGHT_RANGE


### PR DESCRIPTION
## About The Pull Request

Pretty straight-forward. The public door assembly (Not to be confused with public 2) didn't have an override to the right file in the aesthetics file.
Adds it in, redirects it to appropriate file. Yeehaw. 
Now shows up as 
![image](https://user-images.githubusercontent.com/84706993/169627232-7cdc6bb6-d882-4c7b-99c4-1b34aa16e509.png)
instead of ye ol' TG public door assembly as pictured here
![image](https://user-images.githubusercontent.com/84706993/169627249-9fdf498d-40e2-4a12-b2f0-52536f8546a2.png)

Resolves #13731 

## How This Contributes To The Skyrat Roleplay Experience

Removes some graphical jank.

## Changelog

:cl:
fix: Public airlock assembly has the proper icon again
/:cl: