### PR TITLE
Repaths all improperly pathed duffels

### DIFF
--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -68,7 +68,7 @@
 
 	backpack = /obj/item/storage/backpack/head_of_personnel // SKYRAT EDIT CHANGE - HOP DRIP
 	satchel = /obj/item/storage/backpack/satchel/head_of_personnel // SKYRAT EDIT CHANGE - HOP DRIP
-	duffelbag = /obj/item/storage/backpack/duffel/head_of_personnel // SKYRAT EDIT CHANGE - HOP DRIP
+	duffelbag = /obj/item/storage/backpack/duffelbag/head_of_personnel // SKYRAT EDIT CHANGE - HOP DRIP
 
 	chameleon_extras = list(
 		/obj/item/gun/energy/e_gun,

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -51,7 +51,7 @@
 
 	backpack = /obj/item/storage/backpack/science/robo //SKYRAT CHANGE - Roboticist Bags (CHANGE)
 	satchel = /obj/item/storage/backpack/satchel/tox/robo //SKYRAT CHANGE - Roboticist Bags (CHANGE)
-	duffelbag = /obj/item/storage/backpack/duffel/robo //SKYRAT CHANGE - Roboticist Bags (ADDITION)
+	duffelbag = /obj/item/storage/backpack/duffelbag/robo //SKYRAT CHANGE - Roboticist Bags (ADDITION)
 
 	pda_slot = ITEM_SLOT_LPOCKET
 	skillchips = list(/obj/item/skillchip/job/roboticist)

--- a/modular_skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield.dm
@@ -59,7 +59,7 @@
 	implants = list(/obj/item/implant/mindshield)
 	backpack = /obj/item/storage/backpack/blueshield
 	satchel = /obj/item/storage/backpack/satchel/blueshield
-	duffelbag = /obj/item/storage/backpack/duffel/blueshield
+	duffelbag = /obj/item/storage/backpack/duffelbag/blueshield
 	head = /obj/item/clothing/head/beret/blueshield
 	box = /obj/item/storage/box/survival/security
 	belt = /obj/item/modular_computer/tablet/pda/security

--- a/modular_skyrat/modules/blueshield/code/blueshield_clothing.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield_clothing.dm
@@ -102,7 +102,7 @@
 	icon_state = "satchel-blueshield"
 	inhand_icon_state = "satchel-sec"
 
-/obj/item/storage/backpack/duffel/blueshield
+/obj/item/storage/backpack/duffelbag/blueshield
 	name = "blueshield duffelbag"
 	desc = "A robust duffelbag issued to Nanotrasen's finest."
 	icon = 'modular_skyrat/modules/blueshield/icons/blueshieldpacks.dmi'

--- a/modular_skyrat/modules/command_vendor/code/vending.dm
+++ b/modular_skyrat/modules/command_vendor/code/vending.dm
@@ -46,7 +46,7 @@
 		/obj/item/clothing/neck/mantle/bsmantle = 1,
 		/obj/item/storage/backpack/blueshield = 1,
 		/obj/item/storage/backpack/satchel/blueshield = 1,
-		/obj/item/storage/backpack/duffel/blueshield = 1,
+		/obj/item/storage/backpack/duffelbag/blueshield = 1,
 		/obj/item/clothing/shoes/laceup = 1
 		)
 	access_lists["[ACCESS_HOP]"] = list( // Best head btw
@@ -65,7 +65,7 @@
 		/obj/item/clothing/neck/mantle/hopmantle = 1,
 		/obj/item/storage/backpack/head_of_personnel = 1,
 		/obj/item/storage/backpack/satchel/head_of_personnel = 1,
-		/obj/item/storage/backpack/duffel/head_of_personnel = 1,
+		/obj/item/storage/backpack/duffelbag/head_of_personnel = 1,
 		/obj/item/clothing/shoes/sneakers/brown = 1
 		)
 	access_lists["[ACCESS_CMO]"] = list(

--- a/modular_skyrat/modules/hop_drip/code/head_of_personnel.dm
+++ b/modular_skyrat/modules/hop_drip/code/head_of_personnel.dm
@@ -18,7 +18,7 @@
 	icon_state = "satchel_hop"
 	inhand_icon_state = "satchel_hop"
 
-/obj/item/storage/backpack/duffel/head_of_personnel
+/obj/item/storage/backpack/duffelbag/head_of_personnel
 	name = "head of personnel duffelbag"
 	desc = "A robust duffelbag issued to Nanotrasen's finest second."
 	icon = 'modular_skyrat/modules/hop_drip/icons/hop_packs.dmi'

--- a/modular_skyrat/modules/roboclothes/code/robotics_clothing.dm
+++ b/modular_skyrat/modules/roboclothes/code/robotics_clothing.dm
@@ -16,7 +16,7 @@
 	worn_icon = 'modular_skyrat/modules/roboclothes/icons/robobag_onmob.dmi'
 	icon_state = "satchel-robo"
 
-/obj/item/storage/backpack/duffel/robo
+/obj/item/storage/backpack/duffelbag/robo
 	name = "robotics duffelbag"
 	desc = "A sleek, industrial-strength duffelbag issued to robotics personnel. Smells faintly of oil."
 	icon = 'modular_skyrat/modules/roboclothes/icons/robobag_item.dmi'

--- a/modular_skyrat/modules/roboclothes/code/wardrobes.dm
+++ b/modular_skyrat/modules/roboclothes/code/wardrobes.dm
@@ -1,5 +1,5 @@
 /obj/machinery/vending/wardrobe/robo_wardrobe/Initialize()
 	products[/obj/item/storage/backpack/science/robo] = 3
 	products[/obj/item/storage/backpack/satchel/tox/robo] = 3
-	products[/obj/item/storage/backpack/duffel/robo] = 3
-	. = ..() 
+	products[/obj/item/storage/backpack/duffelbag/robo] = 3
+	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
/obj/item/storage/backpack/duffel 👏 is 👏 not 👏 valid 👏 

## How This Contributes To The Skyrat Roleplay Experience
Actually inheriting the functions of duffel bags is good

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed Roboticist, Head of Personnel, and Blueshield duffelbags to now work like duffelbags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
