### PR TITLE
Re-adds the one true permabrig to Delta

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -35,16 +35,6 @@
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/theater)
-"aaB" = (
-/obj/structure/chair/stool/directional/south,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
 "aaG" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/warning/no_smoking{
@@ -67,6 +57,9 @@
 "aaM" = (
 /turf/closed/wall,
 /area/station/medical/surgery/theatre)
+"aaX" = (
+/turf/closed/wall,
+/area/station/security/prison/garden)
 "aaY" = (
 /obj/effect/landmark/start/hangover/closet,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -158,6 +151,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"acf" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "aci" = (
 /obj/machinery/cryopod{
 	dir = 1
@@ -235,6 +236,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"acO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/trashcart,
+/obj/item/seeds/tower/steel,
+/obj/item/grown/log/bamboo,
+/obj/effect/spawner/random/contraband/cannabis,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "acU" = (
 /obj/structure/table_frame,
 /obj/effect/decal/cleanable/dirt,
@@ -378,9 +387,14 @@
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
 "adU" = (
-/obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/flasher{
+	id = "transferflash";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "aek" = (
@@ -600,18 +614,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
-"agO" = (
-/obj/docking_port/stationary{
-	dheight = 1;
-	dir = 8;
-	dwidth = 12;
-	height = 17;
-	id = "syndicate_ne";
-	name = "northeast of station";
-	width = 23
-	},
-/turf/open/space,
-/area/space/nearstation)
 "agS" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -757,6 +759,17 @@
 "aiK" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard)
+"aiM" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell7";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "aiO" = (
 /obj/structure/cable,
 /obj/structure/table/wood,
@@ -1051,9 +1064,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
-"anf" = (
-/turf/open/floor/iron/white,
-/area/station/security/execution/transfer)
+"anb" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue/side,
+/area/station/security/prison/safe)
 "anp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced,
@@ -1120,6 +1141,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
+"anP" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/secure_closet/brigoff,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
+/area/brigofficer)
 "anV" = (
 /obj/effect/landmark/start/hangover/closet,
 /obj/structure/closet/firecloset,
@@ -1134,30 +1163,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"aoA" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast Door"
-	},
-/obj/machinery/button/flasher{
-	id = "Cell 1";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/east{
-	id = "permashut1";
-	name = "Cell Lockdown Button";
-	pixel_y = -6;
-	req_access = list("brig")
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "aoJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1321,18 +1326,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"aqq" = (
-/obj/machinery/sparker/directional/west{
-	id = "justicespark"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
 "aqu" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Medbay - Chief Medical Officer's Quarters";
@@ -1486,6 +1479,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/service/lawoffice)
+"arL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "arQ" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/blue{
@@ -1525,6 +1523,10 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"asi" = (
+/obj/structure/bed/roller,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "ask" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1696,6 +1698,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"aun" = (
+/obj/structure/bed/maint,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "aut" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1726,10 +1733,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "auy" = (
-/obj/item/kirbyplants/random,
-/obj/structure/sign/warning/electric_shock{
-	pixel_y = -30
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "auB" = (
@@ -1782,17 +1789,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
-"auW" = (
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "Prisoner Telescreen";
-	network = list("prison");
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "auZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1932,9 +1928,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/bar)
 "awO" = (
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/security/prison)
 "awZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -1957,15 +1956,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "axm" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/electric_shock{
-	pixel_x = -32
-	},
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "axr" = (
 /obj/machinery/conveyor{
 	dir = 9;
@@ -2044,14 +2041,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
-"ayH" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Permabrig - Central";
-	network = list("ss13","prison")
-	},
-/obj/item/radio/intercom/prison/directional/west,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "aze" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
@@ -2067,6 +2056,16 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"azk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/security{
+	name = "Isolation Cell"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/safe)
 "azm" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
@@ -2155,12 +2154,21 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "aAA" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/execution)
 "aAG" = (
 /obj/structure/chair{
 	dir = 4
@@ -2171,6 +2179,19 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"aAQ" = (
+/obj/machinery/camera{
+	c_tag = "Prison Isolation Cell";
+	dir = 4;
+	network = list("ss13","prison","isolation")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 6
+	},
+/area/station/security/prison/safe)
 "aAT" = (
 /obj/machinery/shower{
 	dir = 4
@@ -2311,15 +2332,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
-"aCC" = (
-/obj/structure/closet/secure_closet/brig{
-	name = "Prisoner Locker"
-	},
-/obj/machinery/status_display/ai/directional/south,
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/transfer)
 "aCD" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -2356,14 +2368,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"aDl" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
 "aDt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2755,6 +2759,19 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"aIF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/security/prison/mess)
+"aIK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/security/prison)
 "aIV" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron,
@@ -2984,11 +3001,15 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "aNd" = (
-/obj/structure/chair/stool/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/machinery/button/curtain{
+	id = "prisonlibrarycurtain";
+	pixel_x = -24
+	},
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
 /area/station/security/prison)
 "aNq" = (
 /turf/open/floor/iron/grimy,
@@ -3332,15 +3353,28 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aRS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/flasher/directional/south{
-	id = "Cell 5"
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 4;
+	name = "blue line"
 	},
-/turf/open/floor/iron,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/station/security/prison)
+"aSf" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell10";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 1
+	},
 /area/station/security/prison/safe)
 "aSi" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -3351,6 +3385,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
+"aSo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/security/prison/mess)
 "aSB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3387,6 +3426,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/service/library/abandoned)
+"aTy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/public{
+	name = "Prison Cell"
+	},
+/turf/open/floor/iron/dark/blue,
+/area/station/security/prison/safe)
 "aTz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3498,15 +3545,15 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "aVL" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/glasses/blindfold,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/security/execution/transfer)
+/obj/machinery/plate_press{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
 "aVW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3641,6 +3688,12 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
+"aXS" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "aXU" = (
 /obj/docking_port/stationary{
 	dwidth = 1;
@@ -3651,6 +3704,19 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"aXY" = (
+/obj/machinery/button/flasher{
+	id = "IsolationFlash";
+	pixel_x = 21;
+	pixel_y = 21
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/security/prison)
 "aYd" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -3734,6 +3800,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/lockers)
+"aZi" = (
+/obj/machinery/seed_extractor,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood,
+/area/station/security/prison/garden)
 "aZs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -3780,6 +3852,27 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"bap" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = -4
+	},
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 4
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "baw" = (
 /obj/machinery/power/emitter,
 /obj/effect/decal/cleanable/dirt,
@@ -3818,14 +3911,13 @@
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "bbf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast Door"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/security/execution/transfer)
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "bbo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3939,14 +4031,21 @@
 	heat_capacity = 1e+006
 	},
 /area/station/commons/dorms)
-"bcm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
+"bcn" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/dropper,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "bco" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4032,6 +4131,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"bdl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "isolationshutter"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "bdt" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/plasma/spawner/west{
@@ -4109,13 +4216,20 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "beK" = (
+/obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/turf/open/floor/iron/dark/red/side,
+/area/station/security/execution)
+"beM" = (
+/obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
+/area/station/security/prison/safe)
 "beR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -4141,11 +4255,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
-"bfs" = (
-/obj/structure/chair/stool/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "bfy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -4316,15 +4425,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
-"bhz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "bhJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/north,
@@ -4370,19 +4470,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"bii" = (
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 8
-	},
-/obj/machinery/status_display/evac/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Hall";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "bij" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/plating,
@@ -4452,6 +4539,20 @@
 	dir = 4
 	},
 /area/station/engineering/lobby)
+"bjn" = (
+/obj/structure/holohoop{
+	density = 0;
+	pixel_y = 18
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 1;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/station/security/prison)
 "bjr" = (
 /turf/open/floor/iron/dark/corner,
 /area/station/commons/fitness/recreation)
@@ -4514,6 +4615,16 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"bjW" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "bkj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4544,12 +4655,12 @@
 	},
 /area/station/maintenance/port/aft)
 "bku" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/transfer)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "bkE" = (
 /obj/structure/window/reinforced,
 /turf/open/space,
@@ -4641,6 +4752,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
+"blD" = (
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
 "blI" = (
 /obj/machinery/door/window/right/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -4658,7 +4772,7 @@
 "blM" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "brigprison";
-	name = "Prison Blast Door"
+	name = "Prison Blast door"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -4791,6 +4905,16 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/tcommsat/server)
+"bnJ" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 10;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/station/security/prison)
 "bnS" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Holodeck - Fore 2";
@@ -4980,6 +5104,14 @@
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron/checker,
 /area/station/service/theater)
+"bpW" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -22
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "bqd" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -5154,15 +5286,14 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bsD" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/ambrosia_vulgaris{
-	pixel_x = -30
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/glass_large{
+	dir = 8;
+	name = "Cafeteria"
 	},
-/obj/machinery/light/directional/west,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "bsR" = (
 /obj/structure/chair{
 	dir = 8
@@ -5325,14 +5456,11 @@
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden/abandoned)
 "buu" = (
-/obj/machinery/door/airlock{
-	name = "Permabrig Showers"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/security/prison/toilet)
+/area/station/security/prison)
 "buJ" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -5924,16 +6052,18 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "bCC" = (
-/obj/machinery/door/poddoor{
-	id = "justiceblast";
-	name = "Justice Blast Door"
+/obj/machinery/button/curtain{
+	id = "prisoncell9";
+	pixel_y = 21
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/prison/safe)
 "bCD" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5987,12 +6117,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
-"bDw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/security/prison)
 "bDx" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -6187,6 +6311,13 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/maintenance/disposal/incinerator)
+"bFw" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "bFy" = (
 /obj/structure/cable,
 /obj/machinery/conveyor{
@@ -6201,19 +6332,20 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "bFH" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Cell 3";
-	network = list("ss13","prison")
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown3";
+	name = "Lockdown"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+/obj/machinery/button/door{
+	id = "prisonlockdown3";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access = list("brig")
 	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "bFI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -6228,6 +6360,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
+"bFN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "bFT" = (
 /obj/effect/landmark/start/ai,
 /obj/item/radio/intercom/directional/west{
@@ -6299,8 +6440,9 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "bGi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/east,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bGj" = (
@@ -6789,6 +6931,31 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"bMC" = (
+/obj/structure/rack,
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = -6
+	},
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = -6
+	},
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "bMH" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -6817,26 +6984,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "bNv" = (
-/obj/structure/window{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
 	},
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null
-	},
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/onion,
-/obj/item/food/grown/onion,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/poster/ripped{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
+/area/station/security/prison)
 "bNB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7420,6 +7572,22 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"bTm" = (
+/obj/item/chair/plastic{
+	pixel_y = 10
+	},
+/obj/item/chair/plastic{
+	pixel_y = 10
+	},
+/obj/item/chair/plastic{
+	pixel_y = 10
+	},
+/obj/item/chair/plastic{
+	pixel_y = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
 "bTo" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
@@ -7898,10 +8066,15 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "caH" = (
-/obj/effect/decal/remains/human,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/airlock/public/glass{
+	name = "Workshop"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/work)
 "caV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8717,15 +8890,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/command/gateway)
-"cmc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/security/execution/transfer)
 "cme" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -8882,6 +9046,19 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"coe" = (
+/obj/structure/table,
+/obj/item/soap,
+/obj/item/storage/bag/tray,
+/obj/item/storage/box/condimentbottles{
+	pixel_y = 10
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "coj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9007,19 +9184,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
-"cqH" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/structure/sign/poster/official/obey{
-	pixel_x = 30
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Cell 5";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plating,
-/area/station/security/prison/safe)
 "crf" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
@@ -9137,12 +9301,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
-"ctH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+"ctL" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell6";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
 /area/station/security/prison/safe)
 "cui" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9178,10 +9346,18 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "cuB" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/obj/machinery/light_switch/directional/north,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/evidence{
+	name = "Brig Officer's Locker"
+	},
+/obj/item/clothing/mask/whistle,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/brigofficer)
 "cuX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9255,15 +9431,32 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
-"cwa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast Door"
+"cvY" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell11";
+	pixel_y = 21
 	},
-/turf/open/floor/plating,
-/area/station/security/prison/work)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 1
+	},
+/area/station/security/prison/safe)
+"cwa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 9
+	},
+/area/station/security/prison/safe)
 "cwe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -9590,6 +9783,9 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
+"cAq" = (
+/turf/closed/wall/r_wall,
+/area/brigofficer)
 "cAw" = (
 /obj/structure/cable,
 /obj/structure/rack,
@@ -10111,6 +10307,15 @@
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den/gaming)
+"cGc" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "cGh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10318,6 +10523,14 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
+"cIB" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "cIG" = (
 /obj/item/circular_saw,
 /obj/item/scalpel{
@@ -10355,6 +10568,24 @@
 "cJD" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/escape)
+"cJG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Sanitarium";
+	req_access_txt = "2"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/red/side{
+	dir = 8
+	},
+/area/station/security/medical)
 "cJH" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
@@ -10382,15 +10613,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
-"cKa" = (
-/obj/structure/toilet/greyscale,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "cKm" = (
 /obj/structure/chair/comfy/black,
 /obj/structure/cable,
@@ -10751,24 +10973,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "cPO" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/item/seeds/onion,
-/obj/item/seeds/garlic,
-/obj/item/seeds/potato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/effect/spawner/random/contraband/prison,
-/obj/structure/window,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/seeds/tower,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
+/obj/item/pillow{
+	pixel_x = 5;
+	pixel_y = 12
+	},
+/obj/item/pillow,
+/turf/open/floor/carpet/royalblue,
+/area/station/security/prison)
 "cPQ" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -10922,6 +11133,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"cSJ" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "cSK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
@@ -11176,6 +11397,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/captain,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
+"cXJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/security/prison)
 "cXM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -11189,14 +11419,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
-"cYa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
 "cYr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11220,10 +11442,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "cYC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/light/directional/north,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/station/security/prison)
 "cYK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11356,9 +11579,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
-"daD" = (
-/turf/open/floor/plating,
-/area/station/security/prison/mess)
 "daF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11515,6 +11735,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"dcz" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/station/security/prison)
 "dcL" = (
 /obj/structure/sink{
 	dir = 8;
@@ -11526,27 +11751,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
-"dcN" = (
-/obj/machinery/button/flasher{
-	id = "Cell 5";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/east{
-	id = "permashut5";
-	name = "Cell Lockdown Button";
-	pixel_y = -6;
-	req_access = list("brig")
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "dcP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11987,19 +12191,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"djI" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Cell 2";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "djP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -12016,16 +12207,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"dkx" = (
-/obj/machinery/door/window/left/directional/north,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
 "dkz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/directional/west,
@@ -12160,6 +12341,14 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos/project)
+"dlQ" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/item/storage/fancy/egg_box,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "dmo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -12320,6 +12509,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"doX" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "dps" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/hydroponics/soil,
@@ -12327,8 +12530,17 @@
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden/abandoned)
 "dpI" = (
-/turf/closed/wall/r_wall,
-/area/station/security/prison/visit)
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Visitation";
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "dpQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/box,
@@ -12420,7 +12632,8 @@
 "drs" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
-	name = "Storage Closet"
+	name = "Storage Closet";
+	req_access_txt = "63"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -12431,7 +12644,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "drt" = (
@@ -12507,6 +12719,16 @@
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
+"dsw" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/inflatable,
+/obj/item/inflatable/door,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/upper)
 "dsy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12832,25 +13054,6 @@
 	dir = 8
 	},
 /area/station/service/hydroponics)
-"dwX" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 5"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "dwY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12945,6 +13148,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/qm)
+"dyB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "dyH" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -13004,6 +13212,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/commons/dorms)
+"dAd" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = -6;
+	reclaim_rate = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "dAf" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -13242,12 +13461,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "dDV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/security/prison/toilet)
+/obj/machinery/airalarm/directional/east,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "dEb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/north,
@@ -13441,7 +13658,16 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "dGB" = (
-/turf/closed/wall/r_wall,
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/wood,
 /area/station/security/prison/garden)
 "dGM" = (
 /obj/item/radio/intercom/directional/west,
@@ -13488,6 +13714,9 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
+"dHE" = (
+/turf/closed/wall,
+/area/station/security/execution)
 "dHG" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/blue{
@@ -13541,17 +13770,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dIi" = (
-/obj/structure/bed{
-	dir = 4
+/obj/machinery/plate_press{
+	pixel_y = -3
 	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/glasses/blindfold,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/security/execution/transfer)
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
 "dIk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13792,6 +14016,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"dME" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/rec)
 "dMJ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/iron{
@@ -13901,6 +14137,16 @@
 "dNN" = (
 /turf/closed/wall/r_wall,
 /area/station/science/research)
+"dNO" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cafeteria"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "dNP" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -14104,6 +14350,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"dQL" = (
+/obj/machinery/plate_press{
+	pixel_y = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
 "dQS" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -14188,6 +14441,34 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"dSt" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bowl,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/knife/plastic,
+/obj/item/knife/plastic,
+/obj/item/knife/plastic,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "dSv" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -14445,6 +14726,20 @@
 "dYj" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/hfr_room)
+"dYl" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/button/curtain{
+	id = "prisoncell11";
+	pixel_x = 22;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "dYn" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -14513,6 +14808,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"dYU" = (
+/obj/structure/bed,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/mask/muzzle,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
+"dYZ" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell4";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
+	},
+/area/station/security/prison/safe)
 "dZe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14531,6 +14847,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/genetics,
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
+"dZp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "dZw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14647,11 +14970,12 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "eaU" = (
-/obj/structure/window,
-/obj/machinery/seed_extractor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
+/obj/structure/chair/comfy{
+	color = "#596479";
+	pixel_y = 16
+	},
+/turf/open/floor/wood,
+/area/station/security/prison)
 "eba" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
@@ -14764,10 +15088,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "edb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
 /area/station/security/prison)
 "edg" = (
 /obj/effect/spawner/random/structure/grille,
@@ -14785,6 +15107,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"edP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "edS" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -14936,6 +15263,17 @@
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
+"egu" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell3";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "egx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -15072,13 +15410,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
-"eip" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "eir" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
@@ -15127,11 +15458,15 @@
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "eiC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 4;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "eiD" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Virology - Hallway";
@@ -15192,6 +15527,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"ejd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/security/prison)
 "ejl" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -15545,6 +15888,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/toilet/restrooms)
+"eoS" = (
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
+	},
+/obj/machinery/door/window/left/directional/south,
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "eoY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -15629,6 +15981,15 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"epU" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/purple/side,
+/area/station/security/prison/safe)
 "epV" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -16097,6 +16458,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
+"ewL" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/rec)
 "ewM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 9
@@ -16158,10 +16528,12 @@
 /turf/open/floor/iron,
 /area/station/science/breakroom)
 "exd" = (
-/obj/structure/chair/stool/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Prison - Visition (Visitor)";
+	network = list("ss13","prison")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "exi" = (
@@ -16312,6 +16684,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
+"eza" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "eze" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
@@ -16379,11 +16756,17 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "eAz" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/computer/security{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/obj/machinery/computer/security/telescreen/prison{
+	pixel_y = 32
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/brigofficer)
 "eAS" = (
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
@@ -16421,20 +16804,20 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "eBY" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown1";
+	name = "Lockdown"
 	},
-/obj/item/trash/sosjerky,
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = 32
+/obj/machinery/button/door{
+	id = "prisonlockdown1";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access = list("brig")
 	},
-/obj/machinery/light/small/directional/north,
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/security/prison/toilet)
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "eBZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
@@ -16791,6 +17174,41 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/entry)
+"eGV" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown4";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "prisonlockdown4";
+	name = "Lockdown";
+	pixel_x = -24;
+	req_access = list("brig")
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/button/curtain{
+	id = "prisoncell6";
+	pixel_x = -22;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
+"eGX" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
+"eGZ" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "eHq" = (
 /obj/machinery/door/airlock/virology{
 	name = "Virology Cabin"
@@ -16868,8 +17286,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "eHO" = (
-/turf/closed/wall/r_wall,
-/area/station/security/execution/education)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
+/obj/machinery/meter,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/execution)
 "eHY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -16951,6 +17374,26 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
+"eJG" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/machinery/light/small/red/directional/south,
+/obj/item/restraints/handcuffs,
+/obj/item/toy/crayon/spraycan,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/upper)
+"eJI" = (
+/obj/machinery/flasher/directional/north{
+	id = "justiceflash"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/red/side{
+	dir = 1
+	},
+/area/station/security/execution)
 "eJP" = (
 /obj/structure/sign/departments/lawyer{
 	pixel_y = -32
@@ -16984,6 +17427,15 @@
 "eKe" = (
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"eKf" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
+/area/station/security/prison/safe)
 "eKh" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "service_maint_shutters";
@@ -17010,6 +17462,16 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"eKs" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Security - Upper Brig";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "eKz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17139,6 +17601,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"eMH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	name = "Airmix Reserve to Distribution"
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "eMN" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/package_wrap,
@@ -17241,7 +17711,7 @@
 "eNG" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "brigprison";
-	name = "Prison Blast Door"
+	name = "Prison Blast door"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/pods{
@@ -17280,11 +17750,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "eOh" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/work)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "eOn" = (
 /obj/structure/cable,
 /obj/structure/closet/secure_closet/hydroponics,
@@ -17371,6 +17844,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
 /area/station/commons/lounge)
+"ePd" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
 "ePl" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -17398,9 +17877,15 @@
 /area/station/science/research/abandoned)
 "ePH" = (
 /obj/structure/closet/l3closet/security,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot_blue,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/suit/bio_suit/security,
+/obj/item/clothing/head/bio_hood/security,
+/obj/item/clothing/head/bio_hood/security,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "ePJ" = (
@@ -17611,10 +18096,9 @@
 /turf/open/space/basic,
 /area/space)
 "eTv" = (
-/obj/structure/closet/crate/trashcart,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/official/random/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "eTx" = (
@@ -17718,15 +18202,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
-"eUs" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "eUu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17751,6 +18226,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"eUE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/trashcart/filled,
+/obj/effect/spawner/random/contraband/prison,
+/obj/effect/spawner/random/contraband/prison,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/crowbar/large/old,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "eUH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17776,6 +18260,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"eVk" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
 "eVl" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/computer)
@@ -18068,6 +18559,14 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/supermatter/room)
+"eYI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "eYJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18113,6 +18612,18 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"eZC" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera{
+	c_tag = "Security - Genpop Lockers";
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "eZD" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -18152,6 +18663,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"eZS" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "fah" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 6
@@ -18390,6 +18909,14 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"fcX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/security/prison)
 "fdz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18895,12 +19422,6 @@
 "fiO" = (
 /turf/closed/wall,
 /area/station/security/prison)
-"fiQ" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/visit)
 "fiT" = (
 /obj/item/flashlight{
 	pixel_x = 1;
@@ -19029,14 +19550,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "fkY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "visitation";
-	name = "Visitation Shutters"
-	},
-/obj/machinery/door/window/right/directional/south{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "fli" = (
@@ -19250,6 +19764,14 @@
 "fot" = (
 /turf/closed/wall,
 /area/station/ai_monitored/command/storage/eva)
+"foB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
+/area/station/security/prison/safe)
 "foG" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/tile/blue{
@@ -19274,12 +19796,19 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "foT" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/obj/machinery/firealarm/directional/west{
+	pixel_x = -15
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
+/area/brigofficer)
 "foV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -19449,6 +19978,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"fqQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/brigofficer)
 "fqZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/plaque/static_plaque/golden/commission/delta,
@@ -19761,6 +20297,18 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"ftV" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown2";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "ftW" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/breath,
@@ -19818,16 +20366,12 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "fuS" = (
-/obj/machinery/button/flasher{
-	id = "Cell 6";
-	name = "Prisoner Flash";
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "fuV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -20136,6 +20680,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"fzn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/west,
+/obj/machinery/button/curtain{
+	id = "prisoncell7";
+	pixel_x = -22;
+	pixel_y = 10
+	},
+/obj/machinery/airalarm/directional/west{
+	pixel_y = -4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/security/prison)
 "fzp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/landmark/start/depsec/engineering,
@@ -20244,14 +20805,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/science/lobby)
-"fAr" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron,
-/area/station/security/prison/visit)
 "fAt" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -20372,6 +20925,17 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"fBO" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell8";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "fBP" = (
 /obj/structure/chair{
 	dir = 8
@@ -20449,27 +21013,15 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "fDm" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt2";
-	name = "Cell 2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/cryopod{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/delivery/white{
+	color = "#00ff00";
+	name = "green"
 	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "fDo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20665,6 +21217,19 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"fGP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/cardboard,
+/obj/item/weldingtool/mini,
+/obj/item/grown/cotton/durathread,
+/obj/item/reagent_containers/hypospray/medipen/oxandrolone,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/stack/sheet/iron/twenty,
+/obj/item/radio,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "fGT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21073,13 +21638,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/station/service/theater/abandoned)
-"fMd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/prison/safe)
 "fMk" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -21104,6 +21662,21 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
+"fMH" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown2";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "prisonlockdown1";
+	name = "Lockdown";
+	pixel_x = -24;
+	req_access = list("brig")
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "fMN" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -21455,6 +22028,9 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"fSX" = (
+/turf/closed/wall,
+/area/station/security/prison/mess)
 "fTq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -21553,6 +22129,15 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"fVJ" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "fVQ" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -21587,6 +22172,13 @@
 /obj/machinery/computer/secure_data,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hos)
+"fWw" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
 "fWA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -21610,6 +22202,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"fWP" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "fWZ" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -21708,6 +22307,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
+"fYl" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "fYu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21756,10 +22365,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"fYX" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "fYZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -21877,8 +22482,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "gaM" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/station/security/execution/transfer)
 "gbk" = (
 /obj/structure/table,
@@ -21935,18 +22541,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"gbZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "justicechamber";
-	name = "Justice Chamber Blast Door"
-	},
-/obj/structure/sign/warning/electric_shock{
-	pixel_x = 32
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/execution/education)
 "gca" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -22620,10 +23214,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "gky" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/public{
+	name = "Prison Cell"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/brown,
+/area/station/security/prison/safe)
 "gkB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23351,12 +23949,28 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "gul" = (
-/obj/machinery/meter,
-/obj/machinery/door/window/right/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/machinery/door/poddoor/preopen{
+	id = "justicechamber";
+	name = "Justice Chamber Blast door"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/door/window/brigdoor/left/directional/west{
+	req_access = list("brig")
+	},
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	req_access = list("brig")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/execution)
 "guq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -23627,6 +24241,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"gxw" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "gxD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23784,7 +24403,11 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Security - Escape Pod"
 	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -23808,24 +24431,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"gzQ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 3"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "gzU" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -23949,6 +24554,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"gBM" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "gBP" = (
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
@@ -24043,6 +24653,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"gDd" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "gDg" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -24246,11 +24868,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "gER" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/random/contraband/prison,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 8
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
 /area/station/security/prison)
 "gFb" = (
 /obj/structure/disposalpipe/segment{
@@ -24454,6 +25078,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"gHZ" = (
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/light,
+/obj/structure/table/reinforced,
+/obj/machinery/processor{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "gIh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24547,6 +25180,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"gJj" = (
+/obj/structure/table,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 10
+	},
+/area/station/security/prison/safe)
 "gJk" = (
 /turf/closed/wall,
 /area/station/security/execution/transfer)
@@ -24625,6 +25265,21 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
+"gKa" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = " Prison - Cafeteria";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "gKA" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -24786,11 +25441,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gNp" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clipboard,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/security/prison)
 "gNx" = (
 /obj/effect/landmark/secequipment,
 /obj/machinery/light/small/directional/east,
@@ -24835,12 +25490,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"gOo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
 "gOr" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -24976,11 +25625,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
-"gPG" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/turf_decal/tile/brown/half/contrasted,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "gPL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
@@ -25024,11 +25668,10 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "gPY" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/turf/open/floor/iron/dark/red/side{
+	dir = 9
+	},
+/area/station/security/execution)
 "gQh" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -25088,33 +25731,12 @@
 /turf/open/floor/glass,
 /area/station/maintenance/space_hut/observatory)
 "gRc" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/knife/plastic,
-/obj/item/knife/plastic,
-/obj/item/knife/plastic,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
+/obj/effect/spawner/random/structure/girder{
+	loot = list(/obj/structure/falsewall=50,/turf/closed/wall=50);
+	name = "fifty% falsewall, fifty% wall"
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "gRg" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -25174,41 +25796,53 @@
 /area/station/maintenance/department/science)
 "gRU" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button/ignition{
-	id = "justicespark";
+/obj/item/reagent_containers/glass/bottle/morphine{
 	pixel_x = 7;
-	pixel_y = 24;
-	req_access = list("armory")
+	pixel_y = 7
 	},
-/obj/machinery/button/flasher{
-	id = "justiceflash";
-	pixel_x = 6;
-	pixel_y = 34;
-	req_access = list("armory")
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = -7;
+	pixel_y = 7
 	},
-/obj/item/folder/red{
-	pixel_x = 3
+/obj/item/reagent_containers/glass/bottle/chloralhydrate{
+	pixel_x = -7
 	},
-/obj/item/restraints/handcuffs,
-/obj/item/taperecorder,
+/obj/item/reagent_containers/glass/bottle/facid{
+	pixel_x = 7
+	},
+/obj/item/storage/backpack/duffelbag/sec/surgery{
+	pixel_y = 5
+	},
 /obj/machinery/button/door/directional/north{
 	id = "justiceblast";
 	name = "Justice Shutters Control";
 	pixel_x = -6;
-	req_access = list("armory")
+	req_access_txt = "63"
 	},
 /obj/machinery/button/door/directional/north{
 	id = "justicechamber";
 	name = "Justice Chamber Control";
 	pixel_x = -6;
 	pixel_y = 34;
-	req_access = list("armory")
+	req_access_txt = "3"
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+/obj/machinery/button/ignition{
+	id = "justicespark";
+	pixel_x = 7;
+	pixel_y = 24;
+	req_access_txt = "63"
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/machinery/button/flasher{
+	id = "justiceflash";
+	pixel_x = 6;
+	pixel_y = 34;
+	req_access_txt = "63"
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark/red/side{
+	dir = 9
+	},
+/area/station/security/execution)
 "gSf" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -25266,16 +25900,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
-"gTH" = (
-/obj/machinery/flasher/directional/south{
-	id = "Cell 6"
-	},
-/obj/machinery/light/small/broken/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/security/prison/safe)
 "gTO" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
@@ -25672,20 +26296,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "hbq" = (
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "Prisoner Telescreen";
-	network = list("prison");
-	pixel_x = 27
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "hbt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -25877,12 +26489,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"hdm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/medbay/alt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/execution/transfer)
 "hdC" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/east,
@@ -26174,9 +26780,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "hhn" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "hhy" = (
 /obj/machinery/air_sensor/ordnance_burn_chamber,
 /turf/open/floor/engine/vacuum,
@@ -26204,6 +26811,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/mix)
+"hhP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/rank/prisoner/classic,
+/obj/item/clothing/suit/jacket/leather/overcoat,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "hhV" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
@@ -26221,6 +26836,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"hif" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/work)
 "hih" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -26281,15 +26906,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"hiW" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/item/reagent_containers/syringe,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/security/execution/transfer)
 "hiZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -26481,6 +27097,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain/private)
+"hnx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "hnB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -26632,6 +27254,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos/project)
+"hqP" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "hqV" = (
 /obj/structure/chair{
 	dir = 8
@@ -26710,6 +27341,22 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"hrN" = (
+/obj/structure/toilet/secret{
+	dir = 4;
+	secret_type = /obj/item/card/emag/one_shot
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
+"hrU" = (
+/obj/structure/curtain/bounty,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/rec)
 "hrY" = (
 /obj/machinery/light/directional/north,
 /obj/item/flashlight/lamp,
@@ -26907,6 +27554,11 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
+"hvX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "hwa" = (
 /obj/structure/chair{
 	dir = 1
@@ -26943,13 +27595,6 @@
 /mob/living/basic/cockroach,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
-"hwB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "hwC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27184,15 +27829,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
-"hzZ" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/station/security/prison/work)
 "hAc" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -27245,6 +27881,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"hAV" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/hypospray/medipen/atropine,
+/obj/item/grenade/smokebomb,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/upper)
 "hBr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/computer/atmos_control/plasma_tank{
@@ -27264,6 +27910,15 @@
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen/coldroom)
+"hBK" = (
+/obj/machinery/status_display/ai/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/closet/secure_closet/brig/genpop,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "hCd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27625,6 +28280,11 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"hGp" = (
+/turf/open/floor/iron/dark/red/side{
+	dir = 4
+	},
+/area/station/security/execution)
 "hGt" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -27866,6 +28526,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
+"hJC" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell6";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "hJE" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Science Maintenance"
@@ -27976,13 +28647,17 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "hLe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast Door"
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/turnstile{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "permaturnstile";
+	name = "Lockdown"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark,
 /area/station/security/prison)
 "hMa" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2,
@@ -28001,10 +28676,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "hMx" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom/prison/directional/east,
+/obj/machinery/camera{
+	c_tag = " Prison - Central";
+	network = list("ss13","prison")
+	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "hMH" = (
@@ -28122,6 +28798,11 @@
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/iron/white,
 /area/station/maintenance/fore)
+"hNV" = (
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/security/prison)
 "hOa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/poddoor{
@@ -28273,6 +28954,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
+"hQf" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 5;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
+/area/station/security/prison)
 "hQj" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -28636,6 +29327,10 @@
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/r_wall,
 /area/station/medical/chemistry)
+"hTY" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "hUb" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -29044,9 +29739,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
-"hZL" = (
-/turf/open/floor/plating,
-/area/station/security/prison/work)
 "hZQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/closet/bombcloset,
@@ -29135,12 +29827,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"ibb" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "ibk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -29431,6 +30117,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
+"ifg" = (
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 6
+	},
+/area/station/security/prison/safe)
 "ifl" = (
 /obj/structure/sink{
 	dir = 4;
@@ -29471,13 +30165,6 @@
 /obj/item/clothing/mask/gas/owl_mask,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"ifQ" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "ifR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -29593,25 +30280,6 @@
 	},
 /turf/closed/wall,
 /area/station/medical/medbay/lobby)
-"igV" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "igX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -29741,6 +30409,17 @@
 	icon_state = "chapel"
 	},
 /area/station/service/chapel)
+"iin" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell8";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "iio" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -29749,8 +30428,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "iiy" = (
-/obj/structure/easel,
-/turf/open/floor/iron,
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
 /area/station/security/prison)
 "iiB" = (
 /obj/machinery/cryopod,
@@ -29894,11 +30573,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "iko" = (
-/obj/structure/sign/poster/official/here_for_your_safety{
-	pixel_x = 30
+/obj/structure/window/reinforced/tinted{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "ikq" = (
@@ -29908,6 +30586,13 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
+"iks" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "iky" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
@@ -30298,6 +30983,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/break_room)
+"ipX" = (
+/obj/structure/punching_bag,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/prison)
 "iqa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/airalarm/directional/east,
@@ -30366,17 +31055,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/command/gateway)
-"irb" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/plant_analyzer,
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Garden";
-	network = list("ss13","prison")
-	},
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
 "irf" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -30561,12 +31239,20 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/bar)
 "itW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison)
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
+	},
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "itZ" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron{
@@ -30606,33 +31292,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
-"iut" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "justicechamber";
-	name = "Justice Chamber Blast Door"
-	},
-/obj/machinery/door/window/brigdoor/right/directional/north{
-	dir = 2;
-	name = "Justice Chamber";
-	req_access = list("armory")
-	},
-/obj/machinery/door/window/brigdoor/right/directional/north{
-	name = "Justice Chamber";
-	req_access = list("armory")
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
 "iuD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -30683,10 +31342,21 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ivi" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/obj/item/folder/red,
+/obj/item/pen,
+/obj/structure/table/glass,
+/obj/item/folder/white{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "ivt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -30700,6 +31370,21 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"ivL" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "ivR" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
 	dir = 4
@@ -30860,14 +31545,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/fore)
-"ixG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "ixI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31184,6 +31861,21 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/maintenance/port/greater)
+"iBv" = (
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
+	},
+/obj/machinery/camera{
+	c_tag = " Prison - Garden";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "iBO" = (
 /obj/machinery/power/turbine/inlet_compressor,
 /turf/open/floor/engine,
@@ -31199,13 +31891,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/theater/abandoned)
 "iCi" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/security/execution/transfer)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/cardboard,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating,
+/area/station/security/prison/work)
 "iCu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31322,6 +32016,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/command/bridge)
+"iDH" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 5
+	},
+/area/station/security/prison/safe)
 "iDP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31406,7 +32116,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/beer{
 	desc = "Whatever it is, it reeks of foul, putrid froth.";
-	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing = 15);
+	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing=15);
 	name = "Delta-Down";
 	pixel_x = 5;
 	pixel_y = 5
@@ -31549,14 +32259,19 @@
 /area/station/hallway/secondary/construction)
 "iGx" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/red/side{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/execution)
 "iGI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -31577,15 +32292,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "iGN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "iGU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -31899,12 +32608,26 @@
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
 "iLS" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Visitation"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/iron/dark,
+/area/station/security/execution)
+"iLV" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/structure/cable,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3;
+	pixel_y = 16
+	},
 /turf/open/floor/iron,
-/area/station/security/prison/visit)
+/area/station/security/prison/mess)
 "iMf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
@@ -31940,6 +32663,14 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
+"iMI" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
+/area/station/security/prison/safe)
 "iMK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -32000,12 +32731,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "iNn" = (
-/obj/structure/sign/poster/official/help_others{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/structure/barricade/wooden,
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "iNw" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/camera/directional/south{
@@ -32048,6 +32777,9 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/half,
 /area/station/engineering/main)
+"iNQ" = (
+/turf/closed/wall/r_wall,
+/area/station/security/prison/shower)
 "iNR" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/status_display/evac/directional/east,
@@ -32070,6 +32802,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"iOc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/button/curtain{
+	id = "prisoncell8";
+	pixel_x = -22;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/security/prison)
 "iOj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -32184,12 +32929,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "iPK" = (
-/obj/structure/toilet/greyscale,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
+/obj/structure/cable,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/area/brigofficer)
 "iQg" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -32331,10 +33075,16 @@
 /area/station/engineering/main)
 "iSj" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "iSk" = (
@@ -32399,6 +33149,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/command/corporate_showroom)
+"iSV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/cable,
+/obj/effect/decal/remains/human{
+	desc = "They look like human remains. The bones are charred and burned.";
+	name = "charred remains"
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/work)
 "iTq" = (
 /obj/structure/table,
 /obj/item/extinguisher/mini,
@@ -32494,6 +33254,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"iVh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/security/glass{
+	name = "Perma Office"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/purple,
+/area/brigofficer)
 "iVn" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -32715,6 +33485,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
+"iYH" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "iYK" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -32924,6 +33705,18 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"jaR" = (
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "jaV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -32956,6 +33749,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"jbc" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
+/area/station/security/prison/rec)
 "jbr" = (
 /obj/structure/curtain/cloth/fancy/mechanical/start_closed{
 	desc = "A set of curtains serving as a fancy theater backdrop. They can only be opened by a button.";
@@ -33171,12 +33968,6 @@
 "jdL" = (
 /turf/closed/wall,
 /area/station/maintenance/fore)
-"jdT" = (
-/obj/structure/chair/stool/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/security/prison)
 "jej" = (
 /obj/machinery/power/smes,
 /obj/machinery/light/small/directional/south,
@@ -33274,6 +34065,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/toilet/restrooms)
+"jfC" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "jfE" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -33771,6 +34569,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"jkM" = (
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/wood/tile,
+/area/station/security/execution/transfer)
 "jkZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33823,12 +34625,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jlI" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Permabrig - Workroom";
-	network = list("ss13","prison")
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/security/prison/work)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/security/prison)
 "jlV" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -33878,6 +34682,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/processing)
+"jmD" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "jmF" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/carbon_input{
 	dir = 4
@@ -33926,6 +34737,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"jnF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/station/security/prison)
 "jnG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33973,10 +34800,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
-"joy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
 "joJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -34070,6 +34893,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"jqN" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "jrp" = (
 /turf/closed/wall,
 /area/station/cargo/storage)
@@ -34223,6 +35052,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"juu" = (
+/obj/structure/sign/warning/vacuum{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark/red/side{
+	dir = 5
+	},
+/area/station/security/execution)
 "juv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -34284,16 +35121,6 @@
 	dir = 1
 	},
 /area/station/service/bar)
-"jva" = (
-/obj/structure/table/glass,
-/obj/item/folder/blue,
-/obj/item/healthanalyzer,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/security/execution/transfer)
 "jvm" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -34459,11 +35286,11 @@
 /area/station/medical/medbay/central)
 "jxg" = (
 /obj/structure/closet/secure_closet/injection,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/dark/red/side{
+	dir = 5
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/execution)
 "jxn" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/machinery/light/directional/east,
@@ -34608,20 +35435,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"jzo" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/contraband/prison,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/machinery/light/directional/south,
-/obj/item/radio/intercom/prison/directional/south,
-/turf/open/floor/iron,
-/area/station/security/prison/work)
 "jzC" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
@@ -34906,6 +35719,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"jDo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "jDp" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/effect/decal/cleanable/dirt,
@@ -35108,11 +35927,12 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/aft)
 "jGu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "jGx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -35229,18 +36049,22 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "jHw" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
 	},
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison)
+/obj/structure/water_source{
+	dir = 8;
+	name = "sink";
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "jHP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35288,6 +36112,17 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"jIi" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell4";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "jIs" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -35376,6 +36211,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/command/storage/eva)
+"jJJ" = (
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/security/prison)
 "jJK" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Departures - Port";
@@ -35585,8 +36425,25 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "jMs" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/iron,
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
+	},
+/obj/item/seeds/tobacco,
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
+"jMu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/station/security/prison)
 "jMw" = (
 /obj/structure/disposalpipe/segment,
@@ -35679,14 +36536,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "jNH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/brown/side,
+/area/station/security/prison/safe)
 "jNI" = (
 /obj/item/storage/box/gloves{
 	pixel_x = 3;
@@ -35984,19 +36842,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "jQz" = (
-/obj/structure/table,
-/obj/item/book/manual/chef_recipes,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 2
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/public{
+	name = "Prison Cell"
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/storage/fancy/egg_box,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
+/turf/open/floor/iron/dark/brown,
+/area/station/security/prison/safe)
 "jQI" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -36007,8 +36859,14 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
 "jQZ" = (
-/turf/closed/wall,
-/area/station/security/prison/toilet)
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "jRb" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -36184,6 +37042,28 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/corporate_showroom)
+"jTx" = (
+/obj/structure/closet/secure_closet/freezer/meat{
+	req_access = null
+	},
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/security/prison/mess)
 "jTy" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/purple,
@@ -36258,6 +37138,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
+"jUW" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/station/security/prison/safe)
 "jVd" = (
 /obj/structure/table,
 /obj/item/camera_film{
@@ -36270,6 +37169,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"jVw" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall/rust,
+/area/station/security/prison/mess)
 "jVy" = (
 /obj/machinery/door/airlock/research{
 	name = "Ordnance Lab"
@@ -36508,13 +37411,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "jYh" = (
-/obj/machinery/plate_press,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/security/prison/work)
+/area/station/security/prison)
 "jYo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36860,12 +37762,36 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"kcC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/security/prison)
 "kcK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /mob/living/basic/cockroach,
 /turf/open/floor/wood,
 /area/station/service/theater/abandoned)
+"kcQ" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 5
+	},
+/area/station/security/prison/safe)
 "kcS" = (
 /obj/item/kirbyplants/random,
 /obj/effect/mapping_helpers/broken_floor,
@@ -36949,6 +37875,10 @@
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"kdu" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "kdy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -37097,6 +38027,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/science/research/abandoned)
+"kfk" = (
+/obj/machinery/oven,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "kfv" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
@@ -37310,11 +38244,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "kho" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
-/turf/open/floor/iron,
 /area/station/security/prison)
 "khv" = (
 /obj/structure/cable,
@@ -37395,12 +38330,10 @@
 /turf/closed/wall,
 /area/station/maintenance/disposal)
 "kie" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/brigofficer)
 "kii" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -37568,6 +38501,16 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
+"kkG" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "kkN" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -37847,6 +38790,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"koE" = (
+/obj/machinery/camera{
+	c_tag = " Prison - (North-West) Blue Wing";
+	dir = 5;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "koJ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/yellow{
@@ -38060,6 +39013,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
+"kso" = (
+/obj/item/trash/popcorn,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 9
+	},
+/area/station/security/prison/safe)
 "ksq" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -38182,12 +39150,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
-"ktU" = (
-/obj/structure/curtain,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/security/prison/toilet)
 "kub" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit/green,
@@ -38369,11 +39331,17 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "kxA" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/turnstile{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "permaturnstile";
+	name = "Lockdown"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark,
 /area/station/security/prison)
 "kxC" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -38511,6 +39479,12 @@
 "kzc" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/aft)
+"kzH" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
 "kzI" = (
 /obj/structure/table/wood,
 /obj/item/electronics/airalarm,
@@ -38518,22 +39492,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/electronic_marketing_den)
-"kzP" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Sanitarium"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/station/security/execution/transfer)
 "kzV" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/department_orders/service,
@@ -38925,15 +39883,15 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "kFm" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 8;
+	name = "blue line"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/turf/open/floor/iron/dark/blue/side{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/area/station/security/prison)
 "kFr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -39281,6 +40239,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
+"kJc" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/iron/dark,
+/area/station/security/execution)
 "kJd" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -39301,6 +40264,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
+"kJo" = (
+/obj/effect/spawner/random/structure/girder{
+	loot = list(/obj/structure/falsewall=50,/turf/closed/wall=50);
+	name = "fifty% falsewall, fifty% wall"
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/work)
 "kJr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -39370,15 +40340,21 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
-"kLh" = (
-/obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"kKU" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/flasher/directional/south{
-	id = "Cell 3"
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
+"kLh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "kLu" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/bookcase/random,
@@ -39552,11 +40528,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
-"kNE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
 "kNR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -39607,6 +40578,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
+"kOR" = (
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "kOY" = (
 /obj/structure/closet/wardrobe/black,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -40025,6 +41001,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"kUj" = (
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "kUn" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -40033,10 +41015,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "kUq" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/security/prison)
 "kUu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -40668,6 +41654,18 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
+"lbB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = " Prison - Pool";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/rec)
 "lbF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40727,15 +41725,16 @@
 /area/station/command/heads_quarters/captain)
 "lcI" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/button/door/directional/north{
 	id = "brigprison";
 	name = "Prison Lockdown";
-	req_access = list("brig_entrance")
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+	req_access_txt = "63"
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -41260,21 +42259,6 @@
 /obj/item/storage/secure/briefcase,
 /turf/open/floor/wood,
 /area/station/command/meeting_room/council)
-"ljD" = (
-/obj/machinery/button/flasher{
-	id = "visitorflash";
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/button/door/directional/north{
-	id = "visitation";
-	name = "Visitation Shutters";
-	pixel_x = 6;
-	req_access = list("brig")
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/visit)
 "ljK" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -41549,6 +42533,17 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"lnk" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "lnm" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/effect/turf_decal/stripes/line{
@@ -41704,6 +42699,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"lpu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/built,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/station/security/prison/upper)
 "lpv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41867,6 +42871,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"lrQ" = (
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "lrY" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/delivery,
@@ -41970,10 +42979,13 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "ltT" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/station/security/prison)
 "ltV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42114,6 +43126,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"lvp" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 9
+	},
+/area/station/security/prison/safe)
 "lvt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42198,6 +43229,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"lwy" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "lwD" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42281,7 +43318,8 @@
 	dir = 8;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -42344,24 +43382,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
-"lyd" = (
-/obj/machinery/flasher{
-	id = "justiceflash";
-	pixel_x = 26;
-	req_access = list("security")
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/flasher/directional/east{
-	id = "justiceflash";
-	req_access = list("security")
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
 "lyf" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
@@ -42704,6 +43724,25 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"lEf" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/camera{
+	c_tag = " Prison - Janitorial";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/station/security/prison)
 "lEg" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/directional/west,
@@ -42757,6 +43796,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"lEw" = (
+/obj/structure/bed,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/mask/muzzle,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Prison Sanitarium";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "lEI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -42832,6 +43886,18 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
+"lFO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 5
+	},
+/area/station/security/prison/safe)
 "lFP" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -42913,6 +43979,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
+"lHg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/large,
+/obj/item/crowbar/red,
+/obj/effect/spawner/random/contraband/prison,
+/obj/effect/spawner/random/contraband/prison,
+/obj/effect/spawner/random/contraband/prison,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/work)
 "lHl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -43103,6 +44179,15 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
+"lJX" = (
+/obj/item/stack/sheet/cardboard{
+	amount = 10
+	},
+/obj/structure/loom,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
 "lJZ" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "evashutters";
@@ -43178,13 +44263,17 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "lKr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/flasher/directional/south{
-	id = "Cell 2"
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/light/directional/east,
+/obj/structure/closet/secure_closet/evidence{
+	name = "Brig Officer's Locker"
 	},
-/turf/open/floor/plating,
-/area/station/security/prison/safe)
+/obj/item/clothing/mask/whistle,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/brigofficer)
 "lKw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -43259,6 +44348,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/qm)
+"lKY" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "lLb" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43377,25 +44470,15 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "lMN" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt1";
-	name = "Cell 1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut1"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
 /turf/open/floor/iron,
-/area/station/security/prison/safe)
+/area/station/security/prison)
 "lMU" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
 /turf/open/floor/plating,
@@ -43494,6 +44577,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"lOz" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisonlibrarycurtain";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "lOM" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -43508,6 +44601,17 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"lOP" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "lOW" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -43539,7 +44643,10 @@
 /obj/item/clothing/suit/armor/vest,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "lPh" = (
@@ -43791,6 +44898,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"lRk" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 6
+	},
+/area/station/security/prison/safe)
 "lRw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -43858,6 +44977,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"lTe" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/execution)
 "lTg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -43870,7 +45002,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=0.01;n2=0.01;TEMP=2.7";
+	luminosity = 2;
+	temperature = 2.7
+	},
 /area/station/security/execution/transfer)
 "lTo" = (
 /obj/docking_port/stationary{
@@ -44056,6 +45192,10 @@
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"lVO" = (
+/obj/item/soap/nanotrasen,
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
 "lVQ" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -44232,15 +45372,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"lYv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "lYF" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/status_display/evac/directional/west,
@@ -44329,8 +45460,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "mad" = (
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/station/security/execution/transfer)
 "mae" = (
 /obj/machinery/door/window/right/directional/east{
@@ -44494,6 +45626,12 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
+"mcT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "mcV" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room"
@@ -44637,6 +45775,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"mek" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/fedora,
+/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "men" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -44956,14 +46102,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"miw" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "miC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -45019,17 +46157,24 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/bar)
 "miS" = (
-/obj/structure/table,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/turf/open/floor/plating,
-/area/station/security/prison/mess)
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 5
+	},
+/area/station/security/prison/safe)
 "miT" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/structure/chair/office{
@@ -45084,6 +46229,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
+"mjS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "mkb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45277,6 +46427,31 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"mmV" = (
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/clothing/gloves/color/blue,
+/obj/item/clothing/suit/caution,
+/obj/item/clothing/suit/caution,
+/obj/item/clothing/suit/caution,
+/obj/item/clothing/suit/caution,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/mop,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/storage/bag/trash,
+/obj/item/pushbroom,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/station/security/prison)
 "mnf" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -45398,17 +46573,17 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "mor" = (
-/obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
-/obj/item/electropack,
-/obj/item/assembly/signaler,
-/obj/machinery/light/directional/west,
-/obj/item/clothing/head/helmet/sec,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
+/obj/machinery/door/window/left/directional/east,
+/obj/structure/closet/crate,
+/obj/item/tank/internals/oxygen/red{
+	pixel_x = 3
 	},
+/obj/item/tank/internals/oxygen/red{
+	pixel_x = -3
+	},
+/obj/item/wrench,
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/execution)
 "mou" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -45514,25 +46689,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "mpO" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt3";
-	name = "Cell 3"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut3"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "mpR" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue{
@@ -45624,6 +46786,12 @@
 /obj/structure/mirror/directional/south,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
+"mqW" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
 "mra" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/bot,
@@ -45642,10 +46810,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"mrq" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/work)
 "mrw" = (
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/iron/half{
@@ -45711,17 +46875,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "msM" = (
-/obj/structure/closet/crate,
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/obj/item/toy/beach_ball/holoball/dodgeball,
+/obj/machinery/camera{
+	c_tag = " Prison - Library";
+	network = list("ss13","prison")
+	},
+/obj/structure/closet/crate/bin,
+/obj/item/toy/figure/syndie,
 /obj/effect/spawner/random/contraband/prison,
-/obj/item/instrument/harmonica,
-/obj/item/storage/dice,
-/obj/item/toy/cards/deck/tarot,
-/obj/machinery/light/directional/south,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
 /area/station/security/prison)
 "msR" = (
 /obj/effect/turf_decal/tile/red{
@@ -45834,6 +46997,18 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"mtA" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/rec)
 "mtL" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/decal/cleanable/dirt,
@@ -45939,12 +47114,17 @@
 /area/station/engineering/supermatter/room)
 "mvn" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/execution)
 "mvp" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase{
@@ -46407,14 +47587,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/medical/morgue)
-"mBJ" = (
-/obj/structure/closet/secure_closet/brig{
-	name = "Prisoner Locker"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/transfer)
 "mBM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -46489,13 +47661,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"mCH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
 "mCM" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/tcomms,
@@ -46740,14 +47905,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "mFw" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/obj/effect/landmark/start/brigoff,
+/turf/open/floor/iron/dark/blue,
+/area/brigofficer)
 "mGm" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
@@ -46922,6 +48088,17 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"mHV" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/light/directional/south,
+/obj/item/storage/photo_album/prison,
+/obj/item/camera,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "mHX" = (
 /obj/machinery/holopad{
 	pixel_x = -16
@@ -46960,6 +48137,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
+"mIx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/east{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/station/security/prison)
 "mIA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -47037,6 +48227,17 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
+"mJI" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/rec)
 "mJN" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -47106,11 +48307,19 @@
 /area/station/service/kitchen)
 "mKL" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/red/side{
+	dir = 10
+	},
+/area/station/security/execution)
 "mKP" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/disposalpipe/segment{
@@ -47172,11 +48381,13 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "mLs" = (
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "mLt" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase{
@@ -47256,6 +48467,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
+"mNz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/station/security/prison/upper)
 "mNC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47586,6 +48804,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/abandoned_gambling_den/gaming)
+"mRk" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/security/prison/mess)
 "mRE" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -47608,20 +48830,6 @@
 "mSe" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/safe)
-"mSj" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Visitation"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/visit)
 "mSl" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -47709,17 +48917,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"mTf" = (
-/obj/machinery/washing_machine,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/warning/electric_shock{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/work)
 "mTl" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -47794,16 +48991,26 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
-"mVr" = (
+"mVa" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = 32
+	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/iron/kitchen{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/area/station/security/prison)
 "mVB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48314,14 +49521,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
-"nbw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "nbI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/meter,
@@ -48370,6 +49569,21 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
+"ncf" = (
+/obj/structure/curtain/cloth,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
+"ncn" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
+/area/station/security/prison/safe)
 "ncp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
@@ -48481,6 +49695,21 @@
 	heat_capacity = 1e+006
 	},
 /area/station/commons/dorms)
+"nea" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass{
+	dir = 8
+	},
+/obj/structure/grille/broken,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "nef" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -48569,27 +49798,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
-"nfQ" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast Door"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast Door"
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Visitation"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/visit)
 "nfX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -48794,6 +50002,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"njg" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
+"njj" = (
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "njo" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch/directional/south,
@@ -48874,26 +50090,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "nke" = (
-/obj/structure/cable,
-/obj/machinery/button/flasher{
-	id = "Cell 4";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/east{
-	id = "permashut4";
-	name = "Cell Lockdown Button";
-	pixel_y = -6;
-	req_access = list("brig")
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/prison)
 "nkk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -48907,26 +50105,27 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "nkn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/red/side{
+	dir = 6
+	},
+/area/station/security/execution)
 "nku" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "nkD" = (
-/obj/structure/chair/stool/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "nkG" = (
 /obj/structure/table/wood/poker,
 /obj/effect/decal/cleanable/dirt,
@@ -48971,10 +50170,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
 "nlk" = (
-/obj/structure/window,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/wood,
 /area/station/security/prison/garden)
 "nlB" = (
 /obj/structure/disposalpipe/segment{
@@ -48988,6 +50186,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"nlM" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "nlS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -49375,6 +50583,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"nra" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "nrd" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/camera/directional/south{
@@ -49384,6 +50599,28 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
+"nrk" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate,
+/obj/item/inflatable/door,
+/obj/item/clothing/suit/fire/atmos{
+	armor = list("melee"=40,"bullet"=30,"laser"=20,"energy"=20,"bomb"=20,"bio"=10,"rad"=20,"fire"=80,"acid"=50);
+	desc = "An old, reinforced and obviously stolen firesuit. There's an expiry date for the thermal padding, safe to say it's well past the expiration date.";
+	name = "padded firesuit";
+	slowdown = 0.25
+	},
+/obj/item/stack/cable_coil,
+/obj/item/melee/chainofcommand{
+	damtype = "stamina";
+	desc = "Feels a lot softer than a real whip. Looks like it'll still sting and hurt, but it won't leave deep lacerations.";
+	force = 30;
+	name = "leather whip"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/upper)
 "nru" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -49440,13 +50677,20 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/storage/gas)
+"nsp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "nsr" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 7
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/security/prison/mess)
+/area/station/security/prison)
 "nsG" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -49546,6 +50790,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"nuS" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "nuY" = (
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/airalarm/directional/east,
@@ -49668,14 +50917,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"nwN" = (
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "nwW" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
@@ -49865,11 +51106,13 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/iron/grimy,
 /area/station/command/bridge)
+"nzb" = (
+/turf/closed/wall,
+/area/station/security/prison/rec)
 "nzh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/security/execution/transfer)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/security/prison/work)
 "nzi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -50542,11 +51785,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/bar)
-"nIr" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "nIv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -50595,13 +51833,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "nJg" = (
-/obj/structure/table,
-/obj/structure/cable,
-/obj/item/toy/cards/deck,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison)
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
+	},
+/obj/item/seeds/cotton/durathread,
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "nJp" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/iron/dark,
@@ -50749,15 +51991,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"nKG" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
 "nKH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -51165,6 +52398,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"nPH" = (
+/turf/closed/wall,
+/area/station/security/prison/upper)
 "nPL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -51233,6 +52469,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"nQr" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown4";
+	name = "Lockdown"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "nQI" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma,
@@ -51627,16 +52872,10 @@
 /turf/open/floor/iron/recharge_floor,
 /area/station/science/research/abandoned)
 "nVV" = (
-/obj/machinery/light/small/directional/west,
-/obj/item/clothing/suit/caution,
-/obj/structure/sign/poster/official/no_erp{
-	pixel_x = -30
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/security/prison/toilet)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "nVW" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
@@ -51657,10 +52896,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"nWe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/security/prison/mess)
 "nWi" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave{
@@ -51696,10 +52931,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
-"nWw" = (
-/mob/living/simple_animal/mouse/gray,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "nWH" = (
 /obj/effect/landmark/start/scientist,
 /obj/effect/turf_decal/tile/red{
@@ -52015,6 +53246,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/range)
+"oaD" = (
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
+	},
+/obj/item/seeds/tower,
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "oaF" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -52359,6 +53602,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"odP" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell5";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "odU" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -52386,14 +53640,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
-"oeo" = (
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/north,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/prison/toilet)
 "oez" = (
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start/hangover,
@@ -52411,6 +53657,17 @@
 	heat_capacity = 1e+006
 	},
 /area/station/hallway/primary/central/aft)
+"oeD" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/north,
+/obj/item/storage/box/tail_pin,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "oeK" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -52597,6 +53854,13 @@
 "ogZ" = (
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"ohd" = (
+/obj/effect/spawner/random/structure/girder{
+	loot = list(/obj/structure/falsewall=50,/turf/closed/wall=50);
+	name = "fifty% falsewall, fifty% wall"
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/shower)
 "ohh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/no_smoking{
@@ -52634,11 +53898,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
-"ohB" = (
-/obj/structure/chair/stool/directional/south,
-/obj/item/radio/intercom/prison/directional/west,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
 "ohH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52906,6 +54165,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"omr" = (
+/obj/structure/closet/crate/large,
+/obj/item/melee/chainofcommand{
+	damtype = "stamina";
+	desc = "Feels a lot softer than a real whip. Looks like it'll still sting and hurt, but it won't leave deep lacerations.";
+	force = 30;
+	name = "leather whip"
+	},
+/obj/item/grenade/smokebomb,
+/obj/item/screwdriver,
+/obj/item/toy/crayon/spraycan,
+/obj/item/radio,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "omI" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet"
@@ -53017,6 +54291,20 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"onK" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
+"onQ" = (
+/obj/structure/table,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
 "onR" = (
 /obj/structure/sign/warning/secure_area{
 	pixel_x = -32
@@ -53223,11 +54511,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"orh" = (
-/obj/machinery/light/directional/west,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/security/prison)
 "orx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53287,10 +54570,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "osU" = (
-/obj/structure/window,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/wood,
+/area/station/security/prison)
 "osY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -53362,16 +54644,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
-"ouc" = (
-/obj/structure/sign/warning/electric_shock{
-	pixel_y = -30
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Permabrig - Fitness";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
 "ouo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -53410,8 +54682,40 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "ouH" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/flasher{
+	id = "visitorflash";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
+"ouO" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
+	},
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/italian,
+/obj/item/storage/box/ingredients/fruity,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/american,
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour=600);
+	name = "Premium All-Purpose Flour (16KG)";
+	volume = 600
+	},
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	list_reagents = list(/datum/reagent/consumable/enzyme=500);
+	name = "universe-sized universal enyzyme";
+	volume = 500
+	},
+/obj/item/reagent_containers/food/condiment/rice{
+	list_reagents = list(/datum/reagent/consumable/rice=150);
+	name = "Basmati Rice Sack (4KG)";
+	volume = 150
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/security/prison/mess)
 "ouP" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -53549,6 +54853,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
+"owr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "owu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53936,13 +55246,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"oAI" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/shovel/spade,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
 "oAM" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
@@ -54151,10 +55454,10 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "oDK" = (
-/obj/machinery/door/window/left/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
+/obj/structure/bookcase/random/adult,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood,
+/area/station/security/prison)
 "oDR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -54244,6 +55547,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
+"oEQ" = (
+/turf/open/floor/iron/dark/red/side{
+	dir = 6
+	},
+/area/station/security/execution)
 "oEV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54261,12 +55569,8 @@
 	},
 /area/station/service/chapel)
 "oFe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "oFh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54507,15 +55811,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"oHS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "justicechamber";
-	name = "Justice Chamber Blast Door"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/execution/education)
 "oIi" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -54708,6 +56003,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"oLc" = (
+/obj/structure/curtain/bounty,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/rec)
 "oLd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -54729,6 +56029,17 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
+"oLw" = (
+/obj/structure/bed/maint,
+/obj/machinery/flasher{
+	id = "IsolationFlash";
+	pixel_y = 28
+	},
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 5
+	},
+/area/station/security/prison/safe)
 "oLz" = (
 /obj/structure/cable,
 /obj/structure/chair/office{
@@ -55722,11 +57033,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "oYI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/chair/office,
+/turf/open/floor/wood,
 /area/station/security/prison)
 "oYP" = (
 /obj/structure/table/reinforced,
@@ -55821,19 +57129,16 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"pao" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast Door"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "paq" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/station/service/theater)
+"par" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/closet/secure_closet/brig/genpop,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "pas" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -55936,12 +57241,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"pcA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
 "pcC" = (
 /obj/structure/table/wood,
 /obj/item/coin/antagtoken,
@@ -56012,24 +57311,19 @@
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "pdF" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
 	},
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/item/tank/internals/oxygen/red{
-	pixel_x = 3
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
 	},
-/obj/item/tank/internals/oxygen/red{
-	pixel_x = -3
+/turf/open/floor/iron/dark/red/side{
+	dir = 8
 	},
-/obj/item/wrench,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/execution)
 "pdK" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -56130,6 +57424,21 @@
 "peU" = (
 /turf/closed/wall/r_wall,
 /area/station/science/breakroom)
+"peV" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/structure/rack,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/mesh,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/reagent_containers/syringe/contraband/space_drugs,
+/obj/item/reagent_containers/syringe{
+	list_reagents = list(/datum/reagent/drug/aphrodisiac=20);
+	name = "crocin syringe";
+	pixel_y = 6
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "pfd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -56186,12 +57495,33 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "pfK" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Prison"
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/button/door{
+	id = "permainner";
+	name = "Inner Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -6;
+	pixel_y = 25;
+	req_access_txt = "2";
+	specialfunctions = 4
+	},
+/obj/machinery/button/door{
+	id = "permaouter";
+	name = "Outer Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 6;
+	pixel_y = 25;
+	req_access_txt = "2";
+	specialfunctions = 4
+	},
+/obj/machinery/button/door{
+	id = "permaturnstile";
+	name = "Turnstile Lockdown";
+	pixel_y = 37;
+	req_access_txt = "2"
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "pfQ" = (
@@ -56241,6 +57571,14 @@
 "pgb" = (
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"pgf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/public{
+	name = "Prison Cell"
+	},
+/turf/open/floor/iron/dark/purple,
+/area/station/security/prison/safe)
 "pgl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment{
@@ -56337,6 +57675,18 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"phe" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/station/security/prison)
 "phj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/trinary/filter{
@@ -56489,6 +57839,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"piW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/station/security/prison/upper)
 "pja" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 8
@@ -56522,6 +57879,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"pjz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible/layer4,
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "pjG" = (
 /obj/structure/fluff/metalpole{
 	dir = 1
@@ -56767,6 +58131,17 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
+"pmo" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/public/glass{
+	name = "Janitorial"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "pmp" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -56777,15 +58152,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/service/library/abandoned)
-"pmD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast Door"
-	},
-/turf/open/floor/plating,
-/area/station/security/prison/visit)
 "pmE" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -56971,13 +58337,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "pqi" = (
-/obj/structure/table/glass,
-/obj/item/storage/medkit/regular,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
+/obj/structure/cable,
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/security/execution/transfer)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/security/prison/work)
 "pqq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -57078,17 +58445,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
-"prB" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/camera/directional/north{
-	c_tag = "Permabrig - Isolation";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plating,
-/area/station/security/prison/safe)
 "prJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57146,6 +58502,30 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/toilet/restrooms)
+"psw" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell8";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/station/security/prison/safe)
+"psO" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "psP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57275,6 +58655,22 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"put" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/west{
+	pixel_y = -4
+	},
+/obj/machinery/button/curtain{
+	id = "prisoncell4";
+	pixel_x = -22;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/security/prison)
 "puv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -57484,15 +58880,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs/aft)
-"pxM" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/prison/visit)
 "pxN" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -57630,7 +59017,7 @@
 "pzv" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "brigprison";
-	name = "Prison Blast Door"
+	name = "Prison Blast door"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -58046,6 +59433,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"pEq" = (
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "pEx" = (
 /obj/machinery/cryopod,
 /obj/effect/turf_decal/siding/white,
@@ -58144,14 +59535,8 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "pGj" = (
-/obj/structure/table,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/storage/crayons,
-/turf/open/floor/iron,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/wood,
 /area/station/security/prison)
 "pGo" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -58221,10 +59606,11 @@
 	},
 /area/station/maintenance/port/greater)
 "pGO" = (
-/obj/machinery/light/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/visit)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/execution)
 "pHj" = (
 /obj/machinery/status_display/ai/directional/east,
 /obj/effect/turf_decal/tile/green,
@@ -58307,6 +59693,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
+"pHT" = (
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "pHW" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -58521,12 +59912,16 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "pKy" = (
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 11
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell9";
+	name = "curtain"
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "pKI" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -58548,14 +59943,25 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
-"pKW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+"pKV" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell4";
+	name = "curtain"
 	},
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
+"pLc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "pLg" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -58679,20 +60085,28 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "pMa" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/security/prison/safe)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/button/curtain{
+	id = "prisoncell3";
+	pixel_x = -22;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/station/security/prison)
 "pMt" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "brigprison";
-	name = "Prison Blast Door"
+	name = "Prison Blast door"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/button/door/directional/east{
 	id = "brigprison";
 	name = "Prison Lockdown";
-	req_access = list("brig")
+	req_access_txt = "63"
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -58718,6 +60132,9 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"pMM" = (
+/turf/closed/wall/r_wall,
+/area/station/security/execution)
 "pMP" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -58987,6 +60404,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/service/lawoffice)
+"pQK" = (
+/obj/machinery/button/door{
+	id = "isolationshutter";
+	name = "Isolation Shutter";
+	pixel_y = 23;
+	req_access = list("security")
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/security/prison)
 "pQS" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
@@ -59014,6 +60445,9 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/electronic_marketing_den)
+"pRa" = (
+/turf/closed/wall/r_wall,
+/area/station/security/prison/upper)
 "pRf" = (
 /obj/machinery/computer/rdservercontrol{
 	dir = 4
@@ -59023,6 +60457,10 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"pRh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "pRw" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -59181,9 +60619,6 @@
 /area/station/maintenance/port/greater)
 "pTq" = (
 /obj/machinery/light/small/directional/south,
-/obj/structure/sign/warning/secure_area{
-	pixel_y = -32
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -59381,9 +60816,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hop)
 "pVE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "pVK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -59422,12 +60859,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"pWF" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "pWK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59538,6 +60969,15 @@
 /obj/item/paper_bin,
 /turf/open/floor/plating,
 /area/station/service/library/abandoned)
+"pYc" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "pYl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -59595,6 +61035,23 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"pYO" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/east{
+	pixel_y = -5
+	},
+/obj/machinery/button/curtain{
+	id = "prisoncell10";
+	pixel_x = 22;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "pYT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59657,27 +61114,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
-"pZC" = (
-/obj/structure/cable,
-/obj/machinery/button/flasher{
-	id = "Cell 3";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/east{
-	id = "permashut3";
-	name = "Cell Lockdown Button";
-	pixel_y = -6;
-	req_access = list("brig")
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "pZE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -59808,6 +61244,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"qcm" = (
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "qcp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -59853,8 +61294,10 @@
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "qcT" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/station/security/prison)
 "qdi" = (
 /obj/structure/dresser,
@@ -60063,6 +61506,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/aft)
+"qgm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/purple/side{
+	dir = 5
+	},
+/area/station/security/prison/safe)
 "qgC" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	piping_layer = 2
@@ -60366,12 +61821,6 @@
 "qjy" = (
 /turf/open/floor/circuit/green,
 /area/station/science/research/abandoned)
-"qjz" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/transfer)
 "qjO" = (
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -60438,15 +61887,16 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "qkL" = (
-/obj/structure/table,
-/obj/structure/window{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/west,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 9
 	},
-/obj/structure/reagent_dispensers/servingdish,
-/obj/structure/reagent_dispensers/servingdish,
-/obj/item/clothing/head/chefhat,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
+/area/station/security/prison/safe)
 "qkS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60896,6 +62346,12 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"qrr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/security/prison)
 "qrt" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61017,20 +62473,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "qsK" = (
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "Prisoner Telescreen";
-	network = list("prison");
-	pixel_x = 27
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/area/brigofficer)
 "qsL" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -61141,6 +62587,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"quD" = (
+/obj/machinery/camera{
+	c_tag = " Prison - East Hallway";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "quE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61204,7 +62657,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=0.01;n2=0.01;TEMP=2.7";
+	luminosity = 2;
+	temperature = 2.7
+	},
 /area/station/security/execution/transfer)
 "quU" = (
 /obj/structure/disposalpipe/segment,
@@ -61293,6 +62750,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"qvG" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
+"qvJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
 "qvW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -61703,6 +63171,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
+"qBA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "qBD" = (
 /obj/item/book/manual/wiki/engineering_hacking{
 	pixel_x = -3;
@@ -61819,6 +63291,17 @@
 /obj/item/circuitboard/machine/chem_master,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/port/fore)
+"qDS" = (
+/obj/item/toy/plush/beeplushie{
+	desc = "Maybe hugging this will make you feel better about yourself.";
+	name = "Therabee"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
+/area/station/security/prison/safe)
 "qDT" = (
 /obj/structure/bookcase/manuals/engineering,
 /turf/open/floor/wood,
@@ -61866,6 +63349,15 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"qEB" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/lighter,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
+/area/station/security/prison/safe)
 "qEQ" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating/airless,
@@ -61952,14 +63444,16 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "qGu" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast Door"
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen"
 	},
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "qGz" = (
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb,
@@ -62162,6 +63656,19 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"qIZ" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "qJb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -62213,9 +63720,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "qJJ" = (
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/plating,
-/area/station/security/prison/work)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/security/prison)
 "qJN" = (
 /obj/machinery/button/door{
 	id = "brigwindows";
@@ -62309,6 +63820,21 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
+"qKS" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/item/reagent_containers/hypospray/medipen,
+/obj/item/toy/crayon/spraycan,
+/obj/effect/spawner/random/contraband/prison,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/station/security/prison)
 "qKW" = (
 /obj/machinery/light/directional/west,
 /obj/structure/bookcase/random/fiction,
@@ -62738,6 +64264,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
+"qRr" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "qRw" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -62831,6 +64365,15 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
+"qSV" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/button/flasher{
+	id = "transferflash";
+	pixel_y = 24
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "qTs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62919,12 +64462,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
-"qUq" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "qUr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62981,15 +64518,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
-"qVf" = (
-/obj/structure/chair,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/toy/figure/prisoner,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
 "qVg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63072,21 +64600,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"qWT" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prisoner Workroom"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/work)
 "qWU" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/purple/fourcorners,
@@ -63213,6 +64726,20 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
+"qYT" = (
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/closet/secure_closet/brig/genpop,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
+"qZi" = (
+/obj/structure/rack,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/muzzle,
+/obj/item/restraints/handcuffs,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "qZn" = (
 /obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -63224,15 +64751,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"qZD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "qZQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -63295,14 +64813,6 @@
 /obj/effect/turf_decal/trimline/blue/end,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/project)
-"raA" = (
-/obj/structure/closet/secure_closet/brig{
-	name = "Prisoner Locker"
-	},
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/transfer)
 "raH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -63386,6 +64896,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"rcp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/station/security/prison)
 "rcw" = (
 /obj/structure/fireaxecabinet/directional/east,
 /turf/open/floor/iron/dark,
@@ -63428,18 +64942,17 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
-"rcX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
 "rda" = (
-/turf/open/floor/iron,
-/area/station/security/prison/work)
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell11";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "rde" = (
 /obj/machinery/space_heater/improvised_chem_heater,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -63476,10 +64989,18 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "rdm" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/brown/tom,
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
+/obj/machinery/door_timer{
+	id = "isolation";
+	name = "Solitary Timer";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/security/prison)
 "rdr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -63629,6 +65150,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science/research)
+"reA" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "reH" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64125,14 +65657,14 @@
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "rkZ" = (
-/obj/machinery/door/window/left/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Justice gas pump"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "justicechamber";
+	name = "Justice Chamber Blast door"
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/execution)
 "rla" = (
 /turf/closed/indestructible/opshuttle,
 /area/station/science/ordnance/bomb)
@@ -64199,6 +65731,15 @@
 /obj/item/food/grown/poppy/geranium,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"rlP" = (
+/obj/machinery/sparker/directional/south{
+	id = "justicespark"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/red/side,
+/area/station/security/execution)
 "rlY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/xeno_spawn,
@@ -64298,14 +65839,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage)
-"rnA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "rnM" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -64337,6 +65870,18 @@
 "rov" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/lobby)
+"roB" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown1";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "roZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
@@ -64416,6 +65961,20 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"rqX" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/station/security/prison)
 "rqY" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -64437,6 +65996,16 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
+"rrD" = (
+/obj/machinery/deepfryer,
+/obj/machinery/light/directional/north,
+/obj/machinery/camera{
+	c_tag = " Prison - Kitchen";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "rrF" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
@@ -64516,12 +66085,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/corporate_showroom)
-"rsO" = (
-/obj/structure/window,
-/obj/machinery/biogenerator,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
 "rsR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64698,11 +66261,27 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "rvn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = " Prison - (East) Brown Wing";
+	network = list("ss13","prison")
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/button/curtain{
+	id = "prisoncell9";
+	pixel_x = 22;
+	pixel_y = -22
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
+/area/station/security/prison)
+"rvz" = (
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/security/prison)
 "rvC" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/ids,
@@ -64748,8 +66327,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "rwn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
 /area/station/security/prison)
 "rwt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65057,6 +66641,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"rBp" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/station/security/prison)
 "rBB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -65084,11 +66673,10 @@
 "rBK" = (
 /turf/closed/wall/r_wall,
 /area/station/science/explab)
-"rBN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/security/prison/work)
+"rBO" = (
+/obj/machinery/griddle,
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "rBQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65200,6 +66788,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/surgery/theatre)
+"rDs" = (
+/obj/structure/chair/stool,
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "rDF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -65242,6 +66834,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"rEr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "rEA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -65581,12 +67179,30 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "rIn" = (
-/obj/machinery/door/window/right/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/wirecutters,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/secateurs,
+/obj/item/secateurs,
+/obj/machinery/light/directional/north,
+/obj/item/plant_analyzer,
+/obj/item/plant_analyzer,
+/turf/open/floor/wood,
 /area/station/security/prison/garden)
 "rIt" = (
 /obj/structure/cable,
@@ -65668,16 +67284,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"rJx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/flasher/directional/south{
-	id = "Cell 1"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "rJy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65920,6 +67526,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"rLG" = (
+/obj/structure/cable,
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "rLI" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -66282,6 +67894,14 @@
 	icon_state = "chapel"
 	},
 /area/station/service/chapel)
+"rPw" = (
+/obj/structure/bed/maint,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/station/security/prison/upper)
 "rPA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -66346,11 +67966,10 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "rQv" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/turf/open/floor/iron/dark/red/side{
+	dir = 10
+	},
+/area/station/security/execution)
 "rQw" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -66363,14 +67982,10 @@
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
 "rQG" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/item/reagent_containers/syringe,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/security/execution/transfer)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
 "rQI" = (
 /obj/machinery/airlock_sensor/incinerator_atmos{
 	pixel_x = 24
@@ -66389,6 +68004,16 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"rQN" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/purple/side,
+/area/station/security/prison/safe)
 "rQO" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -66422,15 +68047,9 @@
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "rQS" = (
-/obj/structure/sign/warning/electric_shock{
-	pixel_x = -32
-	},
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/prison)
 "rRa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66957,25 +68576,16 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "rXh" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt3";
-	name = "Cell 4"
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut4"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "rXq" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -67103,6 +68713,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"rZC" = (
+/obj/structure/cable,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "rZD" = (
 /obj/machinery/computer/security{
 	dir = 4
@@ -67240,6 +68856,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"sbu" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "sbv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -67509,17 +69129,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
-"sfl" = (
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/work)
+"sfk" = (
+/obj/machinery/door/airlock/freezer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "sfn" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -67934,6 +69549,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"sld" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "sli" = (
 /obj/structure/table/glass,
 /obj/item/assembly/igniter,
@@ -68176,6 +69797,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
+"snZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner,
+/area/station/security/prison)
 "sog" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 8
@@ -68227,6 +69854,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"soM" = (
+/obj/structure/loom,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
 "soN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
@@ -68385,6 +70016,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
+"srJ" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/camera{
+	c_tag = " Prison - (North-West) Blue Wing Upper";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "srO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68515,6 +70157,17 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/theater)
+"sug" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets/donkpocketberry,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "suj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68707,11 +70360,15 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "swn" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/structure/table/reinforced,
+/obj/item/electropack,
+/obj/item/assembly/signaler,
+/obj/machinery/light/directional/west,
+/obj/item/clothing/head/helmet/sec,
+/turf/open/floor/iron/dark/red/side{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/execution)
 "swt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68789,6 +70446,21 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"sxM" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
+	},
+/obj/item/reagent_containers/glass/bottle/nutrient/rh,
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "sxR" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -69262,6 +70934,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/lockers)
+"sEg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "sEi" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -69393,13 +71071,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "sGe" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/east,
-/obj/item/radio/intercom/directional/east,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/security/prison/garden)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "sGi" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -69452,6 +71128,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"sGD" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "sGJ" = (
 /obj/machinery/holopad/secure,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -69586,6 +71270,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
+"sIn" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell7";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "sIp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69988,14 +71683,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "sMN" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/bookcase/random/religion,
+/obj/item/radio/intercom/directional/east{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/security/prison)
 "sMP" = (
 /obj/structure/window/reinforced{
@@ -70163,9 +71857,19 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "sON" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/iron,
-/area/station/security/prison)
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/garden)
 "sOZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair,
@@ -70227,8 +71931,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "sQh" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/airalarm/directional/north,
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
+	},
+/obj/machinery/door/window/right/directional/south,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "sQn" = (
@@ -70258,24 +71966,6 @@
 "sQA" = (
 /turf/closed/wall,
 /area/station/command/meeting_room/council)
-"sQD" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 4"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "sQJ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -70310,6 +72000,11 @@
 /obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"sQX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/red/directional/west,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "sRh" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -70537,6 +72232,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
+"sUB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "sUQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -70709,19 +72408,25 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	aiControlDisabled = 1;
-	name = "Education Chamber"
+	name = "Education Chamber";
+	req_access_txt = "3"
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/execution)
 "sXf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -70748,6 +72453,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/cmo)
+"sXn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/station/security/prison/upper)
 "sXE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/structure/lattice/catwalk,
@@ -70810,6 +72523,19 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"sYu" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permaouter";
+	name = "Permabrig Transfer"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "sYD" = (
 /obj/effect/turf_decal/trimline/yellow/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -70846,10 +72572,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "sYX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood,
 /area/station/security/prison)
 "sZe" = (
 /obj/machinery/space_heater,
@@ -70892,20 +72617,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"sZE" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Cell 1";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "sZL" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -71156,9 +72867,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "tcz" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/bombcloset/security,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot_blue,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/head/bomb_hood/security,
+/obj/item/clothing/head/bomb_hood/security,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "tcB" = (
@@ -71236,6 +72950,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"tdy" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "tdz" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -71544,6 +73266,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"tjT" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "tjY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -71593,6 +73325,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"tlp" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "tlq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
@@ -71750,6 +73492,16 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
+"tnp" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/garden)
 "tns" = (
 /obj/structure/table/wood,
 /obj/machinery/keycard_auth/directional/west,
@@ -71996,32 +73748,6 @@
 "tqo" = (
 /turf/closed/wall,
 /area/station/engineering/main)
-"tqp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/status_display/evac/directional/north,
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/glass/bottle/chloralhydrate{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/glass/bottle/facid{
-	pixel_x = 7
-	},
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
 "tqs" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -72294,6 +74020,14 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"ttg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/security/prison)
 "tti" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -72749,13 +74483,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"tyG" = (
-/obj/structure/table,
-/obj/item/kitchen/fork/plastic,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
 "tyI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72828,6 +74555,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
+"tzd" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood/tile,
+/area/station/security/execution/transfer)
+"tzj" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "tzm" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -72980,6 +74720,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
+"tBW" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side,
+/area/station/security/prison)
 "tBX" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -72995,12 +74742,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "tCd" = (
+/obj/item/trash/chips,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison/work)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = " Prison - (East) Brown Wing Upper";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/security/prison)
 "tCe" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -73077,6 +74830,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"tDl" = (
+/obj/structure/cable,
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "tDs" = (
 /turf/closed/wall,
 /area/station/service/electronic_marketing_den)
@@ -73373,14 +75138,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
-"tFV" = (
-/obj/machinery/vending/sustenance,
-/obj/machinery/camera/directional/south{
-	c_tag = "Permabrig - Kitchen";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
 "tGd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -73498,13 +75255,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
-"tHT" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/spawner/random/contraband/prison,
-/turf/open/floor/iron/white,
-/area/station/security/prison/toilet)
 "tHX" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -73630,6 +75380,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"tJX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "tJZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73816,6 +75573,15 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
+"tLZ" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/rec)
 "tMl" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -74094,9 +75860,9 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "tOY" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/prison)
 "tPc" = (
@@ -74468,16 +76234,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "tTQ" = (
-/obj/structure/sign/poster/ripped{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/obj/structure/cable,
+/turf/open/floor/iron/dark/blue,
+/area/brigofficer)
 "tUc" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -74502,17 +76264,27 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "tUs" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light_switch/directional/south,
-/obj/item/flashlight/lamp,
-/obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
+/obj/machinery/door/window/right/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/execution)
 "tUB" = (
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permainner";
+	name = "Permabrig Transfer"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark,
 /area/station/security/prison)
 "tVb" = (
 /obj/item/kirbyplants/random,
@@ -74663,10 +76435,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
-"tWG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "tWI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -75008,11 +76776,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"ubh" = (
-/obj/machinery/light/directional/east,
-/mob/living/simple_animal/mouse/white,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
 "ubk" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -75312,6 +77075,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
+"ufH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
+"ufK" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 6
+	},
+/area/station/security/prison/safe)
 "ufO" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/firecloset,
@@ -75327,15 +77108,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
+"ufQ" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "ufR" = (
 /turf/closed/wall/r_wall,
 /area/station/security/warden)
 "ufS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/dark/red/side,
+/area/station/security/execution)
 "ugc" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/structure/sign/poster/random/directional/north,
@@ -75557,15 +77342,16 @@
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "uhN" = (
-/obj/machinery/plate_press,
-/obj/structure/sign/warning/electric_shock{
-	pixel_x = 32
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell10";
+	name = "curtain"
 	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
-/area/station/security/prison/work)
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "uhV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/north,
@@ -75639,16 +77425,16 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
-"ujX" = (
-/obj/structure/table,
-/obj/item/trash/popcorn,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
 "uko" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
+"ukw" = (
+/obj/structure/table,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/prison/work)
 "ukz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -76036,13 +77822,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
-"upM" = (
-/obj/structure/table,
-/obj/item/storage/photo_album/prison,
-/obj/item/camera,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "upQ" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Departures Hallway - Center";
@@ -76263,14 +78042,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"uuf" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
 "uuh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -76279,15 +78050,15 @@
 	},
 /area/station/commons/dorms)
 "uuj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/structure/table/reinforced,
+/obj/item/taperecorder,
+/obj/item/restraints/handcuffs,
+/obj/item/flashlight/lamp,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark/red/side{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/execution)
 "uum" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -76456,6 +78227,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"uwI" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 1;
+	name = "blue line"
+	},
+/obj/structure/sign/gym/right{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/station/security/prison)
 "uwJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -76774,6 +78558,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"uBn" = (
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/poddoor{
+	id = "justiceblast";
+	name = "Justice Blast door"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/execution)
 "uBv" = (
 /obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -76892,6 +78684,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"uCV" = (
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/wrench,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "uCY" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -76918,6 +78717,23 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
+"uDw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/west,
+/obj/structure/extinguisher_cabinet/directional/west{
+	pixel_y = -6
+	},
+/obj/machinery/button/curtain{
+	id = "prisoncell5";
+	pixel_x = -22;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/security/prison)
 "uDz" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -77065,9 +78881,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "uGe" = (
-/obj/structure/sign/warning/secure_area{
-	pixel_x = -32
-	},
 /obj/machinery/light/small/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -77312,16 +79125,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "uKd" = (
-/obj/machinery/light/directional/south,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "uKw" = (
 /turf/closed/wall,
 /area/station/commons/fitness/recreation)
@@ -77952,23 +79763,11 @@
 	},
 /area/station/hallway/secondary/entry)
 "uSh" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/obj/effect/landmark/start/brigoff,
+/turf/open/floor/iron/dark/blue,
+/area/brigofficer)
 "uSp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78174,6 +79973,14 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
+"uVh" = (
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 6
+	},
+/area/station/security/prison/safe)
 "uVk" = (
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
@@ -78304,6 +80111,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
+"uWv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "uWI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -78341,9 +80152,20 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "uWT" = (
-/obj/structure/punching_bag,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/hydroponics/soil{
+	desc = "A patch of fertile soil that you can plant stuff in.";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "dirt";
+	layer = 2.0001;
+	plane = -7;
+	self_sustaining = 1
+	},
+/obj/item/seeds/tomato,
 /turf/open/floor/plating,
-/area/station/security/prison)
+/area/station/security/prison/garden)
 "uXh" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/iron/dark,
@@ -78615,6 +80437,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"vba" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/rec)
 "vbf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -78716,11 +80544,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"vcf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "vcl" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Vacant Commissary"
@@ -78735,6 +80558,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"vct" = (
+/obj/structure/bed/maint,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = 32
+	},
+/turf/open/floor/iron{
+	icon = 'icons/turf/floors.dmi'
+	},
+/area/station/security/prison/upper)
 "vcD" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -78951,6 +80784,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"vfS" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/computer/cryopod{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#00ff00";
+	name = "green"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
+"vgb" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/sink{
+	pixel_y = 22
+	},
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
 "vgf" = (
 /obj/machinery/door_timer{
 	id = "medcell";
@@ -79470,11 +81326,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "vnI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/stool/directional/north,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Prison - Visitation (Prisoner)";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "vnQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -79574,6 +81436,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"vpv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "vpJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -79722,6 +81590,17 @@
 /obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
+"vry" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell6";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "vrE" = (
 /turf/open/floor/iron{
 	dir = 4;
@@ -79737,6 +81616,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"vso" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "vsp" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -79767,6 +81652,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/station/service/library)
+"vsy" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 1;
+	name = "blue line"
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/station/security/prison)
 "vsA" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -79788,6 +81683,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"vsL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/rec)
 "vsN" = (
 /obj/machinery/disposal/bin,
 /obj/structure/cable,
@@ -79816,13 +81717,16 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "vtd" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Prison Port"
+/obj/structure/bed/roller,
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "vtf" = (
 /obj/item/target,
 /obj/structure/training_machine,
@@ -79852,6 +81756,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"vtq" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell7";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/station/security/prison/safe)
 "vtz" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -79922,6 +81837,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"vuI" = (
+/obj/structure/barricade/wooden{
+	opacity = 1
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/security/prison/rec)
 "vuV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -80227,6 +82155,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
+"vyk" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/station/security/prison)
 "vyn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -80449,6 +82390,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
+"vBz" = (
+/obj/machinery/light/directional/south,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
 "vBA" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -80828,6 +82775,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/checkpoint)
+"vFV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/security/prison)
 "vFX" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/machinery/status_display/evac/directional/south,
@@ -80887,13 +82842,6 @@
 /obj/item/paicard,
 /turf/open/floor/carpet,
 /area/station/service/library/abandoned)
-"vGv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "vGz" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -81011,12 +82959,6 @@
 /obj/item/mop,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"vII" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "vIQ" = (
 /turf/closed/wall/r_wall,
 /area/station/command/teleporter)
@@ -81071,27 +83013,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/checker,
 /area/station/service/theater)
-"vJh" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt3";
-	name = "Cell 5"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut5"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "vJl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -81600,6 +83521,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
+"vPY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/security/prison/upper)
 "vPZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -81659,6 +83586,17 @@
 	dir = 8
 	},
 /area/station/service/kitchen)
+"vRa" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "prisoncell5";
+	name = "curtain"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "vRg" = (
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
@@ -81683,7 +83621,11 @@
 /obj/item/storage/box/bodybags,
 /obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -81854,10 +83796,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/bar)
 "vTP" = (
-/obj/structure/chair/stool/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/station/security/prison)
 "vTZ" = (
 /obj/structure/closet/secure_closet/security/sec,
@@ -81975,17 +83917,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "vVt" = (
-/obj/structure/window,
-/obj/structure/sink{
-	pixel_y = 30
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/security/prison/garden)
 "vVu" = (
 /obj/effect/spawner/structure/window,
@@ -82304,6 +84240,25 @@
 	},
 /turf/closed/wall,
 /area/station/commons/storage/primary)
+"vZc" = (
+/obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 10
+	},
+/area/station/security/prison/safe)
+"vZh" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/station/security/prison)
 "vZo" = (
 /obj/machinery/smartfridge,
 /obj/effect/turf_decal/bot,
@@ -82473,6 +84428,20 @@
 	dir = 1
 	},
 /area/station/commons/locker)
+"waY" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "wbe" = (
 /turf/closed/wall,
 /area/station/service/hydroponics/garden)
@@ -82529,13 +84498,13 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "wbz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
+/area/station/security/prison)
 "wbD" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Library Access"
@@ -82572,6 +84541,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
+"wbS" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell5";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
+	},
+/area/station/security/prison/safe)
 "wbY" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 1
@@ -82608,19 +84588,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
-"wcD" = (
-/obj/structure/bed,
-/obj/item/bedsheet/orange,
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Cell 4";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "wcF" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Medical Officer's Quarters"
@@ -82720,6 +84687,10 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
+"wdU" = (
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/prison)
 "web" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -82872,6 +84843,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"wfu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/security/prison)
 "wfv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -83059,9 +85039,9 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "wgT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/station/security/prison)
 "wgU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/east,
@@ -83076,15 +85056,6 @@
 	},
 /turf/open/floor/iron/dark/airless,
 /area/station/science/ordnance/freezerchamber)
-"whh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/security/execution/transfer)
 "whj" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -83366,15 +85337,17 @@
 	},
 /area/station/maintenance/disposal/incinerator)
 "wlK" = (
-/obj/structure/sign/poster/official/work_for_a_future{
-	pixel_y = -32
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "prisonlockdown3";
+	name = "Lockdown"
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "wlS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -83413,13 +85386,6 @@
 	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/greater)
-"wml" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
 "wms" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -83597,9 +85563,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
-"wpl" = (
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
 "wps" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom/directional/east,
@@ -83729,6 +85692,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"wqC" = (
+/obj/docking_port/stationary{
+	dheight = 1;
+	dir = 8;
+	dwidth = 12;
+	height = 17;
+	id = "syndicate_ne";
+	name = "northeast of station";
+	width = 23
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "wqF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -83760,6 +85735,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"wqR" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/security/prison)
 "wqT" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
@@ -83773,6 +85754,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"wro" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/visit)
 "wry" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -83927,6 +85917,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"wtU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "wud" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -83953,6 +85949,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"wuk" = (
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "wuz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -84177,6 +86177,21 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"wwO" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/janitorialcart{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/station/security/prison)
 "wwQ" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/nanotrasen{
@@ -84262,6 +86277,17 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
+"wxx" = (
+/obj/machinery/button/curtain{
+	id = "prisoncell3";
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/purple/side{
+	dir = 1
+	},
+/area/station/security/prison/safe)
 "wxG" = (
 /obj/structure/closet/secure_closet/security/science,
 /obj/machinery/status_display/evac/directional/north,
@@ -84495,12 +86521,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
-"wAe" = (
-/obj/structure/table,
-/obj/machinery/computer/libraryconsole/bookmanagement,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "wAw" = (
 /obj/machinery/newscaster/directional/east,
 /turf/closed/wall,
@@ -84807,6 +86827,9 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"wFB" = (
+/turf/closed/wall,
+/area/station/security/prison/shower)
 "wFF" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -84928,6 +86951,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"wHt" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron,
+/area/station/security/prison/mess)
 "wHC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -85084,6 +87118,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"wKa" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "wKl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -85452,6 +87494,14 @@
 /obj/item/storage/dice,
 /turf/open/floor/carpet,
 /area/station/service/library/abandoned)
+"wQJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "wQN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -85643,14 +87693,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/station/service/library/abandoned)
-"wTD" = (
-/obj/machinery/door/airlock/security{
-	name = "Isolation Cell"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/floor/plating,
-/area/station/security/execution/transfer)
 "wTF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -85896,6 +87938,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"wXZ" = (
+/turf/open/space/basic,
+/area/space/nearstation)
 "wYx" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall/r_wall,
@@ -85958,6 +88003,19 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/station/medical/break_room)
+"wZp" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/east{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/dark/brown/side{
+	dir = 6
+	},
+/area/station/security/prison/safe)
 "wZv" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -86292,12 +88350,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "xda" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/machinery/door/airlock/security{
+	name = "Permabrig Visitation"
 	},
-/obj/item/soap/homemade,
-/turf/open/floor/iron/white,
-/area/station/security/prison/toilet)
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/visit)
 "xds" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -86369,6 +88429,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"xec" = (
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/blue/side,
+/area/station/security/prison/safe)
 "xee" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -86404,6 +88476,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"xel" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/light/cold/no_nightlight/directional/north,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 9
+	},
+/area/station/security/prison/safe)
 "xeo" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -86518,6 +88597,18 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/engineering/gravity_generator)
+"xfv" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen{
+	dir = 1
+	},
+/area/station/security/prison)
 "xfx" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -86536,6 +88627,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"xga" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/prison/rec)
 "xgm" = (
 /obj/structure/chair{
 	dir = 4
@@ -86723,6 +88819,11 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"xiU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/station/security/prison)
 "xiV" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -86768,6 +88869,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"xjP" = (
+/obj/machinery/chem_master/condimaster,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "xkc" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/testlab)
@@ -86887,6 +88993,11 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"xmo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "xms" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -86907,6 +89018,22 @@
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
+"xmW" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/item/storage/bag/tray,
+/obj/item/kitchen/rollingpin,
+/obj/item/clothing/suit/apron/chef,
+/turf/open/floor/iron/kitchen,
+/area/station/security/prison/mess)
 "xna" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -87022,14 +89149,20 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "xnM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/flasher/directional/south{
-	id = "Cell 4"
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 9;
+	name = "blue line"
 	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
+/obj/machinery/camera{
+	c_tag = " Prison - (West) Purple Wing";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 6
+	},
+/area/station/security/prison)
 "xnT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
@@ -87411,13 +89544,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
-"xsP" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
 "xsQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/window/left/directional/north{
@@ -87547,6 +89673,12 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/lobby)
+"xus" = (
+/obj/structure/bed/maint,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "xuy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -87754,8 +89886,11 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint)
 "xxf" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/station/security/prison)
 "xxk" = (
 /obj/structure/window/reinforced{
@@ -87810,6 +89945,19 @@
 	},
 /turf/open/floor/glass,
 /area/station/maintenance/space_hut/observatory)
+"xxP" = (
+/obj/structure/cable,
+/obj/item/storage/toolbox/drone,
+/obj/structure/rack,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/machinery/camera{
+	c_tag = "Security - Prison Outpost";
+	network = list("ss13","Security","prison")
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark/blue/side,
+/area/brigofficer)
 "xxZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -87838,16 +89986,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
-"xyf" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "xyh" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -88047,20 +90185,28 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "xAc" = (
-/obj/structure/chair/office{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/red/side{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/execution)
 "xAk" = (
-/obj/structure/table,
-/obj/item/trash/raisins,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
+/obj/item/trash/energybar,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/security/prison)
 "xAo" = (
 /turf/closed/wall,
 /area/station/security/detectives_office/private_investigators_office)
@@ -88202,12 +90348,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "xCi" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Permabrig - Kitchen Entrance";
-	network = list("ss13","prison")
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/wood,
 /area/station/security/prison)
 "xCt" = (
 /obj/machinery/computer/telecomms/server{
@@ -88466,16 +90608,10 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "xFh" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK";
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "xFo" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/mech_bay_recharge_port,
@@ -88917,6 +91053,9 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
+"xMh" = (
+/turf/closed/wall/r_wall,
+/area/station/security/prison/rec)
 "xMi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
@@ -89096,6 +91235,11 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
 /area/station/command/meeting_room/council)
+"xOx" = (
+/obj/structure/cable,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
+/area/station/security/prison/rec)
 "xOz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -89165,26 +91309,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "xON" = (
+/obj/structure/table,
+/obj/machinery/computer/secure_data/laptop{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/machinery/button/flasher{
-	id = "Cell 2";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/east{
-	id = "permashut2";
-	name = "Cell Lockdown Button";
-	pixel_y = -6;
-	req_access = list("brig")
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/turf/open/floor/iron/dark/blue/side,
+/area/brigofficer)
 "xOQ" = (
 /obj/structure/chair{
 	dir = 8
@@ -89218,12 +91349,21 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/vault,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
+"xPx" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison/mess)
 "xPz" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/toy/figure/syndie,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating,
+/obj/machinery/camera{
+	c_tag = " Prison - Entrance";
+	network = list("ss13","prison")
+	},
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "xPM" = (
 /obj/structure/cable,
@@ -89268,6 +91408,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
+"xQk" = (
+/obj/structure/table,
+/obj/item/toy/plush/borbplushie{
+	name = "Therapeep"
+	},
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "xQq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -89310,11 +91457,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xQT" = (
-/obj/machinery/flasher/directional/north{
-	id = "visitorflash"
+/obj/structure/table,
+/obj/structure/window/reinforced/tinted{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/chair/stool/directional/east,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "xQW" = (
@@ -89334,6 +91485,10 @@
 	dir = 4
 	},
 /area/station/commons/fitness/recreation)
+"xQZ" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/security/prison/safe)
 "xRo" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -89897,7 +92052,15 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "xZd" = (
-/obj/item/radio/intercom/prison/directional/north,
+/obj/structure/table,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "xZy" = (
@@ -89914,6 +92077,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"xZL" = (
+/obj/machinery/light/directional/south,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool,
+/area/station/security/prison/rec)
 "xZM" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -89939,12 +92107,23 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "yau" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 8
+	},
+/area/brigofficer)
 "yaG" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -90151,6 +92330,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
+"ydG" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/brigoff,
+/turf/open/floor/iron/dark/blue/side,
+/area/brigofficer)
+"ydI" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9";
+	dir = 6;
+	name = "blue line"
+	},
+/obj/structure/sign/gym{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 9
+	},
+/area/station/security/prison)
 "ydL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -90205,6 +92402,11 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/port/fore)
+"yes" = (
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
+/area/station/security/prison)
 "yeE" = (
 /obj/structure/table,
 /obj/item/storage/briefcase,
@@ -90265,6 +92467,14 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"yfU" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/brown/side{
+	dir = 10
+	},
+/area/station/security/prison/safe)
 "yfX" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
@@ -90492,6 +92702,20 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"yjo" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_y = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "yjp" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -139083,10 +141307,10 @@ aaa
 aaa
 aaa
 aaa
+abj
+abj
+abj
 aaa
-abj
-abj
-abj
 abj
 abj
 abj
@@ -139342,12 +141566,12 @@ aaa
 aaa
 aaa
 aaa
+aad
+aaa
+aaa
 aaa
 aaa
 aad
-aaa
-aad
-aaa
 aaa
 aaa
 aaa
@@ -139361,7 +141585,7 @@ aaa
 aad
 aaa
 aaa
-aaa
+abj
 abj
 abj
 abj
@@ -139599,12 +141823,12 @@ aaa
 aaa
 aaa
 aaa
+aad
+aaa
+aaa
 aaa
 aaa
 aad
-aaa
-aad
-aaa
 aaa
 aaa
 aaa
@@ -139847,32 +142071,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aac
-aaa
-aac
-aad
-aad
-aad
+mSe
+mSe
+iin
+mSe
+mSe
+aiM
+mSe
+mSe
+vry
+mSe
+mSe
+odP
+mSe
+mSe
+jIi
+mSe
+mSe
+mSe
+fhW
+fhW
+fhW
+fhW
+fhW
+fhW
+fhW
+fhW
 aad
 aad
 aad
@@ -140104,32 +142328,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aad
-aaa
-aaa
-aad
-aaa
-aad
-aaa
-aaa
-aac
-aaa
-aaa
-aaa
-aad
-aaa
-aad
-aaa
-aaa
-aad
+mSe
+jUW
+vZc
+lTv
+jUW
+vZc
+lTv
+jUW
+vZc
+lTv
+lvp
+eKf
+lTv
+lvp
+beM
+lTv
+lvp
+gJj
+uMy
+soM
+blD
+bTm
+lJX
+hif
+lHg
+fhW
 aaa
 aaa
 aaa
@@ -140357,41 +142581,41 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aad
-aaa
-aaa
-aad
-aad
-aac
-aac
-aad
-aad
-aaa
-aaa
-aaa
-qIH
-qIH
-qIH
-qIH
-qIH
-qIH
-jrA
-jrA
-qIH
-qIH
-aaa
+iNQ
+iNQ
+iNQ
+iNQ
+mSe
+psw
+anb
+lTv
+vtq
+anb
+lTv
+ctL
+xec
+lTv
+wbS
+rQN
+lTv
+dYZ
+rQN
+lTv
+wxx
+epU
+uMy
+onQ
+blD
+onK
+ukw
+uMy
+iSV
+lET
+lET
+pWT
+pWT
+pWT
+lET
 lET
 euZ
 kgE
@@ -140614,41 +142838,41 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
-aaa
-aaa
-abj
-aaa
-aad
-aaa
-aaa
-aad
-mSe
-mSe
-mSe
-mSe
-hiW
+iNQ
+hrN
+kzH
+eVk
+lTv
+lFO
+iMI
+lTv
+lFO
+iMI
+lTv
+lFO
+iMI
+lTv
+qgm
+uVh
+lTv
+qgm
+uVh
+lTv
+qgm
+ifg
+uMy
+dQL
+blD
+onK
 dIi
-cmc
+uMy
 pqi
-jrA
+lET
 ivi
-eip
+vso
 bku
-qIH
-aaa
+vso
+yjo
 lET
 wEz
 uKI
@@ -140869,43 +143093,43 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
-aaa
-aaa
-abj
+aac
 aad
-aad
-aad
-qYo
-qYo
-mSe
-prB
-gTH
-mSe
-jva
-anf
+iNQ
+vgb
+lVO
+vBz
+lTv
+aTy
+fBO
+lTv
+aTy
+sIn
+lTv
+aTy
+hJC
+lTv
+pgf
+vRa
+lTv
+pgf
+pKV
+lTv
+pgf
+egu
+uMy
+uMy
+ufH
+onK
+ukw
+kJo
 nzh
-nzh
-kzP
+lET
 mLs
-evg
-qjz
-qIH
-aad
+mcT
+uKI
+pRh
+bcn
 lET
 wam
 khv
@@ -141124,45 +143348,45 @@ aaa
 aaa
 aaa
 aaa
+aac
 aaa
+aac
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
-aaa
-aaa
-aad
-aaa
-aaa
-qYo
-aaa
-aaa
-mSe
+iNQ
+ePd
+mqW
+fWw
+ncf
+vFV
+ejd
+iOc
+ejd
+fcX
+fzn
+ejd
+ejd
+eGV
+ejd
+ejd
+uDw
+cXJ
+ejd
+put
+ejd
+ejd
 pMa
 caH
-mSe
+qvJ
 rQG
 aVL
-whh
+uMy
 iCi
-hdm
+lET
 vtd
 uKd
-qIH
-qIH
-aaa
+lEw
+dYU
+lOP
 lET
 xnm
 khv
@@ -141381,45 +143605,45 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
+aac
 aad
-qIH
-qIH
+aac
+aaa
+iNQ
+ohd
+wFB
+wFB
+wFB
+wfu
+srJ
+kOR
+kOR
+iks
+kOR
+jMu
+koE
+nQr
+kOR
+kOR
+kOR
+kOR
 bbf
-bbf
-bbf
-bbf
-qIH
-qIH
-qIH
-wTD
-qIH
-qIH
-qIH
-qIH
-qIH
-qIH
-qUq
-xFy
-qIH
-qIH
-qIH
+kOR
+kOR
+rvz
+kKU
+fhW
+fhW
+fhW
+fhW
+fhW
+fhW
+lET
+pWT
+cJG
+lET
+lET
+lET
 lET
 pWT
 pVm
@@ -141638,41 +143862,41 @@ aaa
 aaa
 aaa
 aaa
+aac
 aaa
+aac
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-xTK
-qYo
-qYo
-qYo
-aaa
-bbf
-fYX
-eAz
-eAz
+pRa
+sUB
+nrk
+dsw
+nPH
+fSX
+fSX
+fSX
+mRk
+dNO
+mRk
+fSX
+fSX
+fSX
+ydI
 kFm
-eAz
+kFm
+kFm
+kFm
+hQf
 rQS
-eAz
+hNV
 fuS
-hwB
+cAq
 eAz
 yau
 foT
 kie
-eAz
-pao
-miw
+aaa
+rkd
+qri
 evg
 cay
 eNG
@@ -141895,41 +144119,41 @@ aaa
 aaa
 aaa
 aaa
+aac
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-xTK
-aaa
-aaa
-uHd
-aaa
-bbf
-auW
-mFw
-dcN
+aac
+aad
+pRa
+sUB
+sQX
+sUB
+hAV
+fSX
+lnk
+gKa
+fWP
+hqP
+fWP
+fYl
+tjT
+fSX
+uwI
 hbq
-mFw
+hbq
+hbq
+hbq
+tBW
 nke
-qsK
-mFw
-pZC
+hNV
+nsp
+kie
 qsK
 mFw
 xON
-qsK
-oGF
-aoA
-xyf
+kie
+aaa
+rkd
+qri
 xFy
 jrA
 blM
@@ -142152,41 +144376,41 @@ aaa
 aaa
 aaa
 aaa
+aac
 aaa
+aac
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-uHd
-qYo
-qYo
-uHd
-qYo
-mSe
-mSe
-dwX
-mSe
-mSe
-sQD
-mSe
-mSe
-gzQ
-mSe
-mSe
+pRa
+sUB
+sUB
+sUB
+eJG
+fSX
+oeD
+doX
+acf
+hqP
+wHt
+iLV
+mHV
+fSX
+bjn
+wuk
+hbq
+hbq
+hbq
+tBW
+ipX
+kcC
+nsp
+iVh
+fqQ
 uSh
-mSe
-mSe
-igV
-mSe
-qri
+xxP
+cAq
+aad
+qIH
+nFD
 xFy
 nKH
 pMt
@@ -142409,41 +144633,41 @@ aaa
 aaa
 aaa
 aaa
+aac
+aad
+aac
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-uHd
-aaa
-aaa
-uHd
-aaa
-mSe
-cKa
-bhz
-lTv
-iPK
-lYv
-lTv
-iPK
-bcm
-lTv
+pRa
+nPH
+nPH
+nPH
+nPH
+fSX
+waY
+psO
+fWP
+hqP
+fWP
+qIZ
+psO
+fSX
+vsy
+hbq
+hbq
+hbq
+hbq
+tBW
+nke
+hNV
+nsp
+kie
 iPK
 tTQ
-lTv
-cKa
-fMd
-mSe
-nFD
+ydG
+kie
+aaa
+rkd
+qri
 xFy
 qIH
 qIH
@@ -142666,40 +144890,40 @@ aaa
 aaa
 aaa
 aaa
+aac
 aaa
+aac
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-uHd
-aaa
-aaa
-uHd
-qYo
-mSe
-pWF
+pRa
+hvX
+sUB
+sUB
+eUE
+fSX
+tdy
+fWP
+fWP
+hqP
+fWP
+sGD
+eGZ
+fSX
+bnJ
+eiC
 aRS
-lTv
+eiC
 eiC
 xnM
-lTv
-eiC
+wdU
+hNV
 kLh
-lTv
+cAq
 cuB
 lKr
-lTv
-ctH
-rJx
-mSe
+anP
+kie
+aaa
+rkd
 qri
 xFy
 qIH
@@ -142925,38 +145149,38 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-aaa
-aaa
-qYo
-aaa
-mSe
-cqH
-nbw
-lTv
-wcD
-ixG
-lTv
+aac
+aad
+pRa
+pjz
+eMH
+pHT
+eZS
+fSX
+aXS
+qRr
+qRr
+cSJ
+hqP
+pYc
+gDd
+aaX
+aaX
+hTY
+hTY
+aaX
+hTY
+hTY
+aaX
 bFH
 wlK
-lTv
-djI
-rnA
-lTv
-sZE
+qWZ
+qWZ
+qWZ
+qWZ
+qWZ
 iGN
-mSe
+qWZ
 uxm
 apo
 qIH
@@ -143184,41 +145408,41 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-vVc
-vVc
-qYo
-aaa
-mSe
-lTv
-vJh
-lTv
-lTv
+pRa
+bMC
+gxw
+mjS
+fSX
+fSX
+jVw
+nra
+sug
+kkG
+iYH
+pYc
+ivL
+aaX
+aZi
+sxM
 rXh
-lTv
-lTv
+jaR
+oaD
+rXh
+hTY
+hNV
 mpO
-lTv
-lTv
 fDm
-lTv
-lTv
+vfS
+fDm
+fiO
+wQJ
 lMN
-mSe
-qri
-xFy
+qWZ
+jqN
+eZC
 qIH
 qIH
-jrA
+qIH
 cjN
 fSi
 sHr
@@ -143441,41 +145665,41 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-aaa
-aaa
-qYo
-dGB
+pRa
+bap
+edP
+owr
+eza
+wtU
+dAd
+vpv
+njj
+xPx
+qRr
+pYc
+reA
+aaX
 dGB
 uWT
-qkJ
-ayH
-orh
-tWG
-nWw
+rXh
+rXh
+rXh
+rXh
+hTY
 qcT
 rwn
 kho
-vcf
+ltT
 ltT
 tUB
-pcA
-ouc
-qWZ
-qri
+ryY
+ryY
+sYu
+jfC
 xFy
-cwH
-qIH
-aaa
+qcm
+jkM
+tzd
 cjN
 qVc
 sHr
@@ -143698,41 +145922,41 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-qYo
-dGB
-dGB
-dGB
-dGB
+pRa
+nPH
+nPH
+tDl
+fSX
+cIB
+xmo
+xmW
+njj
+tlp
+qRr
+nlM
+fVJ
+tnp
 vVt
 sON
-qkJ
-ifQ
-vGv
-cYC
-qZD
+rXh
+rXh
+rXh
+iBv
+aaX
 cYC
 eTv
-bii
-nwN
+vxr
+ryY
 hMx
-bGi
+fiO
 adU
 tOY
-hLe
+qWZ
 pfK
-evg
-cHQ
-jrA
-aad
+xFy
+hBK
+qIH
+qIH
 cjN
 uTy
 nsG
@@ -143955,40 +146179,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-uHd
-aaa
-qGu
+pRa
+acO
+hhP
+dZp
+fSX
+dlQ
+xmo
+coe
+sld
+fSX
+fSX
 axm
 bsD
-oAI
+aaX
 nlk
-gOo
-bfs
-jdT
-vxr
-wAe
-jQZ
+sON
+rXh
+rXh
+rXh
+rXh
+hTY
 buu
+snZ
+lwy
 jQZ
-jQZ
-jQZ
-fiO
+kOR
 kxA
-vII
-gPG
+qkJ
+vxr
 hLe
 qri
-xFy
-cYy
-qIH
+evg
+par
+jrA
 aaa
 hQq
 cXi
@@ -144210,41 +146434,41 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-uHd
-qYo
-uHd
-aaa
-qGu
+aac
+aad
+pRa
+fGP
+mek
+hnx
+fSX
+rrD
+xmo
+rBO
+uWv
+gHZ
+fSX
 kUq
 oFe
-wml
+aaX
 rIn
 itW
 nJg
 jHw
-vxr
+rXh
 jMs
-jQZ
-oeo
-ktU
+hTY
+hNV
+nsp
 dDV
 nVV
+pEq
 fiO
-uuf
 bGi
 xPz
 qWZ
-qri
-mVr
-gJk
+qSV
+xFy
+qYT
 qIH
 aad
 cjN
@@ -144465,43 +146689,43 @@ aaa
 aaa
 aaa
 aaa
+aac
 aaa
+aac
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-uHd
-aaa
-uHd
-aaa
+pRa
+nPH
+nPH
+tDl
+fSX
+kfk
+rEr
+rEr
+sEg
+jDo
 qGu
 wbz
 pVE
-rcX
-rsO
-vxr
-upM
-ibb
-bDw
-jMs
-jQZ
+aaX
+aaX
+lOz
+lOz
+aaX
+lOz
+lOz
+aaX
 eBY
-jQZ
-tHT
+roB
+bAv
 xda
 bAv
 bAv
-mSj
 bAv
-dpI
+bAv
+qIH
 qri
 xFy
-aCC
+qIH
 qIH
 aaa
 cjN
@@ -144664,6 +146888,7 @@ aaa
 aaa
 aaa
 aaa
+wXZ
 aaa
 aaa
 aaa
@@ -144721,45 +146946,44 @@ aaa
 aaa
 aaa
 aaa
+aac
+aad
+aac
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-xTK
-aaa
-qYo
-aaa
-qGu
-cYa
-pVE
-mCH
+pRa
+arL
+piW
+hnx
+fSX
+dSt
+dyB
+xjP
+jmD
+wKa
+fSX
+wbz
+kdu
+fiO
 eaU
-qcT
+rBp
 vTP
 aNd
-qkJ
+wqR
 msM
-jQZ
-jQZ
-jQZ
-jQZ
-jQZ
+fiO
+hNV
+nsp
 bAv
-sQh
 anE
+rDs
+sQh
+bpW
 auy
 dpI
-qri
-evg
-mBJ
-jrA
+jfC
+xFy
+cwH
+qIH
 aad
 cjN
 fSL
@@ -144979,44 +147203,44 @@ aaa
 aaa
 aaa
 aaa
+aac
 aaa
+aac
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-uHd
-aaa
-uHd
-aaa
-qGu
+njg
+rPw
+nea
+dZp
+fSX
+fSX
+sfk
+lTv
+lTv
+lTv
+lTv
 rdm
 wgT
-pKW
+fiO
 oDK
 edb
-rwn
-ryY
-vxr
+xiU
+rcp
+qrr
 xxf
-aaB
+fiO
 gNp
-ohB
-ujX
-vnI
+nsp
 bAv
+vnI
+cGc
 xZd
-anE
-xyU
-pmD
-qri
-xFy
-raA
+bFw
+nuS
 qIH
+eKs
+evg
+cHQ
+jrA
 aaa
 cjN
 kOA
@@ -145236,43 +147460,43 @@ aaa
 aaa
 aaa
 aaa
+aac
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-uHd
-qYo
-uHd
-aaa
-qGu
-aDl
+aac
+aad
+pRa
+nPH
+nPH
+sXn
+fSX
+ouO
+aSo
+lTv
+xel
+qDS
+azk
+wbz
 sGe
-irb
+fiO
 osU
 iiy
-tUB
-ryY
+xiU
+dcz
 oYI
 sYX
-dkx
+fiO
+gNp
 jGu
-jGu
-daD
-ouH
 bAv
+ouH
+wro
 xQT
 iko
 exd
-pxM
-qri
-oXp
 qIH
+qri
+xFy
+cYy
 qIH
 aad
 aad
@@ -145493,44 +147717,44 @@ aaa
 aaa
 aaa
 aaa
+aac
 aaa
+aac
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-qYo
-dGB
-dGB
-dGB
-dGB
+pRa
+vPY
+piW
+tJX
+fSX
+jTx
+aIF
+lTv
+oLw
+aAQ
+bdl
+aXY
+quD
+fiO
 cPO
 pGj
-nIr
+xiU
 sMN
 xCi
 gER
-aaB
+fiO
 xAk
 nkD
-kNE
-tyG
 bAv
+xyU
+rDs
+eoS
+gBM
 fkY
-bAv
-fkY
-dpI
+qIH
 iwQ
-xFy
-jrA
-aaa
+oXp
+qIH
+qIH
 aad
 aaa
 bRF
@@ -145750,40 +147974,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aac
 aad
+aac
 aaa
-aaa
-aaa
-aaa
-dGB
-dGB
-uMy
-uMy
-qWT
-uMy
-uMy
-uMy
+pRa
+aun
+qvG
+mNz
+fSX
+fSX
+fSX
+lTv
+lTv
+lTv
+lTv
+pQK
+oFe
+fiO
+fiO
+fiO
+bjW
+fiO
+fiO
+fiO
+fiO
 awO
-joy
-wpl
-tFV
-bAv
-fAr
-xyU
-fiQ
-dpI
+kKU
+lTv
+lTv
+lTv
+pMM
+pMM
+pMM
+pMM
 vGz
 evg
 jrA
@@ -145989,6 +148213,7 @@ aaa
 aaa
 aaa
 aaa
+wqC
 aaa
 aaa
 aaa
@@ -146006,42 +148231,41 @@ aaa
 aaa
 aaa
 aaa
+aac
 aaa
+aac
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-vVc
-qYo
-uHd
-uHd
-uHd
-uHd
-qYo
-qYo
-cwa
-mTf
+pRa
+nPH
+nPH
+lpu
+nzb
+ewL
+ewL
+ewL
+lbB
+oLc
+yes
+ttg
+jJJ
+fMH
+aIK
+aIK
 qJJ
 tCd
 jlI
 jYh
-uMy
+aIK
 bNv
-nWe
+nsp
 gky
 qkL
-bAv
-ljD
+foB
+pMM
 iLS
 pGO
-nfQ
-eUs
+pMM
+oGF
 xFy
 jrA
 aaa
@@ -146255,7 +148479,6 @@ aaa
 aaa
 aaa
 aaa
-agO
 aaa
 aaa
 aaa
@@ -146267,37 +148490,38 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-aaa
-aaa
-aaa
-cwa
+aac
+aad
+pRa
+vPY
+piW
+pLc
+vuI
+vsL
+vba
+vba
+vba
+hrU
+mIx
+nsr
+bFN
+ftV
 eOh
-rBN
-tCd
-hZL
-jzo
-uMy
+eOh
+nsr
+dYl
+nsr
+nsr
+pYO
 nsr
 rvn
-wpl
+lTv
 miS
+wZp
+pMM
+kJc
 eHO
-eHO
-eHO
-eHO
-eHO
+pMM
 lcI
 lxl
 qIH
@@ -146525,36 +148749,36 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-wVj
-aaa
-uHd
-aaa
-aaa
-aaa
-cwa
-hzZ
+pRa
+vct
+qvG
+eYI
+nzb
+dME
+mtA
+tLZ
+mJI
+fiO
+fiO
+pmo
+fiO
+fiO
+lTv
+jQz
 rda
-sfl
-mrq
+lTv
+jQz
 uhN
-uMy
+lTv
 jQz
 pKy
-ubh
+lTv
 gRc
-eHO
-tqp
+mSe
+pMM
 mor
 tUs
-eHO
+pMM
 eDD
 jrA
 qIH
@@ -146782,32 +149006,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-uHd
-qYo
-uHd
-qYo
-fhW
-fhW
+pRa
+pRa
+pRa
+pRa
+xMh
+xOx
+jbc
+jbc
+jbc
+fiO
+wwO
+rqX
+phe
+jnF
+lTv
 cwa
+qEB
+lTv
 cwa
-cwa
-fhW
-fhW
-eHO
-eHO
-eHO
-eHO
-eHO
+yfU
+lTv
+kso
+ncn
+lTv
+qBA
+pMM
 gRU
 xAc
 mKL
@@ -147039,36 +149263,36 @@ aaa
 aaa
 aaa
 aaa
+aad
+aad
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-uHd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xga
+xOx
+jbc
+jbc
+xZL
+fiO
+lEf
+xfv
+vZh
+qKS
+lTv
+cvY
+jNH
+lTv
+aSf
+jNH
+lTv
 bCC
 jNH
-aqq
+lTv
 hhn
-oHS
+pMM
 swn
 aAA
 beK
-eHO
+pMM
 pzv
 blM
 hzG
@@ -147295,37 +149519,37 @@ aaa
 aaa
 aaa
 aaa
+aad
+aad
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-uHd
-qYo
-vVc
-vVc
-vVc
-qYo
-qYo
-aaa
-aaa
-bCC
-hhn
-qVf
-xsP
-iut
+xga
+jbc
+jbc
+jbc
+jbc
+fiO
+vyk
+mVa
+vZh
+mmV
+lTv
+iDH
+ufK
+lTv
+kcQ
+lRk
+lTv
+kcQ
+ufK
+lTv
+qBA
+pMM
 uuj
 mvn
 ufS
-eHO
+pMM
 gVV
 jrA
 qIH
@@ -147551,38 +149775,38 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-aaa
-aaa
+aac
+aad
 aaa
 aaa
 aaa
 aad
-aaa
-aaa
-bCC
+xga
+xga
+xga
+xMh
+xMh
+qWZ
+ufQ
+lKY
+ufQ
+fiO
+lTv
+lTv
 xFh
-lyd
+lTv
+lTv
+xFh
+lTv
+lTv
+xFh
+lTv
 iNn
-gbZ
+pMM
 jxg
 iGx
 nkn
-eHO
+pMM
 iSj
 mad
 vRS
@@ -147808,38 +150032,38 @@ aaa
 aaa
 aaa
 aaa
+aac
+aac
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-uHd
-uHd
-uHd
-qYo
-aFo
 aad
 aad
 aad
-eHO
-eHO
-eHO
-eHO
-eHO
-nKG
+aaa
+aaa
+aaa
+aad
+qWZ
+rLG
+lrQ
+rZC
+tzj
+qBA
+qBA
+qBA
+qBA
+qBA
+omr
+lTv
+eGX
+peV
+qZi
+qBA
+pMM
+rkZ
 gul
 rkZ
-eHO
+pMM
 ndO
 rGN
 lPd
@@ -148066,37 +150290,37 @@ aaa
 aaa
 aaa
 aaa
+aac
+aac
+aad
+aad
+aad
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-xTK
-xTK
-xTK
-aaa
-qYo
-qYo
-qYo
-aaa
-eHO
+aad
+aad
+qWZ
+ufQ
+qWZ
+ufQ
+qWZ
+mSe
+mSe
+mSe
+mSe
+mSe
+mSe
+mSe
+uCV
+qBA
+qBA
+xQZ
+pMM
 gPY
 pdF
 rQv
-eHO
+pMM
 gzp
 tfv
 gaM
@@ -148324,41 +150548,41 @@ aaa
 aaa
 aaa
 aaa
+aac
+aac
+aad
 aaa
 aaa
 aaa
+aad
+aad
+aaa
+aaa
+aad
+aaa
+aad
 aaa
 aaa
 aaa
+aad
 aaa
+aad
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qYo
-qYo
-xTK
-xTK
-xTK
-aaa
-eHO
-eHO
-eHO
-eHO
-eHO
+mSe
+xQk
+asi
+xus
+kUj
+pMM
+eJI
+lTe
+rlP
+pMM
 rkd
 cva
 rkd
 gJk
-qYo
+sbu
 xTK
 xTK
 xTK
@@ -148582,35 +150806,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-vVc
-vVc
-aaa
-aaa
-qYo
-qYo
-qYo
+aac
+aac
 aaa
 aaa
 aad
-gJk
+aad
+aaa
+aaa
+aac
+aac
+aac
+aac
+aac
+aaa
+aaa
+aac
+aac
+aac
+aaa
+mSe
+mSe
+mSe
+mSe
+mSe
+pMM
+juu
+hGp
+oEQ
+pMM
 lTm
 lTm
 quS
@@ -148840,39 +151064,39 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-vVc
-vVc
-vVc
-aaa
-xTK
+aac
+aac
 aad
-gJk
+aad
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aad
+aaa
+aaa
+aaa
+pMM
+uBn
+uBn
+uBn
+dHE
 rkd
 vWW
 rkd
 gJk
-qYo
+sbu
 qYo
 xTK
 xTK
@@ -149098,6 +151322,8 @@ aaa
 aaa
 aaa
 aaa
+aac
+aac
 aaa
 aaa
 aaa
@@ -149114,16 +151340,14 @@ aaa
 aaa
 aaa
 aaa
+aac
+aac
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-xTK
-aad
 gJk
 aaa
 xZM
@@ -149358,7 +151582,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wVj
 aaa
 aaa
 aaa
@@ -150144,7 +152368,7 @@ aaa
 aaa
 aaa
 aaa
-aab
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Re-adds @KathrinBailey 's delta permabrig previously obliterated by the access overhaul. Probably butchered it somewhere along the lines but I attempted to fix all the lingering access issues.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
The default brig of Delta station, as well as a few others, are not designed to cater towards Skyrat's permabrig prisoners.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog
Re-adds KathrinBailey's Delta Permabrig from the most recent version I could find.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jakkie Sergal
add: Re-adds KathrinBailey Delta Permabrig
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
