### PR TITLE
Fixes stasis removing numbing and adds pre-surgery warning. 

### DIFF
--- a/code/datums/components/surgery_initiator.dm
+++ b/code/datums/components/surgery_initiator.dm
@@ -329,7 +329,7 @@
 	)
 
 	if(!(HAS_TRAIT(target, TRAIT_NUMBED) || target.stat >= UNCONSCIOUS)) ///skyrat add start - warning for unanesthetized surgery
-		to_chat(user, span_warning("You notice [target] react to your touch and realize they might feel this.")) ///skyrat add end
+		balloon_alert(user, "not numbed!") ///skyrat add end
 	
 	log_combat(user, target, "operated on", null, "(OPERATION TYPE: [procedure.name]) (TARGET AREA: [selected_zone])")
 

--- a/code/datums/components/surgery_initiator.dm
+++ b/code/datums/components/surgery_initiator.dm
@@ -328,6 +328,9 @@
 		span_notice("You drape [parent] over [target]'s [parse_zone(selected_zone)] to prepare for \an [procedure.name]."),
 	)
 
+	if(!(HAS_TRAIT(target, TRAIT_NUMBED) || target.stat >= UNCONSCIOUS)) ///skyrat add start - warning for unanesthetized surgery
+		to_chat(user, span_warning("You notice [target] react to your touch and realize they might feel this.")) ///skyrat add end
+	
 	log_combat(user, target, "operated on", null, "(OPERATION TYPE: [procedure.name]) (TARGET AREA: [selected_zone])")
 
 /datum/component/surgery_initiator/proc/surgery_needs_exposure(datum/surgery/surgery, mob/living/target)

--- a/code/datums/components/surgery_initiator.dm
+++ b/code/datums/components/surgery_initiator.dm
@@ -329,7 +329,7 @@
 	)
 
 	if(!(HAS_TRAIT(target, TRAIT_NUMBED) || target.stat >= UNCONSCIOUS)) ///skyrat add start - warning for unanesthetized surgery
-		balloon_alert(user, "not numbed!") ///skyrat add end
+		target.balloon_alert(user, "not numbed!") ///skyrat add end
 	
 	log_combat(user, target, "operated on", null, "(OPERATION TYPE: [procedure.name]) (TARGET AREA: [selected_zone])")
 

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -262,8 +262,8 @@
 		return
 	ADD_TRAIT(owner, TRAIT_IMMOBILIZED, TRAIT_STATUS_EFFECT(id))
 	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, TRAIT_STATUS_EFFECT(id))
-	ADD_TRAIT(owner, TRAIT_NUMBED, "stasis") //SKYRAT EDIT START - STASIS APPLIES NUMBING
-	owner.throw_alert("numbed", /atom/movable/screen/alert/numbed) //SKYRAT EDIT END
+	ADD_TRAIT(owner, TRAIT_NUMBED, TRAIT_STATUS_EFFECT(id)) //SKYRAT EDIT START - STASIS APPLIES NUMBING
+	owner.throw_alert("stasis numbed", /atom/movable/screen/alert/numbed) //SKYRAT EDIT END
 	owner.add_filter("stasis_status_ripple", 2, list("type" = "ripple", "flags" = WAVE_BOUNDED, "radius" = 0, "size" = 2))
 	var/filter = owner.get_filter("stasis_status_ripple")
 	animate(filter, radius = 0, time = 0.2 SECONDS, size = 2, easing = JUMP_EASING, loop = -1, flags = ANIMATION_PARALLEL)
@@ -281,8 +281,8 @@
 	REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, TRAIT_STATUS_EFFECT(id))
 	REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, TRAIT_STATUS_EFFECT(id))
 	if(HAS_TRAIT(owner, TRAIT_NUMBED)) //SKYRAT EDIT START - STASIS END REMOVES NUMBING
-		REMOVE_TRAIT(owner, TRAIT_NUMBED, "stasis")
-		owner.clear_alert("numbed") //SKYRAT EDIT END
+		REMOVE_TRAIT(owner, TRAIT_NUMBED, TRAIT_STATUS_EFFECT(id))
+		owner.clear_alert("stasis numbed") //SKYRAT EDIT END
 	owner.remove_filter("stasis_status_ripple")
 	update_time_of_death()
 	if(iscarbon(owner))


### PR DESCRIPTION
## About The Pull Request

Fixes stasis numbing + numbing agents cancelling each other out.

Adds a little to_chat pre-surgery warning if your target isn't numb or unconscious when preparing a surgery with drapes.

## How This Contributes To The Skyrat Roleplay Experience

One of the reasons for making stasis tables numb again in the first place (inshallah we will be abandoning them altogether) was that the way it worked before sucked and made it very easy to give a person morphine they wouldn't process only to start cutting and have them scream bloody murder. In any situation, being able to tell before starting your surgery that this might hurt the person or you have something to fix is a good thing for doctors trying to minimize bad moodies and maximize speed for their patients.

Getting punished for trying to numb your patients with chemicals by having it cancel out with stasis also sucks and so is fixed.

## Changelog

:cl:
qol: Added a little warning if you try to start a surgery on somebody who isn't numbed.
fix: Stasis + numbing agents no longer cancel each other out for surgical numbing.
/:cl: