### PR TITLE
[Host] Triangulate Weakpoint objective now requires 80 crew to take

### DIFF
--- a/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
+++ b/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
@@ -11,6 +11,7 @@
 	progression_minimum = 45 MINUTES
 	progression_reward = list(15 MINUTES, 20 MINUTES)
 	telecrystal_reward = list(3, 5)
+	population_requirement = 80 //SKYRAT EDIT
 
 	var/progression_objectives_minimum = 20 MINUTES
 

--- a/code/modules/antagonists/traitor/traitor_objective.dm
+++ b/code/modules/antagonists/traitor/traitor_objective.dm
@@ -44,6 +44,10 @@
 	var/original_progression = 0
 	/// Abstract type that won't be included as a possible objective
 	var/abstract_type = /datum/traitor_objective
+	// SKYRAT EDIT START
+	/// The amount of crew required for the objective to appeaar
+	var/population_requirement = 0
+	// SKYRAT EDIT END
 
 /// Returns a list of variables that can be changed by config, allows for balance through configuration.
 /// It is not recommended to finetweak any values of objectives on your server.

--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -117,7 +117,7 @@
 /datum/uplink_handler/proc/try_add_objective(datum/traitor_objective/objective_typepath)
 	var/datum/traitor_objective/objective = new objective_typepath(src)
 	var/should_abort = SEND_SIGNAL(objective, COMSIG_TRAITOR_OBJECTIVE_PRE_GENERATE, owner, potential_duplicate_objectives[objective_typepath]) & COMPONENT_TRAITOR_OBJECTIVE_ABORT_GENERATION
-	if(should_abort || !objective.generate_objective(owner, potential_duplicate_objectives[objective_typepath]))
+	if((objective.population_requirement > length(get_crewmember_minds())) || should_abort || !objective.generate_objective(owner, potential_duplicate_objectives[objective_typepath])) //SKYRRAT EDIT: POPULATION REQUIREMNT
 		qdel(objective)
 		return
 	if(!handle_duplicate(objective))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
## How This Contributes To The Skyrat Roleplay Experience
Host request, lowpop bombing bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Triangulate Weakpoint is not available below 80 crewmembers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
