### PR TITLE
fixes BS and NTC interlink office access

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -9310,7 +9310,8 @@
 "pPo" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
-	req_one_access_txt = "20;101"
+	req_access = list("captain");
+	req_one_access = null
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
@@ -11531,6 +11532,13 @@
 "xUn" = (
 /obj/machinery/photocopier,
 /turf/open/floor/carpet/executive,
+/area/centcom/interlink)
+"xVA" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Administrative Office";
+	req_one_access_txt = list("cent_general","captain")
+	},
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "xYR" = (
 /obj/effect/turf_decal/siding/wood{
@@ -26822,7 +26830,7 @@ aiL
 aiL
 aiL
 aiL
-pPo
+xVA
 hvQ
 hvQ
 hvQ


### PR DESCRIPTION
## About The Pull Request

Access broke in the refactor

## How This Contributes To The Skyrat Roleplay Experience

no more ahelping / just shooting down the windows

## Changelog
:cl:
fix: The blueshield and NTC can now access their respective offices on the interlink once more.
/:cl: