### PR TITLE
adds admin verbs for spawning / deleting liquids

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -128,6 +128,7 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/add_mob_ability,
 	/datum/admins/proc/station_traits_panel,
 	/client/proc/spawn_pollution, // SKYRAT EDIT ADDITION
+	/client/proc/spawn_liquid, // SKYRAT EDIT ADDITION
 	))
 GLOBAL_PROTECT(admin_verbs_fun)
 GLOBAL_LIST_INIT(admin_verbs_spawn, list(/datum/admins/proc/spawn_atom, /datum/admins/proc/podspawn_atom, /datum/admins/proc/spawn_cargo, /datum/admins/proc/spawn_objasmob, /client/proc/respawn_character, /datum/admins/proc/beaker_panel))
@@ -302,6 +303,7 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	/client/proc/toggle_combo_hud,
 	/client/proc/admin_open_event_spawners_menu, //SKYRAT EDIT ADDITION - EVENTS
 	/client/proc/spawn_pollution, // SKYRAT EDIT ADDITION
+	/client/proc/spawn_liquid,
 	/client/proc/debug_huds
 	))
 GLOBAL_PROTECT(admin_verbs_hideable)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -21,6 +21,7 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/tag_datum_mapview,
 	/client/proc/debugstatpanel,
 	/client/proc/fix_air, /*resets air in designated radius to its default atmos composition*/
+	/client/proc/remove_liquid, // SKYRAT EDIT ADDITION
 	/client/proc/revokebunkerbypass, //SKYRAT EDIT ADDITION - PANICBUNKER
 	/client/proc/addbunkerbypass, //SKYRAT EDIT ADDITION - PANICBUNKER
 	/client/proc/requests

--- a/modular_skyrat/modules/liquids/code/tools.dm
+++ b/modular_skyrat/modules/liquids/code/tools.dm
@@ -1,0 +1,28 @@
+/client/proc/spawn_liquid()
+	set category = "Admin.Fun"
+	set name = "Spawn Liquid"
+	set desc = "Spawns an amount of chosen liquid at your current location."
+
+	var/choice
+	var/valid_id
+	while(!valid_id)
+		choice = tgui_input_text(usr, "Enter the ID of the reagent you want to add.", "Search reagents")
+		if(isnull(choice)) //Get me out of here!
+			break
+		if (!ispath(text2path(choice)))
+			choice = pick_closest_path(choice, make_types_fancy(subtypesof(/datum/reagent)))
+			if (ispath(choice))
+				valid_id = TRUE
+		else
+			valid_id = TRUE
+		if(!valid_id)
+			to_chat(usr, span_warning("A reagent with that ID doesn't exist!"))
+	if(!choice)
+		return
+	var/volume = tgui_input_number(usr, "Volume:", "Choose volume")
+	if(!volume)
+		return
+	var/turf/epicenter = get_turf(mob)
+	epicenter.add_liquid(choice, volume)
+	message_admins("[ADMIN_LOOKUPFLW(usr)] spawned liquid at [epicenter.loc] ([choice] - [volume]).")
+	log_admin("[key_name(usr)] spawned liquid at [epicenter.loc] ([choice] - [volume]).")

--- a/modular_skyrat/modules/liquids/code/tools.dm
+++ b/modular_skyrat/modules/liquids/code/tools.dm
@@ -26,3 +26,16 @@
 	epicenter.add_liquid(choice, volume)
 	message_admins("[ADMIN_LOOKUPFLW(usr)] spawned liquid at [epicenter.loc] ([choice] - [volume]).")
 	log_admin("[key_name(usr)] spawned liquid at [epicenter.loc] ([choice] - [volume]).")
+
+/client/proc/remove_liquid(turf/epicenter in world)
+	set name = "Remove Liquids"
+	set category = "Admin.Game"
+	set desc = "Fixes air in specified radius."
+
+	var/range = tgui_input_number(usr, "Enter range:", "Range selection", 2)
+
+	for(var/obj/effect/abstract/liquid_turf/liquid in range(range, epicenter))
+		qdel(liquid, TRUE)
+
+	message_admins("[key_name_admin(usr)] removed liquids with range [range] in [epicenter.loc.name]")
+	log_game("[key_name_admin(usr)] removed liquids with range [range] in [epicenter.loc.name]")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5364,6 +5364,7 @@
 #include "modular_skyrat\modules\liquids\code\ocean_mapgen.dm"
 #include "modular_skyrat\modules\liquids\code\ocean_ruins.dm"
 #include "modular_skyrat\modules\liquids\code\ocean_turfs.dm"
+#include "modular_skyrat\modules\liquids\code\tools.dm"
 #include "modular_skyrat\modules\liquids\code\liquid_systems\liquid_controller.dm"
 #include "modular_skyrat\modules\liquids\code\liquid_systems\liquid_effect.dm"
 #include "modular_skyrat\modules\liquids\code\liquid_systems\liquid_groups.dm"


### PR DESCRIPTION
## About The Pull Request

Spawn Liquid
- Basically pollution spawn verb, liquid edition. Spawns a liquid of your choice, and the volume you choose, on the turf below you.

Remove Liquids
-  Basically fix air verb, liquid edition. Deletes all the liquids in the specified range

## How This Contributes To The Skyrat Roleplay Experience

`DEAD: STAFF (Hacker T.Dog) says, "it would be [nice to have a verb for spawning liquids].. COOOOOODEJANNNNNIES!!"`
`RatFromTheJungle commented 24 minutes ago "ok but where's the button to clean them all up fr.."`

## Changelog
:cl:
admin: Admins now have a verb to spawn liquids on the turf below them.
/:cl: