### PR TITLE
fixes .223 stinger bullets not loading into the proper magazine

### DIFF
--- a/modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm
@@ -31,7 +31,7 @@
 	icon = 'modular_skyrat/modules/gunsgalore/icons/guns/gunsgalore_items.dmi'
 	icon_state = "m16"
 	ammo_type = /obj/item/ammo_casing/oldarms/a223
-	caliber = "223"
+	caliber = CALIBER_223
 	max_ammo = 20
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
   


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

.223 Stinger rounds will now be able to actually go into the magazine they were intended to go into, because someone messed up with making said magazine's caliber `CALIBER_223`

## How This Contributes To The Skyrat Roleplay Experience

guncargoooo

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: .223 stinger rounds can now be loaded into the mk-11.4 rifle's magazine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
