### PR TITLE
Hides ongoing vote count from non-admins

### DIFF
--- a/tgui/packages/tgui/interfaces/VotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/VotePanel.tsx
@@ -163,7 +163,7 @@ const ChoicesPanel = (props, context) => {
                       name="vote-yea"
                     />
                   )}
-                  {choice.votes} Votes
+                  {user.isLowerAdmin ? `${choice.votes} Votes` : ""/* SKYRAT EDIT*/}
                 </LabeledList.Item>
                 <LabeledList.Divider />
               </Box>


### PR DESCRIPTION
## About The Pull Request

Non-admins can no longer see how many people have voted for each option in an ongoing vote.
Inspired by https://github.com/ParadiseSS13/Paradise/pull/17838

I have *zero* experience with tsx and very little with js so if there's a better way to do this I'm all ears.

## How This Contributes To The Skyrat Roleplay Experience

I'm interested to see how this shakes up vote outcomes once the influence of what everyone else has voted for is removed, particularly in the map and transfer votes.

## Changelog
:cl:
del: Non-admins can no longer see how many votes an option has in an ongoing vote.
/:cl: