### PR TITLE
makes less-than-lethals unusable by pacifists

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -41,7 +41,6 @@
 	name = ".38 Rubber bullet casing"
 	desc = "A .38 rubber bullet casing, manufactured to exceedingly bouncy standards."
 	projectile_type = /obj/projectile/bullet/c38/match/bouncy
-	harmful = FALSE //SKYRAT EDIT ADDITION
 
 /obj/item/ammo_casing/c38/dumdum
 	name = ".38 DumDum bullet casing"

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -27,7 +27,6 @@
 	icon_state = "bshell"
 	custom_materials = list(/datum/material/iron=250)
 	projectile_type = /obj/projectile/bullet/shotgun_beanbag
-	harmful = FALSE //SKYRAT EDIT ADDITION
 
 /obj/item/ammo_casing/shotgun/incendiary
 	name = "incendiary slug"
@@ -91,7 +90,6 @@
 	pellets = 6
 	variance = 20
 	custom_materials = list(/datum/material/iron=4000)
-	harmful = FALSE //SKYRAT EDIT ADDITION
 
 /obj/item/ammo_casing/shotgun/incapacitate
 	name = "custom incapacitating shot"

--- a/modular_skyrat/modules/modular_weapons/code/modular_projectiles.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modular_projectiles.dm
@@ -18,7 +18,6 @@
 	desc = "A .32 rubber bullet casing."
 	caliber = "c32acp"
 	projectile_type = /obj/projectile/bullet/c32/rubber
-	harmful = FALSE
 
 /obj/projectile/bullet/c32/rubber
 	name = ".32 rubber bullet"
@@ -62,7 +61,6 @@
 	desc = "A 10mm Magnum bullet casing. This fires a non-lethal projectile to cause compliance by pain and bruising. Don't aim for the head."
 	caliber = CALIBER_10MM
 	projectile_type = /obj/projectile/bullet/c10mm/rubber
-	harmful = FALSE
 
 /obj/projectile/bullet/c10mm/rubber
 	name = "10mm Magnum rubber ball"
@@ -119,7 +117,6 @@
 	name = "4.6x30mm rubber bullet casing"
 	desc = "A 4.6x30mm rubber bullet casing."
 	projectile_type = /obj/projectile/bullet/c46x30mm_rubber
-	harmful = FALSE
 
 /*
 *	5.56x30mm MARS
@@ -131,7 +128,6 @@
 	desc = "A 5.56mm rubber bullet casing."
 	caliber = CALIBER_A556
 	projectile_type = /obj/projectile/bullet/a556/rubber
-	harmful = FALSE
 
 /obj/projectile/bullet/a556/rubber
 	name = "5.56mm rubber bullet"
@@ -167,7 +163,6 @@
 	icon_state = "762-casing"
 	caliber = CALIBER_A762
 	projectile_type = /obj/projectile/bullet/a762/rubber
-	harmful = FALSE
 
 /obj/projectile/bullet/a762/rubber
 	name = "7.62mm rubber bullet"
@@ -225,7 +220,6 @@
 	desc = "A .34 rubber bullet casing."
 	caliber = "c34acp"
 	projectile_type = /obj/projectile/bullet/c34/rubber
-	harmful = FALSE
 
 /obj/projectile/bullet/c34/rubber
 	name = ".34 rubber bullet"
@@ -315,7 +309,6 @@
 	name = "4.2x30mm rubber bullet casing"
 	desc = "A 4.2x30mm rubber bullet casing."
 	projectile_type = /obj/projectile/bullet/c42x30mm_rubber
-	harmful = FALSE
 
 /*
 *	12mm
@@ -346,7 +339,6 @@
 	name = "12mm Magnum rubber bullet casing"
 	desc = "A low powder load 12mm Magnum bullet casing with a flat rubber tip. Headshots heavily discouraged."
 	projectile_type = /obj/projectile/bullet/c12mm/rubber
-	harmful = FALSE
 
 /obj/projectile/bullet/c12mm
 	name = "12mm bullet"

--- a/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
@@ -227,7 +227,6 @@
 	icon_state = "bshell"
 	custom_materials = list(/datum/material/iron=250)
 	projectile_type = /obj/projectile/bullet/s14gauge_beanbag
-	harmful = FALSE
 
 /obj/item/ammo_casing/s14gauge/buckshot
 	name = "14 gauge buckshot shell"
@@ -245,7 +244,6 @@
 	pellets = 5
 	variance = 25
 	custom_materials = list(/datum/material/iron=4000)
-	harmful = FALSE //SKYRAT EDIT ADDITION //What? This is our own file.
 
 /obj/item/ammo_casing/s14gauge/stunslug
 	name = "14 gauge taser slug"
@@ -253,7 +251,6 @@
 	icon_state = "stunshell"
 	projectile_type = /obj/projectile/bullet/s14gauge_stunslug
 	custom_materials = list(/datum/material/iron=500,/datum/material/gold=100)
-	harmful = FALSE
 
 /obj/item/storage/box/rubbershot_14gauge
 	name = "box of 14 gauge rubber shots"

--- a/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
@@ -29,7 +29,6 @@
 	icon_state = "sr-casing"
 	caliber = CALIBER_6MM
 	projectile_type = /obj/projectile/bullet/advanced/b6mm/rubber
-	harmful = FALSE
 
 /obj/projectile/bullet/advanced/b6mm/rubber
 	name = "6mm dissuasive pellet"
@@ -115,7 +114,6 @@
 	icon = 'modular_skyrat/modules/sec_haul/icons/guns/ammo_cartridges.dmi'
 	icon_state = "sr-casing"
 	projectile_type = /obj/projectile/bullet/advanced/b9mm/rubber
-	harmful = FALSE
 
 /obj/projectile/bullet/advanced/b9mm/rubber
 	name = "9mm rubber bullet"
@@ -172,7 +170,6 @@
 	icon_state = "sr-casing"
 	caliber = CALIBER_10MMAUTO
 	projectile_type = /obj/projectile/bullet/advanced/b10mm/rubber
-	harmful = FALSE
 
 /obj/projectile/bullet/advanced/b10mm/rubber
 	name = "10mm Auto rubber bullet"
@@ -229,7 +226,6 @@
 	icon_state = "sr-casing"
 	caliber = CALIBER_12MM
 	projectile_type = /obj/projectile/bullet/advanced/b12mm/rubber
-	harmful = FALSE
 
 /obj/projectile/bullet/advanced/b12mm/rubber
 	name = "12.7x30mm beanbag slug"
@@ -360,7 +356,6 @@
 	icon_state = "sr-casing"
 	caliber = CALIBER_473MM
 	projectile_type = /obj/projectile/bullet/advanced/b473/rubber
-	harmful = FALSE
 
 /obj/projectile/bullet/advanced/b473/rubber
 	name = "4.73x33mm rubber bullet"

--- a/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/cmg.dm
@@ -66,7 +66,6 @@
 	name = ".45 rubber bullet casing"
 	desc = "A .45 rubber bullet casing."
 	projectile_type = /obj/projectile/bullet/c45/rubber
-	harmful = FALSE
 
 /obj/projectile/bullet/c45/rubber
 	name = ".45 rubber bullet"


### PR DESCRIPTION
## About The Pull Request

Rubbers do damage, yet are set to `harmful = FALSE` for some reason, meaning pacifists can use them. That makes no sense, and is inconsistent with how pacifism is meant to work.

## How This Contributes To The Skyrat Roleplay Experience

Consistency issues, pacifists should not be able to shoot someone for 10 damage with rubbers.

## Changelog
:cl:
balance: Pacifism now prevents you using less-than-lethal ammo, i.e. rubbershot and rubber bullets.
/:cl: