### PR TITLE
Adjusts the range of the mold foam and smoke effects

### DIFF
--- a/modular_skyrat/modules/biohazard_blob/code/biohazard_blob_structures.dm
+++ b/modular_skyrat/modules/biohazard_blob/code/biohazard_blob_structures.dm
@@ -101,7 +101,7 @@
 				reagents.my_atom = src
 				reagents.add_reagent(/datum/reagent/cordycepsspores, 50)
 				var/datum/effect_system/fluid_spread/smoke/chem/smoke_machine/puff = new
-				puff.set_up(4, location = my_turf, carry = reagents, efficiency = 24)
+				puff.set_up(5, location = my_turf, carry = reagents, efficiency = 24)
 				puff.attach(src)
 				puff.start()
 			if(BIO_BLOB_TYPE_FIRE)
@@ -125,7 +125,7 @@
 				R.my_atom = src
 				R.add_reagent(/datum/reagent/toxin, 30)
 				var/datum/effect_system/fluid_spread/foam/foam = new
-				foam.set_up(200, location = my_turf, carry = R)
+				foam.set_up(4, location = my_turf, carry = R)
 				foam.start()
 			if(BIO_BLOB_TYPE_RADIOACTIVE)
 				visible_message(span_warning("The [src] emits a strong radiation pulse!"))
@@ -134,7 +134,7 @@
 				R.my_atom = src
 				R.add_reagent(/datum/reagent/toxin/mutagen, 50)
 				var/datum/effect_system/fluid_spread/foam/foam = new
-				foam.set_up(200, location = my_turf, carry = R)
+				foam.set_up(5, location = my_turf, carry = R)
 				foam.start()
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
For some reason #13407 changed (clarification, this is a fault of one of the maintainers here, not the guy behind the original PR) the range of the toxic and radioactive foam effects from 40 and 50 respectively (still way too high, I've lower them to 4 and 5) to a whooping 200, which is enough to theorically cover the entire z-level. Also, the same port changed the range of a mold smoke effect from 5 to 4.

That said, I'm changing the values of these fluid effects to 4, 5 and 4 again. Better late than never, this issue has been around for almost a month now, notwithstanding how easily it can be fixed.

## How This Contributes To The Skyrat Roleplay Experience
Read above, I don't want to repeat myself.

## Changelog

:cl:
fix: Stops the mold foam effects from having a station-covering range of 200. It should be 4/5 now.
/:cl:

