### PR TITLE
Fixing the Compiler Warning (maybe fixing CI)

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -159,7 +159,7 @@ There are several things that need to be remembered:
 		//handled_by_bodytype MUST be set to FALSE under the if(!icon_exists()) statement, or everything breaks.
 		//"override_file = handled_by_bodytype ? icon_file : null" MUST be added to the arguments of build_worn_icon()
 		//Friendly reminder that icon_exists(file, state, scream = TRUE) is your friend when debugging this code.
-		var/handled_by_bodytype = TRUE
+//		var/handled_by_bodytype = TRUE // SKYRAT EDIT REMOVAL - Fixing CI, unused variable
 		var/icon_file
 		var/woman
 		var/mutant_override = FALSE // SKYRAT EDIT ADDITION
@@ -189,7 +189,7 @@ There are several things that need to be remembered:
 				isinhands = FALSE,
 				female_uniform = woman ? uniform.female_sprite_flags : null,
 				override_state = target_overlay,
-				override_file = mutant_override ? icon_file : null, // SKYRAT EDIT CHANGE - ORIGINAL: override_file = handled_by_bodytype ? icon_file : null,	
+				override_file = mutant_override ? icon_file : null, // SKYRAT EDIT CHANGE - ORIGINAL: override_file = handled_by_bodytype ? icon_file : null,
 			)
 
 		if(!mutant_override && (OFFSET_UNIFORM in dna.species.offset_features)) // SKYRAT EDIT CHANGE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It's good not to have erroneous warnings due to things not being used. Delete this comment when it's used. 

## How This Contributes To The Skyrat Roleplay Experience

Development experience improvement

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: comments out an unused variable in /mob/living/carbon/human/update_inv_w_uniform()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
