### PR TITLE
Gives Contractors access to the Manifest app

### DIFF
--- a/modular_skyrat/modules/contractor/code/items/tablet.dm
+++ b/modular_skyrat/modules/contractor/code/items/tablet.dm
@@ -8,6 +8,8 @@
 	uplink.computer = src
 
 	hard_drive.store_file(uplink)
+	hard_drive.store_file(new /datum/computer_file/program/crew_manifest)
+	hard_drive.store_file(new /datum/computer_file/program/messenger)
 
 	install_component(new /obj/item/computer_hardware/battery(src, /obj/item/stock_parts/cell/computer))
 	install_component(hard_drive)

--- a/modular_skyrat/modules/contractor/code/items/tablet.dm
+++ b/modular_skyrat/modules/contractor/code/items/tablet.dm
@@ -9,7 +9,6 @@
 
 	hard_drive.store_file(uplink)
 	hard_drive.store_file(new /datum/computer_file/program/crew_manifest)
-	hard_drive.store_file(new /datum/computer_file/program/messenger)
 
 	install_component(new /obj/item/computer_hardware/battery(src, /obj/item/stock_parts/cell/computer))
 	install_component(hard_drive)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the title app to their tablet

## How This Contributes To The Skyrat Roleplay Experience
Manifest - good for setting up a plan to kidnap your target

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Contractor tablet now comes with the manifest apps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
