### PR TITLE
[hotfix] burstfire is a strange beast NO GBP NO GBP NOGBP

### DIFF
--- a/modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm
@@ -13,6 +13,7 @@
 	weapon_weight = WEAPON_HEAVY
 	mag_type = /obj/item/ammo_box/magazine/m16/vintage/oldarms
 	fire_delay = 3.5
+	burst_size = 1
 	fire_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/fire/m16_fire.ogg'
 	fire_sound_volume = 50
 	rack_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/interact/sfrifle_cock.ogg'

--- a/modular_skyrat/modules/gunsgalore/code/guns/mp40.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/mp40.dm
@@ -11,7 +11,7 @@
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	mag_type = /obj/item/ammo_box/magazine/mp40
 	can_suppress = FALSE
-	burst_size = 3
+	burst_size = 1
 	fire_delay = 1.7
 	fire_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/fire/mp40_fire.ogg'
 	fire_sound_volume = 100

--- a/modular_skyrat/modules/gunsgalore/code/guns/stg.dm
+++ b/modular_skyrat/modules/gunsgalore/code/guns/stg.dm
@@ -14,6 +14,7 @@
 	mag_type = /obj/item/ammo_box/magazine/stg
 	can_suppress = FALSE
 	fire_delay = 1.5
+	burst_size = 1
 	fire_sound = 'modular_skyrat/modules/gunsgalore/sound/guns/fire/stg_fire.ogg'
 	fire_sound_volume = 70
 	alt_icons = TRUE


### PR DESCRIPTION

## About The Pull Request

actually removes burst fire, because, for some ungodly reason, you have to manually set the burst size to 1 or else the gun assumes it's allowed to have burst mode anyway, after specifically telling it not to have burst mode

## How This Contributes To The Skyrat Roleplay Experience
it doesn't

## Changelog


:cl:
fix: guns that aren't supposed to have burst, no longer have burst

/:cl:

