### PR TITLE
Makes ears/frills/horns match the same hide mutant parts logic of every other accessory.

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/ears.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/ears.dm
@@ -7,13 +7,13 @@
 
 /datum/sprite_accessory/ears/is_hidden(mob/living/carbon/human/human, obj/item/bodypart/bodypart)
 	if(
-		(human.head && (human.head.flags_inv & HIDEHAIR))
-		|| (human.wear_mask && (human.wear_mask.flags_inv & HIDEHAIR))
-		|| human.try_hide_mutant_parts
-		|| !bodypart
+		(human.head && (human.head.flags_inv & HIDEHAIR)) \
+		|| (human.wear_mask && (human.wear_mask.flags_inv & HIDEHAIR)) \
+		|| human.try_hide_mutant_parts \
+		|| !bodypart \
 	)
 		//This line basically checks if we FORCE accessory-ears to show, for items with earholes like Balaclavas and Luchador masks
-		if(!(H.head && (H.head.flags_inv & SHOWSPRITEEARS) || (H.wear_mask && (H.wear_mask.flags_inv & SHOWSPRITEEARS)) || !HD))
+		if(!(human.head && (human.head.flags_inv & SHOWSPRITEEARS) || (human.wear_mask && (human.wear_mask.flags_inv & SHOWSPRITEEARS)) || !bodypart))
 			return TRUE
 	return FALSE
 

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/ears.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/ears.dm
@@ -5,8 +5,13 @@
 	relevent_layers = list(BODY_BEHIND_LAYER, BODY_ADJ_LAYER, BODY_FRONT_LAYER)
 	genetic = TRUE
 
-/datum/sprite_accessory/ears/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	if((H.head && (H.head.flags_inv & HIDEHAIR)) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR)) || H.try_hide_mutant_parts || !HD)
+/datum/sprite_accessory/ears/is_hidden(mob/living/carbon/human/human, obj/item/bodypart/bodypart)
+	if(
+		(human.head && (human.head.flags_inv & HIDEHAIR))
+		|| (human.wear_mask && (human.wear_mask.flags_inv & HIDEHAIR))
+		|| human.try_hide_mutant_parts
+		|| !bodypart
+	)
 		//This line basically checks if we FORCE accessory-ears to show, for items with earholes like Balaclavas and Luchador masks
 		if(!(H.head && (H.head.flags_inv & SHOWSPRITEEARS) || (H.wear_mask && (H.wear_mask.flags_inv & SHOWSPRITEEARS)) || !HD))
 			return TRUE

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/ears.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/ears.dm
@@ -6,7 +6,7 @@
 	genetic = TRUE
 
 /datum/sprite_accessory/ears/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	if(H.head && ((H.head.flags_inv & HIDEHAIR)  && H.try_hide_mutant_parts) || ((H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR))  && H.try_hide_mutant_parts) || !HD)
+	if((H.head && (H.head.flags_inv & HIDEHAIR)) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR)) || H.try_hide_mutant_parts || !HD)
 		//This line basically checks if we FORCE accessory-ears to show, for items with earholes like Balaclavas and Luchador masks
 		if(!(H.head && (H.head.flags_inv & SHOWSPRITEEARS) || (H.wear_mask && (H.wear_mask.flags_inv & SHOWSPRITEEARS)) || !HD))
 			return TRUE

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/frills.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/frills.dm
@@ -5,8 +5,12 @@
 	relevent_layers = list(BODY_ADJ_LAYER)
 	genetic = TRUE
 
-/datum/sprite_accessory/frills/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	if((H.head && (H.head.flags_inv & HIDEEARS)) || H.try_hide_mutant_parts || !HD)
+/datum/sprite_accessory/frills/is_hidden(mob/living/carbon/human/human, obj/item/bodypart/bodypart)
+	if(
+		(human.head && (human.head.flags_inv & HIDEEARS))
+		|| human.try_hide_mutant_parts
+		|| !bodypart
+	)
 		return TRUE
 	return FALSE
 

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/frills.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/frills.dm
@@ -6,7 +6,7 @@
 	genetic = TRUE
 
 /datum/sprite_accessory/frills/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	if(H.head && (H.try_hide_mutant_parts || (H.head.flags_inv & HIDEEARS) || !HD))
+	if((H.head && (H.head.flags_inv & HIDEEARS)) || H.try_hide_mutant_parts || !HD)
 		return TRUE
 	return FALSE
 

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/frills.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/frills.dm
@@ -7,9 +7,9 @@
 
 /datum/sprite_accessory/frills/is_hidden(mob/living/carbon/human/human, obj/item/bodypart/bodypart)
 	if(
-		(human.head && (human.head.flags_inv & HIDEEARS))
-		|| human.try_hide_mutant_parts
-		|| !bodypart
+		(human.head && (human.head.flags_inv & HIDEEARS)) \
+		|| human.try_hide_mutant_parts \
+		|| !bodypart \
 	)
 		return TRUE
 	return FALSE

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/horns.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/horns.dm
@@ -7,7 +7,7 @@
 	genetic = TRUE
 
 /datum/sprite_accessory/horns/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	if(H.head && ((H.head.flags_inv & HIDEHAIR) && H.try_hide_mutant_parts) || !HD)
+	if((H.head && (H.head.flags_inv & HIDEHAIR)) || H.try_hide_mutant_parts || !HD)
 		return TRUE
 	return FALSE
 

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/horns.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/horns.dm
@@ -6,8 +6,8 @@
 	default_color = "#555555"
 	genetic = TRUE
 
-/datum/sprite_accessory/horns/is_hidden(mob/living/carbon/human/H, obj/item/bodypart/HD)
-	if((H.head && (H.head.flags_inv & HIDEHAIR)) || H.try_hide_mutant_parts || !HD)
+/datum/sprite_accessory/horns/is_hidden(mob/living/carbon/human/human, obj/item/bodypart/bodypart)
+	if(human.try_hide_mutant_parts || !bodypart)
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For some reason, most sprite accessories, eg tails, etc. follow the logic of matching the HIDE* flags, unless Hide Mutant Bodyparts is on, then it's always hidden.

For some reason, mutant ears, horns, and frills followed a different logic of always being visible, unless Hide Mutant Bodyparts is on, then it actually uses the flags. Ironically meaning that unless the clothing is supposed to hide hair, the Hide Mutant Bodyparts command doesn't appear to the user to work.

Fixes #13556

This makes it impossible to make everything sensibly use the item flags which I would think should be the default behavior since ears poking through spacesuits and hoods doesn't really make sense, and following the flags for these slots was the default behavior to my knowledge (at least with teshari) before the external organs refactor stuff.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

consistent logic.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes visible ear visibility to work the way it did before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
