### PR TITLE
Fix: Department Guard Vests

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/clothing_variation_overrides/under.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/clothing_variation_overrides/under.dm
@@ -17,7 +17,7 @@
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 /obj/item/clothing/under/misc/bouncer
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
 /obj/item/clothing/under/rank/security/officer/spacepol
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON

--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -21,6 +21,7 @@
 	name = "customs agent uniform"
 	icon_state = "customs_uniform"
 	worn_icon_state = "customs_uniform"
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 /obj/item/clothing/suit/armor/vest/blueshirt/skyrat
 	icon_state = "barney_armor"
@@ -28,6 +29,7 @@
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
 	unique_reskin = null
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 /obj/item/clothing/suit/armor/vest/blueshirt/skyrat/guard
 	icon_state = "guard_armor"

--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -21,7 +21,6 @@
 	name = "customs agent uniform"
 	icon_state = "customs_uniform"
 	worn_icon_state = "customs_uniform"
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 /obj/item/clothing/suit/armor/vest/blueshirt/skyrat
 	icon_state = "barney_armor"


### PR DESCRIPTION
## About The Pull Request

Someone mentioned to me a few minutes ago about the Science, customs guard, and bouncer(?) vests being broken for Digi people.
This sets the flag and fixes that so no more checkerboard vests for those departments

Edit: Additionally, I realized while fixing this the bouncer uniform was also flagged incorrectly and displaying as the non-digi version for digi. 

![image](https://user-images.githubusercontent.com/84706993/172034864-9c623aca-68b8-4960-b97a-1530ae1148c4.png)


This PR now also addresses that issue aswell.

![image](https://user-images.githubusercontent.com/84706993/172034905-de21251b-cd06-49c7-b4f1-d4e66b1819fb.png)


## How This Contributes To The Skyrat Roleplay Experience

Fixing sprite issues. Nothing big but no one likes to see checkboards.

![image](https://user-images.githubusercontent.com/84706993/172034724-77e56df3-ed3f-41ce-ae28-c4cea988ac70.png)

## Changelog

:cl:
fix: Fixed vests for Science, Medical and Service guard roles for digitigrade people.
/:cl: