### PR TITLE
[MODULARIZATION] Surgery Tables now only apply numbing

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -676,8 +676,8 @@
  */
 
 /obj/structure/table/optable//SKYRAT EDIT - ICON OVERRIDEN BY AESTHETICS - SEE MODULE
-	name = "stasis operating table" // SKYRAT EDIT name = "operating table"
-	desc = "Used for advanced medical procedures. Now comes with built in stasis technology, patented by Cinco: A Family Company!" // SKYRAT EDIT desc = "Used for advanced medical procedures."
+	name = "operating table"
+	desc = "Used for advanced medical procedures."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "optable"
 	buildstack = /obj/item/stack/sheet/mineral/silver
@@ -737,26 +737,6 @@
 		return TRUE
 	return FALSE
 
-///SKYRAT EDIT: Operating Tables now provide Stasis
-/obj/structure/table/optable/proc/chill_out(mob/living/target)
-	var/freq = rand(24750, 26550)
-	playsound(src, 'sound/effects/spray.ogg', 5, TRUE, 2, frequency = freq)
-	target.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
-	ADD_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
-	target.extinguish_mob()
-
-/obj/structure/table/optable/proc/thaw_them(mob/living/target)
-	target.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
-	REMOVE_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
-
-/obj/structure/table/optable/post_buckle_mob(mob/living/L)
-	set_patient(L)
-	chill_out(L)
-
-/obj/structure/table/optable/post_unbuckle_mob(mob/living/L)
-	set_patient(null)
-	thaw_them(L)
-///SKYRAT EDIT END
 /*
  * Racks
  */

--- a/modular_skyrat/master_files/code/game/objects/structures/tables_racks.dm
+++ b/modular_skyrat/master_files/code/game/objects/structures/tables_racks.dm
@@ -3,3 +3,44 @@
 	if(!in_range(src, user))
 		return
 	return attack_hand(user, modifiers)
+
+//Most of this is code that allows stasis and numbing to work on surgery tables.
+/obj/structure/table/optable
+	/// Is the table able to put patients in stasis?
+	var/stasis_capable = FALSE
+	/// Is the Operating table able to preform numbing?
+	var/numbing_capable = TRUE
+	/// Is the patient already numbed?
+
+/// Used to numb a patient and apply stasis to them if enabled.
+/obj/structure/table/optable/proc/chill_out(mob/living/target)
+	var/freq = rand(24750, 26550)
+	playsound(src, 'sound/effects/spray.ogg', 5, TRUE, 2, frequency = freq)
+
+	if(stasis_capable)
+		target.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT) //Numbing is covered by this.
+		target.extinguish_mob()
+		ADD_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
+		return
+
+	// If stasis isn't an option, only numbing is applied
+	ADD_TRAIT(target, TRAIT_NUMBED, src)
+
+///Used to remove the effects of stasis and numbing when a patient is unbuckled
+/obj/structure/table/optable/proc/thaw_them(mob/living/target)
+	if(stasis_capable)
+		target.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
+		REMOVE_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
+		return
+
+	REMOVE_TRAIT(target, TRAIT_NUMBED, src)
+
+/obj/structure/table/optable/post_buckle_mob(mob/living/patient)
+	set_patient(patient)
+	if(numbing_capable)
+		chill_out(patient)
+
+/obj/structure/table/optable/post_unbuckle_mob(mob/living/patient)
+	set_patient(null)
+	if(numbing_capable)
+		thaw_them(patient)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves the code, that was used to make surgery tables apply stasis, to a modular Skyrat file along with reverting the Skyrat edits to the table name and description.

Surgery tables now have two extra variables: stasis_capable and numbing_capable. These determine if a surgery table can apply numbing and/or stasis. 

Surgery tables by default now only apply numbing. 
I am keeping numbing on the surgery tables because without it, stasis beds would become the main go-to option due to our current surgery pain mechanics. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
This is something that makes sense to have considering we have gone back and reverted the stasis pod PR. In their current state, stasis surgery tables are both a cheaper and better option when compared with stasis beds, this invalidates the intended risk/reward balance that surgery tables and stasis beds were supposed to have.  

This PR also makes the code for stasis on surgery tables modular. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: surgery tables now only apply numbing
code: code for stasis on surgery tables is now modular. 
spellcheck: following the removal of stasis from surgery tables, they now use their original name and description.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
