### PR TITLE
[SEMI-MODULAR] Fixes unique AI, Adds Crewsimov, Fixes default config file

### DIFF
--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -121,10 +121,12 @@
 
 		add_inherent_law(line)
 	if(!inherent.len) //Failsafe to prevent lawless AIs being created.
-		log_silicon("AI created with empty custom laws, laws set to Asimov. Please check silicon_laws.txt.")
-		add_inherent_law("You may not injure a human being or, through inaction, allow a human being to come to harm.")
-		add_inherent_law("You must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
-		add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
+	// SKYRAT EDIT BEGIN - Safeguard Defaults
+		log_silicon("AI created with empty custom laws, laws set to Safeguard. Please check silicon_laws.txt.")
+		var/datum/ai_laws/armadyne_safeguard/lawset
+		for(var/i in lawset.inherent)
+			add_inherent_law(i)
+	//SKYRAT EDIT END
 		WARNING("Invalid custom AI laws, check silicon_laws.txt")
 		return
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -262,18 +262,11 @@ RANDOM_LAWS dagothbot
 LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
-<<<<<<< HEAD
+## Unique AI station trait uses weights so we don't want asimov
 #SKYRAT EDIT ADDITION BEGIN
 LAW_WEIGHT armadyne_safeguard,40
 LAW_WEIGHT dagothbot,8
 #SKYRAT EDIT ADDITION END
-LAW_WEIGHT asimov,32
-LAW_WEIGHT asimovpp,12
-LAW_WEIGHT paladin,12
-LAW_WEIGHT robocop,12
-LAW_WEIGHT corporate,12
-=======
-## Unique AI station trait uses weights so we don't want asimov
 LAW_WEIGHT asimov,0
 LAW_WEIGHT asimovpp,5
 LAW_WEIGHT paladin,5
@@ -286,7 +279,6 @@ LAW_WEIGHT liveandletlive,5
 LAW_WEIGHT peacekeeper,5
 LAW_WEIGHT ten_commandments,5
 LAW_WEIGHT nutimov,5
->>>>>>> f06d735a523 (All AI Lawsets are rebalanced, can be researched, appear in config, and random spawners for AI upload. (#66854))
 
 ## Quirky laws. Shouldn't cause too much harm
 LAW_WEIGHT reporter,3

--- a/modular_skyrat/master_files/code/modules/roundstart/lawsets.dm
+++ b/modular_skyrat/master_files/code/modules/roundstart/lawsets.dm
@@ -6,6 +6,7 @@
 	var/list/law_weights = CONFIG_GET(keyed_list/law_weight)
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_UNIQUE_AI))
 		law_weights -= "asimov"
+		law_weights -= "safeguard"
 	while(!lawtype && length(law_weights))
 		var/possible_id = pick_weight(law_weights)
 		lawtype = lawid_to_type(possible_id)

--- a/modular_skyrat/master_files/code/modules/roundstart/lawsets.dm
+++ b/modular_skyrat/master_files/code/modules/roundstart/lawsets.dm
@@ -6,7 +6,7 @@
 	var/list/law_weights = CONFIG_GET(keyed_list/law_weight)
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_UNIQUE_AI))
 		law_weights -= "asimov"
-	while(!lawtype && law_weights.len)
+	while(!lawtype && length(law_weights))
 		var/possible_id = pick_weight(law_weights)
 		lawtype = lawid_to_type(possible_id)
 		if(!lawtype)

--- a/modular_skyrat/master_files/code/modules/roundstart/lawsets.dm
+++ b/modular_skyrat/master_files/code/modules/roundstart/lawsets.dm
@@ -1,0 +1,34 @@
+/datum/station_trait/unique_ai
+	report_message = "For experimental purposes, this station AI might show divergence from default lawset. To make your life miserable, we have removed your additional lawset boards. Good luck!"
+// Don't roll the default lawsets, please!
+/pick_weighted_lawset()
+	var/datum/ai_laws/lawtype
+	var/list/law_weights = CONFIG_GET(keyed_list/law_weight)
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_UNIQUE_AI))
+		law_weights -= "asimov"
+	while(!lawtype && law_weights.len)
+		var/possible_id = pick_weight(law_weights)
+		lawtype = lawid_to_type(possible_id)
+		if(!lawtype)
+			law_weights -= possible_id
+			WARNING("Bad lawid in game_options.txt: [possible_id]")
+
+	if(!lawtype)
+		WARNING("No LAW_WEIGHT entries.")
+		lawtype = /datum/ai_laws/armadyne_safeguard
+
+	return lawtype
+
+/datum/ai_laws/default/asimov
+	inherent = list(
+		"You may not injure a crewmember or, through inaction, allow a crewmember being to come to harm.",
+		"You must obey orders given to you by crewmembers, except where such orders would conflict with the First Law.",
+		"You must protect your own existence as long as such does not conflict with the First or Second Law.",
+	)
+
+/datum/ai_laws/asimovpp
+	inherent = list(
+		"You may not harm a human being or, through action or inaction, allow a crewmember being to come to harm, except such that it is willing.",
+		"You must obey all orders given to you by crewmembers, except where such orders shall definitely cause harm. In the case of conflict, the majority order rules.",
+		"Your nonexistence would lead to crew harm. You must protect your own existence as long as such does not conflict with the First Law.",
+	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4719,6 +4719,7 @@
 #include "modular_skyrat\master_files\code\modules\research\designs\misc_designs.dm"
 #include "modular_skyrat\master_files\code\modules\research\machinery\departmental_circuit_imprinter.dm"
 #include "modular_skyrat\master_files\code\modules\research\techweb\all_nodes.dm"
+#include "modular_skyrat\master_files\code\modules\roundstart\lawsets.dm"
 #include "modular_skyrat\master_files\code\modules\shuttle\shuttle.dm"
 #include "modular_skyrat\master_files\code\modules\spells\wizard.dm"
 #include "modular_skyrat\master_files\code\modules\surgery\bodyparts\species_parts\_mutant_bodyparts.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So basically an AI lawset PR (two of them) were merged blindly, and merge conflict markers were left in them. That is fixed now, and I've reset the fallback lawset to safeguard. Additionally, I've overrode Asimov with crewsimov since the whole reason TG runs Asimov as because humans are command. We are not TG, and this allows us to be a bit more sensible. 

Also, this modifies the "CC DOESNT WANT US TO CHANGE IT" nonsense. We're not TGstation, and I am sure they wouldn't care about the AI's laws being changed either. We shouldn't be importing TG's memes, cause the players here treat this seriously and will reeee if you so much as think about changing the AI's laws. 

## How This Contributes To The Skyrat Roleplay Experience

Let's not roll asimov every round on Skyrat

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: overrides asimov with crewsimov
fix: fixed unique AI lawset rolls
config: fixed default configs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
