### PR TITLE
[MODULAR] Fixes the 'SABR' in N-T armories to actually come with a firing-pin.

### DIFF
--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/nanotrasen.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/nanotrasen.dm
@@ -47,7 +47,7 @@
 	restricted = TRUE
 
 /datum/armament_entry/cargo_gun/nanotrasen/smg/saber
-	item_type = /obj/item/gun/ballistic/automatic/proto
+	item_type = /obj/item/gun/ballistic/automatic/proto/unrestricted
 	lower_cost = CARGO_CRATE_VALUE * 16
 	upper_cost = CARGO_CRATE_VALUE * 20
 


### PR DESCRIPTION

## About The Pull Request
Buying a gun, and having it come without a firing pin likely an oversight.

see: https://github.com/Skyrat-SS13/Skyrat-tg/blob/b3f69e840f5b127f4f99f9c151ddca75d7005071/modular_skyrat/master_files/code/modules/projectiles/guns/ballistic/automatic.dm#L26
![image](https://user-images.githubusercontent.com/62520989/174917724-6051b3b5-1e28-4c8b-84dd-8b9beca35ea5.png)
![image](https://user-images.githubusercontent.com/62520989/174917766-694645c5-e61e-4e22-a11d-045cdde4eac4.png)

No, I don't know why the standard comes without a firing pin either


## Changelog



:cl:
fix: N-T armories has finally fixed an assembly line issue, the SMG SABR actually comes with it's firing pin now.
/:cl:

