### PR TITLE
Fixes OPFOR runtime

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -853,7 +853,7 @@
 
 /datum/opposing_force/proc/roundend_report()
 	var/list/report = list("<br>")
-	report += span_greentext(mind_reference.current.real_name)
+	report += span_greentext(mind_reference.current?.real_name)
 
 	if(set_backstory)
 		report += "<b>Had an approved OPFOR application with the following backstory:</b><br>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Mind_reference.current doesn't always exist, runtiming the end-of-round screen, making some (or all) OPFORs not appear

## How This Contributes To The Skyrat Roleplay Experience
bugs bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed end-of-round OPFOR report runtime
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
