### PR TITLE
re-adds some lost accesses (QM, Atmos Tech)

### DIFF
--- a/modular_skyrat/master_files/code/datums/id_trim/jobs.dm
+++ b/modular_skyrat/master_files/code/datums/id_trim/jobs.dm
@@ -29,6 +29,11 @@
 
 	access |= ACCESS_WEAPONS
 
+/datum/id_trim/job/atmospheric_technician/New()
+	. = ..()
+
+	minimal_access |= ACCESS_ENGINE_EQUIP
+
 /datum/id_trim/job/chief_medical_officer/New()
 	. = ..()
 
@@ -48,7 +53,7 @@
 /datum/id_trim/job/quartermaster/New()
 	. = ..()
 
-	access |= ACCESS_WEAPONS
+	access |= list(ACCESS_BRIG_ENTRACE, ACCESS_COMMAND, ACCESS_KEYCARD_AUTH, ACCESS_WEAPONS)
 
 /datum/id_trim/job/blueshield
 	assignment = "Blueshield"

--- a/modular_skyrat/master_files/code/datums/id_trim/jobs.dm
+++ b/modular_skyrat/master_files/code/datums/id_trim/jobs.dm
@@ -12,22 +12,22 @@
 /datum/id_trim/job/head_of_security/New()
 	. = ..()
 
-	access |= list(ACCESS_ENTER_GENPOP, ACCESS_LEAVE_GENPOP)
+	minimal_access |= list(ACCESS_ENTER_GENPOP, ACCESS_LEAVE_GENPOP)
 
 /datum/id_trim/job/warden/New()
 	. = ..()
 
-	access |= list(ACCESS_ENTER_GENPOP, ACCESS_LEAVE_GENPOP)
+	minimal_access |= list(ACCESS_ENTER_GENPOP, ACCESS_LEAVE_GENPOP)
 
 /datum/id_trim/job/security_officer/New()
 	. = ..()
 
-	access |= list(ACCESS_ENTER_GENPOP, ACCESS_LEAVE_GENPOP)
+	minimal_access |= list(ACCESS_ENTER_GENPOP, ACCESS_LEAVE_GENPOP)
 
 /datum/id_trim/job/chief_engineer/New()
 	. = ..()
 
-	access |= ACCESS_WEAPONS
+	minimal_access |= ACCESS_WEAPONS
 
 /datum/id_trim/job/atmospheric_technician/New()
 	. = ..()
@@ -37,23 +37,23 @@
 /datum/id_trim/job/chief_medical_officer/New()
 	. = ..()
 
-	access |= ACCESS_WEAPONS
+	minimal_access |= ACCESS_WEAPONS
 
 /datum/id_trim/job/research_director/New()
 	. = ..()
 
-	access |= ACCESS_WEAPONS
+	minimal_access |= ACCESS_WEAPONS
 
 
 /datum/id_trim/job/head_of_personnel/New()
 	. = ..()
 
-	access |= ACCESS_WEAPONS
+	minimal_access |= ACCESS_WEAPONS
 
 /datum/id_trim/job/quartermaster/New()
 	. = ..()
 
-	access |= list(ACCESS_BRIG_ENTRACE, ACCESS_COMMAND, ACCESS_KEYCARD_AUTH, ACCESS_WEAPONS)
+	minimal_access |= list(ACCESS_BRIG_ENTRACE, ACCESS_COMMAND, ACCESS_KEYCARD_AUTH, ACCESS_WEAPONS)
 
 /datum/id_trim/job/blueshield
 	assignment = "Blueshield"


### PR DESCRIPTION
## About The Pull Request

got lost in https://github.com/Skyrat-SS13/Skyrat-tg/pull/13751

updates some instances of `access = ` to `minimal_access = `

## How This Contributes To The Skyrat Roleplay Experience

fix

## Changelog
:cl:
fix: QMs and atmos techs once more have the access they temporarily lost
/:cl: