### PR TITLE
gas miner box fix

### DIFF
--- a/modular_skyrat/modules/modular_items/code/gas_miner_beacon.dm
+++ b/modular_skyrat/modules/modular_items/code/gas_miner_beacon.dm
@@ -103,5 +103,5 @@
 	desc = "Contains two beacons for delivery of atmospheric gas miners."
 
 /obj/item/storage/box/gas_miner_beacons/PopulateContents()
-	new /obj/item/gas_miner_beacon
-	new /obj/item/gas_miner_beacon
+	new /obj/item/gas_miner_beacon(src)
+	new /obj/item/gas_miner_beacon(src)


### PR DESCRIPTION
## About The Pull Request

oops

## Changelog
:cl:
fix: Gas miner beacon boxes are no longer empty
/:cl: