### PR TITLE
Fixes Drifting Contractors ruleset

### DIFF
--- a/modular_skyrat/modules/contractor/code/datums/midround/ruleset.dm
+++ b/modular_skyrat/modules/contractor/code/datums/midround/ruleset.dm
@@ -11,7 +11,7 @@
 		JOB_SECURITY_OFFICER,
 	)
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
-	required_candidates = 1
+	required_candidates = 2
 	weight = 6
 	cost = 10
 	requirements = list(101,101,101,80,60,50,30,20,10,10)
@@ -20,8 +20,8 @@
 	var/list/spawn_locs = list()
 
 /datum/dynamic_ruleset/midround/from_ghosts/contractor/ready(forced = FALSE)
-	//if(prob(33))
-	//	required_candidates++
+	if(prob(33))
+		required_candidates++
 	if (required_candidates > (length(dead_players) + length(list_observers)))
 		return FALSE
 	for(var/obj/effect/landmark/carpspawn/carp in GLOB.landmarks_list)

--- a/modular_skyrat/modules/contractor/code/datums/midround/ruleset.dm
+++ b/modular_skyrat/modules/contractor/code/datums/midround/ruleset.dm
@@ -32,11 +32,6 @@
 		return FALSE
 	return ..()
 
-/*
-/datum/dynamic_ruleset/midround/from_ghosts/contractor/generate_ruleset_body(mob/applicant)
-	..()
-	return applicant*/
-
 /datum/dynamic_ruleset/midround/from_ghosts/contractor/finish_setup(mob/new_character, index)
 	..()
 	new_character.forceMove(pick_n_take(spawn_locs))

--- a/modular_skyrat/modules/contractor/code/datums/midround/ruleset.dm
+++ b/modular_skyrat/modules/contractor/code/datums/midround/ruleset.dm
@@ -11,7 +11,7 @@
 		JOB_SECURITY_OFFICER,
 	)
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
-	required_candidates = 2
+	required_candidates = 1
 	weight = 6
 	cost = 10
 	requirements = list(101,101,101,80,60,50,30,20,10,10)
@@ -20,32 +20,25 @@
 	var/list/spawn_locs = list()
 
 /datum/dynamic_ruleset/midround/from_ghosts/contractor/ready(forced = FALSE)
-	if(prob(33))
-		required_candidates++
+	//if(prob(33))
+	//	required_candidates++
 	if (required_candidates > (length(dead_players) + length(list_observers)))
 		return FALSE
 	for(var/obj/effect/landmark/carpspawn/carp in GLOB.landmarks_list)
 		spawn_locs += carp.loc
 	if(!length(spawn_locs))
-		log_admin("Cannot accept Drifting Contractor ruleset. Couldn't find any carp spawn points.")
-		message_admins("Cannot accept Drifting Contractor ruleset. Couldn't find any carp spawn points.")
+		log_admin("Cannot accept Drifting Contractors ruleset. Couldn't find any carp spawn points.")
+		message_admins("Cannot accept Drifting Contractors ruleset. Couldn't find any carp spawn points.")
 		return FALSE
 	return ..()
 
-
+/*
 /datum/dynamic_ruleset/midround/from_ghosts/contractor/generate_ruleset_body(mob/applicant)
-	var/mob/living/carbon/human/operative = new(pick(spawn_locs))
-	operative.dna.remove_all_mutations()
-	operative.randomize_human_appearance(~RANDOMIZE_SPECIES)
-	operative.dna.update_dna_identity()
-	return operative
+	..()
+	return applicant*/
 
 /datum/dynamic_ruleset/midround/from_ghosts/contractor/finish_setup(mob/new_character, index)
-	if(!usr.mind)
-		usr.mind = new /datum/mind(usr.key)
-	usr.mind.transfer_to(new_character)
-	new_character.ckey = usr.ckey
 	..()
+	new_character.forceMove(pick_n_take(spawn_locs))
 	new_character.mind.set_assigned_role(SSjob.GetJobType(/datum/job/drifting_contractor))
-	new_character.mind.special_role = ROLE_DRIFTING_CONTRACTOR
 	new_character.mind.active = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turns out this spawned people mindless and naked. IT WORKED ON A LOCAL OKAY

## How This Contributes To The Skyrat Roleplay Experience
Bugs bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Drifting Contractors midround ruleset no longer spawns people naked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
