### PR TITLE
[Modular] Show prisoner policy warnings to prisoners on spawn.

### DIFF
--- a/modular_skyrat/modules/warning/prisoner_warning.dm
+++ b/modular_skyrat/modules/warning/prisoner_warning.dm
@@ -1,0 +1,4 @@
+/datum/job/prisoner/after_spawn(mob/living/carbon/human/H, mob/M)
+	. = ..()
+	var/linktopolicy = "https://docs.google.com/document/d/e/2PACX-1vQVFGahOD5A1R5qFhtVAmhxN7xz51JCGw-uMaw_WvhkGcB_M_fdQvr7-VxIYEhh5pZnC77eHvuMSrfB/pub"
+	to_chat(M, (span_doyourjobidiot("As a roundstart/latejoin prisoner, you are not an antagonist. You are allowed to cause moderate amounts of drama and shenanigans, but you should not be security's main focus. Do not be unmanageable.  \nRefer to the Prisoner Section of 'General Player Policy and Standards'!\n\nIf you intend to break out of prison, submit an opposing force application or press F1 to admin help it! \n<a href=\"[linktopolicy]\"> Click here to read the policy! </a>")))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5845,6 +5845,7 @@
 #include "modular_skyrat\modules\vox_sprites\code\head.dm"
 #include "modular_skyrat\modules\vox_sprites\code\security.dm"
 #include "modular_skyrat\modules\vox_sprites\code\sneakers.dm"
+#include "modular_skyrat\modules\warning\prisoner_warning.dm"
 #include "modular_skyrat\modules\welding_sparks\code\weldingtool.dm"
 #include "modular_skyrat\modules\wrestlingring\code\wrestlingring.dm"
 #include "modular_skyrat\modules\xenoarch\code\area.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This shows prisoners a warning about self-antag and links them to the policy documents on spawn. 
![dreamseeker_nDtWUsFUmJ](https://user-images.githubusercontent.com/77420409/172027497-cae7da58-8910-4209-82ab-77bcf985e4df.png)


## How This Contributes To The Skyrat Roleplay Experience

Policy is a good thing.

## Changelog

no true code changes

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
