### PR TITLE
Lowers chem regen for changelings.

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -41,7 +41,7 @@
 	/// The max chemical storage the changeling currently has.
 	var/total_chem_storage = 100 // SKYRAT EDIT - ORIGINAL: 75
 	/// The chemical recharge rate per life tick.
-	var/chem_recharge_rate = 1.5 // SKYRAT EDIT - ORIGINAL: 0.5
+	var/chem_recharge_rate = 0.7 // SKYRAT EDIT - ORIGINAL: 0.5
 	/// Any additional modifiers triggered by changelings that modify the chem_recharge_rate.
 	var/chem_recharge_slowdown = 0
 	/// The range this ling can sting things.
@@ -99,7 +99,7 @@
 	var/list/stolen_memories = list()
 
 	var/true_form_death //SKYRAT EDIT ADDITION: The time that the horror form died.
-	
+
 	// SKYRAT EDIT START
 	var/datum/changeling_profile/current_profile = null
 	var/list/mimicable_quirks_list = list(
@@ -488,7 +488,7 @@
 	new_profile.underwear = target.underwear
 	new_profile.undershirt = target.undershirt
 	new_profile.socks = target.socks
-	
+
 	// SKYRAT EDIT START
 	new_profile.underwear_color = target.underwear_color
 	new_profile.undershirt_color = target.undershirt_color
@@ -505,7 +505,7 @@
 	for(var/datum/quirk/target_quirk in target.quirks)
 		LAZYADD(new_profile.quirks, new target_quirk.type)
 	//SKYRAT EDIT END
-	
+
 	// Grab skillchips they have
 	new_profile.skillchips = target.clone_skillchip_list(TRUE)
 
@@ -540,7 +540,7 @@
 		new_profile.worn_icon_list[slot] = clothing_item.worn_icon
 		new_profile.worn_icon_state_list[slot] = clothing_item.worn_icon_state
 		new_profile.exists_list[slot] = 1
-		
+
 		// SKYRAT EDIT START
 		new_profile.worn_icon_digi_list[slot] = clothing_item.worn_icon_digi
 		new_profile.worn_icon_teshari_list[slot] = clothing_item.worn_icon_teshari
@@ -733,7 +733,7 @@
 	user.underwear = chosen_profile.underwear
 	user.undershirt = chosen_profile.undershirt
 	user.socks = chosen_profile.socks
-	
+
 	// SKYRAT EDIT START
 	user.underwear_color = chosen_profile.underwear_color
 	user.undershirt_color = chosen_profile.undershirt_color
@@ -749,21 +749,21 @@
 	user.selected_scream = new chosen_profile.scream_type
 	user.selected_laugh = new chosen_profile.laugh_type
 	user.age = chosen_profile.age
-	
+
 	// Only certain quirks will be copied, to avoid making the changeling blind or wheelchair-bound when they can simply pretend to have these quirks.
-	
+
 	for(var/datum/quirk/target_quirk in user.quirks)
 		for(var/mimicable_quirk in mimicable_quirks_list)
 			if(target_quirk.name == mimicable_quirk)
 				user.remove_quirk(target_quirk.type)
 				break
-	
+
 	for(var/datum/quirk/target_quirk in chosen_profile.quirks)
 		for(var/mimicable_quirk in mimicable_quirks_list)
 			if(target_quirk.name == mimicable_quirk)
 				user.add_quirk(target_quirk.type)
 				break
-	
+
 	// SKYRAT EDIT END
 
 	chosen_dna.transfer_identity(user, TRUE)
@@ -844,7 +844,7 @@
 		new_flesh_item.inhand_icon_state = chosen_profile.inhand_icon_state_list[slot]
 		new_flesh_item.worn_icon = chosen_profile.worn_icon_list[slot]
 		new_flesh_item.worn_icon_state = chosen_profile.worn_icon_state_list[slot]
-		
+
 		// SKYRAT EDIT START
 		new_flesh_item.worn_icon_digi = chosen_profile.worn_icon_digi_list[slot]
 		new_flesh_item.worn_icon_teshari = chosen_profile.worn_icon_teshari_list[slot]
@@ -867,7 +867,7 @@
 			attempted_fake_scar.fake = TRUE
 
 	user.regenerate_icons()
-	
+
 	// SKYRAT EDIT START
 	chosen_dna.transfer_identity(user, TRUE)
 	user.updateappearance(mutcolor_update = TRUE, eyeorgancolor_update = TRUE)
@@ -915,7 +915,7 @@
 	var/datum/icon_snapshot/profile_snapshot
 	/// ID HUD icon associated with the profile
 	var/id_icon
-	
+
 	/// SKYRAT EDIT START
 	var/underwear_color
 	var/undershirt_color
@@ -966,7 +966,7 @@
 	new_profile.stored_scars = stored_scars.Copy()
 	new_profile.profile_snapshot = profile_snapshot
 	new_profile.id_icon = id_icon
-	
+
 	// SKYRAT EDIT START
 	new_profile.underwear_color = underwear_color
 	new_profile.undershirt_color = undershirt_color

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -41,7 +41,7 @@
 	/// The max chemical storage the changeling currently has.
 	var/total_chem_storage = 100 // SKYRAT EDIT - ORIGINAL: 75
 	/// The chemical recharge rate per life tick.
-	var/chem_recharge_rate = 0.7 // SKYRAT EDIT - ORIGINAL: 0.5
+	var/chem_recharge_rate = 1 // SKYRAT EDIT - ORIGINAL: 0.5
 	/// Any additional modifiers triggered by changelings that modify the chem_recharge_rate.
 	var/chem_recharge_slowdown = 0
 	/// The range this ling can sting things.


### PR DESCRIPTION
It's still like a good 0.2 above the standard TG 0.5

## About The Pull Request

Simply changes a single variable to reduce the chemical regen of changelings to something a little more reasonable.
Former: 1.5 chem regen per second.
Now: 0.7 chem regen per second.
Base: 0.5 chem regen per second.

## How This Contributes To The Skyrat Roleplay Experience

Changelings had tripple the chemical regen over base TG changelings, and there's no major reason for them to have this since even the new guncargo guns have trouble dispatching a changeling.
Changelings should be powerful but tripple the chemical regen is a little much.
Hopefully they're a little less painful to fight as they won't be able to heal as rapidly and constantly, making a changeling player consider their actions more carefully.

## Changelog


:cl:

balance: Rebalances changeling chemical regen to 0.7 from 1.5

/:cl:

