### PR TITLE
Bureaucratic error no longer closes job slots

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -12,6 +12,7 @@
 
 /datum/round_event/bureaucratic_error/start()
 	var/list/jobs = SSjob.joinable_occupations.Copy()
+	/*
 	if(prob(33)) // Only allows latejoining as a single role. Add latejoin AI bluespace pods for fun later.
 		var/datum/job/overflow = pick_n_take(jobs)
 		overflow.spawn_positions = -1
@@ -22,8 +23,9 @@
 				continue
 			current.total_positions = 0
 	else // Adds/removes a random amount of job slots from all jobs.
-		for(var/datum/job/current as anything in jobs)
-			if(!current.allow_bureaucratic_error)
-				continue
-			var/ran = rand(-2,4)
-			current.total_positions = max(current.total_positions + ran, 0)
+	*/ // SKYRAT EDIT REMOVAL - no more locking off jobs
+	for(var/datum/job/current as anything in jobs)
+		if(!current.allow_bureaucratic_error)
+			continue
+		var/ran = rand(1,4) // SKYRAT EDIT - no more locking off jobs
+		current.total_positions = max(current.total_positions + ran, 0)


### PR DESCRIPTION
## About The Pull Request

Closes https://github.com/Skyrat-SS13/Skyrat-tg/pull/14290
Stops the bureaucratic error from closing job slots, it now only opens new ones.

## How This Contributes To The Skyrat Roleplay Experience

Locking everyone out of joining the round is zzzzzz not fun
Punishes people OOCly for something nobody possibly has control over
Host request

## Changelog
:cl:
del: Bureaucratic error no longer closes job slots
/:cl: