### PR TITLE
[MODULAR] Adds 9x19mm Peacekeeper and 10mm Auto ammo to autolathes

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/autolathe_designs.dm
+++ b/modular_skyrat/modules/modular_weapons/code/autolathe_designs.dm
@@ -98,3 +98,37 @@
 	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/ammo_casing/c10mm/rubber
 	category = list("initial", "Security")
+
+// Peackeaper Rounds
+/datum/design/b9mm
+	name = "Ammo Box (9x19mm Peacekeeper FMJ)"
+	id = "b9mm"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 30000)
+	build_path = /obj/item/ammo_box/advanced/b9mm
+	category = list("hacked", "Security")
+
+/datum/design/b9mm_rubber
+	name = "9x19mm Peacekeeper rubber bullet"
+	id = "b9mm_rubber"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 1000)
+	build_path = /obj/item/ammo_casing/b9mm/rubber
+	category = list("hacked", "Security")
+
+
+/datum/design/b10mm
+	name = "Ammo Box (10mm Auto)"
+	id = "b10mm"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 30000)
+	build_path = /obj/item/ammo_box/advanced/b10mm
+	category = list("hacked", "Security")
+
+/datum/design/b10mm_rubber
+	name = "10mm Auto rubber bullet"
+	id = "b10mm_rubber"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 1000)
+	build_path = /obj/item/ammo_casing/b10mm/rubber
+	category = list("hacked", "Security")

--- a/modular_skyrat/modules/modular_weapons/code/autolathe_designs.dm
+++ b/modular_skyrat/modules/modular_weapons/code/autolathe_designs.dm
@@ -99,7 +99,7 @@
 	build_path = /obj/item/ammo_casing/c10mm/rubber
 	category = list("initial", "Security")
 
-// Peackeaper Rounds
+// Peacekeeper Rounds
 /datum/design/b9mm
 	name = "Ammo Box (9x19mm Peacekeeper FMJ)"
 	id = "b9mm"
@@ -115,7 +115,6 @@
 	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/ammo_casing/b9mm/rubber
 	category = list("hacked", "Security")
-
 
 /datum/design/b10mm
 	name = "Ammo Box (10mm Auto)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds 9x19mm Peacekeeper and 10mm Auto to autolathes, Full ammo boxes can be printed, alongside single rubber bullets.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
9x19mm and 10mm Auto are widely used enough by guncargo weapons that I think it makes sense for these to be available through the autolathe like other common ammo types.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds 9x19mm Peacekeeper and 10mm Auto ammo to autolathes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
