### PR TITLE
[Modular] [Icebox] Tints the permabrig windows

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -1364,9 +1364,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "axF" = (
-/obj/effect/spawner/random/structure/billboard/nanotrasen,
-/turf/open/lava/plasma/ice_moon,
-/area/icemoon/underground/explored)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "axM" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
@@ -13876,13 +13879,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"euM" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
 "evb" = (
 /turf/open/floor/iron,
 /area/station/service/janitor)
@@ -51242,13 +51238,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"qyt" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
 "qyI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -69772,6 +69761,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark/textured,
 /area/ai_monitored/security/armory/upper)
+"wzU" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "wAc" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/warning/no_smoking{
@@ -103997,7 +103993,7 @@ ghx
 ghx
 ghx
 ghx
-axF
+ghx
 dcw
 fGI
 mHv
@@ -104768,7 +104764,7 @@ ghx
 ghx
 ghx
 ghx
-axF
+ghx
 dcw
 fGI
 gTW
@@ -161578,7 +161574,7 @@ dpC
 cGQ
 whr
 nmr
-qyt
+axF
 gjq
 gjq
 gjq
@@ -163377,7 +163373,7 @@ pbB
 tzf
 ozX
 ozX
-euM
+wzU
 gjq
 pfw
 iDt

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -39081,6 +39081,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"mBb" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "mBm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/cafeteria,
@@ -69761,13 +69768,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark/textured,
 /area/ai_monitored/security/armory/upper)
-"wzU" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
 "wAc" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/warning/no_smoking{
@@ -163373,7 +163373,7 @@ pbB
 tzf
 ozX
 ozX
-wzU
+mBb
 gjq
 pfw
 iDt

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -143,11 +143,10 @@
 	},
 /area/station/security/prison/safe)
 "adD" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/lava/plasma/ice_moon,
-/area/icemoon/underground/explored)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "adW" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -9656,7 +9655,7 @@
 /area/station/hallway/primary/central)
 "dcw" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/security/prison/workout)
 "dcx" = (
@@ -13877,6 +13876,13 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"euM" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "evb" = (
 /turf/open/floor/iron,
 /area/station/service/janitor)
@@ -20509,13 +20515,6 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"gBX" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/security/prison/work)
 "gCd" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -27800,6 +27799,7 @@
 	cycle_id = "perma-entrance"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
 "iSW" = (
@@ -32069,6 +32069,7 @@
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
 "kkZ" = (
@@ -39524,11 +39525,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
-"mJX" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/turf/open/floor/plating,
-/area/station/security/prison/rec)
 "mJZ" = (
 /obj/structure/fence{
 	dir = 4
@@ -44478,9 +44474,7 @@
 /area/station/cargo/storage)
 "ooW" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/security/prison/rec)
 "opa" = (
@@ -44627,7 +44621,7 @@
 /area/station/engineering/main)
 "oqL" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/security/prison/work)
 "oqM" = (
@@ -44799,7 +44793,7 @@
 /area/station/cargo/storage)
 "ots" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/security/prison/mess)
 "otw" = (
@@ -51248,6 +51242,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"qyt" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "qyI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -62898,8 +62899,8 @@
 /turf/closed/wall/r_wall,
 /area/icemoon/underground/explored)
 "upw" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/security/prison)
 "upK" = (
@@ -97841,7 +97842,7 @@ oSU
 fIt
 lWI
 lWI
-adD
+lWI
 lWI
 ena
 ghx
@@ -99643,7 +99644,7 @@ oQg
 bAk
 mAO
 kXY
-mJX
+ooW
 xuo
 xuo
 xlq
@@ -99900,7 +99901,7 @@ roH
 foO
 bDF
 kXY
-mJX
+ooW
 xuo
 xuo
 xlq
@@ -100157,7 +100158,7 @@ pqu
 dEz
 gcP
 hOA
-mJX
+ooW
 xuo
 xuo
 xlq
@@ -100414,7 +100415,7 @@ tKB
 foO
 bdo
 kXY
-mJX
+ooW
 xuo
 xuo
 xlq
@@ -100932,7 +100933,7 @@ nNn
 nDr
 tCV
 drY
-mJX
+ooW
 ghx
 ghx
 ghx
@@ -101170,7 +101171,7 @@ iDt
 iDt
 iDt
 tWK
-xby
+adD
 dSm
 hMS
 vVH
@@ -101189,7 +101190,7 @@ wYq
 nkP
 kry
 uRi
-mJX
+ooW
 ghx
 ghx
 ghx
@@ -101427,7 +101428,7 @@ iDt
 iDt
 iDt
 iDt
-xby
+adD
 byq
 tIS
 tlS
@@ -101446,7 +101447,7 @@ nNn
 scQ
 aJu
 ong
-mJX
+ooW
 ghx
 ghx
 ghx
@@ -102969,7 +102970,7 @@ ghx
 ghx
 ghx
 ghx
-xby
+adD
 nXj
 xRP
 nId
@@ -103226,7 +103227,7 @@ ghx
 ghx
 ghx
 ghx
-xby
+adD
 lFe
 rvj
 gcE
@@ -103483,7 +103484,7 @@ ghx
 ghx
 ghx
 ghx
-xby
+adD
 sJi
 wOp
 gaS
@@ -161310,9 +161311,9 @@ tjo
 xMq
 iDt
 hPs
-gBX
-gBX
-gBX
+oqL
+oqL
+oqL
 ugh
 hPs
 nDE
@@ -161577,7 +161578,7 @@ dpC
 cGQ
 whr
 nmr
-hVY
+qyt
 gjq
 gjq
 gjq
@@ -163364,7 +163365,7 @@ iDt
 iDt
 iDt
 hPs
-gBX
+oqL
 hPs
 cIc
 cIc
@@ -163376,7 +163377,7 @@ pbB
 tzf
 ozX
 ozX
-hVY
+euM
 gjq
 pfw
 iDt
@@ -164133,7 +164134,7 @@ iDt
 iDt
 ijY
 hPs
-gBX
+oqL
 qgA
 jrf
 tHt
@@ -165675,7 +165676,7 @@ ijY
 iDt
 iDt
 hPs
-gBX
+oqL
 hPs
 vnQ
 vxM
@@ -166448,7 +166449,7 @@ xMq
 iDt
 ebd
 ugh
-gBX
+oqL
 hPs
 cIc
 cIc
@@ -166706,7 +166707,7 @@ xMq
 iDt
 iDt
 iDt
-xby
+adD
 olV
 mcF
 xEI


### PR DESCRIPTION
## About The Pull Request

This PR simply replaces the permabrig hull windows with tinted windows.

## How This Contributes To The Skyrat Roleplay Experience

This will help combat permabrig becoming inhabitable ten minutes in because an ice welp decided to try busting through a wall five minutes into the round. This is not well balanced nor enjoyable PvE gameplay and there simply does not exist a reason to subject every prisoner to this hell every time icebox is rolled.
## Changelog

:cl: Danger Kitten
balance: NanoTrasen has tinted the permabrig windows for the "safety" of their prisoners.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
