### PR TITLE
make the current map not appear in map votes

### DIFF
--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -10,7 +10,7 @@
 	var/list/maps = shuffle(global.config.maplist)
 	for(var/map in maps)
 		var/datum/map_config/possible_config = config.maplist[map]
-		if(!possible_config.votable || (possible_config.map_name in SSpersistence.blocked_maps))
+		if(!possible_config.votable || (possible_config.map_name in SSpersistence.blocked_maps) || possible_config.map_name == SSmapping.config?.map_name) // SKYRAT EDIT - Can't vote for the current map
 			continue
 
 		default_choices += possible_config.map_name


### PR DESCRIPTION
## About The Pull Request

Blocks the current map from appearing in the map vote

## How This Contributes To The Skyrat Roleplay Experience

Playing a map back to back is generally not great. New players may come in and vote for it while others have to play the same map repeatedly.

## Changelog
:cl:
qol: You can no longer vote for the current map in the end of round map vote.
/:cl: