### PR TITLE
Laughtrack emote for synthetics!

### DIFF
--- a/modular_skyrat/modules/emotes/code/synth_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/synth_emotes.dm
@@ -143,7 +143,6 @@
 	key = "laughtrack"
 	message = "plays a laughtrack."
 	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
 	sound = 'sound/items/sitcomlaugh2.ogg'
 	silicon_allowed = TRUE
 	allowed_species = list(/datum/species/robotic/ipc, /datum/species/robotic/synthliz, /datum/species/robotic/synthetic_human, /datum/species/robotic/synthetic_mammal)

--- a/modular_skyrat/modules/emotes/code/synth_emotes.dm
+++ b/modular_skyrat/modules/emotes/code/synth_emotes.dm
@@ -138,3 +138,13 @@
 	silicon_allowed = TRUE
 	allowed_species = list(/datum/species/robotic/ipc, /datum/species/robotic/synthliz, /datum/species/robotic/synthetic_human, /datum/species/robotic/synthetic_mammal)
 	cooldown = 2 SECONDS
+
+/datum/emote/living/human/laughtrack
+	key = "laughtrack"
+	message = "plays a laughtrack."
+	emote_type = EMOTE_AUDIBLE
+	vary = TRUE
+	sound = 'sound/items/sitcomlaugh2.ogg'
+	silicon_allowed = TRUE
+	allowed_species = list(/datum/species/robotic/ipc, /datum/species/robotic/synthliz, /datum/species/robotic/synthetic_human, /datum/species/robotic/synthetic_mammal)
+	cooldown = 2 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just cracked a great joke? Nobody laughing? Tough crowd? Fear not, synthetics! Now you'll be able to summon your own laugh track to give your overused yo mama joke the attention it deserves!

https://user-images.githubusercontent.com/77675526/172962313-a296568f-aebd-4894-8d72-e5a4df5a95c6.mp4

## How This Contributes To The Skyrat Roleplay Experience

Emote variety is good. 

Having a readily-available laugh track is integral to comedic moments.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new *laughtrack emote for synthetics to play on a whim!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
