### PR TITLE
Wings and Cat tails are no longer locked to your skin/hair color

### DIFF
--- a/modular_skyrat/modules/customization/modules/surgery/organs/tails.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/tails.dm
@@ -18,6 +18,7 @@
 
 /obj/item/organ/external/tail/cat
 	mutantpart_info = list(MUTANT_INDEX_NAME = "Cat", MUTANT_INDEX_COLOR_LIST = list("#FFAA00"))
+	color_source = ORGAN_COLOR_OVERRIDE
 
 /obj/item/organ/external/tail/monkey
 	mutantpart_info = list(MUTANT_INDEX_NAME = "Monkey", MUTANT_INDEX_COLOR_LIST = list("#FFFFFF"))

--- a/modular_skyrat/modules/customization/modules/surgery/organs/wings.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/wings.dm
@@ -5,6 +5,7 @@
 	slot = ORGAN_SLOT_WINGS
 	mutantpart_key = "wings"
 	mutantpart_info = list(MUTANT_INDEX_NAME = "Bat", MUTANT_INDEX_COLOR_LIST = list("#335533"))
+	color_source = ORGAN_COLOR_OVERRIDE
 	///Whether the wings should grant flight on insertion.
 	var/unconditional_flight
 	///What species get flights thanks to those wings. Important for moth wings
@@ -20,6 +21,12 @@
 	return GLOB.sprite_accessories["wings"]
 
 //TODO: Well you know what this flight stuff is a bit complicated and hardcoded, this is enough for now
+
+/obj/item/organ/external/wings/override_color(rgb_value)
+	if(mutantpart_key)
+		return mutantpart_info[MUTANT_INDEX_COLOR_LIST][1]
+
+	return rgb_value
 
 /obj/item/organ/external/wings/moth
 	name = "moth wings"


### PR DESCRIPTION
## About The Pull Request
Turns out I forgot those two when fixing everything else. Oh well!

## How This Contributes To The Skyrat Roleplay Experience
Something something flesh-colored wings are kind of cursed sometimes.

## Changelog

:cl: GoldenAlpharex
fix: Cat tails are now colored using their own colors again, rather than being only based on the color of your hair.
fix: Wings are now colored using their own colors again, rather than being only based on your skin color.
/:cl: