### PR TITLE
Nerfs reagent katana

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
@@ -49,8 +49,6 @@
 	desc = "A katana that can be imbued with a reagent. It's very sharp, but not quite million-times-folded sharp."
 	force = 15
 	armour_penetration = 25 //Slices through armour like butter, but can't quite bisect a knight like the real thing.
-	wound_bonus = 20
-	bare_wound_bonus = 40
 	icon_state = "katana"
 	inhand_icon_state = "katana"
 	hitsound = 'sound/weapons/bladeslice.ogg'


### PR DESCRIPTION
## About The Pull Request

Yeah I kinda missed this in my balancing run
Removes the wound chance bonuses on the katana

## How This Contributes To The Skyrat Roleplay Experience
It's currently like the second best sword in the game right now you can feasibly get

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Reagent katana no longer has ridiculous wound bonuses
/:cl:
