### PR TITLE
[MODULAR] Replaces Stasis Pods in BlueShift with Stasis Beds.

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_upper.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_upper.dmm
@@ -21001,7 +21001,9 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/stasissleeper,
+/obj/machinery/stasis{
+	dir = 1
+	},
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floormed"
 	},
@@ -23896,20 +23898,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/station/maintenance/port/upper)
-"hTK" = (
-/obj/effect/turf_decal/stripes/white/line{
-	color = "#52B4E9";
-	dir = 6;
-	name = "blue line"
-	},
-/obj/effect/turf_decal/tile/blue/full,
-/obj/machinery/stasissleeper{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/evac{
-	icon_state = "floormed"
-	},
-/area/station/medical/cryo)
 "hTM" = (
 /turf/closed/wall,
 /area/station/commons/dorms)
@@ -44166,8 +44154,8 @@
 	pixel_x = -24
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/stasissleeper{
-	dir = 4
+/obj/machinery/stasis{
+	dir = 1
 	},
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floormed"
@@ -58713,7 +58701,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/stasissleeper,
+/obj/machinery/stasis,
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floormed"
 	},
@@ -62748,7 +62736,7 @@
 	name = "blue line"
 	},
 /obj/effect/turf_decal/tile/blue/full,
-/obj/machinery/stasissleeper{
+/obj/machinery/stasis{
 	dir = 1
 	},
 /turf/open/floor/iron/shuttle/evac{
@@ -63860,9 +63848,7 @@
 	name = "blue line"
 	},
 /obj/effect/turf_decal/tile/blue/full,
-/obj/machinery/stasissleeper{
-	dir = 8
-	},
+/obj/machinery/stasis,
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "floormed"
 	},
@@ -111674,7 +111660,7 @@ kGc
 tUv
 kEd
 qpQ
-hTK
+vLN
 upb
 sQl
 gGy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It does what the title says. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Stasis pods aren't standard anymore, Blueshift was the only station where stasis beds didn't come standard.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Blueshift now uses stasis beds instead of stasis pods.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
