### PR TITLE
Title screen code cleanup, loading progress bar, and main menu

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -160,8 +160,8 @@ SUBSYSTEM_DEF(ticker)
 				discord_alerted = TRUE
 				send2chat("<@&[CONFIG_GET(string/game_alert_role_id)]> New round starting on [SSmapping.config.map_name], [CONFIG_GET(string/servername)]! \nIf you wish to be pinged for game related stuff, go to <#[CONFIG_GET(string/role_assign_channel_id)]> and assign yourself the roles.", CONFIG_GET(string/chat_announce_new_game)) // Skyrat EDIT -- role pingcurrent_state = GAME_STATE_PREGAME
 			current_state = GAME_STATE_PREGAME
-			change_title_screen() //SKYRAT EDIT ADDITION - Title screen
-			addtimer(CALLBACK(GLOBAL_PROC, .proc/change_title_screen), 1 SECONDS) //SKYRAT EDIT ADDITION - Title screen
+			SStitle.change_title_screen() //SKYRAT EDIT ADDITION - Title screen
+			addtimer(CALLBACK(SStitle, /datum/controller/subsystem/title/.proc/change_title_screen), 1 SECONDS) //SKYRAT EDIT ADDITION - Title screen
 			//Everyone who wants to be an observer is now spawned
 			SEND_SIGNAL(src, COMSIG_TICKER_ENTER_PREGAME)
 			fire()

--- a/config/skyrat/title_html.txt
+++ b/config/skyrat/title_html.txt
@@ -1,4 +1,4 @@
-	<html>
+<html>
 		<head>
 			<meta http-equiv="X-UA-Compatible" content="IE=edge">
 			<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -15,13 +15,14 @@
 					background-color: black;
 					padding-top: 5vmin;
 					-ms-user-select: none;
+					cursor: default;
 				}
 
 				img {
 					border-style:none;
 				}
 
