### PR TITLE
Permit HUD QOL

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -29,4 +29,4 @@
 	new /obj/item/clothing/suit/hooded/wintercoat/qm(src)
 	new /obj/item/gun/ballistic/rifle/boltaction/brand_new/quartermaster(src) // SKYRAT EDIT - The QM's 'special' head item. It spawns loaded, but you have to find more ammo if you run out and get ready to manually load rounds in!
 	new /obj/item/cargo_teleporter(src) // SKYRAT EDIT - Adds a cargo teleporter to QM locker, so they can intice others to research it
-	new /obj/item/clothing/glasses/hud/gun_permit(src) //SKYRAT EDIT - GUN CARGO
+	new /obj/item/clothing/glasses/hud/gun_permit/sunglasses(src) //SKYRAT EDIT - GUN CARGO

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1204,6 +1204,7 @@
 		"diagnostic_hud_projector",
 		"meson_hud_projector",
 		"science_hud_projector",
+		"permit_glasses",
 		//SKYRAT EDIT END - RESEARCH DESIGNS
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -153,7 +153,6 @@
 		/obj/item/clothing/mask/bandana/striped/cargo = 3,
 		/obj/item/clothing/head/soft = 3,
 		/obj/item/radio/headset/headset_cargo = 3,
-		/obj/item/clothing/glasses/hud/gun_permit = 5, //SKYRAT ADDITION
 	)
 	premium = list(
 		/obj/item/clothing/under/rank/cargo/miner = 3,

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -153,6 +153,7 @@
 		/obj/item/clothing/mask/bandana/striped/cargo = 3,
 		/obj/item/clothing/head/soft = 3,
 		/obj/item/radio/headset/headset_cargo = 3,
+		/obj/item/clothing/glasses/hud/gun_permit = 5,
 	)
 	premium = list(
 		/obj/item/clothing/under/rank/cargo/miner = 3,

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -153,7 +153,7 @@
 		/obj/item/clothing/mask/bandana/striped/cargo = 3,
 		/obj/item/clothing/head/soft = 3,
 		/obj/item/radio/headset/headset_cargo = 3,
-		/obj/item/clothing/glasses/hud/gun_permit = 5,
+		/obj/item/clothing/glasses/hud/gun_permit = 5, //SKYRAT ADDITION
 	)
 	premium = list(
 		/obj/item/clothing/under/rank/cargo/miner = 3,

--- a/modular_skyrat/modules/gun_cargo/code/objects/hud_glasses.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/hud_glasses.dm
@@ -5,3 +5,10 @@
 	worn_icon = 'modular_skyrat/modules/gun_cargo/icons/hud_goggles_worn.dmi'
 	icon_state = "permithud"
 	hud_type = DATA_HUD_PERMIT
+
+/obj/item/clothing/glasses/hud/gun_permit/sunglasses
+	name = "permit HUD sunglasses"
+	desc = "A pair of sunglasses with a heads-up display that scans humanoids in view, and displays if their current ID possesses a firearms permit or not."
+	darkness_view = 1
+	flash_protect = FLASH_PROTECTION_FLASH
+	tint = 1

--- a/modular_skyrat/modules/gun_cargo/code/objects/hud_glasses.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/hud_glasses.dm
@@ -21,4 +21,4 @@
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
 	build_path = /obj/item/clothing/glasses/hud/gun_permit
 	category = list("Equipment")
-	departmental_flags = DEPARTMENT_BITFLAG_SUPPLY
+	departmental_flags = DEPARTMENT_BITFLAG_CARGO

--- a/modular_skyrat/modules/gun_cargo/code/objects/hud_glasses.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/hud_glasses.dm
@@ -12,3 +12,13 @@
 	darkness_view = 1
 	flash_protect = FLASH_PROTECTION_FLASH
 	tint = 1
+
+/datum/design/permit_hud
+	name = "Gun Permit HUD glasses"
+	desc = "A heads-up display that scans humanoids in view, and displays if their current ID possesses a firearms permit or not."
+	id = "permit_glasses"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	build_path = /obj/item/clothing/glasses/hud/gun_permit
+	category = list("Equipment")
+	departmental_flags = DEPARTMENT_BITFLAG_SUPPLY

--- a/modular_skyrat/modules/gun_cargo/code/objects/vending.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/vending.dm
@@ -1,4 +1,0 @@
-/obj/machinery/vending/wardrobe/cargo_wardrobe
-	skyrat_products = list(
-		/obj/item/clothing/glasses/hud/gun_permit = 4,
-	)

--- a/modular_skyrat/modules/modular_vending/code/wardrobes.dm
+++ b/modular_skyrat/modules/modular_vending/code/wardrobes.dm
@@ -39,6 +39,7 @@
 		/obj/item/clothing/under/rank/cargo/tech/skyrat/casualman = 3,
 		/obj/item/clothing/suit/gorka/supply = 3,
 		/obj/item/clothing/suit/toggle/jacket/supply = 3,
+		/obj/item/clothing/glasses/hud/gun_permit = 5, //from Gun_Cargo module
 	)
 
 	skyrat_contraband = list(

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5318,7 +5318,6 @@
 #include "modular_skyrat\modules\gun_cargo\code\objects\hud_glasses.dm"
 #include "modular_skyrat\modules\gun_cargo\code\objects\keycard_auth.dm"
 #include "modular_skyrat\modules\gun_cargo\code\objects\suppressor.dm"
-#include "modular_skyrat\modules\gun_cargo\code\objects\vending.dm"
 #include "modular_skyrat\modules\gun_cargo\code\objects\guns\interdyne.dm"
 #include "modular_skyrat\modules\gun_cargo\code\objects\guns\izhevsk.dm"
 #include "modular_skyrat/modules/gun_cargo/code/objects/guns/oldarms.dm"


### PR DESCRIPTION
## About The Pull Request
Adds Permit HUD sunglasses and adds a pair to the QM locker.
Adds Permit HUDs to techwebs
Adds 5 Permit HUDs to cargodrobe (Note as of this edit, this is a fix to a previous bugged addition)
(Note I did not change the sprite because some chucklefuck made Permit huds already look like shades)

## How This Contributes To The Skyrat Roleplay Experience

The Quartermaster shouldn't have to choose  between doing their job and ~~style~~ flash protection
Why didn't we give any to cargo techs anyway?

## Changelog

:cl:
qol: The quartermaster"s Permit HUD in their locker comes with flash protection now.
qol: Permit HUDs now available in the cargodrobe.
qol: Permit HUDs now available in protolathe with HUD research
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
