### PR TITLE
Adds a chat message to (re/de)mentoring

### DIFF
--- a/modular_skyrat/modules/mentor/code/dementor.dm
+++ b/modular_skyrat/modules/mentor/code/dementor.dm
@@ -7,6 +7,7 @@
 	if (/client/proc/mentor_unfollow in verbs)
 		mentor_unfollow()
 	GLOB.mentors -= src
+	to_chat(src, span_interface("You are no longer a mentor."))
 	log_mentor("MENTOR: [src] dementored.")
 	add_verb(src,/client/proc/cmd_mentor_rementor)
 
@@ -17,5 +18,6 @@
 		return
 	add_mentor_verbs()
 	GLOB.mentors[src] = TRUE
+	to_chat(src, span_interface("You are now a mentor."))
 	log_mentor("MENTOR: [src] rementored.")
 	remove_verb(src,/client/proc/cmd_mentor_rementor)


### PR DESCRIPTION
## About The Pull Request

Adds a message to chat saying you have dementored (or rementored).

## How This Contributes To The Skyrat Roleplay Experience

It's nice to have a little feedback.

## Changelog
:cl:
qol: using the (re/de)mentor verb now gives a chat message telling you you've done so.
/:cl:
