### PR TITLE
[MODULAR] Ears stay revealed unless verb'd away

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/ears.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/ears.dm
@@ -6,7 +6,7 @@
 	genetic = TRUE
 
 /datum/sprite_accessory/ears/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	if(H.head && (H.head.flags_inv & HIDEHAIR) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR)) || !HD)
+	if(H.head && ((H.head.flags_inv & HIDEHAIR)  && H.try_hide_mutant_parts) || ((H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR))  && H.try_hide_mutant_parts) || !HD)
 		//This line basically checks if we FORCE accessory-ears to show, for items with earholes like Balaclavas and Luchador masks
 		if(!(H.head && (H.head.flags_inv & SHOWSPRITEEARS) || (H.wear_mask && (H.wear_mask.flags_inv & SHOWSPRITEEARS)) || !HD))
 			return TRUE


### PR DESCRIPTION
## About The Pull Request

Just like https://github.com/Skyrat-SS13/Skyrat-tg/pull/10643 and how tails function, ears stay revealed when a user wears a covering article of clothing; unless they use the 'hide mutant parts' verb.

## How This Contributes To The Skyrat Roleplay Experience

Its just ugly in terms of immersion breaking and functionality, the only point against it is for gameplay purposes; but the hide verb is perfect for that purpose. If you want to be an unknown you can use that verb.

## Changelog
:cl:
code: Ears don't hide themselves automatically anymore when a helmet is worn
/:cl:
