### PR TITLE
Adds a chameleon module to all interdyne/ds2 modsuits

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -1398,7 +1398,6 @@
 	lethal = 1;
 	name = "Base turret controls";
 	pixel_y = 30;
-	req_access = null;
 	req_access = list("syndicate")
 	},
 /turf/open/floor/iron/edge,
@@ -4008,10 +4007,10 @@
 "Ve" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/suit_storage_unit/syndicate,
 /obj/machinery/airalarm/directional/east{
 	req_access = list(150)
 	},
+/obj/machinery/suit_storage_unit/syndicate/chameleon,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "Vk" = (

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -736,7 +736,6 @@
 	lethal = 1;
 	name = "Base turret controls";
 	pixel_y = 30;
-	req_access = null;
 	req_access = list("syndicate")
 	},
 /turf/open/floor/iron/edge,
@@ -3232,7 +3231,7 @@
 /obj/machinery/airalarm/directional/east{
 	req_access = list(150)
 	},
-/obj/machinery/suit_storage_unit/syndicate/no_access,
+/obj/machinery/suit_storage_unit/syndicate/chameleon,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "MW" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -4712,7 +4712,7 @@
 /obj/machinery/airalarm/directional/north{
 	req_access = list(150)
 	},
-/obj/machinery/suit_storage_unit/syndicate/no_access,
+/obj/machinery/suit_storage_unit/syndicate/chameleon,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
 "qs" = (
@@ -4757,7 +4757,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/suit_storage_unit/syndicate/no_access,
+/obj/machinery/suit_storage_unit/syndicate/chameleon,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/mining_equipment)
 "qw" = (
@@ -6435,7 +6435,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/security/prison)
 "wk" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/suit_storage_unit/syndicate/no_access,
+/obj/machinery/suit_storage_unit/syndicate/chameleon,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/cargo/mining_equipment)
 "wl" = (
@@ -8218,7 +8218,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/syndicate/no_access,
+/obj/machinery/suit_storage_unit/syndicate/chameleon,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/admiral)
 "Ck" = (
@@ -13419,7 +13419,6 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/medical1{
-	req_access = null;
 	req_access = list("syndicate")
 	},
 /obj/item/storage/bag/chemistry,
@@ -13721,7 +13720,7 @@
 	},
 /obj/effect/turf_decal/siding/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/suit_storage_unit/syndicate/no_access,
+/obj/machinery/suit_storage_unit/syndicate/chameleon,
 /turf/open/floor/iron/large,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "UJ" = (
@@ -13938,7 +13937,7 @@
 /area/ruin/space/has_grav/skyrat/interdynefob/maintenance/southwest)
 "VD" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/suit_storage_unit/syndicate/no_access,
+/obj/machinery/suit_storage_unit/syndicate/chameleon,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/security/armory)
 "VE" = (
@@ -13955,7 +13954,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/engineering)
 "VF" = (
-/obj/machinery/suit_storage_unit/syndicate/no_access,
+/obj/machinery/suit_storage_unit/syndicate/chameleon,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/eva)
 "VH" = (

--- a/modular_skyrat/master_files/code/game/machinery/suit_storage.dm
+++ b/modular_skyrat/master_files/code/game/machinery/suit_storage.dm
@@ -1,2 +1,2 @@
-/obj/machinery/suit_storage_unit/syndicate/no_access
-	mod_type = /obj/item/mod/control/pre_equipped/nuclear/no_access
+/obj/machinery/suit_storage_unit/syndicate/chameleon
+	mod_type = /obj/item/mod/control/pre_equipped/nuclear/chameleon

--- a/modular_skyrat/master_files/code/modules/mod/mod_types.dm
+++ b/modular_skyrat/master_files/code/modules/mod/mod_types.dm
@@ -1,2 +1,8 @@
-/obj/item/mod/control/pre_equipped/nuclear/no_access
-	req_access = null
+/obj/item/mod/control/pre_equipped/nuclear/chameleon
+	initial_modules = list(
+		/obj/item/mod/module/storage/syndicate,
+		/obj/item/mod/module/emp_shield,
+		/obj/item/mod/module/magnetic_harness,
+		/obj/item/mod/module/jetpack/advanced,
+		/obj/item/mod/module/chameleon,
+	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the chameleon module to all ds2/interdyne modsuits. Allows you to disguise your modsuit while undeployed as any other modsuit.
Reverts #13661

## How This Contributes To The Skyrat Roleplay Experience
Needs to be less obvious that they're not syndicates

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Interdyne/DS2 modsuits now start with chameleon modules
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
