### PR TITLE
Reduces the amount of cables needed to put wire on barricades, also adds something to the description that you can actually add wire to begin with

### DIFF
--- a/modular_skyrat/modules/barricades/code/barricade.dm
+++ b/modular_skyrat/modules/barricades/code/barricade.dm
@@ -46,6 +46,8 @@
 
 /obj/structure/deployable_barricade/examine(mob/user)
 	. = ..()
+	if(!is_wired)
+		. += span_info("Barbed wire could be added with some <b>cable</b>.")
 	if(is_wired)
 		. += span_info("It has barbed wire along the top.")
 
@@ -95,7 +97,7 @@
 /obj/structure/deployable_barricade/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/stack/cable_coil) && can_wire)
 		var/obj/item/stack/S = I
-		if(S.use(15))
+		if(S.use(5))
 			wire()
 		else
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Did you know that you could add barbed wire to barricades? No? Well now you do.
Also, the wire cost was 15 cable per barricade, meaning a full coil of wires could net you two (2) whole barbed barricades, seems like a bit much to me.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
What if, theoretically, players knew about mechanics without having to look into the code or just get a lucky guess?

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: barricades now tell you that you can put barbed wire on them
balance: the barbed wire cost has been lowered from 15 cables per barricades to 5 per barricade
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
