### PR TITLE
[MODULAR] Yet Another Gun Balance PR, PT.II Revenge of the ammobox

### DIFF
--- a/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
@@ -1,6 +1,9 @@
 /obj/item/ammo_box/
 	w_class = WEIGHT_CLASS_NORMAL
 
+obj/item/ammo_box/magazine/
+	w_class = WEIGHT_CLASS_SMALL
+
 /obj/item/ammo_box/c9mm/ap
 	name = "ammo box (9mm AP)"
 	ammo_type = /obj/item/ammo_casing/c9mm/ap

--- a/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
@@ -6,6 +6,12 @@
 
 /obj/item/ammo_box/a762
 	w_class = WEIGHT_CLASS_SMALL
+	
+/obj/item/ammo_box/a357
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/ammo_box/c38
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ammo_box/c9mm/ap
 	name = "ammo box (9mm AP)"

--- a/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
@@ -1,3 +1,6 @@
+/obj/item/ammo_box/
+	w_class = WEIGHT_CLASS_NORMAL
+
 /obj/item/ammo_box/c9mm/ap
 	name = "ammo box (9mm AP)"
 	ammo_type = /obj/item/ammo_casing/c9mm/ap

--- a/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
@@ -4,6 +4,9 @@
 /obj/item/ammo_box/magazine
 	w_class = WEIGHT_CLASS_SMALL
 
+/obj/item/ammo_box/a762
+	w_class = WEIGHT_CLASS_SMALL
+
 /obj/item/ammo_box/c9mm/ap
 	name = "ammo box (9mm AP)"
 	ammo_type = /obj/item/ammo_casing/c9mm/ap

--- a/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_box
 	w_class = WEIGHT_CLASS_NORMAL
 
-obj/item/ammo_box/magazine/
+/obj/item/ammo_box/magazine
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ammo_box/c9mm/ap

--- a/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/ammo_boxes.dm
@@ -1,4 +1,4 @@
-/obj/item/ammo_box/
+/obj/item/ammo_box
 	w_class = WEIGHT_CLASS_NORMAL
 
 obj/item/ammo_box/magazine/

--- a/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
@@ -1,5 +1,4 @@
 /obj/item/ammo_box/advanced
-	w_class = WEIGHT_CLASS_NORMAL
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
 /datum/techweb_node/peacekeeper_ammo_advanced

--- a/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/ammo.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_box/advanced
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
 /datum/techweb_node/peacekeeper_ammo_advanced


### PR DESCRIPTION


## About The Pull Request
Standardizes all ammo-boxes to use weight_class_normal, as compared to some being /tiny/, and others being bulky, for no discernible reason (usually, the /weaker/ ammo's were bulky, while the better were tiny, letting you carry 7 boxes of makarov ammo in your internals box, but not the 15 damage peacekeeper 9mil)
## How This Contributes To The Skyrat Roleplay Experience
All boxes of ammo are now the same size, and no longer fit in cardboard boxes, to prevent holyshit you could literally carry like 600 rounds in your backpack.

## Changelog



:cl:

balance: All ammo boxes which were previously tiny, or bulky, have been made to the new standard of ambiguously  'normal sized' per corporate regulations.
/:cl:

