### PR TITLE
Ghost Cafe un-weirdining

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -3740,7 +3740,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "aKD" = (
-/obj/machinery/vending/wardrobe/chef_wardrobe,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aKP" = (
@@ -3897,9 +3897,9 @@
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
 "aME" = (
-/obj/machinery/computer/slot_machine,
-/obj/item/coin/silver,
-/obj/item/coin/silver,
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/cas,
+/obj/item/toy/cards/deck/kotahi,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aMG" = (
@@ -4236,7 +4236,10 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafedorms)
 "aOw" = (
-/obj/effect/spawner/random/entertainment/arcade,
+/obj/machinery/computer/slot_machine,
+/obj/item/coin/silver,
+/obj/item/coin/silver,
+/obj/item/coin,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aOz" = (
@@ -4447,6 +4450,7 @@
 	pixel_x = -3;
 	pixel_y = 2
 	},
+/obj/item/toy/cards/deck/tarot,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aQf" = (
@@ -6708,6 +6712,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"fvx" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafepark)
 "fwc" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/chair/stool/bar/directional/west{
@@ -7089,6 +7100,14 @@
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"gPN" = (
+/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/eighties,
+/area/centcom/holding/cafe)
 "gVy" = (
 /obj/structure/table/glass,
 /obj/item/paper/pamphlet/centcom/visitor_info{
@@ -7108,6 +7127,12 @@
 	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/interlink)
+"gWT" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/cas/black,
+/obj/item/toy/cards/deck/wizoff,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "gYg" = (
 /obj/structure/transit_tube/curved{
 	dir = 8
@@ -7930,6 +7955,14 @@
 /obj/structure/chair/sofa/right,
 /turf/open/floor/wood,
 /area/centcom/holding/cafedorms)
+"koF" = (
+/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/eighties,
+/area/centcom/holding/cafe)
 "kqG" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 9
@@ -7977,10 +8010,9 @@
 /turf/closed/indestructible/wood,
 /area/centcom/holding/cafe)
 "kFE" = (
-/obj/structure/flora/bush/lavendergrass{
-	icon_state = "lavendergrass_4"
-	},
-/turf/closed/indestructible/wood,
+/obj/structure/spacevine,
+/obj/structure/fans/tiny/invisible,
+/turf/open/misc/grass/planet,
 /area/centcom/holding/cafepark)
 "kGR" = (
 /obj/structure/dresser,
@@ -8103,6 +8135,13 @@
 /obj/structure/closet/secure_closet/brig/genpop,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"kYn" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/skill_station,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafepark)
 "kYL" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4
@@ -8165,6 +8204,10 @@
 	},
 /turf/open/misc/asteroid,
 /area/centcom/interlink)
+"liK" = (
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/holding/cafe)
 "lkh" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -9138,6 +9181,14 @@
 	},
 /turf/open/misc/grass/planet,
 /area/centcom/holding/cafepark)
+"ptd" = (
+/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/eighties,
+/area/centcom/holding/cafe)
 "puo" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/light{
@@ -52738,12 +52789,12 @@ ajj
 aCf
 ayI
 aPf
-ajj
 aFy
 aFy
 aFy
 aFy
-aCM
+aFy
+aFy
 ayd
 aIV
 aAz
@@ -53041,8 +53092,8 @@ aPf
 ajj
 ajj
 ajj
-aIm
-aFP
+kFE
+aaY
 aPf
 aPf
 aPf
@@ -53252,7 +53303,7 @@ ajj
 ayI
 aPf
 aFP
-kFE
+aFy
 xQj
 pCd
 dpe
@@ -54537,11 +54588,11 @@ ajj
 aqP
 aPf
 aFP
-awU
-aqf
-aqf
-aqf
-aqf
+aFy
+avn
+aNY
+aNY
+asY
 aqf
 awM
 aBd
@@ -54550,7 +54601,7 @@ aBd
 aBd
 aNn
 aqf
-aOw
+koF
 aUo
 aUz
 aqf
@@ -54794,9 +54845,9 @@ ajj
 aqP
 aPf
 aFP
-aFP
-aqf
-avn
+aFy
+qRd
+aNY
 aNY
 aNY
 aEL
@@ -54807,7 +54858,7 @@ akJ
 aBd
 rxB
 aFn
-aUo
+gPN
 aUo
 azm
 aTb
@@ -55051,9 +55102,9 @@ ajj
 aqP
 aPf
 aFP
-aIV
-aqf
+aFy
 avn
+aNY
 aNY
 aIx
 aqf
@@ -55308,10 +55359,10 @@ ajj
 aqP
 aPf
 aFB
-aFP
-aqf
+aFy
+liK
 aNY
-qRd
+aNY
 asY
 aqf
 aLY
@@ -55321,7 +55372,7 @@ aBd
 aBd
 aZK
 aFn
-aUo
+koF
 aUo
 aUo
 aTb
@@ -55578,7 +55629,7 @@ haZ
 aBd
 aQD
 aqf
-aOw
+ptd
 aUo
 aUo
 aqf
@@ -55609,9 +55660,9 @@ aYt
 aVS
 aAr
 umm
+kYn
 aYc
-aYc
-aYc
+fvx
 aDB
 umm
 ajj
@@ -55835,7 +55886,7 @@ aqf
 aXl
 aqf
 aqf
-aME
+aOw
 aUo
 aUz
 aqf
@@ -57133,8 +57184,8 @@ aGo
 aSg
 aqf
 aUo
-aCD
-aCD
+aME
+gWT
 aqf
 aXd
 aUo


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/102828457/170162068-2a26b1a7-5892-4b8f-af77-c02683cdd39b.png)
This area looked a bit odd. I simply made it...Not.
I also shifted some vendors around, added more cards, threw in a skillsoft machine and beautified the mini-cade.
![image](https://user-images.githubusercontent.com/102828457/170162473-cde89003-c0c9-4bb7-9589-e1a1c1b13885.png)

## How This Contributes To The Skyrat Roleplay Experience

It looks nice.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Cursor
add: The Ghost Cafe now has a skillsoft machine. Go on then. Learn about...Wine?
fix: Ghost Cafe's chem lab now has it's missing wall. Bobert the Constructor has been fired.
fix: The Ghost Cafe management also hired an interior decorator. His name is Jim, be nice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
