### PR TITLE
Chameleon Contractor Baton

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -346,7 +346,7 @@
 
 /obj/item/melee/baton/telescopic/contractor_baton
 	name = "contractor baton"
-	desc = "A compact, specialised baton assigned to Syndicate contractors. Applies light electrical shocks to targets."
+	desc = "A compact, specialised baton assigned to Syndicate contractors. Applies light electrical shocks to targets. Chameleon technology allows the baton to disguise as a common item, but power draw doubles the cooldown of the baton as a side effect." //SKYRAT EDIT: CHAMELEON
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "contractor_baton"
 	worn_icon_state = "contractor_baton"

--- a/modular_skyrat/modules/contractor/code/datums/baton_disguise.dm
+++ b/modular_skyrat/modules/contractor/code/datums/baton_disguise.dm
@@ -8,13 +8,4 @@
 	if(disguised)
 		baton.undisguise(src, null, owner)
 		return
-	baton.lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
-	baton.righthand_file = 'icons/mob/inhands/items_righthand.dmi'
-	baton.inhand_icon_state = "rods"
-	baton.name = "iron rod"
-	baton.icon = 'icons/obj/stack_objects.dmi'
-	baton.icon_state = "rods"
-	disguised = TRUE
-	owner.regenerate_icons()
-	baton.update_appearance()
-	baton.balloon_alert(owner, "baton disguised")
+	baton.disguise(src, owner)

--- a/modular_skyrat/modules/contractor/code/datums/baton_disguise.dm
+++ b/modular_skyrat/modules/contractor/code/datums/baton_disguise.dm
@@ -1,0 +1,18 @@
+/datum/action/item_action/disguise
+	name = "Toggle Baton Disguise"
+	/// If it is applied or not
+	var/disguised = FALSE
+
+/datum/action/item_action/disguise/Trigger(trigger_flags)
+	var/obj/item/melee/baton/telescopic/contractor_baton/baton = target
+	if(disguised)
+		baton.undisguise(src, null, owner)
+		return
+	baton.lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
+	baton.righthand_file = 'icons/mob/inhands/items_righthand.dmi'
+	baton.inhand_icon_state = "rods"
+	baton.name = "iron rod"
+	disguised = TRUE
+	owner.regenerate_icons()
+	baton.update_appearance()
+	baton.balloon_alert(owner, "baton disguised")

--- a/modular_skyrat/modules/contractor/code/datums/baton_disguise.dm
+++ b/modular_skyrat/modules/contractor/code/datums/baton_disguise.dm
@@ -12,6 +12,8 @@
 	baton.righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	baton.inhand_icon_state = "rods"
 	baton.name = "iron rod"
+	baton.icon = 'icons/obj/stack_objects.dmi'
+	baton.icon_state = "rods"
 	disguised = TRUE
 	owner.regenerate_icons()
 	baton.update_appearance()

--- a/modular_skyrat/modules/contractor/code/items/baton.dm
+++ b/modular_skyrat/modules/contractor/code/items/baton.dm
@@ -102,10 +102,26 @@
 	name = initial(name)
 	icon = initial(icon)
 	icon_state = active ? "[initial(icon_state)]_on" : initial(icon_state)
+	desc = initial(desc)
+	cooldown = initial(cooldown)
 	baton_disguise.disguised = FALSE
 	user.regenerate_icons()
 	update_appearance()
 	balloon_alert(user, "baton undisguised")
+
+/obj/item/melee/baton/telescopic/contractor_baton/proc/disguise(datum/source, mob/user)
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
+	inhand_icon_state = "rods"
+	name = "iron rod"
+	icon = 'icons/obj/stack_objects.dmi'
+	icon_state = "rods"
+	desc = "Some rods. Can be used for building or something."
+	cooldown = initial(cooldown) * 2
+	baton_disguise.disguised = TRUE
+	user.regenerate_icons()
+	update_appearance()
+	balloon_alert(user, "baton disguised")
 
 /obj/item/melee/baton/telescopic/contractor_baton/proc/add_upgrade(obj/item/baton_upgrade/upgrade)
 	if(!(upgrade_flags & upgrade.upgrade_flag))

--- a/modular_skyrat/modules/contractor/code/items/baton.dm
+++ b/modular_skyrat/modules/contractor/code/items/baton.dm
@@ -74,6 +74,8 @@
 	if(baton_disguise.disguised)
 		lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 		righthand_file = 'icons/mob/inhands/items_righthand.dmi'
+		icon = 'icons/obj/stack_objects.dmi'
+		icon_state = "rods"
 		inhand_icon_state = "rods"
 		user.regenerate_icons()
 		update_appearance()
@@ -81,6 +83,8 @@
 		lefthand_file = initial(lefthand_file)
 		righthand_file = initial(righthand_file)
 		inhand_icon_state = active ? on_inhand_icon_state : null // When inactive, there is no inhand icon_state.
+		icon = initial(icon)
+		icon_state = active ? "[initial(icon_state)]_on" : initial(icon_state)
 	src.active = active
 	playsound(user ? user : src, on_sound, 50, TRUE)
 	balloon_alert(user, active ? "extended" : "collapsed")
@@ -96,6 +100,8 @@
 	lefthand_file = initial(lefthand_file)
 	righthand_file = initial(righthand_file)
 	name = initial(name)
+	icon = initial(icon)
+	icon_state = active ? "[initial(icon_state)]_on" : initial(icon_state)
 	baton_disguise.disguised = FALSE
 	user.regenerate_icons()
 	update_appearance()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5012,6 +5012,7 @@
 #include "modular_skyrat\modules\connecting_computer\code\_computer.dm"
 #include "modular_skyrat\modules\connecting_computer\code\non_connecting_computers.dm"
 #include "modular_skyrat\modules\container_emotes\code\container_emotes.dm"
+#include "modular_skyrat\modules\contractor\code\datums\baton_disguise.dm"
 #include "modular_skyrat\modules\contractor\code\datums\contract.dm"
 #include "modular_skyrat\modules\contractor\code\datums\contractor_datum.dm"
 #include "modular_skyrat\modules\contractor\code\datums\contractor_hub.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows the contractor baton to disguise as iron rods, until the baton is used, at which point it automatically undisguises.

## How This Contributes To The Skyrat Roleplay Experience
It allows the contractor to get a jump on targets without being exposed by the baton's sprite (the sound is still audible for those with sharp ears)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Contractor baton now has chameleon functionality
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
