### PR TITLE
Makes status bar not show when title screen browser up

### DIFF
--- a/modular_skyrat/modules/title_screen/code/new_player.dm
+++ b/modular_skyrat/modules/title_screen/code/new_player.dm
@@ -124,6 +124,7 @@
 		return
 
 	winset(src, "title_browser", "is-disabled=false;is-visible=true")
+	winset(src, "status_bar", "is-visible=false")
 
 	var/datum/asset/assets = get_asset_datum(/datum/asset/simple/lobby) //Sending pictures to the client
 	assets.send(src)
@@ -150,6 +151,7 @@
 /mob/dead/new_player/proc/hide_title_screen()
 	if(client?.mob)
 		winset(client, "title_browser", "is-disabled=true;is-visible=false")
+		winset(client, "status_bar", "is-visible=true")
 
 /mob/dead/new_player/proc/play_lobby_button_sound()
 	SEND_SOUND(src, sound('modular_skyrat/master_files/sound/effects/save.ogg'))

--- a/modular_skyrat/modules/title_screen/code/title_screen_controls.dm
+++ b/modular_skyrat/modules/title_screen/code/title_screen_controls.dm
@@ -57,6 +57,7 @@
 		new_player.show_title_screen()
 	else
 		winset(src, "title_browser", "is-disabled=true;is-visible=false")
+		winset(src, "status_bar", "is-visible=true")
 
 /**
  * An admin debug command that enables you to change the HTML on the go.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Make the status bar in the bottom left go away when the title screen is up, since it otherwise is just covering up the corner and showing the ref URL's that the menu buttons go to.

Note that these 3 spots in the code are the sum total of places that the title browser is made visible or not.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Looks better

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

infinitely minor visual tweak

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
