### PR TITLE
You can no longer join families that are too large compared to others

### DIFF
--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -380,6 +380,15 @@
 		return
 	var/datum/antagonist/gang/is_gangster = user.mind.has_antag_datum(/datum/antagonist/gang)
 	var/real_name_backup = user.real_name
+	//SKYRAT EDIT START
+	var/smallest_family_size
+	for(var/datum/team/gang/other_gang as anything in handler.gangs)
+		if(!smallest_family_size || (smallest_family_size > length(other_gang.members)))
+			smallest_family_size = length(other_gang.members)
+	if(length(team_to_use.members) > (smallest_family_size + 2))
+		to_chat(user, span_warning("Seems that another family is too smal for this one to induct more!"))
+		return
+	//SKYRAT EDIT END
 	if(is_gangster)
 		if(is_gangster.my_gang == team_to_use)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If a family's behind more than 2 people, then others cannot recruit more.

## How This Contributes To The Skyrat Roleplay Experience
A cautiously experimental attempt to stop snowballing cases where family population is something like 19:3:5

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Families with 3 or more people than the smallest one cannot induct more.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
