### PR TITLE
[NONMODULAR] [Test] Relegates Round Timer To Observers

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -45,10 +45,7 @@ SUBSYSTEM_DEF(statpanels)
 			" ",
 			"OOC: [GLOB.ooc_allowed ? "Enabled" : "Disabled"]",
 			" ",
-			//"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]",
 			"Station Time: [station_time_timestamp()]",
-			//"Round Timer: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]",
-			//"Actual Round Timer: [time2text(real_round_time, "hh:mm:ss", 0)]"
 		)
 		// SKYRAT EDIT END
 

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -34,8 +34,6 @@ SUBSYSTEM_DEF(statpanels)
 			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)"
 		)
 		*/
-		var/round_time = world.time - SSticker.round_start_time
-		var/real_round_time = world.timeofday - SSticker.real_round_start_time
 		global_data = list(
 			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)",
 			"Map: [SSmapping.config?.map_name || "Loading..."]",

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -45,10 +45,10 @@ SUBSYSTEM_DEF(statpanels)
 			" ",
 			"OOC: [GLOB.ooc_allowed ? "Enabled" : "Disabled"]",
 			" ",
-			"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]",
+			//"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]",
 			"Station Time: [station_time_timestamp()]",
-			"Round Timer: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]",
-			"Actual Round Timer: [time2text(real_round_time, "hh:mm:ss", 0)]"
+			//"Round Timer: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]",
+			//"Actual Round Timer: [time2text(real_round_time, "hh:mm:ss", 0)]"
 		)
 		// SKYRAT EDIT END
 

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -37,6 +37,14 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	. = ..()
 	. += ""
 
+	//SKYRAT EDIT BEGIN: Removing Round Timer
+	var/round_time = world.time - SSticker.round_start_time
+	var/real_round_time = world.timeofday - SSticker.real_round_start_time
+	. += "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]"
+	. += "Round Timer: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]"
+	. += "Actual Round Timer: [time2text(real_round_time, "hh:mm:ss", 0)]"
+	//SKYRAT EDIT END
+
 	if(SSticker.HasRoundStarted())
 		return
 
@@ -52,13 +60,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	if(client.holder)
 		. += "Players Ready: [SSticker.totalPlayersReady]"
 		. += "Admins Ready: [SSticker.total_admins_ready] / [length(GLOB.admins)]"
-	//SKYRAT EDIT BEGIN: Removing Round Timer
-	var/round_time = world.time - SSticker.round_start_time
-	var/real_round_time = world.timeofday - SSticker.real_round_start_time
-	. += "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]"
-	. += "Round Timer: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]"
-	. += "Actual Round Timer: [time2text(real_round_time, "hh:mm:ss", 0)]"
-	//SKYRAT EDIT END
+
 /mob/dead/proc/server_hop()
 	set category = "OOC"
 	set name = "Server Hop!"

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -52,7 +52,11 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	if(client.holder)
 		. += "Players Ready: [SSticker.totalPlayersReady]"
 		. += "Admins Ready: [SSticker.total_admins_ready] / [length(GLOB.admins)]"
-
+	//SKYRAT EDIT BEGIN: Round Timer Social Experiment
+	. += "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]"
+	. += "Round Timer: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]",
+	. += "Actual Round Timer: [time2text(real_round_time, "hh:mm:ss", 0)]"
+	//SKYRAT EDIT END
 /mob/dead/proc/server_hop()
 	set category = "OOC"
 	set name = "Server Hop!"

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -52,7 +52,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	if(client.holder)
 		. += "Players Ready: [SSticker.totalPlayersReady]"
 		. += "Admins Ready: [SSticker.total_admins_ready] / [length(GLOB.admins)]"
-	//SKYRAT EDIT BEGIN: Round Timer Social Experiment
+	//SKYRAT EDIT BEGIN: Removing Round Timer
 	. += "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]"
 	. += "Round Timer: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]",
 	. += "Actual Round Timer: [time2text(real_round_time, "hh:mm:ss", 0)]"

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -54,7 +54,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 		. += "Admins Ready: [SSticker.total_admins_ready] / [length(GLOB.admins)]"
 	//SKYRAT EDIT BEGIN: Removing Round Timer
 	. += "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]"
-	. += "Round Timer: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]",
+	. += "Round Timer: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]"
 	. += "Actual Round Timer: [time2text(real_round_time, "hh:mm:ss", 0)]"
 	//SKYRAT EDIT END
 /mob/dead/proc/server_hop()

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -53,6 +53,8 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 		. += "Players Ready: [SSticker.totalPlayersReady]"
 		. += "Admins Ready: [SSticker.total_admins_ready] / [length(GLOB.admins)]"
 	//SKYRAT EDIT BEGIN: Removing Round Timer
+	var/round_time = world.time - SSticker.round_start_time
+	var/real_round_time = world.timeofday - SSticker.real_round_start_time
 	. += "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]"
 	. += "Round Timer: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]"
 	. += "Actual Round Timer: [time2text(real_round_time, "hh:mm:ss", 0)]"

--- a/modular_skyrat/modules/customization/modules/mob/living/living.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/living.dm
@@ -11,7 +11,7 @@
 	. = ..()
 	. += ""
 
-	if(client.holder)
+	if(client?.holder)
 		var/round_time = world.time - SSticker.round_start_time
 		var/real_round_time = world.timeofday - SSticker.real_round_start_time
 		. += "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]"

--- a/modular_skyrat/modules/customization/modules/mob/living/living.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/living.dm
@@ -12,6 +12,8 @@
 	. += ""
 
 	if(client.holder)
+		var/round_time = world.time - SSticker.round_start_time
+		var/real_round_time = world.timeofday - SSticker.real_round_start_time
 		. += "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]"
 		. += "Round Timer: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]"
 		. += "Actual Round Timer: [time2text(real_round_time, "hh:mm:ss", 0)]"

--- a/modular_skyrat/modules/customization/modules/mob/living/living.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/living.dm
@@ -6,3 +6,12 @@
 			popup.set_content(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s temporary flavor text", replacetext(temporary_flavor_text, "\n", "<BR>")))
 			popup.open()
 			return
+
+/mob/living/get_status_tab_items()
+	. = ..()
+	. += ""
+
+	if(client.holder)
+		. += "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]"
+		. += "Round Timer: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]"
+		. += "Actual Round Timer: [time2text(real_round_time, "hh:mm:ss", 0)]"


### PR DESCRIPTION
## About The Pull Request
A social experiment, if you will. A bit of a jape. Tomfoolery. Please testmerge this for about a week.
This removes the ability for people in the actual round to see how far in it is. Station time remains, as well as manual ways of checking (like your desktop clocks.) Observers and people in the lobby can still check.

## How This Contributes To The Skyrat Roleplay Experience
I noticed something during the status panel being broken. I noticed, particularly, that people seemed to be less afraid to start bigger projects/longer roleplay scenarios, and a definitive increase in continue votes. I think it'll have people act a lot better (generally) to no longer have 'it's almost two hours in' hanging over their heads like a cartoon anvil.

## Changelog

:cl:
del: Round timers are no longer viewable by the living.
/:cl: