### PR TITLE
Latejoining AI now syncs unsynced borgs & All (non-posi) latejoining borgs are synced to the AI.

### DIFF
--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -42,7 +42,7 @@
 		if(sync_target.emagged) // Skip emagged cyborgs, they don't sync up to the AI anyways and emagged borgs are already outed by just looking at a robotics console.
 			continue
 		if(sync_target.connected_ai)
-			return
+			continue
 		sync_target.notify_ai(AI_NOTIFICATION_CYBORG_DISCONNECTED)
 		sync_target.set_connected_ai(ai_spawn)
 		log_combat(ai_spawn, sync_target, "synced cyborg [ADMIN_LOOKUP(sync_target)] to [ADMIN_LOOKUP(ai_spawn)] (AI spawn syncage)")

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -37,7 +37,7 @@
 	ai_spawn.log_current_laws()
 	// SKYRAT EDIT ADDITION START
 	for(var/mob/living/silicon/robot/sync_target in GLOB.silicon_mobs)
-		if(!(sync_target.z in SSmapping.levels_by_trait(ZTRAIT_STATION))) // Skip ghost cafe, interlink, and other cyborgs.
+		if(!(sync_target.z in SSmapping.levels_by_trait(ZTRAIT_STATION)) || (sync_target.z in SSmapping.levels_by_trait(ZTRAIT_ICE_RUINS_UNDERGROUND))) // Skip ghost cafe, interlink, and other cyborgs.
 			continue
 		if(sync_target.emagged) // Skip emagged cyborgs, they don't sync up to the AI anyways and emagged borgs are already outed by just looking at a robotics console.
 			continue

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -26,13 +26,36 @@
 
 /datum/job/ai/after_spawn(mob/living/spawned, client/player_client)
 	. = ..()
+	/* SKYRAT REMOVAL START
 	//we may have been created after our borg
 	if(SSticker.current_state == GAME_STATE_SETTING_UP)
 		for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
 			if(!R.connected_ai)
 				R.TryConnectToAI()
+	*/ //SKYRAT REMOVAL END
 	var/mob/living/silicon/ai/ai_spawn = spawned
 	ai_spawn.log_current_laws()
+	// SKYRAT EDIT ADDITION START
+	for(var/mob/living/silicon/robot/sync_target in GLOB.silicon_mobs)
+		if(!(sync_target.z in SSmapping.levels_by_trait(ZTRAIT_STATION))) // Skip ghost cafe, interlink, and other cyborgs.
+			continue
+		if(sync_target.emagged) // Skip emagged cyborgs, they don't sync up to the AI anyways and emagged borgs are already outed by just looking at a robotics console.
+			continue
+		if(sync_target.connected_ai)
+			return
+		sync_target.notify_ai(AI_NOTIFICATION_CYBORG_DISCONNECTED)
+		sync_target.set_connected_ai(ai_spawn)
+		log_combat(ai_spawn, sync_target, "synced cyborg [ADMIN_LOOKUP(sync_target)] to [ADMIN_LOOKUP(ai_spawn)] (AI spawn syncage)")
+		if(sync_target.shell)
+			sync_target.undeploy()
+			sync_target.notify_ai(AI_NOTIFICATION_AI_SHELL)
+		else
+			sync_target.notify_ai(TRUE)
+		sync_target.visible_message(span_notice("[sync_target] gently chimes."), span_notice("LawSync protocol engaged."))
+		log_combat(ai_spawn, sync_target, "forcibly synced cyborg laws via spawning in")
+		sync_target.lawsync()
+		sync_target.show_laws()
+	// SKYRAT EDIT ADDITION END
 
 
 /datum/job/ai/get_roundstart_spawn_point()

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -29,6 +29,31 @@
 	spawned.gender = NEUTER
 	var/mob/living/silicon/robot/robot_spawn = spawned
 	robot_spawn.notify_ai(AI_NOTIFICATION_NEW_BORG)
+	//SKYRAT EDIT START
+	var/list/malf_ais = list()
+	var/list/regular_ais = list()
+	for(var/mob/living/silicon/ai/ai_possible as anything in GLOB.ai_list)
+		if(ai_possible.mind?.has_antag_datum(/datum/antagonist/malf_ai))
+			malf_ais |= ai_possible
+			continue
+		regular_ais |= ai_possible
+	var/mob/selected_ai
+	if(length(malf_ais))
+		selected_ai = pick(malf_ais)
+	if(length(regular_ais) && !selected_ai)
+		selected_ai = pick(regular_ais)
+	if(selected_ai)
+		robot_spawn.set_connected_ai(selected_ai)
+		log_combat(selected_ai, robot_spawn, "synced cyborg [ADMIN_LOOKUP(robot_spawn)] to [ADMIN_LOOKUP(selected_ai)] (Cyborg spawn syncage)")
+		if(robot_spawn.shell) //somehow?
+			robot_spawn.undeploy()
+			robot_spawn.notify_ai(AI_NOTIFICATION_AI_SHELL)
+		else
+			robot_spawn.notify_ai(TRUE)
+		robot_spawn.visible_message(span_notice("[robot_spawn] gently chimes."), span_notice("LawSync protocol engaged."))
+		robot_spawn.lawsync()
+		robot_spawn.show_laws()
+	//SKYRAT EDIT END
 	if(!robot_spawn.connected_ai) // Only log if there's no Master AI
 		robot_spawn.log_current_laws()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Any AI who latejoins will automatically sync all unsynced borgs who joined before it will be forcibly synced to it. Emagged borgs and borgs synced to another AI are exempt.

After some maint discussion, all latejoining borgs (not posi-brained borgs) are now synced to the AI should there be one. Malfs get priority.

## How This Contributes To The Skyrat Roleplay Experience
I have seen many a borg announce to security/command/the station that the AI's malf because they can hear :b frequency. Also, this gives malfs more room for things to do, since they'll have more ~~helper minions~~ synced borgs to do their bidding
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Latejoining AI will automatically sync all unsynced, un-emagged borgs to it
balance: Latejoining borgs now automatically sync to an AI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
