### PR TITLE
Raising maximal character's body size

### DIFF
--- a/code/__DEFINES/~skyrat_defines/DNA.dm
+++ b/code/__DEFINES/~skyrat_defines/DNA.dm
@@ -47,7 +47,7 @@
 #define MAXIMUM_MARKINGS_PER_LIMB 3
 
 #define BODY_SIZE_NORMAL 1.00
-#define BODY_SIZE_MAX 1.5
+#define BODY_SIZE_MAX 2
 #define BODY_SIZE_MIN 0.8
 
 //In inches


### PR DESCRIPTION
## About The Pull Request

Getting custom character's body size to the same limit as oversized quirk has.

## How This Contributes To The Skyrat Roleplay Experience

A possibility to _**roleplay**_ as a large character without mechanical necessity to slowdown at each airlock/without debuffs from oversized's quirk, as well as buffs.

## Changelog

qol: Raised maximal character's size from 1.5 to 2.