### PR TITLE
Fixes borg missing messenger app

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -85,13 +85,13 @@
 	modularInterface.saved_identification = real_name || name
 	if(istype(src, /mob/living/silicon/robot))
 		modularInterface.saved_job = "Cyborg"
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated/borg)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/robot)
 	if(istype(src, /mob/living/silicon/ai))
 		modularInterface.saved_job = "AI"
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/ai)
 	if(istype(src, /mob/living/silicon/pai))
 		modularInterface.saved_job = "pAI Messenger"
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/ai)
 
 /mob/living/silicon/robot/model/syndicate/create_modularInterface()
 	if(!modularInterface)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -85,13 +85,13 @@
 	modularInterface.saved_identification = real_name || name
 	if(istype(src, /mob/living/silicon/robot))
 		modularInterface.saved_job = "Cyborg"
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/robot)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated/borg)
 	if(istype(src, /mob/living/silicon/ai))
 		modularInterface.saved_job = "AI"
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/ai)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated)
 	if(istype(src, /mob/living/silicon/pai))
 		modularInterface.saved_job = "pAI Messenger"
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/ai)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated)
 
 /mob/living/silicon/robot/model/syndicate/create_modularInterface()
 	if(!modularInterface)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -85,13 +85,13 @@
 	modularInterface.saved_identification = real_name || name
 	if(istype(src, /mob/living/silicon/robot))
 		modularInterface.saved_job = "Cyborg"
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated/borg)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated/borg) // SKYRAT EDIT ADDITION - cyborg PDA messenger
 	if(istype(src, /mob/living/silicon/ai))
 		modularInterface.saved_job = "AI"
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated) // SKYRAT EDIT ADDITION - cyborg PDA messenger
 	if(istype(src, /mob/living/silicon/pai))
 		modularInterface.saved_job = "pAI Messenger"
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated) // SKYRAT EDIT ADDITION - cyborg PDA messenger
 
 /mob/living/silicon/robot/model/syndicate/create_modularInterface()
 	if(!modularInterface)

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -178,7 +178,7 @@
 	store_file(new /datum/computer_file/program/crew_manifest(src)) // SKYRAT EDIT ADD
 
 // For borg integrated tablets. No downloader.
-/obj/item/computer_hardware/hard_drive/small/integrated/install_default_programs() // SKYRAT EDIT ADDITION - Reverts TG Change breaking PDA's
+/obj/item/computer_hardware/hard_drive/small/integrated/install_default_programs() // SKYRAT EDIT ADDITION - cyborg PDA messenger
 	var/datum/computer_file/program/messenger/messenger = new(src)
 	messenger.is_silicon = TRUE
 	store_file(messenger)

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -183,7 +183,7 @@
 	messenger.is_silicon = TRUE
 	store_file(messenger)
 
-/obj/item/computer_hardware/hard_drive/small/integrated/borg/install_default_programs() // SKYRAT EDIT ADDITION - Reverts TG Change breaking PDA's
+/obj/item/computer_hardware/hard_drive/small/integrated/borg/install_default_programs() // SKYRAT EDIT ADDITION - cyborg PDA messenger
 	store_file(new /datum/computer_file/program/computerconfig(src)) // Computer configuration utility, allows hardware control and displays more info than status bar
 	store_file(new /datum/computer_file/program/filemanager(src)) // File manager, allows text editor functions and basic file manipulation.
 	store_file(new /datum/computer_file/program/robotact(src))

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -178,16 +178,21 @@
 	store_file(new /datum/computer_file/program/crew_manifest(src)) // SKYRAT EDIT ADD
 
 // For borg integrated tablets. No downloader.
-/obj/item/computer_hardware/hard_drive/small/ai/install_default_programs()
+/obj/item/computer_hardware/hard_drive/small/integrated/install_default_programs() // SKYRAT EDIT ADDITION - Reverts TG Change breaking PDA's
 	var/datum/computer_file/program/messenger/messenger = new(src)
 	messenger.is_silicon = TRUE
 	store_file(messenger)
 
-/obj/item/computer_hardware/hard_drive/small/robot/install_default_programs()
+/obj/item/computer_hardware/hard_drive/small/integrated/borg/install_default_programs() // SKYRAT EDIT ADDITION - Reverts TG Change breaking PDA's
 	store_file(new /datum/computer_file/program/computerconfig(src)) // Computer configuration utility, allows hardware control and displays more info than status bar
 	store_file(new /datum/computer_file/program/filemanager(src)) // File manager, allows text editor functions and basic file manipulation.
 	store_file(new /datum/computer_file/program/robotact(src))
 	store_file(new /datum/computer_file/program/crew_manifest(src)) // SKYRAT EDIT ADDITION - Manifests for cyborgs
+	/* SKYRAT EDIT ADDITION Start- Returns Messenger to borgs */
+	var/datum/computer_file/program/messenger/messenger = new(src) 
+	messenger.is_silicon = TRUE
+	store_file(messenger)
+	/* SKYRAT EDIT ADDITION End- Returns Messenger to borgs */
 
 // Syndicate variant - very slight better
 /obj/item/computer_hardware/hard_drive/portable/syndicate

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -178,21 +178,21 @@
 	store_file(new /datum/computer_file/program/crew_manifest(src)) // SKYRAT EDIT ADD
 
 // For borg integrated tablets. No downloader.
-/obj/item/computer_hardware/hard_drive/small/integrated/install_default_programs() // SKYRAT EDIT ADDITION - Reverts TG Change breaking PDA's
+/obj/item/computer_hardware/hard_drive/small/robot/install_default_programs()
 	var/datum/computer_file/program/messenger/messenger = new(src)
 	messenger.is_silicon = TRUE
 	store_file(messenger)
 
-/obj/item/computer_hardware/hard_drive/small/integrated/borg/install_default_programs() // SKYRAT EDIT ADDITION - Reverts TG Change breaking PDA's
+/obj/item/computer_hardware/hard_drive/small/robot/install_default_programs()
 	store_file(new /datum/computer_file/program/computerconfig(src)) // Computer configuration utility, allows hardware control and displays more info than status bar
 	store_file(new /datum/computer_file/program/filemanager(src)) // File manager, allows text editor functions and basic file manipulation.
 	store_file(new /datum/computer_file/program/robotact(src))
 	store_file(new /datum/computer_file/program/crew_manifest(src)) // SKYRAT EDIT ADDITION - Manifests for cyborgs
-	/* SKYRAT EDIT ADDITION Start- Returns Messenger to borgs */
+	/* SKYRAT EDIT ADDITION Start- PDA Messenger to borgs */
 	var/datum/computer_file/program/messenger/messenger = new(src) 
 	messenger.is_silicon = TRUE
 	store_file(messenger)
-	/* SKYRAT EDIT ADDITION End- Returns Messenger to borgs */
+	/* SKYRAT EDIT ADDITION Start- PDA Messenger to borgs */
 
 // Syndicate variant - very slight better
 /obj/item/computer_hardware/hard_drive/portable/syndicate

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -178,12 +178,12 @@
 	store_file(new /datum/computer_file/program/crew_manifest(src)) // SKYRAT EDIT ADD
 
 // For borg integrated tablets. No downloader.
-/obj/item/computer_hardware/hard_drive/small/integrated/install_default_programs() // SKYRAT EDIT ADDITION - cyborg PDA messenger
+/obj/item/computer_hardware/hard_drive/small/ai/install_default_programs()
 	var/datum/computer_file/program/messenger/messenger = new(src)
 	messenger.is_silicon = TRUE
 	store_file(messenger)
 
-/obj/item/computer_hardware/hard_drive/small/integrated/borg/install_default_programs() // SKYRAT EDIT ADDITION - cyborg PDA messenger
+/obj/item/computer_hardware/hard_drive/small/robot/install_default_programs()
 	store_file(new /datum/computer_file/program/computerconfig(src)) // Computer configuration utility, allows hardware control and displays more info than status bar
 	store_file(new /datum/computer_file/program/filemanager(src)) // File manager, allows text editor functions and basic file manipulation.
 	store_file(new /datum/computer_file/program/robotact(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

TG removed the messenger app with the reasoning of never having it, revert of PR  https://github.com/Skyrat-SS13/Skyrat-tg/pull/13785  that shouldnt have been merged.

## How This Contributes To The Skyrat Roleplay Experience

Borgs have always had messenger on Skyrat, it invites crew interaction and allows private requests to be made. The code also disallowed the app to be migrated due to the drive change so not even crew could help.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

qol: Returns Borg PDA messaging

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