-				.fone{
+				.fone {
 					position: absolute;
 					width: auto;
 					height: 100vmin;
@@ -49,12 +50,43 @@
 
 				.container_terminal {
 					position: absolute;
-					width: auto;
+					width: 100%;
+					height: calc(100% - 7vmin);
+					overflow: clip;
 					box-sizing: border-box;
-					padding-top: 3vmin;
+					padding: 3vmin 2vmin;
 					top: 0%;
 					left:0%;
 					z-index: 1;
+				}
+
+				.container_progress {
+					position: absolute;
+					box-sizing: border-box;
+					bottom: 3vmin;
+					left: 2vmin;
+					height: 4vmin;
+					width: calc(100% - 4vmin);
+					border-left: 2px solid green;
+					border-right: 2px solid green;
+					padding: 4px;
+					background-color: black;
+				}
+
+				.progress_bar {
+					width: 0%;
+					height: 100%;
+					background-color: green;
+				}
+
+				@keyframes fade_out {
+					to {
+						opacity: 0;
+					}
+				}
+
+				.fade_out {
+					animation: fade_out 2s both;
 				}
 
 				.container_notice {
@@ -62,12 +94,13 @@
 					width: auto;
 					box-sizing: border-box;
 					padding-top: 1vmin;
-					top: 0%;
-					left:0%;
+					top: calc(50% - 10vmin);
+					left:50%;
+					transform: translate(-50%, -50%);
 					z-index: 1;
 				}
 
-				.menu_a {
+				.menu_button {
 					display: inline-block;
 					font-family: "Fixedsys";
 					font-weight: lighter;
@@ -85,9 +118,10 @@
 					border: 2px solid white;
 					background-color: #0080ff;
 					opacity: 0.5;
+					cursor: pointer;
 				}
 
-				.menu_a:hover {
+				.menu_button:hover {
 					border-left: 3px solid red;
 					border-right: 3px solid red;
 					font-weight: bolder;
@@ -99,7 +133,7 @@
 				50% {opacity: 0;}
 				}
 
-				.menu_ab {
+				.menu_poll {
 					display: inline-block;
 					font-family: "Fixedsys";
 					font-weight: lighter;
@@ -120,13 +154,14 @@
 					animation: pollsmove 5s infinite;
 				}
 
-				.menu_b {
+				.terminal_text {
 					display: inline-block;
 					font-weight: lighter;
 					text-decoration: none;
 					width: 100%;
 					text-align: right;
 					color:green;
+					text-shadow: 1px 1px black;
 					margin-right: 0%;
 					margin-top: 0px;
 					font-size: 2vmin;
@@ -134,7 +169,7 @@
 					letter-spacing: 1px;
 				}
 
-				.menu_c {
+				.menu_notice {
 					display: inline-block;
 					font-family: "Fixedsys";
 					font-weight: lighter;
@@ -142,6 +177,7 @@
 					width: 100%;
 					text-align: left;
 					color: red;
+					text-shadow: 1px 1px black;
 					margin-right: 0%;
 					margin-top: 0px;
 					font-size: 3vmin;

--- a/config/skyrat/title_html.txt
+++ b/config/skyrat/title_html.txt
@@ -22,7 +22,7 @@
 					border-style:none;
 				}
 
-				.fone {
+				.bg {
 					position: absolute;
 					width: auto;
 					height: 100vmin;
@@ -32,20 +32,6 @@
 					left:50%;
 					transform: translate(-50%, -50%);
 					z-index: 0;
-				}
-
-				.container_nav {
-					position: absolute;
-					width: auto;
-					min-width: 100vmin;
-					min-height: 10vmin;
-					padding-left: 0vmin;
-					padding-top: 45vmin;
-					box-sizing: border-box;
-					top: 50%;
-					left:50%;
-					transform: translate(-50%, -50%);
-					z-index: 1;
 				}
 
 				.container_terminal {
@@ -58,6 +44,21 @@
 					top: 0%;
 					left:0%;
 					z-index: 1;
+				}
+
+				.terminal_text {
+					display: inline-block;
+					font-weight: lighter;
+					text-decoration: none;
+					width: 100%;
+					text-align: right;
+					color:green;
+					text-shadow: 1px 1px black;
+					margin-right: 0%;
+					margin-top: 0px;
+					font-size: 2vmin;
+					line-height: 1vmin;
+					letter-spacing: 1px;
 				}
 
 				.container_progress {
@@ -89,84 +90,112 @@
 					animation: fade_out 2s both;
 				}
 
+				.container_nav {
+					position: absolute;
+					box-sizing: border-box;
+					width: 90vmin;
+					min-height: 10vmin;
+					top: calc(50% + 22.5vmin);
+					left:50%;
+					transform: translate(-50%, -50%);
+					z-index: 1;
+					border: 2px solid white;
+					border-radius: 4px;
+					box-shadow: 2px 2px #333, inset 1px 1px #333;
+					background: linear-gradient(to bottom, rgba(68, 68, 204, 0.9), rgba(0, 0, 102, 0.9));
+					opacity: 75%;
+					padding: 1em;
+				}
+
+				.container_nav hr {
+					height: 2px;
+					background-color: #cde;
+					border: none;
+					box-shadow: 2px 2px black;
+				}
+
+				.menu_button {
+					display: block;
+					box-sizing: border-box;
+					font-family: "Fixedsys";
+					font-weight: lighter;
+					text-decoration: none;
+					font-size: 4vmin;
+					text-shadow: 2px 2px black;
+					line-height: 4vmin;
+					width: 100%;
+					text-align: left;
+					color: #cde;
+					height: 4vmin;
+					padding-left: 5vmin;
+					letter-spacing: 1px;
+					cursor: pointer;
+					white-space: nowrap;
+					overflow: hidden;
+				}
+
+				.menu_button:hover {
+					padding-left: 0px;
+					color: yellow;
+				}
+
+				.menu_button:active {
+					padding-left: 0px;
+					transform: translate(2px, 2px);
+				}
+
+				.menu_button:hover::before {
+					content: "☞";
+					text-align: center;
+					width: 5vmin;
+					display: inline-block;
+				}
+
+				@keyframes pulse_button {
+					0% {transform: translateX(0px);}
+					100% {transform: translateX(2px);}
+				}
+
+				.menu_button:active::before {
+					content: "☛";
+					text-align: center;
+					width: 5vmin;
+					animation: pulse_button 0.25s infinite alternate;
+				}
+
+				@keyframes pollsbox {
+					0% {color: #cde;}
+					50% {color: #f80;}
+				}
+
+				.menu_newpoll {
+					animation: pollsbox 2s step-start infinite;
+					padding-left: 0px;
+				}
+
+				.menu_newpoll::before {
+					content: "→";
+					text-align: center;
+					width: 5vmin;
+					display: inline-block;
+				}
+
+				.menu_newpoll::after {
+					content: "←";
+					text-align: center;
+					width: 5vmin;
+					display: inline-block;
+				}
+
 				.container_notice {
 					position: absolute;
-					width: auto;
 					box-sizing: border-box;
+					width: auto;
 					padding-top: 1vmin;
 					top: calc(50% - 10vmin);
 					left:50%;
 					transform: translate(-50%, -50%);
 					z-index: 1;
-				}
-
-				.menu_button {
-					display: inline-block;
-					font-family: "Fixedsys";
-					font-weight: lighter;
-					text-decoration: none;
-					width: 100%;
-					text-align: left;
-					color: #add8e6;
-					margin-right: 100%;
-					margin-top: 5px;
-					padding-left: 6px;
-					font-size: 4vmin;
-					line-height: 4vmin;
-					height: 4vmin;
-					letter-spacing: 1px;
-					border: 2px solid white;
-					background-color: #0080ff;
-					opacity: 0.5;
-					cursor: pointer;
-				}
-
-				.menu_button:hover {
-					border-left: 3px solid red;
-					border-right: 3px solid red;
-					font-weight: bolder;
-					color: red;
-					padding-left: 3px;
-				}
-
-				@keyframes pollsmove {
-				50% {opacity: 0;}
-				}
-
-				.menu_poll {
-					display: inline-block;
-					font-family: "Fixedsys";
-					font-weight: lighter;
-					text-decoration: none;
-					width: 100%;
-					text-align: left;
-					color: #add8e6;
-					margin-right: 100%;
-					margin-top: 5px;
-					padding-left: 6px;
-					font-size: 4vmin;
-					line-height: 4vmin;
-					height: 4vmin;
-					letter-spacing: 1px;
-					border: 2px solid white;
-					background-color: #0080ff;
-					opacity: 0.5;
-					animation: pollsmove 5s infinite;
-				}
-
-				.terminal_text {
-					display: inline-block;
-					font-weight: lighter;
-					text-decoration: none;
-					width: 100%;
-					text-align: right;
-					color:green;
-					text-shadow: 1px 1px black;
-					margin-right: 0%;
-					margin-top: 0px;
-					font-size: 2vmin;
-					line-height: 1vmin;
-					letter-spacing: 1px;
 				}
 
 				.menu_notice {
@@ -177,13 +206,20 @@
 					width: 100%;
 					text-align: left;
 					color: red;
-					text-shadow: 1px 1px black;
+					text-shadow: 1px 0px black, -1px 0px black, 0px 1px black, 0px -1px black, 2px 0px black, -2px 0px black, 0px 2px black, 0px -2px black;
 					margin-right: 0%;
 					margin-top: 0px;
 					font-size: 3vmin;
 					line-height: 2vmin;
 				}
 
+				.unchecked {
+					color: #F44;
+				}
+
+				.checked {
+					color: #4F4;
+				}
 			</style>
 		</head>
 		<body>

--- a/modular_skyrat/modules/title_screen/code/_title_screen_defines.dm
+++ b/modular_skyrat/modules/title_screen/code/_title_screen_defines.dm
@@ -1,13 +1,9 @@
-GLOBAL_VAR(current_title_screen)
-
-GLOBAL_VAR(current_title_screen_notice)
-
-GLOBAL_VAR(title_html)
-
-GLOBAL_LIST_EMPTY(title_screens)
+#define DEFAULT_TITLE_MAP_LOADTIME 150 SECONDS
 
 #define DEFAULT_TITLE_SCREEN_IMAGE 'modular_skyrat/modules/title_screen/icons/skyrat_title_screen.png'
 #define DEFAULT_TITLE_LOADING_SCREEN 'modular_skyrat/modules/title_screen/icons/loading_screen.gif'
+
+#define TITLE_PROGRESS_CACHE_FILE "data/progress_cache.json"
 
 #define DEFAULT_TITLE_HTML {"
 	<html>
@@ -27,13 +23,14 @@ GLOBAL_LIST_EMPTY(title_screens)
 					background-color: black;
 					padding-top: 5vmin;
 					-ms-user-select: none;
+					cursor: default;
 				}
 
 				img {
 					border-style:none;
 				}
 
-				.fone{
+				.fone {
 					position: absolute;
 					width: auto;
 					height: 100vmin;
@@ -61,12 +58,43 @@ GLOBAL_LIST_EMPTY(title_screens)
 
 				.container_terminal {
 					position: absolute;
-					width: auto;
+					width: 100%;
+					height: calc(100% - 7vmin);
+					overflow: clip;
 					box-sizing: border-box;
-					padding-top: 3vmin;
+					padding: 3vmin 2vmin;
 					top: 0%;
 					left:0%;
 					z-index: 1;
+				}
+
+				.container_progress {
+					position: absolute;
+					box-sizing: border-box;
+					bottom: 3vmin;
+					left: 2vmin;
+					height: 4vmin;
+					width: calc(100% - 4vmin);
+					border-left: 2px solid green;
+					border-right: 2px solid green;
+					padding: 4px;
+					background-color: black;
+				}
+
+				.progress_bar {
+					width: 0%;
+					height: 100%;
+					background-color: green;
+				}
+
+				@keyframes fade_out {
+					to {
+						opacity: 0;
+					}
+				}
+
+				.fade_out {
+					animation: fade_out 2s both;
 				}
 
 				.container_notice {
@@ -74,12 +102,13 @@ GLOBAL_LIST_EMPTY(title_screens)
 					width: auto;
 					box-sizing: border-box;
 					padding-top: 1vmin;
-					top: 0%;
-					left:0%;
+					top: calc(50% - 10vmin);
+					left:50%;
+					transform: translate(-50%, -50%);
 					z-index: 1;
 				}
 
-				.menu_a {
+				.menu_button {
 					display: inline-block;
 					font-family: "Fixedsys";
 					font-weight: lighter;
@@ -97,9 +126,10 @@ GLOBAL_LIST_EMPTY(title_screens)
 					border: 2px solid white;
 					background-color: #0080ff;
 					opacity: 0.5;
+					cursor: pointer;
 				}
 
-				.menu_a:hover {
+				.menu_button:hover {
 					border-left: 3px solid red;
 					border-right: 3px solid red;
 					font-weight: bolder;
@@ -111,7 +141,7 @@ GLOBAL_LIST_EMPTY(title_screens)
 				50% {opacity: 0;}
 				}
 
-				.menu_ab {
+				.menu_poll {
 					display: inline-block;
 					font-family: "Fixedsys";
 					font-weight: lighter;
@@ -132,13 +162,14 @@ GLOBAL_LIST_EMPTY(title_screens)
 					animation: pollsmove 5s infinite;
 				}
 
-				.menu_b {
+				.terminal_text {
 					display: inline-block;
 					font-weight: lighter;
 					text-decoration: none;
 					width: 100%;
 					text-align: right;
 					color:green;
+					text-shadow: 1px 1px black;
 					margin-right: 0%;
 					margin-top: 0px;
 					font-size: 2vmin;
@@ -146,7 +177,7 @@ GLOBAL_LIST_EMPTY(title_screens)
 					letter-spacing: 1px;
 				}
 
-				.menu_c {
+				.menu_notice {
 					display: inline-block;
 					font-family: "Fixedsys";
 					font-weight: lighter;
@@ -154,6 +185,7 @@ GLOBAL_LIST_EMPTY(title_screens)
 					width: 100%;
 					text-align: left;
 					color: red;
+					text-shadow: 1px 1px black;
 					margin-right: 0%;
 					margin-top: 0px;
 					font-size: 3vmin;

--- a/modular_skyrat/modules/title_screen/code/_title_screen_defines.dm
+++ b/modular_skyrat/modules/title_screen/code/_title_screen_defines.dm
@@ -30,7 +30,7 @@
 					border-style:none;
 				}
 
-				.fone {
+				.bg {
 					position: absolute;
 					width: auto;
 					height: 100vmin;
@@ -40,20 +40,6 @@
 					left:50%;
 					transform: translate(-50%, -50%);
 					z-index: 0;
-				}
-
-				.container_nav {
-					position: absolute;
-					width: auto;
-					min-width: 100vmin;
-					min-height: 10vmin;
-					padding-left: 0vmin;
-					padding-top: 45vmin;
-					box-sizing: border-box;
-					top: 50%;
-					left:50%;
-					transform: translate(-50%, -50%);
-					z-index: 1;
 				}
 
 				.container_terminal {
@@ -66,6 +52,21 @@
 					top: 0%;
 					left:0%;
 					z-index: 1;
+				}
+
+				.terminal_text {
+					display: inline-block;
+					font-weight: lighter;
+					text-decoration: none;
+					width: 100%;
+					text-align: right;
+					color:green;
+					text-shadow: 1px 1px black;
+					margin-right: 0%;
+					margin-top: 0px;
+					font-size: 2vmin;
+					line-height: 1vmin;
+					letter-spacing: 1px;
 				}
 
 				.container_progress {
@@ -97,84 +98,112 @@
 					animation: fade_out 2s both;
 				}
 
+				.container_nav {
+					position: absolute;
+					box-sizing: border-box;
+					width: 90vmin;
+					min-height: 10vmin;
+					top: calc(50% + 22.5vmin);
+					left:50%;
+					transform: translate(-50%, -50%);
+					z-index: 1;
+					border: 2px solid white;
+					border-radius: 4px;
+					box-shadow: 2px 2px #333, inset 1px 1px #333;
+					background: linear-gradient(to bottom, rgba(68, 68, 204, 0.9), rgba(0, 0, 102, 0.9));
+					opacity: 75%;
+					padding: 1em;
+				}
+
+				.container_nav hr {
+					height: 2px;
+					background-color: #cde;
+					border: none;
+					box-shadow: 2px 2px black;
+				}
+
+				.menu_button {
+					display: block;
+					box-sizing: border-box;
+					font-family: "Fixedsys";
+					font-weight: lighter;
+					text-decoration: none;
+					font-size: 4vmin;
+					text-shadow: 2px 2px black;
+					line-height: 4vmin;
+					width: 100%;
+					text-align: left;
+					color: #cde;
+					height: 4vmin;
+					padding-left: 5vmin;
+					letter-spacing: 1px;
+					cursor: pointer;
+					white-space: nowrap;
+					overflow: hidden;
+				}
+
+				.menu_button:hover {
+					padding-left: 0px;
+					color: yellow;
+				}
+
+				.menu_button:active {
+					padding-left: 0px;
+					transform: translate(2px, 2px);
+				}
+
+				.menu_button:hover::before {
+					content: "☞";
+					text-align: center;
+					width: 5vmin;
+					display: inline-block;
+				}
+
+				@keyframes pulse_button {
+					0% {transform: translateX(0px);}
+					100% {transform: translateX(2px);}
+				}
+
+				.menu_button:active::before {
+					content: "☛";
+					text-align: center;
+					width: 5vmin;
+					animation: pulse_button 0.25s infinite alternate;
+				}
+
+				@keyframes pollsbox {
+					0% {color: #cde;}
+					50% {color: #f80;}
+				}
+
+				.menu_newpoll {
+					animation: pollsbox 2s step-start infinite;
+					padding-left: 0px;
+				}
+
+				.menu_newpoll::before {
+					content: "→";
+					text-align: center;
+					width: 5vmin;
+					display: inline-block;
+				}
+
+				.menu_newpoll::after {
+					content: "←";
+					text-align: center;
+					width: 5vmin;
+					display: inline-block;
+				}
+
 				.container_notice {
 					position: absolute;
-					width: auto;
 					box-sizing: border-box;
+					width: auto;
 					padding-top: 1vmin;
 					top: calc(50% - 10vmin);
 					left:50%;
 					transform: translate(-50%, -50%);
 					z-index: 1;
-				}
-
-				.menu_button {
-					display: inline-block;
-					font-family: "Fixedsys";
-					font-weight: lighter;
-					text-decoration: none;
-					width: 100%;
-					text-align: left;
-					color: #add8e6;
-					margin-right: 100%;
-					margin-top: 5px;
-					padding-left: 6px;
-					font-size: 4vmin;
-					line-height: 4vmin;
-					height: 4vmin;
-					letter-spacing: 1px;
-					border: 2px solid white;
-					background-color: #0080ff;
-					opacity: 0.5;
-					cursor: pointer;
-				}
-
-				.menu_button:hover {
-					border-left: 3px solid red;
-					border-right: 3px solid red;
-					font-weight: bolder;
-					color: red;
-					padding-left: 3px;
-				}
-
-				@keyframes pollsmove {
-				50% {opacity: 0;}
-				}
-
-				.menu_poll {
-					display: inline-block;
-					font-family: "Fixedsys";
-					font-weight: lighter;
-					text-decoration: none;
-					width: 100%;
-					text-align: left;
-					color: #add8e6;
-					margin-right: 100%;
-					margin-top: 5px;
-					padding-left: 6px;
-					font-size: 4vmin;
-					line-height: 4vmin;
-					height: 4vmin;
-					letter-spacing: 1px;
-					border: 2px solid white;
-					background-color: #0080ff;
-					opacity: 0.5;
-					animation: pollsmove 5s infinite;
-				}
-
-				.terminal_text {
-					display: inline-block;
-					font-weight: lighter;
-					text-decoration: none;
-					width: 100%;
-					text-align: right;
-					color:green;
-					text-shadow: 1px 1px black;
-					margin-right: 0%;
-					margin-top: 0px;
-					font-size: 2vmin;
-					line-height: 1vmin;
-					letter-spacing: 1px;
 				}
 
 				.menu_notice {
@@ -185,13 +214,20 @@
 					width: 100%;
 					text-align: left;
 					color: red;
-					text-shadow: 1px 1px black;
+					text-shadow: 1px 0px black, -1px 0px black, 0px 1px black, 0px -1px black, 2px 0px black, -2px 0px black, 0px 2px black, 0px -2px black;
 					margin-right: 0%;
 					margin-top: 0px;
 					font-size: 3vmin;
 					line-height: 2vmin;
 				}
 
+				.unchecked {
+					color: #F44;
+				}
+
+				.checked {
+					color: #4F4;
+				}
 			</style>
 		</head>
 		<body>

--- a/modular_skyrat/modules/title_screen/code/new_player.dm
+++ b/modular_skyrat/modules/title_screen/code/new_player.dm
@@ -136,7 +136,7 @@
 /mob/dead/new_player/proc/update_title_screen()
 	var/dat = get_title_html()
 
-	src << browse(GLOB.current_title_screen, "file=loading_screen.gif;display=0")
+	src << browse(SStitle.current_title_screen, "file=loading_screen.gif;display=0")
 	src << browse(dat, "window=title_browser")
 
 /datum/asset/simple/lobby
@@ -250,9 +250,9 @@
 		qdel(query_get_new_polls)
 		return
 	if(query_get_new_polls.NextRow())
-		output +={"<a class="menu_ab" href='?src=\ref[src];viewpoll=1'>POLLS (NEW)</a>"}
+		output +={"<a class="menu_poll" href='?src=\ref[src];viewpoll=1'>POLLS (NEW)</a>"}
 	else
-		output +={"<a class="menu_a" href='?src=\ref[src];viewpoll=1'>POLLS</a>"}
+		output +={"<a class="menu_button" href='?src=\ref[src];viewpoll=1'>POLLS</a>"}
 	qdel(query_get_new_polls)
 	if(QDELETED(src))
 		return

--- a/modular_skyrat/modules/title_screen/code/new_player.dm
+++ b/modular_skyrat/modules/title_screen/code/new_player.dm
@@ -27,7 +27,7 @@
 		play_lobby_button_sound()
 		var/datum/preferences/preferences = client.prefs
 		preferences.write_preference(GLOB.preference_entries[/datum/preference/toggle/be_antag], !preferences.read_preference(/datum/preference/toggle/be_antag))
-		client << output(!preferences.read_preference(/datum/preference/toggle/be_antag), "title_browser:toggle_antag")
+		client << output(preferences.read_preference(/datum/preference/toggle/be_antag), "title_browser:toggle_antag")
 		return
 
 	if(href_list["character_setup"])
@@ -250,7 +250,7 @@
 		qdel(query_get_new_polls)
 		return
 	if(query_get_new_polls.NextRow())
-		output +={"<a class="menu_poll" href='?src=\ref[src];viewpoll=1'>POLLS (NEW)</a>"}
+		output +={"<a class="menu_button menu_newpoll" href='?src=\ref[src];viewpoll=1'>POLLS (NEW)</a>"}
 	else
 		output +={"<a class="menu_button" href='?src=\ref[src];viewpoll=1'>POLLS</a>"}
 	qdel(query_get_new_polls)

--- a/modular_skyrat/modules/title_screen/code/title_screen_controls.dm
+++ b/modular_skyrat/modules/title_screen/code/title_screen_controls.dm
@@ -17,9 +17,9 @@
 			var/file = input(usr) as icon|null
 			if(!file)
 				return
-			change_title_screen(file)
+			SStitle.change_title_screen(file)
 		if("Reset")
-			change_title_screen()
+			SStitle.change_title_screen()
 		if("Cancel")
 			return
 
@@ -36,50 +36,13 @@
 	log_admin("[key_name(usr)] is setting the title screen notice.")
 	message_admins("[key_name_admin(usr)] is setting the title screen notice.")
 
-	var/new_notice = input(usr, "Please input a notice to be displayed on the title screen:", "Titlescreen Notice")
+	var/new_notice = input(usr, "Please input a notice to be displayed on the title screen:", "Titlescreen Notice") as text|null
+	SStitle.set_notice(new_notice)
 	if(!new_notice)
-		set_title_screen_notice()
 		return
-	set_title_screen_notice(new_notice)
 	for(var/mob/dead/new_player/new_player in GLOB.new_player_list)
 		to_chat(new_player, span_boldannounce("TITLE NOTICE UPDATED: [new_notice]"))
 		SEND_SOUND(new_player,  sound('modular_skyrat/modules/admin/sound/duckhonk.ogg'))
-
-/**
- * Adds a startup message to the splashscreen.
- */
-/proc/add_startup_message(msg)
-	var/msg_dat = {"<p class="menu_b">[msg]</p>"}
-
-	GLOB.startup_messages.Insert(1, msg_dat)
-
-	for(var/mob/dead/new_player/iterating_new_player in GLOB.new_player_list)
-		INVOKE_ASYNC(iterating_new_player, /mob/dead/new_player.proc/update_title_screen)
-
-/**
- * Changes the title screen to a new image.
- */
-
-/proc/change_title_screen(new_screen)
-	if(new_screen)
-		GLOB.current_title_screen = new_screen
-	else
-		if(LAZYLEN(GLOB.title_screens))
-			GLOB.current_title_screen = pick(GLOB.title_screens)
-		else
-			GLOB.current_title_screen = DEFAULT_TITLE_SCREEN_IMAGE
-
-	for(var/mob/dead/new_player/new_player in GLOB.new_player_list)
-		INVOKE_ASYNC(new_player, /mob/dead/new_player.proc/show_title_screen)
-
-/**
- * Adds a notice to the main title screen in the form of big red text!
- */
-/proc/set_title_screen_notice(new_title)
-	GLOB.current_title_screen_notice = new_title ? sanitize_text(new_title) : null
-
-	for(var/mob/dead/new_player/new_player in GLOB.new_player_list)
-		INVOKE_ASYNC(new_player, /mob/dead/new_player.proc/show_title_screen)
 
 /**
  * Reloads the titlescreen if it is bugged for someone.
@@ -113,9 +76,7 @@
 	if(!new_html)
 		return
 
-	GLOB.title_html = new_html
-
-	for(var/mob/dead/new_player/new_player in GLOB.new_player_list)
-		INVOKE_ASYNC(new_player, /mob/dead/new_player.proc/show_title_screen)
+	SStitle.title_html = new_html
+	SStitle.show_title_screen()
 
 	message_admins("[key_name_admin(usr)] has changed the title screen HTML.")

--- a/modular_skyrat/modules/title_screen/code/title_screen_html.dm
+++ b/modular_skyrat/modules/title_screen/code/title_screen_html.dm
@@ -7,7 +7,7 @@ GLOBAL_LIST_EMPTY(startup_messages)
 /mob/dead/new_player/proc/get_title_html()
 	var/dat = SStitle.title_html
 	if(SSticker.current_state == GAME_STATE_STARTUP)
-		dat += {"<img src="loading_screen.gif" class="fone" alt="">"}
+		dat += {"<img src="loading_screen.gif" class="bg" alt="">"}
 		dat += {"<div class="container_terminal" id="terminal"></div>"}
 		dat += {"<div class="container_progress" id="progress_container"><div class="progress_bar" id="progress"></div></div>"}
 
@@ -73,11 +73,13 @@ GLOBAL_LIST_EMPTY(startup_messages)
 				progress_current_time = parseFloat(current_time);
 				progress_completion_time = parseFloat(total_time);
 			}
+
+			function update_current_character() {}
 		</script>
 		"}
 
 	else
-		dat += {"<img src="loading_screen.gif" class="fone" alt="">"}
+		dat += {"<img src="loading_screen.gif" class="bg" alt="">"}
 
 		if(SStitle.current_notice)
 			dat += {"
@@ -86,30 +88,24 @@ GLOBAL_LIST_EMPTY(startup_messages)
 			</div>
 		"}
 
-		dat += {"
-		<div class="container_nav">
-			<a class="menu_button" href='?src=\ref[src];character_setup=1'>SETUP ([uppertext(client.prefs.read_preference(/datum/preference/name/real_name))])</a>
-		"}
-
-		dat += {"<a class="menu_button" href='?src=\ref[src];game_options=1'>GAME OPTIONS</a>
-		"}
+		dat += {"<div class="container_nav">"}
 
 		if(!SSticker || SSticker.current_state <= GAME_STATE_PREGAME)
-			dat += {"<a id="ready" class="menu_button" href='?src=\ref[src];toggle_ready=1'>[ready == PLAYER_READY_TO_PLAY ? "READY ☑" : "READY ☒"]</a>
-		"}
+			dat += {"<a id="ready" class="menu_button" href='?src=\ref[src];toggle_ready=1'>[ready == PLAYER_READY_TO_PLAY ? "<span class='checked'>☑</span> READY" : "<span class='unchecked'>☒</span> READY"]</a>"}
 		else
-			dat += {"<a class="menu_button" href='?src=\ref[src];late_join=1'>JOIN</a>
-		"}
-			dat += {"<a class="menu_button" href='?src=\ref[src];view_manifest=1'>CREW</a>
-		"}
+			dat += {"
+				<a class="menu_button" href='?src=\ref[src];late_join=1'>JOIN GAME</a>
+				<a class="menu_button" href='?src=\ref[src];view_manifest=1'>CREW MANIFEST</a>
+			"}
 
-		dat += {"<a id="be_antag" class="menu_button" href='?src=\ref[src];toggle_antag=1'>[client.prefs.read_preference(/datum/preference/toggle/be_antag) ? "BE ANTAG ☑" : "BE ANTAG ☒"]</a>
-		"}
-
-		dat += {"<a class="menu_button" href='?src=\ref[src];observe=1'>OBSERVE</a>
-		"}
+		dat += {"<a class="menu_button" href='?src=\ref[src];observe=1'>OBSERVE</a>"}
 
 		dat += {"
+			<hr>
+			<a class="menu_button" href='?src=\ref[src];character_setup=1'>SETUP CHARACTER (<span id="character_slot">[uppertext(client.prefs.read_preference(/datum/preference/name/real_name))]</span>)</a>
+			<a class="menu_button" href='?src=\ref[src];game_options=1'>GAME OPTIONS</a>
+			<a id="be_antag" class="menu_button" href='?src=\ref[src];toggle_antag=1'>[client.prefs.read_preference(/datum/preference/toggle/be_antag) ? "<span class='checked'>☑</span> BE ANTAGONIST" : "<span class='unchecked'>☒</span> BE ANTAGONIST"]</a>
+			<hr>
 			<a class="menu_button" href='?src=\ref[src];server_swap=1'>SWAP SERVERS</a>
 		"}
 
@@ -121,33 +117,38 @@ GLOBAL_LIST_EMPTY(startup_messages)
 		<script language="JavaScript">
 			var ready_int = 0;
 			var ready_mark = document.getElementById("ready");
-			var ready_marks = \[ 'READY ☒', 'READY ☑' \];
+			var ready_marks = \[ "<span class='unchecked'>☒</span> READY", "<span class='checked'>☑</span> READY" \];
 			function toggle_ready(setReady) {
 				if(setReady) {
 					ready_int = setReady;
-					ready_mark.textContent = ready_marks\[ready_int\];
+					ready_mark.innerHTML = ready_marks\[ready_int\];
 				}
 				else {
 					ready_int++;
 					if (ready_int === ready_marks.length)
 						ready_int = 0;
-					ready_mark.textContent = ready_marks\[ready_int\];
+					ready_mark.innerHTML = ready_marks\[ready_int\];
 				}
 			}
 			var antag_int = 0;
 			var antag_mark = document.getElementById("be_antag");
-			var antag_marks = \[ 'BE ANTAG ☑', 'BE ANTAG ☒' \];
+			var antag_marks = \[ "<span class='unchecked'>☒</span> BE ANTAGONIST", "<span class='checked'>☑</span> BE ANTAGONIST" \];
 			function toggle_antag(setAntag) {
 				if(setAntag) {
 					antag_int = setAntag;
-					antag_mark.textContent = antag_marks\[antag_int\];
+					antag_mark.innerHTML = antag_marks\[antag_int\];
 				}
 				else {
 					antag_int++;
 					if (antag_int === antag_marks.length)
 						antag_int = 0;
-					antag_mark.textContent = antag_marks\[antag_int\];
+					antag_mark.innerHTML = antag_marks\[antag_int\];
 				}
+			}
+
+			var character_name_slot = document.getElementById("character_slot");
+			function update_current_character(name) {
+				character_name_slot.textContent = name.toUpperCase();
 			}
 
 			function append_terminal_text() {}

--- a/modular_skyrat/modules/title_screen/code/title_screen_html.dm
+++ b/modular_skyrat/modules/title_screen/code/title_screen_html.dm
@@ -5,56 +5,112 @@ GLOBAL_LIST_EMPTY(startup_messages)
 #define MAX_STARTUP_MESSAGES 27
 
 /mob/dead/new_player/proc/get_title_html()
-	var/dat = GLOB.title_html
+	var/dat = SStitle.title_html
 	if(SSticker.current_state == GAME_STATE_STARTUP)
 		dat += {"<img src="loading_screen.gif" class="fone" alt="">"}
+		dat += {"<div class="container_terminal" id="terminal"></div>"}
+		dat += {"<div class="container_progress" id="progress_container"><div class="progress_bar" id="progress"></div></div>"}
+
 		dat += {"
-		<div class="container_terminal">
-			<p class="menu_b">SYSTEMS INITIALIZING:</p>
+		<script language="JavaScript">
+			var terminal = document.getElementById("terminal");
+			var terminal_lines = \[
+				"<p class='terminal_text'>SYSTEMS INITIALIZING:</p>",
 		"}
-		var/loop_index = 0
-		for(var/i in GLOB.startup_messages)
-			if(loop_index >= MAX_STARTUP_MESSAGES)
-				break
-			dat += i
-			loop_index++
-		dat += "</div>"
+
+		for(var/message in GLOB.startup_messages)
+			dat += {""[replacetext(message, "\"", "\\\"")]","}
+
+		dat += {"
+			\];
+
+			function append_terminal_text(text) {
+				if(text) {
+					terminal_lines.push(text);
+				}
+				while(terminal_lines.length > [MAX_STARTUP_MESSAGES]) {
+					terminal_lines.shift();
+				}
+
+				terminal.innerHTML = terminal_lines.join("");
+			}
+
+			append_terminal_text();
+
+			var progress_bar = document.getElementById("progress");
+			var progress_container = document.getElementById("progress_container");
+			// Times are all in 10ths of a second, like byond.
+			var progress_current_time = [world.timeofday - SStitle.progress_reference_time];
+			var progress_current_position = 0;
+			var progress_completion_time = [SStitle.average_completion_time];
+			var previous_tick = new Date().getTime();
+
+			setInterval(function() {
+				// Compensate for shakey execution.
+				if(progress_current_time < progress_completion_time) {
+					var current_tick = new Date().getTime();
+					progress_current_time += (current_tick - previous_tick) / 100;
+					previous_tick = current_tick;
+				}
+
+				var new_position = Math.min(progress_current_time / progress_completion_time * 100, 100);
+
+				// Only go forward
+				if(new_position < progress_current_position) {
+					return;
+				}
+				progress_current_position = new_position;
+
+				progress_bar.style.width = "" + progress_current_position + "%";
+
+				if(progress_current_position === 100) {
+					// fade out
+					progress_container.classList.add("fade_out");
+				}
+			}, 50);
+
+			function update_loading_progress(current_time, total_time) {
+				progress_current_time = parseFloat(current_time);
+				progress_completion_time = parseFloat(total_time);
+			}
+		</script>
+		"}
 
 	else
 		dat += {"<img src="loading_screen.gif" class="fone" alt="">"}
 
-		if(GLOB.current_title_screen_notice)
+		if(SStitle.current_notice)
 			dat += {"
 			<div class="container_notice">
-				<p class="menu_c">[GLOB.current_title_screen_notice]</p>
+				<p class="menu_notice">[SStitle.current_notice]</p>
 			</div>
 		"}
 
 		dat += {"
 		<div class="container_nav">
-			<a class="menu_a" href='?src=\ref[src];character_setup=1'>SETUP ([uppertext(client.prefs.read_preference(/datum/preference/name/real_name))])</a>
+			<a class="menu_button" href='?src=\ref[src];character_setup=1'>SETUP ([uppertext(client.prefs.read_preference(/datum/preference/name/real_name))])</a>
 		"}
 
-		dat += {"<a class="menu_a" href='?src=\ref[src];game_options=1'>GAME OPTIONS</a>
+		dat += {"<a class="menu_button" href='?src=\ref[src];game_options=1'>GAME OPTIONS</a>
 		"}
 
 		if(!SSticker || SSticker.current_state <= GAME_STATE_PREGAME)
-			dat += {"<a id="ready" class="menu_a" href='?src=\ref[src];toggle_ready=1'>[ready == PLAYER_READY_TO_PLAY ? "READY ☑" : "READY ☒"]</a>
+			dat += {"<a id="ready" class="menu_button" href='?src=\ref[src];toggle_ready=1'>[ready == PLAYER_READY_TO_PLAY ? "READY ☑" : "READY ☒"]</a>
 		"}
 		else
-			dat += {"<a class="menu_a" href='?src=\ref[src];late_join=1'>JOIN</a>
+			dat += {"<a class="menu_button" href='?src=\ref[src];late_join=1'>JOIN</a>
 		"}
-			dat += {"<a class="menu_a" href='?src=\ref[src];view_manifest=1'>CREW</a>
-		"}
-
-		dat += {"<a id="be_antag" class="menu_a" href='?src=\ref[src];toggle_antag=1'>[client.prefs.read_preference(/datum/preference/toggle/be_antag) ? "BE ANTAG ☑" : "BE ANTAG ☒"]</a>
+			dat += {"<a class="menu_button" href='?src=\ref[src];view_manifest=1'>CREW</a>
 		"}
 
-		dat += {"<a class="menu_a" href='?src=\ref[src];observe=1'>OBSERVE</a>
+		dat += {"<a id="be_antag" class="menu_button" href='?src=\ref[src];toggle_antag=1'>[client.prefs.read_preference(/datum/preference/toggle/be_antag) ? "BE ANTAG ☑" : "BE ANTAG ☒"]</a>
+		"}
+
+		dat += {"<a class="menu_button" href='?src=\ref[src];observe=1'>OBSERVE</a>
 		"}
 
 		dat += {"
-			<a class="menu_a" href='?src=\ref[src];server_swap=1'>SWAP SERVERS</a>
+			<a class="menu_button" href='?src=\ref[src];server_swap=1'>SWAP SERVERS</a>
 		"}
 
 		if(!is_guest_key(src.key))
@@ -63,9 +119,9 @@ GLOBAL_LIST_EMPTY(startup_messages)
 		dat += "</div>"
 		dat += {"
 		<script language="JavaScript">
-			var ready_int=0;
-			var ready_mark=document.getElementById("ready");
-			var ready_marks=new Array('READY ☒', 'READY ☑');
+			var ready_int = 0;
+			var ready_mark = document.getElementById("ready");
+			var ready_marks = \[ 'READY ☒', 'READY ☑' \];
 			function toggle_ready(setReady) {
 				if(setReady) {
 					ready_int = setReady;
@@ -73,14 +129,14 @@ GLOBAL_LIST_EMPTY(startup_messages)
 				}
 				else {
 					ready_int++;
-					if (ready_int == ready_marks.length)
+					if (ready_int === ready_marks.length)
 						ready_int = 0;
 					ready_mark.textContent = ready_marks\[ready_int\];
 				}
 			}
-			var antag_int=0;
-			var antag_mark=document.getElementById("be_antag");
-			var antag_marks=new Array('BE ANTAG ☑', 'BE ANTAG ☒');
+			var antag_int = 0;
+			var antag_mark = document.getElementById("be_antag");
+			var antag_marks = \[ 'BE ANTAG ☑', 'BE ANTAG ☒' \];
 			function toggle_antag(setAntag) {
 				if(setAntag) {
 					antag_int = setAntag;
@@ -88,11 +144,14 @@ GLOBAL_LIST_EMPTY(startup_messages)
 				}
 				else {
 					antag_int++;
-					if (antag_int == antag_marks.length)
+					if (antag_int === antag_marks.length)
 						antag_int = 0;
 					antag_mark.textContent = antag_marks\[antag_int\];
 				}
 			}
+
+			function append_terminal_text() {}
+			function update_loading_progress() {}
 		</script>
 		"}
 	dat += "</body></html>"

--- a/modular_skyrat/modules/title_screen/code/title_screen_pref_middleware.dm
+++ b/modular_skyrat/modules/title_screen/code/title_screen_pref_middleware.dm
@@ -1,0 +1,15 @@
+// This is purely so that we can cleanly update the name in the "Setup Character" menu entry.
+/datum/preference_middleware/titlescreen
+
+/datum/preference_middleware/titlescreen/on_new_character(mob/user)
+	// User changed the slot.
+	if(!istype(user, /mob/dead/new_player))
+		return
+	SStitle.update_character_name(user, preferences.read_preference(/datum/preference/name/real_name))
+
+/datum/preference_middleware/titlescreen/post_set_preference(mob/user, preference, value)
+	// User changed the current slot's name.
+	if(!istype(user, /mob/dead/new_player) || preference != "real_name")
+		return FALSE
+	SStitle.update_character_name(user, value)
+	return FALSE

--- a/modular_skyrat/modules/title_screen/code/title_screen_subsystem.dm
+++ b/modular_skyrat/modules/title_screen/code/title_screen_subsystem.dm
@@ -162,6 +162,15 @@ SUBSYSTEM_DEF(title)
 	show_title_screen()
 
 /**
+ * Update a user's character setup name.
+ * Arguments:
+ * * user - The user being updated
+ * * name - the real name of the current slot.
+ */
+/datum/controller/subsystem/title/proc/update_character_name(mob/user, name)
+	user.client << output(name, "title_browser:update_current_character")
+
+/**
  * Adds a startup message to the splashscreen.
  */
 /proc/add_startup_message(msg)

--- a/modular_skyrat/modules/title_screen/code/title_screen_subsystem.dm
+++ b/modular_skyrat/modules/title_screen/code/title_screen_subsystem.dm
@@ -6,6 +6,24 @@ SUBSYSTEM_DEF(title)
 	var/file_path
 	var/icon/startup_splash
 
+	/// The current title screen being displayed, as a file path text.
+	var/current_title_screen
+	/// The current notice text, or null.
+	var/current_notice
+	/// The preamble html that includes all styling and layout.
+	var/title_html
+	/// The list of possible title screens to rotate through, as file path texts.
+	var/title_screens = list()
+
+	/// average realtime seconds it takes to load the map we're currently running
+	var/average_completion_time = DEFAULT_TITLE_MAP_LOADTIME
+	/// a given startup message => average timestamp in realtime seconds
+	var/list/startup_message_timings = list()
+	/// Raw data to update later
+	var/list/progress_json = list()
+	/// The reference realtime that we're treating as 0 for this run
+	var/progress_reference_time = 0
+
 /datum/controller/subsystem/title/Initialize()
 	var/dat
 	if(!fexists("[global.config.directory]/skyrat/title_html.txt"))
@@ -14,35 +32,157 @@ SUBSYSTEM_DEF(title)
 	else
 		dat = file2text("[global.config.directory]/skyrat/title_html.txt")
 
-	GLOB.title_html = dat
+	title_html = dat
 
 	var/list/provisional_title_screens = flist("[global.config.directory]/title_screens/images/")
-	var/list/title_screens = list()
+	var/list/local_title_screens = list()
 
 	for(var/screen in provisional_title_screens)
 		var/list/formatted_list = splittext(screen, "+")
 		if((LAZYLEN(formatted_list) == 1 && (formatted_list[1] != "exclude" && formatted_list[1] != "blank.png" && formatted_list[1] != "startup_splash")))
-			title_screens += screen
+			local_title_screens += screen
 
 		if(LAZYLEN(formatted_list) > 1 && lowertext(formatted_list[1]) == "startup_splash")
 			var/file_path = "[global.config.directory]/title_screens/images/[screen]"
 			ASSERT(fexists(file_path))
 			startup_splash = new(fcopy_rsc(file_path))
 
+	// Progress stuff
+	check_progress_reference_time()
+	load_progress_json()
+
 	if(startup_splash)
 		change_title_screen(startup_splash)
 	else
 		change_title_screen(DEFAULT_TITLE_LOADING_SCREEN)
 
-	if(length(title_screens))
-		for(var/i in title_screens)
+	if(length(local_title_screens))
+		for(var/i in local_title_screens)
 			var/file_path = "[global.config.directory]/title_screens/images/[i]"
 			ASSERT(fexists(file_path))
 			var/icon/title2use = new(fcopy_rsc(file_path))
-			GLOB.title_screens += title2use
+			title_screens += title2use
 
 	return ..()
+
+/**
+ * Make sure reference time is set up. If not, this is now time 0.
+ */
+/datum/controller/subsystem/title/proc/check_progress_reference_time()
+	if(!progress_reference_time)
+		progress_reference_time = world.timeofday
+
+/**
+ * Handle and clean up leaving startup
+ */
+/datum/controller/subsystem/title/proc/check_finish_progress()
+	//It's the first time we're firing out of startup -> pregame
+	if(progress_json && SSticker.current_state == GAME_STATE_PREGAME)
+		save_progress_json()
+
+/**
+ * Load the progress info json and setup that part of the SS.
+*/
+/datum/controller/subsystem/title/proc/load_progress_json()
+	var/json_file = file(TITLE_PROGRESS_CACHE_FILE)
+	if(!fexists(json_file))
+		return
+
+	// Load map progress cache info
+	progress_json = json_decode(file2text(json_file))
+	var/list/map_info = progress_json[SSmapping.config.map_name]
+	if(!islist(map_info))
+		// If there's none, use the defaults.
+		return
+
+	// Get expected total time and subpart time
+	average_completion_time = map_info["total"] || DEFAULT_TITLE_MAP_LOADTIME
+	startup_message_timings = map_info["messages"] || list()
+
+/datum/controller/subsystem/title/proc/save_progress_json()
+	var/json_file = file(TITLE_PROGRESS_CACHE_FILE)
+	var/list/map_info = list()
+
+	if(progress_json[SSmapping.config.map_name])
+		// Save total time and updated message timings. Latest time is worth 1/4 the "average"
+		map_info["total"] = 0.75 * average_completion_time + 0.25 * (world.timeofday - progress_reference_time)
+	else
+		// New. Just save the time it took.
+		map_info["total"] = world.timeofday - progress_reference_time
+	map_info["messages"] = startup_message_timings
+	progress_json[SSmapping.config.map_name] = map_info
+
+	fdel(json_file)
+	WRITE_FILE(json_file, json_encode(progress_json))
+
+	// We're done, don't touch it again this round.
+	progress_json = null
 
 /datum/controller/subsystem/title/Recover()
 	startup_splash = SStitle.startup_splash
 	file_path = SStitle.file_path
+
+	current_title_screen = SStitle.current_title_screen
+	current_notice = SStitle.current_notice
+	title_html = SStitle.title_html
+	title_screens = SStitle.title_screens
+
+	average_completion_time = SStitle.average_completion_time
+	startup_message_timings = SStitle.startup_message_timings
+	progress_json = SStitle.progress_json
+	progress_reference_time = SStitle.progress_reference_time
+
+/**
+ * Show the title screen to all new players.
+ */
+/datum/controller/subsystem/title/proc/show_title_screen()
+	for(var/mob/dead/new_player/new_player in GLOB.new_player_list)
+		INVOKE_ASYNC(new_player, /mob/dead/new_player.proc/show_title_screen)
+
+/**
+ * Adds a notice to the main title screen in the form of big red text!
+ */
+/datum/controller/subsystem/title/proc/set_notice(new_title)
+	current_notice = new_title ? sanitize_text(new_title) : null
+	show_title_screen()
+
+/**
+ * Changes the title screen to a new image.
+ */
+/datum/controller/subsystem/title/proc/change_title_screen(new_screen)
+	if(new_screen)
+		current_title_screen = new_screen
+	else
+		if(LAZYLEN(title_screens))
+			current_title_screen = pick(title_screens)
+		else
+			current_title_screen = DEFAULT_TITLE_SCREEN_IMAGE
+
+	check_finish_progress()
+	show_title_screen()
+
+/**
+ * Adds a startup message to the splashscreen.
+ */
+/proc/add_startup_message(msg)
+	var/msg_dat = {"<p class="terminal_text">[msg]</p>"}
+
+	GLOB.startup_messages.Insert(1, msg_dat)
+
+	// If we ran before SStitle initialized, set the ref time now.
+	SStitle.check_progress_reference_time()
+
+	// Add or update message history info.
+	var/old_timing = SStitle.startup_message_timings[msg]
+	var/new_timing
+	if(!old_timing)
+		// new message
+		new_timing = world.timeofday - SStitle.progress_reference_time
+	else
+		// old message. Latest time is worth 1/4 the "average"
+		new_timing = 0.75 * old_timing + 0.25 * (world.timeofday - SStitle.progress_reference_time)
+	SStitle.startup_message_timings[msg] = new_timing
+
+	for(var/mob/dead/new_player/new_player in GLOB.new_player_list)
+		new_player.client << output(msg_dat, "title_browser:append_terminal_text")
+		new_player.client << output(list2params(list(new_timing, SStitle.average_completion_time)), "title_browser:update_loading_progress")

--- a/modular_skyrat/modules/title_screen/readme.md
+++ b/modular_skyrat/modules/title_screen/readme.md
@@ -20,12 +20,15 @@ DO NOT UNDER ANY CIRCUMSTANCES RENAME THE ELEMENTS WITHIN THE HTML FILE, KEEP TH
 Elements:
 .container_nav - This is the main menu container box, it defines where the menu is, and what it looks like.
 .container_terminal - This is the startup terminal html, generally, don't change this unless you want a cooler startup terminal.
+.container_progress - This is the container for the progress bar. Changing this likely involves changing the .container_terminal.
+.progress_bar - The moving part of the progress bar. Must start at 0% width; the body script updates the width live.
+.fade_out - Generic class that fades content out. Currently applied to .container_progress when the progress bar overruns 100%.
 .container_notice - This is the admin notice container for when an admin sets the title notice. This button is under fun in the admin tab.
-.menu_a - The "buttons" for the main menu(join, observe, etc).
-.menu_a:hover - The animation for hovering over buttons.
-.menu_ab - This is the new polls text, so players attention is brought to it, flashes in and out with @ pollsmove animation.
-.menu_b - Terminal text
-.menu_c - Admin notice text.
+.menu_button - The "buttons" for the main menu(join, observe, etc).
+.menu_button:hover - The animation for hovering over buttons.
+.menu_poll - This is the new polls text, so players attention is brought to it, flashes in and out with @ pollsmove animation.
+.terminal_text - Terminal text
+.menu_notice - Admin notice text.
 
 REMEMBER, DO NOT EDIT THESE ELEMENT NAMES ELSE THE LOBBYSCREEN WILL BREAK.
 

--- a/modular_skyrat/modules/title_screen/readme.md
+++ b/modular_skyrat/modules/title_screen/readme.md
@@ -18,18 +18,20 @@ We offer the option to customise the lobby HTML by giving you access to a file n
 DO NOT UNDER ANY CIRCUMSTANCES RENAME THE ELEMENTS WITHIN THE HTML FILE, KEEP THEM AS THEY ARE.
 
 Elements:
-.container_nav - This is the main menu container box, it defines where the menu is, and what it looks like.
+.bg - the background image
 .container_terminal - This is the startup terminal html, generally, don't change this unless you want a cooler startup terminal.
+.terminal_text - Terminal text
 .container_progress - This is the container for the progress bar. Changing this likely involves changing the .container_terminal.
 .progress_bar - The moving part of the progress bar. Must start at 0% width; the body script updates the width live.
 .fade_out - Generic class that fades content out. Currently applied to .container_progress when the progress bar overruns 100%.
-.container_notice - This is the admin notice container for when an admin sets the title notice. This button is under fun in the admin tab.
+.container_nav - This is the main menu container box, it defines where the menu is, and what it looks like.
 .menu_button - The "buttons" for the main menu(join, observe, etc).
 .menu_button:hover - The animation for hovering over buttons.
-.menu_poll - This is the new polls text, so players attention is brought to it, flashes in and out with @ pollsmove animation.
-.terminal_text - Terminal text
+.menu_newpoll - This is the new polls text, so players attention is brought to it, flashes in and out with @ pollsmove animation.
+.container_notice - This is the admin notice container for when an admin sets the title notice. This button is under fun in the admin tab.
 .menu_notice - Admin notice text.
-
+.unchecked - Unchecked ☒ box.
+.checked - Checked ☑ box.
 REMEMBER, DO NOT EDIT THESE ELEMENT NAMES ELSE THE LOBBYSCREEN WILL BREAK.
 
 ## Credits:

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5829,6 +5829,7 @@
 #include "modular_skyrat\modules\title_screen\code\new_player.dm"
 #include "modular_skyrat\modules\title_screen\code\title_screen_controls.dm"
 #include "modular_skyrat\modules\title_screen\code\title_screen_html.dm"
+#include "modular_skyrat\modules\title_screen\code\title_screen_pref_middleware.dm"
 #include "modular_skyrat\modules\title_screen\code\title_screen_subsystem.dm"
 #include "modular_skyrat\modules\tribal_extended\code\bow.dm"
 #include "modular_skyrat\modules\tribal_extended\code\crafting.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Most of the changes involve putting procs and vars into SStitle which already was added by the PR instead of a loose collection of globals.
- Note I also renamed the title_html.txt classes to be descriptive instead of the cryptic `menu_a`, `menu_b` etc.
- Changed the title screen notice to appear in the upper center instead of the hard corner.
- Also, the startup messages are added to the bottom of the loading terminal and advance upward consistently.

### A centered notice:
![image](https://user-images.githubusercontent.com/1185434/171060203-b4b65668-3a21-43e9-9fb1-efd8da1bbcee.png)

However, also I added an accurate progress bar to the loading screen.
- The progress bar is fundamentally a fancy egg timer that """""learns""""" how to be better.
- The first time a map is ever loaded:
  - The system just guesses that it'll take 150 seconds as it has nothing else to go on.
  - However, it collects telemetry, including total load time and the timestamp for each startup message and saves it for later.
- On following loads of that map:
  - It uses the average total load time as a baseline for advancing the progress bar.
  - If a startup message happens unexpectedly early, it jumps the progress bar forward to where it should be.
  - If a startup message happens unexpectedly late, it pauses the progress bar to give time for the game to catch up.
  - In the example video, you'll see that these adjustment hitches are very minor, although I'm sure a live server will hitch more due to network traffic, etc.
  - It updates the telemetry for the map, with an exponential falloff biasing towards newer map runs, but only slightly, in case this round's timings are a fluke.

### Example video (move your mouse away to see the actual progress bar):
https://user-images.githubusercontent.com/1185434/170809605-50841189-06f3-463e-870a-cc27da758a2e.mp4

Update: Also made the main menu look better, and the "setup character" menu item update with the current character name.

![image](https://user-images.githubusercontent.com/1185434/171060148-77896db8-5f7a-4953-9387-6a4c43756355.png)

### Main menu preview video
https://imgur.com/a/X5wgBu7

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Progress bars are nice. Accurate progress bars are nicer. (Yes it's possible for repeating tasks.)

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Added a progress bar to the loading screen and made the main menu much nicer.
config: The classes used by config\skyrat\title_html.txt have changed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
