### PR TITLE
brings sec cowboy hats in line with sec beret armour

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/head/head.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/head/head.dm
@@ -44,6 +44,8 @@
 	desc = "A security cowboy hat, perfect for any true lawman"
 	icon_state = "cowboyhat_black"
 	inhand_icon_state = "cowboyhat_black"
+	// same armour as the sec beret
+	armor = list(MELEE = 35, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 20, ACID = 50, WOUND = 4)
 
 /obj/item/clothing/head/kepi
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/hats.dmi'
@@ -100,20 +102,20 @@
 
 
 /obj/item/clothing/head/cowboyhat/wide
-	name = "wide brimmed cowboy hat"
+	name = "wide-brimmed cowboy hat"
 	desc = "A brown cowboy hat for blocking out the sun. Remember: Justice is truth in action. Let that guide you in the coming days."
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/hats.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/head.dmi'
 	icon_state = "cowboy_wide"
 	inhand_icon_state= "cowboy_wide"
 
-/obj/item/clothing/head/cowboyhat/widesec
-	name = "wide brimmed security cowboy hat"
+/obj/item/clothing/head/cowboyhat/wide/sec
+	name = "wide-brimmed security cowboy hat"
 	desc = "A bandit turned sheriff, his enforcement is brutal but effective - whether out of fear or respect is unclear, though not many bodies hang high. A peaceful land, a quiet people."
-	icon = 'modular_skyrat/master_files/icons/obj/clothing/hats.dmi'
-	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/head.dmi'
 	icon_state = "cowboy_black"
 	inhand_icon_state= "cowboy_black"
+	// same armour as the sec beret
+	armor = list(MELEE = 35, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 20, ACID = 50, WOUND = 4)
 
 
 /obj/item/clothing/head/ushanka/sec

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -480,7 +480,7 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 
 /datum/loadout_item/head/cowboyhat_secwide
 	name = "Wide Cowboy Hat, Security"
-	item_path = /obj/item/clothing/head/cowboyhat/widesec
+	item_path = /obj/item/clothing/head/cowboyhat/wide/sec
 	restricted_roles = list(JOB_WARDEN,JOB_DETECTIVE,JOB_SECURITY_MEDIC,JOB_SECURITY_OFFICER,JOB_HEAD_OF_SECURITY,JOB_CORRECTIONS_OFFICER)
 
 /datum/loadout_item/head/ushanka/sec


### PR DESCRIPTION
## About The Pull Request

Security cowboy hats now have the same armour values as security berets

## How This Contributes To The Skyrat Roleplay Experience

Consistency issue

## Changelog
:cl:
fix: Security cowboy hats are now consistent in protection values with security berets
/:cl: