### PR TITLE
New botanist alt-title: "Florist"

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -28,7 +28,7 @@
 	alt_titles = list("Blueshield", "Command Bodyguard", "Executive Protection Agent")
 
 /datum/job/botanist
-	alt_titles = list("Botanist", "Hydroponicist", "Gardener", "Botanical Researcher", "Herbalist")
+	alt_titles = list("Botanist", "Hydroponicist", "Gardener", "Botanical Researcher", "Herbalist", "Florist")
 
 /datum/job/bouncer
 	alt_titles = list("Bouncer", "Service Guard")


### PR DESCRIPTION
## About The Pull Request

Adds the "Florist" alt-title for botany.

## How This Contributes To The Skyrat Roleplay Experience

It's cute! Fun flavour.

## Changelog
:cl:
add: Botanists can now use the "Florist" alternate title.
/:cl: