### PR TITLE
Fixes teshari modsuit suits to use correct sprite

### DIFF
--- a/modular_skyrat/modules/teshari/code/teshari_clothes.dm
+++ b/modular_skyrat/modules/teshari/code/teshari_clothes.dm
@@ -34,7 +34,7 @@
 	species_clothing_color_coords = list(list(SPACESUIT_COLORPIXEL_X_1, SPACESUIT_COLORPIXEL_Y_1))
 	greyscale_config_worn_teshari_fallback = /datum/greyscale_config/teshari/spacesuit
 
-/obj/item/clothing/suit/armor/mod
+/obj/item/clothing/suit/mod
 	species_clothing_color_coords = list(list(MODSUIT_COLORPIXEL_X_1, MODSUIT_COLORPIXEL_Y_1), list(MODSUIT_COLORPIXEL_X_2, MODSUIT_COLORPIXEL_Y_2), list(MODSUIT_COLORPIXEL_X_3, MODSUIT_COLORPIXEL_Y_3))
 	greyscale_config_worn_teshari_fallback = /datum/greyscale_config/teshari/hardsuit
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The path to add the teshari fallback info for the suit part of modsuits was pointing to the original path (`/obj/item/clothing/suit/armor/mod`) before it was refactored. Since the byond language is trash, nothing caught this.

Fixes it so that teshari don't look like perverts in a trenchcoat when wearing a modsuit. They just look stupid for all the other reasons.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Correct sprites.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The torso part of modsuits now appear on teshari correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
