### PR TITLE
Fixes teshari clothing fallback fallback edgecase rendering

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/custom_bodytype.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/custom_bodytype.dm
@@ -108,7 +108,7 @@
 	if(item.greyscale_colors)
 		// Just use the colors already given to us, but re-align to expected colors.
 		var/list/colors = SSgreyscale.ParseColorString(item.greyscale_colors)
-		var/default_color = (length(colors) >= 1) ? colors[1] : "#00000000"
+		var/default_color = (length(colors) >= 1) ? colors[1] : COLOR_DARK
 		var/list/final_list = list()
 		for(var/i in 1 to expected_num_colors)
 			final_list += (i < length(colors)) ? colors[i] : default_color
@@ -120,10 +120,10 @@
 
 		for(var/i in 1 to expected_num_colors)
 			if(length(item.species_clothing_color_coords) < i)
-				color_list += "#00000000"
+				color_list += COLOR_DARK
 				continue
-			var/color = item.species_clothing_color_coords[i]
-			color_list += final_human_icon.GetPixel(color[1], color[2]) || "#00000000"
+			var/coord = item.species_clothing_color_coords[i]
+			color_list += final_human_icon.GetPixel(coord[1], coord[2]) || COLOR_DARK
 
 		fallback_greyscale_colors = color_list.Join("")
 

--- a/modular_skyrat/modules/teshari/code/_clothing_defines.dm
+++ b/modular_skyrat/modules/teshari/code/_clothing_defines.dm
@@ -1,8 +1,8 @@
 // These COLORPIXEL defines indicate the pixel position on the base sprite of a clothing piece from which the color will be taken.
-#define GLASSES_COLORPIXEL_X_1 14
-#define GLASSES_COLORPIXEL_Y_1 26
-#define GLASSES_COLORPIXEL_X_2 17
-#define GLASSES_COLORPIXEL_Y_2 26
+#define GLASSES_COLORPIXEL_X_1 10
+#define GLASSES_COLORPIXEL_Y_1 16
+#define GLASSES_COLORPIXEL_X_2 18
+#define GLASSES_COLORPIXEL_Y_2 16
 
 #define GLOVES_COLORPIXEL_X_1 10
 #define GLOVES_COLORPIXEL_Y_1 13


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For some reason I made (I might have inherited this from the older teshari fallback rendering, don't remember) teshari fallback code fallback to transparent if it couldn't determine clothing colors. Made it dark brown instead since that makes more sense. Also adjusted coords for picking glasses colors.

Inspired by realizing that nightvision mesons are literally invisible when worn by teshari.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

They're in an outfit like people

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Teshari fallback clothing rendering in some edge cases is improved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
