### PR TITLE
[Modular] Yet another guns PR (STG+Mp40 Nerf, armadyne dirt nerfed)

### DIFF
--- a/modular_skyrat/modules/gunsgalore/code/guns/mp40.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/mp40.dm
@@ -21,6 +21,7 @@
 	eject_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/smg_magout.ogg'
 	alt_icons = TRUE
 	realistic = TRUE
+	fire_select_modes = list(SELECT_SEMI_AUTOMATIC, SELECT_FULLY_AUTOMATIC)
 	company_flag = COMPANY_OLDARMS
 
 /obj/item/ammo_box/magazine/mp40

--- a/modular_skyrat/modules/gunsgalore/code/guns/stg.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/stg.dm
@@ -13,13 +13,12 @@
 	weapon_weight = WEAPON_HEAVY
 	mag_type = /obj/item/ammo_box/magazine/stg
 	can_suppress = FALSE
-	burst_size = 4
 	fire_delay = 1.5
 	fire_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/fire/stg_fire.ogg'
 	fire_sound_volume = 70
 	alt_icons = TRUE
 	realistic = TRUE
-	fire_select_modes = list(SELECT_SEMI_AUTOMATIC, SELECT_BURST_SHOT, SELECT_FULLY_AUTOMATIC)
+	fire_select_modes = list(SELECT_SEMI_AUTOMATIC, SELECT_FULLY_AUTOMATIC)
 	rack_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/ltrifle_cock.ogg'
 	load_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/ltrifle_magin.ogg'
 	load_empty_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/ltrifle_magin.ogg'

--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -31,7 +31,7 @@
 	lock_back_sound = 'sound/weapons/gun/pistol/slide_lock.ogg'
 	bolt_drop_sound = 'sound/weapons/gun/pistol/slide_drop.ogg'
 	can_flashlight = TRUE
-	dirt_modifier = 1
+	dirt_modifier = 0.5
 	emp_damageable = TRUE
 	fire_delay = 1.90
 	company_flag = COMPANY_CANTALAN
@@ -77,7 +77,7 @@
 	mag_display_ammo = FALSE
 	can_flashlight = TRUE
 	company_flag = COMPANY_CANTALAN
-	dirt_modifier = 1
+	dirt_modifier = 0.7
 
 /obj/item/ammo_box/magazine/multi_sprite/g18
 	name = "\improper GK-18 magazine"
@@ -139,6 +139,7 @@
 	lock_back_sound = 'sound/weapons/gun/pistol/slide_lock.ogg'
 	bolt_drop_sound = 'sound/weapons/gun/pistol/slide_drop.ogg'
 	realistic = TRUE
+	dirt_modifier = 0.3
 	can_flashlight = TRUE
 	emp_damageable = TRUE
 	company_flag = COMPANY_ARMADYNE
@@ -217,6 +218,7 @@
 	mag_type = /obj/item/ammo_box/magazine/multi_sprite/pdh_peacekeeper
 	fire_sound = 'modular_skyrat/modules/sec_haul/sound/pistol_fire.ogg'
 	realistic = TRUE
+	dirt_modifier = 0.6
 	can_flashlight = TRUE
 	company_flag = COMPANY_ARMADYNE
 
@@ -263,7 +265,7 @@
 	bolt_drop_sound = 'sound/weapons/gun/pistol/slide_drop.ogg'
 	realistic = TRUE
 	can_flashlight = TRUE
-	dirt_modifier = 0.8
+	dirt_modifier = 0.6
 	emp_damageable = TRUE
 	fire_delay = 4.20
 	company_flag = COMPANY_ARMADYNE
@@ -305,7 +307,7 @@
 	rack_sound = 'sound/weapons/gun/pistol/rack.ogg'
 	lock_back_sound = 'sound/weapons/gun/pistol/slide_lock.ogg'
 	bolt_drop_sound = 'sound/weapons/gun/pistol/slide_drop.ogg'
-	dirt_modifier = 0.75
+	dirt_modifier = 0.3
 	emp_damageable = TRUE
 	company_flag = COMPANY_IZHEVSK
 
@@ -1061,6 +1063,7 @@
 	mag_display = TRUE
 	mag_display_ammo = TRUE
 	realistic = TRUE
+	dirt_modifier = 0.4
 	fire_sound = 'sound/weapons/gun/smg/shot.ogg'
 	emp_damageable = TRUE
 	can_bayonet = TRUE


### PR DESCRIPTION
## About The Pull Request
Removes burst first from the STG, as it made an already fantastic gun a god weapon, also removes it from the mp40 for the same reason, burst with the partial-auto aim from clicking on a mob made them far-far-far to strong.

Also, lowers the dirt modifier on alot of the armadyne handguns, and the makarov(Izhevsk) so they're less out shined by literally anything that can't get dirty (which is alot, like, functionally anything from oldarms/bolt/even-the-other-guns-in-izvhevsk are better then then), while not entirely removing the mechanic.





## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

balance: rebalanced the STG and MP40, by removing the burst-fire modes from them.
balance: Nerfed 'dirt' accumulation rate to armadyne (hand)guns, and the R-C Makarov, 
/:cl:

