### PR TITLE
[NON-MODULAR][REVERT] Restores belt weight-class

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -12,7 +12,7 @@
 	attack_verb_simple = list("whip", "lash", "discipline")
 	max_integrity = 300
 	equip_sound = 'sound/items/equip/toolbelt_equip.ogg'
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL // SKYRAT EDIT - `w_class = WEIGHT_CLASS_BULKY`
 	var/content_overlays = FALSE //If this is true, the belt will gain overlays based on what it's holding
 
 /obj/item/storage/belt/suicide_act(mob/living/carbon/user)


### PR DESCRIPTION
## About The Pull Request

It is a revert of https://github.com/Skyrat-SS13/Skyrat-tg/pull/13949, an upstream PR.

## How This Contributes To The Skyrat Roleplay Experience

The original PR claims its an oversight of the laws of physics, and a 'fix' PR. I personally think that its nothing more than a badly designed balancing PR. Maybe in a gameplay environment such as TG station belts shouldn't fit in backpacks when **FILLED**; however even in that environment, not letting an empty belt in your backpack which can be as large as a whole duffel, just is not realism or physics related.
I'd rather keep this reverted until a better system is implemented to make it actually 'realistic' (filled belts dont fit, empty ones do). Right now its a complete hinderance in favor of double-edged 'realism'

## Changelog
:cl:
balance: Belts may be stored inside backpacks again, filled or unfilled
/:cl:
