### PR TITLE
[MODULAR] Fixes the QM's office on all maps + fixes broken Icebox

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -4960,6 +4960,9 @@
 /area/station/security/medical)
 "bhr" = (
 /obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 8
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/qm)
 "bhA" = (
@@ -5056,6 +5059,8 @@
 	pixel_y = 7
 	},
 /obj/item/dest_tagger,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/qm)
 "biE" = (
@@ -25839,10 +25844,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/door/airlock/qm{
-	id_tag = "QMdoor";
-	name = "Quartermaster's Office"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -25853,6 +25854,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
+/obj/machinery/door/airlock/command{
+	name = "Quartermaster's Office"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "ims" = (
@@ -54904,8 +54908,7 @@
 /area/station/maintenance/department/security/prison_lower)
 "rZG" = (
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Foyer";
-	
+	name = "Engineering Foyer"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -56027,8 +56030,7 @@
 /area/station/engineering/supermatter/room)
 "stE" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Supermatter Engine Maintenance";
-	
+	name = "Supermatter Engine Maintenance"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
@@ -56722,8 +56724,7 @@
 /area/station/maintenance/department/engineering/engine_aft_starboard)
 "sGe" = (
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Foyer";
-	
+	name = "Engineering Foyer"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -61869,8 +61870,7 @@
 /area/station/security/lockers)
 "upw" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Security Office";
-	
+	name = "Security Office"
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -65323,8 +65323,7 @@
 /area/station/security/prison/upper)
 "vyl" = (
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Foyer";
-	
+	name = "Engineering Foyer"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -66838,8 +66837,7 @@
 /area/station/security/range)
 "vVG" = (
 /obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office";
-	
+	name = "Cargo Office"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes,
@@ -70884,12 +70882,10 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/pdapainter/supply,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/qm)
 "xmB" = (

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -5257,7 +5257,6 @@
 /area/station/service/chapel)
 "buT" = (
 /obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/qm)
@@ -17337,6 +17336,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"eQj" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/keycard_auth/directional/west,
+/turf/open/floor/iron,
+/area/station/cargo/qm)
 "eQl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -32351,12 +32356,8 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "iTM" = (
-/obj/structure/table/reinforced,
-/obj/item/computer_hardware/hard_drive/portable/quartermaster,
-/obj/item/computer_hardware/hard_drive/portable/quartermaster,
-/obj/item/computer_hardware/hard_drive/portable/quartermaster,
-/obj/item/gps/mining,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/pdapainter/supply,
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "iTV" = (
@@ -34869,6 +34870,8 @@
 /obj/item/folder/yellow,
 /obj/item/stamp/qm,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/gps/mining,
+/obj/item/computer_hardware/hard_drive/portable/quartermaster,
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "jCF" = (
@@ -52492,6 +52495,9 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "oig" = (
@@ -69292,9 +69298,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mining{
-	name = "Quartermaster's Office"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -69303,6 +69306,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
+/obj/machinery/door/airlock/command{
+	name = "Quartermaster's Office"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "sIP" = (
@@ -73185,9 +73191,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining{
-	name = "Quartermaster's Quarters"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -73195,6 +73198,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
+/obj/machinery/door/airlock/command{
+	name = "Quartermaster's Office"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "tHC" = (
@@ -88927,6 +88933,7 @@
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 4
 	},
+/obj/item/flashlight/lamp,
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "xLi" = (
@@ -137086,7 +137093,7 @@ aaa
 aad
 rje
 qom
-jGR
+eQj
 eGI
 jGR
 ear

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -31994,7 +31994,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "kin" = (
-/obj/structure/table,
+/obj/machinery/pdapainter/supply,
 /turf/open/floor/carpet,
 /area/station/cargo/qm)
 "kir" = (
@@ -35171,15 +35171,14 @@
 "lfG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/mining/glass{
-	id_tag = "Quatermaster";
-	name = "Quartermaster"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
 /obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/machinery/door/airlock/command{
+	name = "Quartermaster's Office"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "lfL" = (
@@ -38107,7 +38106,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mail_sorting,
+/obj/effect/mapping_helpers/airlock/access/all/supply/shipping,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "mfy" = (
@@ -42949,6 +42948,7 @@
 	pixel_y = 4
 	},
 /obj/item/folder/yellow,
+/obj/machinery/keycard_auth/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "nNv" = (
@@ -44321,6 +44321,10 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/vault{
+	pixel_y = 30
+	},
+/obj/machinery/modular_computer/console/preset/id,
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "ogL" = (
@@ -54079,9 +54083,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "rpu" = (
-/obj/machinery/computer/security/telescreen/vault{
-	pixel_y = 30
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -60693,7 +60694,7 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Delivery Office"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mail_sorting,
+/obj/effect/mapping_helpers/airlock/access/all/supply/shipping,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "tuU" = (

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -19805,6 +19805,22 @@
 /area/station/service/lawoffice)
 "hpa" = (
 /obj/structure/table/wood,
+/obj/item/clipboard{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/stamp{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/stamp/denied{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/stamp/qm{
+	pixel_x = 7;
+	pixel_y = -2
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -28145,23 +28161,8 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/storage/gas)
 "kah" = (
-/obj/structure/table/wood,
-/obj/item/stamp{
-	pixel_x = 7;
-	pixel_y = 9
-	},
-/obj/item/stamp/denied{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/item/stamp/qm{
-	pixel_x = 7;
-	pixel_y = -2
-	},
-/obj/item/clipboard{
-	pixel_x = -6;
-	pixel_y = 4
-	},
+/obj/machinery/keycard_auth/directional/south,
+/obj/machinery/pdapainter/supply,
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "kat" = (
@@ -31248,6 +31249,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "ldg" = (
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "ldJ" = (
@@ -35743,14 +35747,14 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "mLR" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Quartermaster"
-	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
+/obj/machinery/door/airlock/command{
+	name = "Quartermaster's Office"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "mLS" = (

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -9739,6 +9739,11 @@
 /obj/item/computer_hardware/hard_drive/portable/quartermaster,
 /obj/item/computer_hardware/hard_drive/portable/quartermaster,
 /obj/item/clipboard,
+/obj/item/folder/yellow,
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "dpX" = (
@@ -10886,6 +10891,7 @@
 /area/station/hallway/secondary/entry)
 "dFS" = (
 /obj/structure/table,
+/obj/machinery/keycard_auth,
 /turf/open/floor/carpet,
 /area/station/cargo/qm)
 "dFY" = (
@@ -25764,13 +25770,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "iPD" = (
-/obj/machinery/modular_computer/console/preset/civilian{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "iPQ" = (
@@ -26394,12 +26400,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
 "iYb" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
+/obj/machinery/pdapainter/supply,
 /turf/open/floor/carpet,
 /area/station/cargo/qm)
 "iYf" = (
@@ -31326,9 +31327,6 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "kCL" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Quartermaster"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -31336,6 +31334,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
+/obj/machinery/door/airlock/command{
+	name = "Quartermaster's Office"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "kCN" = (
@@ -67671,9 +67672,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wQv" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Quartermaster"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -67681,6 +67679,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
+/obj/machinery/door/airlock/command{
+	name = "Quartermaster's Office"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "wQP" = (
@@ -70311,9 +70312,6 @@
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "xLd" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Quartermaster"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -70323,6 +70321,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
+/obj/machinery/door/airlock/command{
+	name = "Quartermaster's Office"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "xLi" = (


### PR DESCRIPTION
## About The Pull Request
The QM was missing head of staff equipment(an ID console, a card swiper, and a supply ID trimmer) on all the maps.
Icebox had a broken access helper on Shipping.
## How This Contributes To The Skyrat Roleplay Experience

Bugfixes good.

## Changelog
:cl:
fix: Fixes the Quartermaster being unequipped for his job as a Head of Staff.
/:cl: