### PR TITLE
Adds the gas miner delivery beacon

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -19,6 +19,7 @@
 	new /obj/item/extinguisher/advanced(src)
 	new /obj/item/storage/photo_album/ce(src)
 	new /obj/item/storage/box/skillchips/engineering(src)
+	new /obj/item/storage/box/gas_miner_beacons(src) // SKYRAT EDIT ADDITION
 	new /obj/item/construction/plumbing/engineering(src) //SKYRAT EDIT ADDITION
 	new /obj/item/circuitboard/machine/rodstopper(src) //SKYRAT EDIT ADDITION
 
@@ -87,4 +88,3 @@
 	new /obj/item/clothing/head/hardhat/atmos(src)
 	new /obj/item/clothing/glasses/meson/engine/tray(src)
 	new /obj/item/extinguisher/advanced(src)
-	new /obj/item/gas_miner_beacon(src) // SKYRAT EDIT ADDITION

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -87,3 +87,4 @@
 	new /obj/item/clothing/head/hardhat/atmos(src)
 	new /obj/item/clothing/glasses/meson/engine/tray(src)
 	new /obj/item/extinguisher/advanced(src)
+	new /obj/item/gas_miner_beacon(src) // SKYRAT EDIT ADDITION

--- a/modular_skyrat/modules/cargo/code/packs.dm
+++ b/modular_skyrat/modules/cargo/code/packs.dm
@@ -209,6 +209,15 @@
 	crate_name = "engineering inducer crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
+/datum/supply_pack/engineering/gas_miner
+	name = "Gas Miner Delivery Beacon Crate"
+	desc = "Contains a single gas miner delivery beacon, for the ordering of one gas miner."
+	access = ACCESS_ATMOSPHERICS
+	contains = list(/obj/item/gas_miner_beacon)
+	cost = CARGO_CRATE_VALUE * 50
+	crate_name = "gas miner delivery beacon crate"
+	crate_type = /obj/structure/closet/crate/secure/engineering
+
 /*
 *	MISC
 */

--- a/modular_skyrat/modules/modular_items/code/gas_miner_beacon.dm
+++ b/modular_skyrat/modules/modular_items/code/gas_miner_beacon.dm
@@ -1,0 +1,98 @@
+/obj/item/gas_miner_beacon
+	name = "gas miner beacon"
+	desc = "Once a gas miner type is selected, delivers a gas miner to the target location."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "gangtool-blue"
+	inhand_icon_state = "radio"
+	/// How many charges the beacon has left
+	var/uses = 1
+	/// A list of allowed areas that a miner can be spawned in
+	var/static/list/allowed_areas = list(
+		/area/station/engineering/atmos,
+		/area/station/engineering/atmospherics_engine,
+	)
+	/// A list of possible gas miners available to spawn
+	var/static/list/miners = list(
+		/obj/machinery/atmospherics/miner/carbon_dioxide,
+		/obj/machinery/atmospherics/miner/n2o,
+		/obj/machinery/atmospherics/miner/nitrogen,
+		/obj/machinery/atmospherics/miner/oxygen,
+		/obj/machinery/atmospherics/miner/plasma,
+	)
+	/// The currently selected gas miner, if any
+	var/obj/machinery/atmospherics/miner/selected_miner = null
+
+/obj/item/gas_miner_beacon/examine()
+	. = ..()
+	. += span_warning("Caution: Only works in atmospherics areas.")
+	. += span_notice("Currently selected: [selected_miner ? selected_miner.name : "None"].")
+
+/obj/item/gas_miner_beacon/attack_self(mob/user)
+	if(!can_use_beacon(user))
+		return
+	show_options(user)
+
+/obj/item/gas_miner_beacon/proc/can_use_beacon(mob/living/user)
+	if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+		return TRUE
+	else
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 40, TRUE)
+		return FALSE
+
+/obj/item/gas_miner_beacon/proc/generate_display_names()
+	var/list/miner_list = list()
+	for(var/obj/machinery/atmospherics/miner/iterated_miner as anything in miners)
+		miner_list[initial(iterated_miner.name)] = iterated_miner
+	return miner_list
+
+/obj/item/gas_miner_beacon/proc/show_options(mob/user)
+	var/list/display_names = generate_display_names()
+	if(!length(display_names))
+		return
+	var/choice = tgui_input_list(user, "Choose a miner", "Miner selection", display_names)
+	if(isnull(choice))
+		return
+	if(isnull(display_names[choice]))
+		return
+	if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+		return
+	selected_miner = display_names[choice]
+
+/obj/item/gas_miner_beacon/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	. = ..()
+	if(!selected_miner)
+		balloon_alert(user, "no miner selected!")
+		return
+	var/turf/target_turf = get_turf(target)
+	var/area/target_area = get_area(target)
+	if(!target_turf || !target_area || !is_type_in_list(target_area, allowed_areas))
+		balloon_alert(user, "can't call here!")
+		return
+
+	var/confirmed = tgui_alert(user, "Are you sure you want to call it here?", "Confirmation", list("Yes", "No"))
+	if(confirmed != "Yes")
+		return
+
+	podspawn(list(
+		"target" = get_turf(target),
+		"path" = /obj/structure/closet/supplypod/podspawn/no_return,
+		"style" = STYLE_CENTCOM,
+		"spawn" = selected_miner,
+	))
+
+	if(ishuman(user))
+		var/mob/living/carbon/human/human_user = user
+		if(istype(human_user.ears, /obj/item/radio/headset))
+			to_chat(user, span_notice("You hear something crackle in your ears for a moment before a voice speaks. \
+				\"Please stand by for a message from Central Command.  Message as follows: \
+				[span_bold("Request received. Your miner is inbound, please stand back from the landing site.")] \
+				Message ends.\""))
+
+	uses--
+	if(!uses)
+		qdel(src)
+	else
+		balloon_alert(user, "[uses] use[uses > 1 ? "s" : ""] left!")
+
+/obj/structure/closet/supplypod/podspawn/no_return
+	bluespace = FALSE

--- a/modular_skyrat/modules/modular_items/code/gas_miner_beacon.dm
+++ b/modular_skyrat/modules/modular_items/code/gas_miner_beacon.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "gangtool-blue"
 	inhand_icon_state = "radio"
+	w_class = WEIGHT_CLASS_SMALL
 	/// How many charges the beacon has left
 	var/uses = 1
 	/// A list of allowed areas that a miner can be spawned in
@@ -96,3 +97,11 @@
 
 /obj/structure/closet/supplypod/podspawn/no_return
 	bluespace = FALSE
+
+/obj/item/storage/box/gas_miner_beacons
+	name = "box of gas miner delivery beacons"
+	desc = "Contains two beacons for delivery of atmospheric gas miners."
+
+/obj/item/storage/box/gas_miner_beacons/PopulateContents()
+	new /obj/item/gas_miner_beacon
+	new /obj/item/gas_miner_beacon

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5497,6 +5497,7 @@
 #include "modular_skyrat\modules\modular_items\code\bags.dm"
 #include "modular_skyrat\modules\modular_items\code\ciggies.dm"
 #include "modular_skyrat\modules\modular_items\code\cross.dm"
+#include "modular_skyrat\modules\modular_items\code\gas_miner_beacon.dm"
 #include "modular_skyrat\modules\modular_items\code\goosenade.dm"
 #include "modular_skyrat\modules\modular_items\code\kinetic_crusher.dm"
 #include "modular_skyrat\modules\modular_items\code\makeshift.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a gas miner delivery beacon.
On use in hand, you can choose a gas miner type.
    - You can only pick from basic gas tank gases.
You then use it on a turf to call down a supply pod containing a gas miner.
    - It can deliver to atmospherics areas ONLY.
    - I *may* limit it further to only the turf type present in the respective gas tank but I like the slight flexibility this gives. There's also the issue of if there turfs get destroyed, even if that's rarely ever going to happen.

They are available in two ways.
- There are two in a box in the CE locker at roundstart
- You can buy them from cargo for 10,000 credits each.
     - Something else to get with the dep. orders other than iRCDs

## How This Contributes To The Skyrat Roleplay Experience

Allows for gas miners without map changes, and not quite as free as having them round-start in all tanks.
Also gives a little more flexibility in where they're placed, though not too much.

## Changelog
:cl:
add: Adds gas miner delivery beacons. They are in atmos lockers round start, as well as cargo, and can call down a gas miner delivery pod to any atmos area.
/:cl: