### PR TITLE
Liquid output machines no longer expose their turf to the liquid

### DIFF
--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_plumbers.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_plumbers.dm
@@ -164,7 +164,7 @@
 
 	var/datum/reagents/tempr = new(10000)
 	reagents.trans_to(tempr, target_value, no_react = TRUE)
-	T.add_liquid_from_reagents(tempr)
+	T.add_liquid_from_reagents(tempr, expose_turf = FALSE)
 	qdel(tempr)
 
 /obj/machinery/plumbing/liquid_output_pump/Initialize(mapload, bolt)

--- a/modular_skyrat/modules/liquids/code/liquid_systems/liquid_turf.dm
+++ b/modular_skyrat/modules/liquids/code/liquid_systems/liquid_turf.dm
@@ -71,17 +71,17 @@
 
 	SSliquids.add_active_turf(src)
 
-/turf/proc/add_liquid_from_reagents(datum/reagents/giver, no_react = FALSE)
+/turf/proc/add_liquid_from_reagents(datum/reagents/giver, no_react = FALSE, expose_turf = TRUE)
 	var/list/compiled_list = list()
 	for(var/r in giver.reagent_list)
 		var/datum/reagent/R = r
 		compiled_list[R.type] = R.volume
 	if(!compiled_list.len) //No reagents to add, don't bother going further
 		return
-	add_liquid_list(compiled_list, no_react, giver.chem_temp)
+	add_liquid_list(compiled_list, no_react, expose_turf, giver.chem_temp)
 
 //More efficient than add_liquid for multiples
-/turf/proc/add_liquid_list(reagent_list, no_react = FALSE, chem_temp = 300)
+/turf/proc/add_liquid_list(reagent_list, no_react = FALSE, expose_turf = TRUE, chem_temp = 300)
 	if(!liquids)
 		liquids = new(src)
 	if(liquids.immutable)
@@ -118,8 +118,8 @@
 				qdel(liquids)
 				return
 		qdel(reagents)
-		//Expose turf
-		liquids.ExposeMyTurf()
+		if(expose_turf)
+			liquids.ExposeMyTurf()
 
 	liquids.calculate_height()
 	liquids.set_reagent_color_for_liquid()


### PR DESCRIPTION
## About The Pull Request

Alternative to https://github.com/Skyrat-SS13/Skyrat-tg/pull/14060.

Slightly more no fun allowed version, it stops liquids auto-pumped out from reacting on the turf preventing gas generation at all.

## How This Contributes To The Skyrat Roleplay Experience

see https://github.com/Skyrat-SS13/Skyrat-tg/pull/14060

## Changelog
:cl:
fix: Liquid output pumps no longer expose the turf to the liquids, preventing gas generation
/:cl: