### PR TITLE
Re-adds the red/white quipaos to loadout screen

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -374,7 +374,7 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	item_path = /obj/item/clothing/under/misc/greyshirt
 
 /datum/loadout_item/under/miscellaneous/maidcostume
-	name = "Maid costume"
+	name = "Maid Costume"
 	item_path = /obj/item/clothing/under/costume/maid
 
 /datum/loadout_item/under/miscellaneous/croptop
@@ -396,7 +396,9 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 /datum/loadout_item/under/miscellaneous/qipao_red
 	name = "Qipao, Red"
 	item_path = /obj/item/clothing/under/costume/qipao/red
-
+/datum/loadout_item/under/miscellaneous/fem_skirt
+	name = "Feminine Skirt"
+	item_path = /obj/item/clothing/under/suit/black/female/skirt
 /datum/loadout_item/under/miscellaneous/cheongsam
 	name = "Cheongsam, Black"
 	item_path = /obj/item/clothing/under/costume/cheongsam

--- a/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -385,9 +385,17 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	name = "Royal Kilt"
 	item_path = /obj/item/clothing/under/misc/royalkilt
 
-/datum/loadout_item/under/miscellaneous/qipao
+/datum/loadout_item/under/miscellaneous/qipao_black
 	name = "Qipao, Black"
 	item_path = /obj/item/clothing/under/costume/qipao
+
+/datum/loadout_item/under/miscellaneous/qipao_white
+	name = "Qipao, White"
+	item_path = /obj/item/clothing/under/costume/qipao/white
+
+/datum/loadout_item/under/miscellaneous/qipao_red
+	name = "Qipao, Red"
+	item_path = /obj/item/clothing/under/costume/qipao/red
 
 /datum/loadout_item/under/miscellaneous/cheongsam
 	name = "Cheongsam, Black"

--- a/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -396,9 +396,11 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 /datum/loadout_item/under/miscellaneous/qipao_red
 	name = "Qipao, Red"
 	item_path = /obj/item/clothing/under/costume/qipao/red
+
 /datum/loadout_item/under/miscellaneous/fem_skirt
 	name = "Feminine Skirt"
 	item_path = /obj/item/clothing/under/suit/black/female/skirt
+	
 /datum/loadout_item/under/miscellaneous/cheongsam
 	name = "Cheongsam, Black"
 	item_path = /obj/item/clothing/under/costume/cheongsam


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Apparently these existed previously and no longer do
also adds the feminine skirt that got requested post-PR

## How This Contributes To The Skyrat Roleplay Experience
Requested to readd

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Red and Wite Qipao clothing can now be found in the loadout menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
