### PR TITLE
[MODULAR] Replaces the cargo sec helmet, with the original just-black version.

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -331,7 +331,7 @@
 					/obj/item/toy/crayon/white,
 					/obj/item/clothing/head/fedora/det_hat)
 	crate_name = "forensics crate"
-
+/* // SKYRAT EDIT START - Moved to modular
 /datum/supply_pack/security/helmets
 	name = "Helmets Crate"
 	desc = "Contains three standard-issue brain buckets. Requires Security access to open."
@@ -341,7 +341,7 @@
 					/obj/item/clothing/head/helmet/sec)
 	crate_name = "helmet crate"
 
-/* //SKYRAT EDIT START - CARGO ARMAMENTS
+
 /datum/supply_pack/security/laser
 	name = "Lasers Crate"
 	desc = "Contains three lethal, high-energy laser guns. Requires Security access to open."

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -128,6 +128,15 @@
 					/obj/item/clothing/suit/armor/vest/alt,
 					/obj/item/clothing/suit/armor/vest/alt)
 	crate_name = "armor crate"
+	
+/datum/supply_pack/security/helmets
+	name = "Helmets Crate"
+	desc = "Contains three standard-issue brain buckets. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/clothing/head/helmet/sec/redsec,
+					/obj/item/clothing/head/helmet/sec/redsec,
+					/obj/item/clothing/head/helmet/sec/redsec)
+	crate_name = "helmet crate"
 
 /datum/supply_pack/security/deployablebarricades
 	name = "C.U.C.K.S Deployable Barricades"


### PR DESCRIPTION


## About The Pull Request

Makes the cargo helmets not the super-special security kind, for clarity of where they got it from

## How This Contributes To The Skyrat Roleplay Experience

no more 'is that a security officer, or a particularly rich dep-guard?'

## Changelog



:cl:
add: Added the original security helmets (just black) to the cargo-listings.
/:cl:

