### PR TITLE
Assault Ops equipment nerf

### DIFF
--- a/_maps/shuttles/skyrat/goldeneye_cruiser.dmm
+++ b/_maps/shuttles/skyrat/goldeneye_cruiser.dmm
@@ -186,8 +186,8 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
-	id = "syndicatecruiserbrig";
-	dir = 4
+	dir = 4;
+	id = "syndicatecruiserbrig"
 	},
 /turf/open/floor/plating,
 /area/shuttle/syndicate/cruiser/brig)
@@ -205,16 +205,16 @@
 /obj/machinery/button/door{
 	id = "syndicatecruiserwindows";
 	name = "Window Blast Doors";
+	pixel_x = -5;
 	pixel_y = 7;
-	req_access = list("syndicate");
-	pixel_x = -5
+	req_access = list("syndicate")
 	},
 /obj/machinery/button/door{
 	id = "syndicatecruiserarmory";
 	name = "Armory Blast Doors";
+	pixel_x = -5;
 	pixel_y = -6;
-	req_access = list("syndicate");
-	pixel_x = -5
+	req_access = list("syndicate")
 	},
 /obj/machinery/button/door{
 	id = "syndicatecruiserhall";
@@ -303,12 +303,6 @@
 	dir = 1;
 	pixel_y = 24
 	},
-/obj/item/storage/medkit/tactical,
-/obj/item/storage/medkit/tactical,
-/obj/item/storage/medkit/tactical,
-/obj/item/storage/medkit/tactical,
-/obj/item/storage/medkit/tactical,
-/obj/item/storage/medkit/tactical,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/medical)
 "eT" = (
@@ -430,12 +424,6 @@
 /area/shuttle/syndicate/cruiser/medical)
 "hk" = (
 /obj/structure/rack/shelf,
-/obj/item/melee/powerfist,
-/obj/item/melee/baton,
-/obj/item/melee/baton,
-/obj/item/melee/baton,
-/obj/item/melee/baton,
-/obj/item/melee/baton,
 /obj/item/melee/baton,
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/airalarm/syndicate{
@@ -562,10 +550,9 @@
 	},
 /obj/machinery/turretid{
 	name = "DANGER: Outer Turret Control";
-	req_access = null;
+	pixel_x = -28;
 	req_access = list("syndicate");
-	system_id = "cruiser_turrets_outer";
-	pixel_x = -28
+	system_id = "cruiser_turrets_outer"
 	},
 /turf/open/floor/circuit/red,
 /area/shuttle/syndicate/cruiser/hallway)
@@ -659,11 +646,6 @@
 "mp" = (
 /obj/structure/rack/shelf,
 /obj/item/suppressor,
-/obj/item/suppressor,
-/obj/item/suppressor,
-/obj/item/suppressor,
-/obj/item/suppressor,
-/obj/item/suppressor,
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -720,9 +702,9 @@
 "nD" = (
 /mob/living/simple_animal/bot/medbot{
 	faction = list("Syndicate");
+	maints_access_required = list(150);
 	name = "Kahn";
-	radio_channel = "Syndicate";
-	maints_access_required = list(150)
+	radio_channel = "Syndicate"
 	},
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -822,8 +804,8 @@
 	id = "syndicatecruiserbrig";
 	name = "Brig Shutters";
 	pixel_x = -24;
-	req_access = list("syndicate");
-	pixel_y = -6
+	pixel_y = -6;
+	req_access = list("syndicate")
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/syndicate/cruiser/hallway)
@@ -1219,13 +1201,8 @@
 /area/shuttle/syndicate/cruiser/hallway)
 "Al" = (
 /obj/structure/rack/shelf,
-/obj/item/storage/box/syndie_kit/imp_stealth,
-/obj/item/storage/box/syndie_kit/imp_stealth,
-/obj/item/storage/box/syndie_kit/imp_stealth,
-/obj/item/storage/box/syndie_kit/imp_stealth,
-/obj/item/storage/box/syndie_kit/imp_stealth,
-/obj/item/storage/box/syndie_kit/imp_stealth,
 /obj/effect/turf_decal/bot_white,
+/obj/item/suppressor,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/armory)
 "An" = (
@@ -1321,9 +1298,9 @@
 "CK" = (
 /mob/living/simple_animal/bot/medbot{
 	faction = list("Syndicate");
+	maints_access_required = list(150);
 	name = "James T. Kirk";
-	radio_channel = "Syndicate";
-	maints_access_required = list(150)
+	radio_channel = "Syndicate"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -1434,25 +1411,8 @@
 /area/shuttle/syndicate/cruiser/airlock)
 "Eu" = (
 /obj/structure/rack/shelf,
-/obj/item/grenade/syndieminibomb{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/grenade/syndieminibomb{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/grenade/c4,
-/obj/item/grenade/c4,
-/obj/item/grenade/c4,
-/obj/item/grenade/c4,
-/obj/item/grenade/c4,
-/obj/item/grenade/c4,
-/obj/item/grenade/c4,
-/obj/item/grenade/c4,
-/obj/item/grenade/c4,
-/obj/item/grenade/c4,
 /obj/effect/turf_decal/bot_white,
+/obj/item/melee/baton,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/armory)
 "EL" = (
@@ -1607,7 +1567,6 @@
 /obj/machinery/turretid{
 	name = "Internal Turret Control";
 	pixel_y = 30;
-	req_access = null;
 	req_access = list("syndicate");
 	system_id = "cruiser_turrets_internal"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes (most) of the free equipment on the assops shuttle (combat medkits, batons, c4, minibombs, power fist, suppressors, stealth implants)
Leaves behind 2 batons and 2 suppressors

## How This Contributes To The Skyrat Roleplay Experience
Assops are wildly overtuned so here's part 1 of balance changes

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Removed most free antagonist equipment from the assault ops shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
