### PR TITLE
[Modular]makes stasis surgery modular and makes tables glow

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -737,26 +737,6 @@
 		return TRUE
 	return FALSE
 
-///SKYRAT EDIT: Operating Tables now provide Stasis
-/obj/structure/table/optable/proc/chill_out(mob/living/target)
-	var/freq = rand(24750, 26550)
-	playsound(src, 'sound/effects/spray.ogg', 5, TRUE, 2, frequency = freq)
-	target.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
-	ADD_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
-	target.extinguish_mob()
-
-/obj/structure/table/optable/proc/thaw_them(mob/living/target)
-	target.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
-	REMOVE_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
-
-/obj/structure/table/optable/post_buckle_mob(mob/living/L)
-	set_patient(L)
-	chill_out(L)
-
-/obj/structure/table/optable/post_unbuckle_mob(mob/living/L)
-	set_patient(null)
-	thaw_them(L)
-///SKYRAT EDIT END
 /*
  * Racks
  */

--- a/modular_skyrat/modules/stasisrework/code/stasis_surgery.dm
+++ b/modular_skyrat/modules/stasisrework/code/stasis_surgery.dm
@@ -1,0 +1,32 @@
+// Modular extension of surgery stasis tables.
+
+/obj/structure/table/optable/proc/chill_out(mob/living/target)
+	var/freq = rand(24750, 26550)
+	playsound(src, 'sound/effects/spray.ogg', 5, TRUE, 2, frequency = freq)
+	target.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
+	ADD_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
+	target.extinguish_mob()
+	handle_glow(target, FALSE)
+/obj/structure/table/optable/proc/handle_glow(passed_mob, removing)
+	var/atom/movable/parent_movable = src
+	var/atom/movable/mob = passed_mob
+	if(!istype(parent_movable))
+		return
+	if(removing)
+		parent_movable.remove_filter("thaw_glow")
+		mob.remove_filter("thaw_glow")
+	else if(!removing)
+		parent_movable.add_filter("thaw_glow", 2, list("type" = "outline", "color" = "#14b5ff30", "size" = 2))
+		mob.add_filter("thaw_glow", 2, list("type" = "outline", "color" = "#14b5ff30", "size" = 2))
+/obj/structure/table/optable/proc/thaw_them(mob/living/target)
+	target.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
+	REMOVE_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
+	handle_glow(target, TRUE)
+
+/obj/structure/table/optable/post_buckle_mob(mob/living/L)
+	set_patient(L)
+	chill_out(L)
+
+/obj/structure/table/optable/post_unbuckle_mob(mob/living/L)
+	set_patient(null)
+	thaw_them(L)

--- a/modular_skyrat/modules/stasisrework/code/stasis_surgery.dm
+++ b/modular_skyrat/modules/stasisrework/code/stasis_surgery.dm
@@ -8,15 +8,12 @@
 	target.extinguish_mob()
 	handle_glow(target, FALSE)
 /obj/structure/table/optable/proc/handle_glow(passed_mob, removing)
-	var/atom/movable/parent_movable = src
 	var/atom/movable/mob = passed_mob
-	if(!istype(parent_movable))
+	if(!istype(mob))
 		return
 	if(removing)
-		parent_movable.remove_filter("thaw_glow")
 		mob.remove_filter("thaw_glow")
 	else if(!removing)
-		parent_movable.add_filter("thaw_glow", 2, list("type" = "outline", "color" = "#14b5ff30", "size" = 2))
 		mob.add_filter("thaw_glow", 2, list("type" = "outline", "color" = "#14b5ff30", "size" = 2))
 /obj/structure/table/optable/proc/thaw_them(mob/living/target)
 	target.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5809,6 +5809,7 @@
 #include "modular_skyrat\modules\stasisrework\code\bodybag_structure.dm"
 #include "modular_skyrat\modules\stasisrework\code\machine_circuitboards.dm"
 #include "modular_skyrat\modules\stasisrework\code\medical_designs.dm"
+#include "modular_skyrat\modules\stasisrework\code\stasis_surgery.dm"
 #include "modular_skyrat\modules\stasisrework\code\stasissleeper.dm"
 #include "modular_skyrat\modules\stone\code\ore_veins.dm"
 #include "modular_skyrat\modules\stone\code\stone.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Modularizes stasis operating tables and makes them glow subtly to indicate if the patient is in stasis or not. Looks cool.


https://user-images.githubusercontent.com/77420409/170858950-46612483-4e57-4caa-9f02-1dd359d0c50b.mp4



## How This Contributes To The Skyrat Roleplay Experience

Less people rotting away due to there being no visual indicator they're "on" the table

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: makes stasis surgery modular
qol: made stasis surgery tables visually indicate that they're in use with a faint blue glow. Less inadvertent body decay. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
