### PR TITLE
[NON-MODULAR] Reduces prisoner slots from 12 to 6*.

### DIFF
--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -3,7 +3,7 @@
 	description = "Keep yourself occupied in permabrig."
 	department_head = list("The Security Team")
 	faction = FACTION_STATION
-	total_positions = 12		// SKYRAT EDIT: Original value (0)
+	total_positions = 4		// SKYRAT EDIT: Original value (0)
 	spawn_positions = 2
 	supervisors = "the security team"
 	selection_color = "#ffe1c3"

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -3,7 +3,7 @@
 	description = "Keep yourself occupied in permabrig."
 	department_head = list("The Security Team")
 	faction = FACTION_STATION
-	total_positions = 4		// SKYRAT EDIT: Original value (0)
+	total_positions = 6		// SKYRAT EDIT: Original value (0)
 	spawn_positions = 2
 	supervisors = "the security team"
 	selection_color = "#ffe1c3"


### PR DESCRIPTION
## About The Pull Request

Reduces prisoner slots from 12 to 6.

## How This Contributes To The Skyrat Roleplay Experience

It sucks having up to twelve people join in to potentially require your babysitting/involvement to do anything in the round or even just not die to random events. Especially when your security department is two detectives and an officer. 

One of the problems is that the more people playing prisoner, the more interesting it can become for more people to join in as prisoner. Having it possibly go up to twelve (one less than all the available security slots) with no commensurate requirement for more security (COs in particular) is ridiculous as a cap.

Four is much more manageable even with lowpop in sec but should offer enough slots for COs (who sign up actually expecting to and interested in interacting with prisoners) to have focused RP with their prisoner crews as well (without also being pulled every direction by the management hell of a vortex anomaly spawning in the middle of the prison when it has eight people in it, for instance.) 

Six is a good step in the right direction. Hopefully the state of play won't give me any reason to come back to it - at the very least it should manage the greatest absurdities of prisoner numbers vs. sec.

It should also encourage the people who want to roll prisoner to roll for it roundstart during highpop hours - if the role is so popular, and the mix of people you get in prison is part of what makes it enjoyable, this should satisfy that enjoyment with a more competitive mix of people rolling for it while also making it less prone to being an unasked-for and unmanageable-in-scale pain to manage for people playing regular security. 

## Changelog

:cl:
balance: Reduced prisoner slots from 12 to 6.
/:cl:
