### PR TITLE
[Host] Population-locks the ninja c4 objective

### DIFF
--- a/code/__DEFINES/~skyrat_defines/antagonists.dm
+++ b/code/__DEFINES/~skyrat_defines/antagonists.dm
@@ -15,3 +15,6 @@
 #define ASSAULTOPS_ALL_ALIVE 2
 
 #define GOLDENEYE_REQUIRED_KEYS_MAXIMUM 3
+
+/// Population requirement for bomb objectives (ninja c4, locate weakpoint, etc.) objectives to appear
+#define BOMB_POP_REQUIREMENT 80

--- a/code/modules/antagonists/space_ninja/space_ninja.dm
+++ b/code/modules/antagonists/space_ninja/space_ninja.dm
@@ -72,18 +72,20 @@
 	doorobjective.doors_required = rand(15,40)
 	doorobjective.explanation_text = "Use your gloves to doorjack [doorobjective.doors_required] airlocks on the station."
 	objectives += doorobjective
-
-	//Explosive plant, the bomb will register its completion on priming
-	var/datum/objective/plant_explosive/bombobjective = new /datum/objective/plant_explosive()
-	for(var/sanity in 1 to 100) // 100 checks at most.
-		var/area/selected_area = pick(GLOB.sortedAreas)
-		if(!is_station_level(selected_area.z) || !(selected_area.area_flags & VALID_TERRITORY))
-			continue
-		bombobjective.detonation_location = selected_area
-		break
-	if(bombobjective.detonation_location)
-		bombobjective.explanation_text = "Detonate your starter bomb in [bombobjective.detonation_location].  Note that the bomb will not work anywhere else!"
-		objectives += bombobjective
+	//SKYRAT EDIT START
+	if(length(get_crewmember_minds()) >= BOMB_POP_REQUIREMENT)
+		//Explosive plant, the bomb will register its completion on priming
+		var/datum/objective/plant_explosive/bombobjective = new /datum/objective/plant_explosive()
+		for(var/sanity in 1 to 100) // 100 checks at most.
+			var/area/selected_area = pick(GLOB.sortedAreas)
+			if(!is_station_level(selected_area.z) || !(selected_area.area_flags & VALID_TERRITORY))
+				continue
+			bombobjective.detonation_location = selected_area
+			break
+		if(bombobjective.detonation_location)
+			bombobjective.explanation_text = "Detonate your starter bomb in [bombobjective.detonation_location].  Note that the bomb will not work anywhere else!"
+			objectives += bombobjective
+	//SKYRAT EDIT END
 
 	//Security Scramble, set to complete upon using your gloves on a security console
 	var/datum/objective/securityobjective = new /datum/objective/security_scramble()

--- a/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
+++ b/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
@@ -11,7 +11,7 @@
 	progression_minimum = 45 MINUTES
 	progression_reward = list(15 MINUTES, 20 MINUTES)
 	telecrystal_reward = list(3, 5)
-	population_requirement = 80 //SKYRAT EDIT
+	population_requirement = BOMB_POP_REQUIREMENT //SKYRAT EDIT
 
 	var/progression_objectives_minimum = 20 MINUTES
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Puts the pop requirement (crewmember minds counted) for ninja c4 at 80, same as the locate weakpoint objective

## How This Contributes To The Skyrat Roleplay Experience
The alternative is this getting removed and I don't really want that, 80 crew's a good point where they can handle bombs

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Ninja c4 objective no longer appears below 80 crew members on-station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
