### PR TITLE
Fixes non-gendered chest markings not being visible

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -880,10 +880,8 @@
 
 			var/gender_modifier = ""
 			if(body_zone == BODY_ZONE_CHEST) // Chest markings have male and female versions.
-				if(is_dimorphic)
-					gender_modifier = "_[limb_gender]"
-				else
-					gender_modifier = "_m" // Again, why we don't define if a marking can have male/female is byond me.
+				if(body_marking.gendered)
+					gender_modifier = is_dimorphic ? "_[limb_gender]" : "_m"
 
 			var/mutable_appearance/accessory_overlay
 			var/mutable_appearance/emissive


### PR DESCRIPTION
## About The Pull Request
They weren't showing up because they were getting gendered suffixes (`_m` or `_f`, depending on the body type), which obviously they weren't compatible with.

Because, yes, as it turns out, body markings were, in fact, already gendered.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/13188.

## How This Contributes To The Skyrat Roleplay Experience
Something something peak performance
![image](https://user-images.githubusercontent.com/58045821/171526142-2eddd9a0-05f3-4f10-a128-fda977d38187.png)

## Changelog

:cl: GoldenAlpharex
fix: Chest markings should now all work again. Yes, this includes tattoos and body tonage.
/:cl: