### PR TITLE
Adds Drifting Contractors as a midround heavy ruleset

### DIFF
--- a/modular_skyrat/modules/contractor/code/datums/midround/ruleset.dm
+++ b/modular_skyrat/modules/contractor/code/datums/midround/ruleset.dm
@@ -1,0 +1,51 @@
+/datum/dynamic_ruleset/midround/from_ghosts/contractor
+	name = "Drifting Contractors"
+	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
+	antag_datum = /datum/antagonist/contractor
+	antag_flag = ROLE_DRIFTING_CONTRACTOR
+	antag_flag_override = ROLE_DRIFTING_CONTRACTOR
+	enemy_roles = list(
+		JOB_CAPTAIN,
+		JOB_DETECTIVE,
+		JOB_HEAD_OF_SECURITY,
+		JOB_SECURITY_OFFICER,
+	)
+	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_candidates = 2
+	weight = 4
+	cost = 10
+	requirements = list(101,101,101,80,60,50,30,20,10,10)
+	flags = HIGH_IMPACT_RULESET
+	/// valid places to spawn
+	var/list/spawn_locs = list()
+
+/datum/dynamic_ruleset/midround/from_ghosts/contractor/ready(forced = FALSE)
+	if(prob(33))
+		required_candidates++
+	if (required_candidates > (dead_players.len + list_observers.len))
+		return FALSE
+	for(var/obj/effect/landmark/carpspawn/carp in GLOB.landmarks_list)
+		spawn_locs += carp.loc
+	if(!length(spawn_locs))
+		log_admin("Cannot accept Drifting Contractor ruleset. Couldn't find any carp spawn points.")
+		message_admins("Cannot accept Drifting Contractor ruleset. Couldn't find any carp spawn points.")
+		return FALSE
+	return ..()
+
+
+/datum/dynamic_ruleset/midround/from_ghosts/contractor/generate_ruleset_body(mob/applicant)
+	var/mob/living/carbon/human/operative = new(pick(spawn_locs))
+	operative.dna.remove_all_mutations()
+	operative.randomize_human_appearance(~RANDOMIZE_SPECIES)
+	operative.dna.update_dna_identity()
+	return operative
+
+/datum/dynamic_ruleset/midround/from_ghosts/contractor/finish_setup(mob/new_character, index)
+	if(!usr.mind)
+		usr.mind = new /datum/mind(usr.key)
+	usr.mind.transfer_to(new_character)
+	new_character.ckey = usr.ckey
+	..()
+	new_character.mind.set_assigned_role(SSjob.GetJobType(/datum/job/drifting_contractor))
+	new_character.mind.special_role = ROLE_DRIFTING_CONTRACTOR
+	new_character.mind.active = TRUE

--- a/modular_skyrat/modules/contractor/code/datums/midround/ruleset.dm
+++ b/modular_skyrat/modules/contractor/code/datums/midround/ruleset.dm
@@ -12,7 +12,7 @@
 	)
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 2
-	weight = 4
+	weight = 6
 	cost = 10
 	requirements = list(101,101,101,80,60,50,30,20,10,10)
 	flags = HIGH_IMPACT_RULESET

--- a/modular_skyrat/modules/contractor/code/datums/midround/ruleset.dm
+++ b/modular_skyrat/modules/contractor/code/datums/midround/ruleset.dm
@@ -22,7 +22,7 @@
 /datum/dynamic_ruleset/midround/from_ghosts/contractor/ready(forced = FALSE)
 	if(prob(33))
 		required_candidates++
-	if (required_candidates > (dead_players.len + list_observers.len))
+	if (required_candidates > (length(dead_players) + length(list_observers)))
 		return FALSE
 	for(var/obj/effect/landmark/carpspawn/carp in GLOB.landmarks_list)
 		spawn_locs += carp.loc

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5024,6 +5024,7 @@
 #include "modular_skyrat\modules\contractor\code\datums\midround\event.dm"
 #include "modular_skyrat\modules\contractor\code\datums\midround\objective.dm"
 #include "modular_skyrat\modules\contractor\code\datums\midround\outfit.dm"
+#include "modular_skyrat\modules\contractor\code\datums\midround\ruleset.dm"
 #include "modular_skyrat\modules\contractor\code\datums\midround\trim.dm"
 #include "modular_skyrat\modules\contractor\code\items\baton.dm"
 #include "modular_skyrat\modules\contractor\code\items\boxes.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds drifting contractors as a midround ruleset. 
Cost 10
Weight 6
Spawns 2 (33% of the time a third is added)
Otherwise is virtually the same as the random event

## How This Contributes To The Skyrat Roleplay Experience
Good god we need more midround heavy rulesets, constant ninja is _fun_, right?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Drifting Contractors are now a midround ruleset
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
