### PR TITLE
repaths armoured high vis jacket to pk vest

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/suits/coats.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/suits/coats.dm
@@ -201,18 +201,6 @@
 	. = ..()
 	AddElement(/datum/element/polychromic, list("#55DD55"))
 
-/obj/item/clothing/suit/toggle/brit/sec
-	name = "high vis armored vest"
-	desc = "Oi bruv' you got a loicence for that?"
-	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'
-	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
-	icon_state = "hazardbg"
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	blood_overlay_type = "coat"
-	toggle_noun = "zipper"
-	armor = list(MELEE = 10, BULLET = 5, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
-
-
 /obj/item/clothing/suit/toggle/lawyer/black/better
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -567,7 +567,7 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 
 /datum/loadout_item/suit/brit
 	name = "High Vis Armored Vest"
-	item_path = /obj/item/clothing/suit/toggle/brit/sec
+	item_path = /obj/item/clothing/suit/armor/vest/peacekeeper/brit
 	restricted_roles = list(JOB_HEAD_OF_SECURITY, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_DETECTIVE, JOB_SECURITY_MEDIC, JOB_CORRECTIONS_OFFICER)
 
 /datum/loadout_item/suit/british_jacket

--- a/modular_skyrat/modules/sec_haul/code/misc/vending.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/vending.dm
@@ -58,7 +58,7 @@
 	vend_reply = "Good luck, Peacekeeper!"
 	products = list(/obj/item/clothing/suit/hooded/wintercoat/security = 5,
 					/obj/item/clothing/suit/toggle/jacket/sec = 5,
-					/obj/item/clothing/suit/toggle/brit/sec = 5,
+					/obj/item/clothing/suit/armor/vest/peacekeeper/brit = 5,
 					/obj/item/clothing/neck/security_cape = 5,
 					/obj/item/clothing/neck/security_cape/armplate = 5,
 					/obj/item/storage/backpack/security = 5,

--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
@@ -111,6 +111,16 @@
 	icon_state = "peacekeeper_black"
 	worn_icon_state = "peacekeeper_black"
 
+/obj/item/clothing/suit/armor/vest/peacekeeper/brit
+	name = "high vis armored vest"
+	desc = "Oi bruv, you got a loicence for that?"
+	icon_state = "hazardbg"
+	worn_icon_state = "hazardbg"
+
+/obj/item/clothing/suit/armor/vest/peacekeeper/brit/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/toggle_icon, "zipper")
+
 /obj/item/clothing/suit/armor/hos/trenchcoat/peacekeeper
 	name = "armored peacekeeper trenchcoat"
 	desc = "A trenchcoat enhanced with a special lightweight kevlar. The epitome of tactical plainclothes."


### PR DESCRIPTION
## About The Pull Request

makes armoured high vis jacket a peacekeeper vest subtype
can drop the armour back but I don't really see a reason to

## How This Contributes To The Skyrat Roleplay Experience

consistency
fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/14077

## Changelog
:cl:
fix: The high-vis armoured jacket can now hold security items in the suit slot
/:cl: