### PR TITLE
[MODULAR] The PR that kills the ASHA, (and replaces it with two more fitting old-arms guns)

### DIFF
--- a/code/__DEFINES/~skyrat_defines/projectiles.dm
+++ b/code/__DEFINES/~skyrat_defines/projectiles.dm
@@ -25,3 +25,6 @@
 
 /// The caliber used by the Ripper gen2
 #define CALIBER_B577 ".577 Snider"
+
+/// The caliber used by the Oldarms 'Mk.11.4 rifle'
+#define CALIBER_223 ".223 Stinger"

--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/armadyne_oldarms.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/armadyne_oldarms.dm
@@ -27,17 +27,24 @@
 	lower_cost = CARGO_CRATE_VALUE * 16
 	upper_cost = CARGO_CRATE_VALUE * 20
 	interest_required = PASSED_INTEREST
+	
+/datum/armament_entry/cargo_gun/oldarms/smg/pps
+	item_type = /obj/item/gun/ballistic/automatic/pps 
+	lower_cost = CARGO_CRATE_VALUE * 15
+	upper_cost = CARGO_CRATE_VALUE * 19
+	interest_required = PASSED_INTEREST
 
-/datum/armament_entry/cargo_gun/oldarms/smg/ppsh
-	item_type = /obj/item/gun/ballistic/automatic/ppsh
-	lower_cost = CARGO_CRATE_VALUE * 32
-	upper_cost = CARGO_CRATE_VALUE * 38
-	interest_required = HIGH_INTEREST
 
 /datum/armament_entry/cargo_gun/oldarms/rifle
 	subcategory = ARMAMENT_SUBCATEGORY_ASSAULTRIFLE
 	interest_required = HIGH_INTEREST
 	restricted = TRUE
+	
+/datum/armament_entry/cargo_gun/oldarms/rifle/m16/oldarms
+	item_type = /obj/item/gun/ballistic/automatic/m16/oldarms
+	lower_cost = CARGO_CRATE_VALUE * 20
+	upper_cost = CARGO_CRATE_VALUE * 24
+	interest_required = HIGH_INTEREST
 
 /datum/armament_entry/cargo_gun/oldarms/rifle/vintorez
 	item_type = /obj/item/gun/ballistic/automatic/vintorez

--- a/modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/ballistic/automatic/m16/oldarms
 	name = "\improper Mk-11.4 Rifle"
-	desc = "An old-fashioned rifle from Sol-3's bygone era, rumor has it, it can shoot apart an entire jungle, or desert given the time, has \"Keep out of water\" laser-engraved on the side. Now including a free reflex sight!"
+	desc = "An old-fashioned rifle from Sol-3's bygone era. Rumor has it that it can shoot apart an entire jungle (or desert, given the time). It has \"Keep out of water\" laser-engraved on the side. Now including a free reflex sight!"
 	icon = 'modular_skyrat/modules/gunsgalore/icons/guns/gunsgalore_guns40x32.dmi'
 	icon_state = "m16"
 	lefthand_file = 'modular_skyrat/modules/gunsgalore/icons/guns/gunsgalore_lefthand.dmi'

--- a/modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm
@@ -1,0 +1,47 @@
+/obj/item/gun/ballistic/automatic/m16/oldarms
+	name = "\improper Mk-11.4 Rifle"
+	desc = "An old-fashioned rifle from Sol-3's bygone era, rumor has it, it can shoot apart an entire jungle given the time, has \"Keep out of water\" laser-engraved on the side."
+	icon = 'modular_skyrat/modules/gunsgalore/icons/guns/gunsgalore_guns40x32.dmi'
+	icon_state = "m16"
+	lefthand_file = 'modular_skyrat/modules/gunsgalore/icons/guns/gunsgalore_lefthand.dmi'
+	righthand_file = 'modular_skyrat/modules/gunsgalore/icons/guns/gunsgalore_righthand.dmi'
+	inhand_icon_state = "m16"
+	worn_icon = 'modular_skyrat/modules/gunsgalore/icons/guns/gunsgalore_back.dmi'
+	worn_icon_state = "m16"
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
+	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
+	mag_type = /obj/item/ammo_box/magazine/m16/vintage/oldarms
+  fire_delay = 1.9
+	fire_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/fire/m16_fire.ogg'
+	fire_sound_volume = 50
+	rack_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/sfrifle_cock.ogg'
+	load_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/sfrifle_magin.ogg'
+	load_empty_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/sfrifle_magin.ogg'
+	eject_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/sfrifle_magout.ogg'
+	alt_icons = TRUE
+	realistic = TRUE
+  fire_select_modes = list(SELECT_SEMI_AUTOMATIC, SELECT_FULLY_AUTOMATIC)
+  
+  
+  /obj/item/ammo_box/magazine/m16/vintage/oldarms
+	name = "old-fashioned mk-11.4 rifle magazine"
+	desc = "A double-stack solid magazine that looks rather dated. Holds 20 rounds of .277 Aestus."
+	icon = 'modular_skyrat/modules/gunsgalore/icons/guns/gunsgalore_items.dmi'
+	icon_state = "m16"
+	ammo_type = /obj/item/ammo_casing/oldarms/a223
+	caliber = "223"
+	max_ammo = 20
+	multiple_sprites = AMMO_BOX_FULL_EMPTY
+  
+  /obj/item/ammo_casing/oldarms/a223
+	name = "5.56x45mm bullet casing"
+	desc = "A cheaply made 5.56x45mm bullet casing."
+	caliber = CALIBER_223
+	projectile_type = /obj/projectile/bullet/oldarms/a223
+
+/obj/projectile/bullet/oldarms/a223
+  name = "5.56mm bullet"
+	damage = 26
+	armour_penetration = 5
+	wound_bonus = -20

--- a/modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/ballistic/automatic/m16/oldarms
 	name = "\improper Mk-11.4 Rifle"
-	desc = "An old-fashioned rifle from Sol-3's bygone era, rumor has it, it can shoot apart an entire jungle given the time, has \"Keep out of water\" laser-engraved on the side."
+	desc = "An old-fashioned rifle from Sol-3's bygone era, rumor has it, it can shoot apart an entire jungle, or desert given the time, has \"Keep out of water\" laser-engraved on the side. Now including a free reflex sight!"
 	icon = 'modular_skyrat/modules/gunsgalore/icons/guns/gunsgalore_guns40x32.dmi'
 	icon_state = "m16"
 	lefthand_file = 'modular_skyrat/modules/gunsgalore/icons/guns/gunsgalore_lefthand.dmi'
@@ -12,7 +12,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	mag_type = /obj/item/ammo_box/magazine/m16/vintage/oldarms
-  fire_delay = 1.9
+  	fire_delay = 3.5
 	fire_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/fire/m16_fire.ogg'
 	fire_sound_volume = 50
 	rack_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/sfrifle_cock.ogg'
@@ -21,7 +21,7 @@
 	eject_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/sfrifle_magout.ogg'
 	alt_icons = TRUE
 	realistic = TRUE
-  fire_select_modes = list(SELECT_SEMI_AUTOMATIC, SELECT_FULLY_AUTOMATIC)
+  	fire_select_modes = list(SELECT_SEMI_AUTOMATIC, SELECT_FULLY_AUTOMATIC)
   
   
   /obj/item/ammo_box/magazine/m16/vintage/oldarms
@@ -41,7 +41,7 @@
 	projectile_type = /obj/projectile/bullet/oldarms/a223
 
 /obj/projectile/bullet/oldarms/a223
-  name = "5.56mm bullet"
+  	name = "5.56mm bullet"
 	damage = 26
 	armour_penetration = 5
 	wound_bonus = -20

--- a/modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm
@@ -12,7 +12,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	mag_type = /obj/item/ammo_box/magazine/m16/vintage/oldarms
-  	fire_delay = 3.5
+	fire_delay = 3.5
 	fire_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/fire/m16_fire.ogg'
 	fire_sound_volume = 50
 	rack_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/sfrifle_cock.ogg'
@@ -21,12 +21,12 @@
 	eject_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/sfrifle_magout.ogg'
 	alt_icons = TRUE
 	realistic = TRUE
-  	fire_select_modes = list(SELECT_SEMI_AUTOMATIC, SELECT_FULLY_AUTOMATIC)
+	fire_select_modes = list(SELECT_SEMI_AUTOMATIC, SELECT_FULLY_AUTOMATIC)
   
   
-  /obj/item/ammo_box/magazine/m16/vintage/oldarms
+/obj/item/ammo_box/magazine/m16/vintage/oldarms
 	name = "old-fashioned mk-11.4 rifle magazine"
-	desc = "A double-stack solid magazine that looks rather dated. Holds 20 rounds of .277 Aestus."
+	desc = "A double-stack solid magazine that looks rather dated. Holds 20 rounds of .223 Stinger."
 	icon = 'modular_skyrat/modules/gunsgalore/icons/guns/gunsgalore_items.dmi'
 	icon_state = "m16"
 	ammo_type = /obj/item/ammo_casing/oldarms/a223
@@ -34,14 +34,32 @@
 	max_ammo = 20
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
   
-  /obj/item/ammo_casing/oldarms/a223
-	name = "5.56x45mm bullet casing"
-	desc = "A cheaply made 5.56x45mm bullet casing."
+/obj/item/ammo_casing/oldarms/a223
+	name = ".223 Stinger bullet casing"
+	desc = "A cheaply made .233 Stinger bullet casing."
 	caliber = CALIBER_223
 	projectile_type = /obj/projectile/bullet/oldarms/a223
 
 /obj/projectile/bullet/oldarms/a223
-  	name = "5.56mm bullet"
+	name = ".223 bullet"
 	damage = 26
 	armour_penetration = 5
 	wound_bonus = -20
+	
+/obj/item/ammo_casing/oldarms/a223/rubber
+	name = ".223 Stinger rubber bullet casing"
+	desc = "A cheaply made .233 Stinger bullet casing, now in rubber."
+	caliber = CALIBER_223
+	projectile_type = /obj/projectile/bullet/oldarms/a223/rubber
+	
+/obj/projectile/bullet/oldarms/a223/rubber
+	name = ".223 Rubber"
+	damage = 5
+	stamina = 25
+	ricochets_max = 3
+	ricochet_incidence_leeway = 0
+	ricochet_chance = 130
+	ricochet_decay_damage = 0.5
+	shrapnel_type = null
+	sharpness = NONE
+	embedding = null

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5294,6 +5294,7 @@
 #include "modular_skyrat\modules\gun_cargo\code\objects\vending.dm"
 #include "modular_skyrat\modules\gun_cargo\code\objects\guns\interdyne.dm"
 #include "modular_skyrat\modules\gun_cargo\code\objects\guns\izhevsk.dm"
+#include "modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm"
 #include "modular_skyrat\modules\gunhud\code\gun_hud.dm"
 #include "modular_skyrat\modules\gunhud\code\gun_hud_component.dm"
 #include "modular_skyrat\modules\gunpoint\code\gunpoint.dm"


### PR DESCRIPTION
## About The Pull Request
Kills the balance issue that is the ASHA, replacing it with the 'brand-new' mk-11.4 (m4a1 wannabe, worse then the STG in almost all regards), and a PPS (much weaker PPSH, with a much smaller magazine)

### do not let fruits hear what I named it

## How This Contributes To The Skyrat Roleplay Experience
Turns out, the asha was way-to-good at uraa'ing.
## Changelog


:cl:
add: Add's an oldarms renamed, and nerfed variant of the m16 called the mk-11.4, and a PPS to replace the ASHA.
del: Removes the asha from oldarms, obviously.

/:cl:


