### PR TITLE
Fixes some tail turf emotes

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/tails.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/tails.dm
@@ -10,6 +10,8 @@
 	genetic = TRUE
 	/// A generalisation of the tail-type, e.g. lizard or feline, for MODsuit or other sprites
 	var/general_type
+	/// Can we use this tail for the fluffy tail turf emote?
+	var/fluffy = FALSE
 
 /datum/sprite_accessory/tails/get_special_render_state(mob/living/carbon/human/wearer)
 	// MODsuit tail spriting
@@ -140,6 +142,7 @@
 	name = "Bat (Long)"
 	icon_state = "batl"
 	general_type = "feline"
+	fluffy = TRUE
 
 /datum/sprite_accessory/tails/mammal/wagging/bat_short
 	name = "Bat (Short)"
@@ -195,6 +198,7 @@
 	name = "Fennec"
 	icon_state = "fennec"
 	general_type = "vulpine"
+	fluffy = TRUE
 
 /datum/sprite_accessory/tails/mammal/wagging/fish
 	name = "Fish"
@@ -205,6 +209,7 @@
 	name = "Fox"
 	icon_state = "fox"
 	general_type = "vulpine"
+	fluffy = TRUE
 
 /datum/sprite_accessory/tails/mammal/wagging/vulpkanin/fox/alt_1
 	name = "Fox (Alt 1)"
@@ -234,6 +239,7 @@
 	name = "Husky"
 	icon_state = "husky"
 	general_type = "shepherdlike"
+	fluffy = TRUE
 
 /datum/sprite_accessory/tails/mammal/wagging/insect
 	name = "Insect"
@@ -252,6 +258,7 @@
 	name = "Kitsune"
 	icon_state = "kitsune"
 	general_type = "vulpine" // Vulpine until I can be bothered to make kitsune modsuit tailsprite!
+	fluffy = TRUE
 
 /datum/sprite_accessory/tails/mammal/wagging/lunasune
 	name = "Kitsune (Lunasune)"
@@ -278,6 +285,7 @@
 	name = "Leopard"
 	icon_state = "leopard"
 	general_type = "feline"
+	fluffy = TRUE
 
 /datum/sprite_accessory/tails/mammal/wagging/murid
 	name = "Murid"
@@ -313,6 +321,7 @@
 	name = "Red Panda"
 	icon_state = "wah"
 	extra = TRUE
+	fluffy = TRUE
 
 /datum/sprite_accessory/tails/mammal/wagging/pede
 	name = "Scolipede"
@@ -326,6 +335,7 @@
 	name = "Sergal"
 	icon_state = "sergal"
 	general_type = "shepherdlike"
+	fluffy = TRUE
 
 /datum/sprite_accessory/tails/mammal/servelyn
 	name = "Servelyn"
@@ -364,6 +374,7 @@
 	name = "Skunk"
 	icon_state = "skunk"
 	general_type = "vulpine"
+	fluffy = TRUE
 
 /datum/sprite_accessory/tails/mammal/wagging/snake
 	name = "Snake"
@@ -386,10 +397,12 @@
 	name = "Squirrel"
 	icon_state = "squirrel"
 	color_src = USE_ONE_COLOR
+	fluffy = TRUE
 
 /datum/sprite_accessory/tails/mammal/wagging/stripe
 	name = "Stripe"
 	icon_state = "stripe"
+	fluffy = TRUE
 
 /datum/sprite_accessory/tails/mammal/wagging/straight
 	name = "Straight Tail"
@@ -438,6 +451,7 @@
 	icon_state = "wolf"
 	color_src = USE_ONE_COLOR
 	general_type = "shepherdlike"
+	fluffy = TRUE
 
 /datum/sprite_accessory/tails/mammal/wagging/zorgoia
 	name = "Zorgoia tail"

--- a/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
+++ b/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
@@ -57,13 +57,15 @@
 
 		//body parts
 		if(istype(user.getorganslot(ORGAN_SLOT_TAIL), /obj/item/organ/tail))
-			var/list/fluffy_tails = list("Tamamo Kitsune Tails", "Sergal", "Fox", "Fox (Alt 2)", "Fox (Alt 3)", "Fennec", "Red Panda", "Husky", "Skunk", "Lunasune", "Squirrel", "Wolf", "Stripe", "Kitsune", "Leopard", "Bat (Long)", "Triple Kitsune,", "Septuple Kitsune", "Sabresune")
-			if(human_user.dna.species.mutant_bodyparts["tail"][MUTANT_INDEX_NAME] in fluffy_tails)
+			var/name = human_user.dna.species.mutant_bodyparts["tail"][MUTANT_INDEX_NAME]
+			var/datum/sprite_accessory/tails/tail = GLOB.sprite_accessories["tail"][name]
+			if(tail.fluffy)
 				user.allowed_turfs += "tails"
 
 		if(human_user.dna.species.mutant_bodyparts["taur"])
-			var/list/snake_taurs = list("Naga", "Cybernetic Naga")
-			if(human_user.dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME] in snake_taurs)
+			var/name = human_user.dna.species.mutant_bodyparts["taur"][MUTANT_INDEX_NAME]
+			var/datum/sprite_accessory/taur/taur = GLOB.sprite_accessories["taur"][name]
+			if(taur.taur_mode & STYLE_TAUR_SNAKE)
 				user.allowed_turfs -= list("pawprint", "hoofprint", "clawprint")
 				user.allowed_turfs += "constrict"
 
@@ -165,33 +167,6 @@
 
 	if(current_turf == "web")
 		user.spin(8, 1) //Ssspin a web
-
-		/* Commented out to preserve text.
-		Voter decision to exclude pre-determined messages, can still use this area to apply animation onto the user!
-
-			. = "neatly spins a web beneath them."
-		if("water")
-			. = "submerges their surroundings in a pool of water."
-		if("vines")
-			. = "sprouts vines reaching down beneath them."
-		if("dust")
-			. = "flutters their wings, scattering their dust around."
-		if("smoke")
-			. = "expirates a mist of ashes around them."
-		if("slime")
-			. = "splits their gel, forming an oozing shape."
-		if("xenoresin")
-			. = "secretes thick resin, covering the ground beneath them."
-		if("holoseat")
-			. = "artificially summons a seat beneath them."
-		if("holobed")
-			. = "artificially summons a bed beneath them."
-		if("borgmat")
-			. = "dispenses a soft mat, rolling it out beneath them."
-		*/
-
-
-
 
 	current_turf = null
 	LAZYCLEARLIST(user.allowed_turfs)


### PR DESCRIPTION
## About The Pull Request

Fixes some tail turf emotes that were broken due to not getting their names updated in the list when I renamed some.
Improves the code to *not* need to do that, because that was janky. It's now a var on the sprite accessory.
Did the same for taurs while I was there using the taur type flag, which as a byproduct allows the tentacle taur type to use the constrict emote.

Also deletes some random ass block of commented out code, because guidelines.

## How This Contributes To The Skyrat Roleplay Experience

Fix good, code improvement also good.

## Changelog
:cl:
fix: A few tails which were meant to be able to use the fluffy turf emote and couldn't, now can.
/:cl: