### PR TITLE
Sec webbings cant reskin

### DIFF
--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -106,6 +106,8 @@
 	)
 	component_type = /datum/component/storage/concrete/security
 
+/obj/item/storage/belt/security/webbing
+	uses_advanced_reskins = FALSE
 
 ///Enables you to quickdraw weapons from security holsters
 /datum/component/storage/concrete/security/open_storage(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Disables reskins of sec webbing (a feature for belts that carries from the parent by accident) 

## How This Contributes To The Skyrat Roleplay Experience

It's a bug and I don't want my webbing to look like the ugly belts 

## Changelog
:cl:
fix: Security webbing can no longer be erroneously reskinned into sec belts.
/:cl: