### PR TITLE
[NONMODULAR] Allows Ethereals To Wear Underwear

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -15,7 +15,7 @@
 	payday_modifier = 0.75
 	attack_type = BURN //burn bish
 	damage_overlay_type = "" //We are too cool for regular damage overlays
-	species_traits = list(DYNCOLORS, AGENDER, NO_UNDERWEAR, HAIR, FACEHAIR, HAS_FLESH, HAS_BONE) // i mean i guess they have blood so they can have wounds too
+	species_traits = list(DYNCOLORS, AGENDER, HAIR, FACEHAIR, HAS_FLESH, HAS_BONE) // i mean i guess they have blood so they can have wounds too //SKYRAT EDIT - Removes Lack of Underwear
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_cookie = /obj/item/food/energybar
 	species_language_holder = /datum/language_holder/ethereal


### PR DESCRIPTION
## About The Pull Request
I simply can't make good outfits without the ability to access shirts, it's impossible. This doesn't give them sexes, so it doesn't violate lore of them being asexual and nonbinary.

## How This Contributes To The Skyrat Roleplay Experience
Customization is important, m'kay?

## Changelog
:cl:
qol: Ethereals can now access underwear, shirts, and socks.
/:cl: