### PR TITLE
[IceBox] Fix prison sepia tiles

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -20049,7 +20049,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/sepia,
+/turf/open/floor/iron/sepia,
 /area/station/security/prison/rec)
 "gzY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21667,9 +21667,9 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "gZb" = (
-/mob/living/carbon/human/species/monkey,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "gZl" = (
@@ -22385,7 +22385,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/iron/sepia,
 /area/station/security/prison/rec)
 "hkb" = (
 /obj/structure/table/wood,
@@ -26280,7 +26280,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/iron/sepia,
 /area/station/security/prison/rec)
 "ixH" = (
 /obj/structure/railing/corner{
@@ -31523,7 +31523,7 @@
 "keD" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteen_nineteen,
-/turf/open/floor/sepia,
+/turf/open/floor/iron/sepia,
 /area/station/security/prison/rec)
 "keP" = (
 /turf/closed/wall,
@@ -32279,7 +32279,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/sepia,
+/turf/open/floor/iron/sepia,
 /area/station/security/prison/rec)
 "kqV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -47033,7 +47033,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/iron/sepia,
 /area/station/security/prison/rec)
 "pdy" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -52424,7 +52424,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/sepia,
+/turf/open/floor/iron/sepia,
 /area/station/security/prison/rec)
 "qSx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
@@ -54259,11 +54259,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /mob/living/simple_animal/bot/secbot/beepsky{
 	desc = "Powered by the tears and sweat of laborers.";
 	name = "Prison Ofitser"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
 "rAC" = (
@@ -62405,7 +62405,7 @@
 	c_tag = "Security - Permabrig Meditation";
 	network = list("ss13","prison")
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/iron/sepia,
 /area/station/security/prison/rec)
 "ugq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -62745,7 +62745,7 @@
 /obj/item/storage/toolbox/artistic,
 /obj/structure/rack,
 /obj/item/storage/crayons,
-/turf/open/floor/sepia,
+/turf/open/floor/iron/sepia,
 /area/station/security/prison/rec)
 "umi" = (
 /obj/structure/window/reinforced,
@@ -67912,7 +67912,7 @@
 /obj/structure/easel,
 /obj/item/canvas/nineteen_nineteen,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/sepia,
+/turf/open/floor/iron/sepia,
 /area/station/security/prison/rec)
 "vUW" = (
 /obj/item/stack/cable_coil{
@@ -72766,10 +72766,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "xuQ" = (
-/mob/living/carbon/human/species/monkey,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "xuR" = (
@@ -74541,8 +74541,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/simple_animal/bot/secbot/pingsky,
 /obj/structure/cable/layer3,
+/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "yap" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the slowdown tiles in ice box prison with decorative variants
## How This Contributes To The Skyrat Roleplay Experience

No real reason for them to be there, they should just be the iron tile decorative variant.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The magically slow sepia tiles in icebox prison have been replaced with decorative tiling.
/:cl: