### PR TITLE
Ashwalkers killing megafauna will always drop the crusher trophy

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -91,6 +91,13 @@
 	if(crusher_dmg && crusher_loot && crusher_dmg.total_damage >= maxHealth * 0.6)
 		spawn_crusher_loot()
 		crusher_kill = TRUE
+	//SKYRAT EDIT START
+	for(var/mob/living/carbon/human/maybe_ashie in range(7))
+		if(is_species(maybe_ashie, /datum/species/lizard/ashwalker))
+			to_chat(maybe_ashie, span_notice(span_bold("The Necropolis has blessed your kill, dropping its trophy!")))
+			spawn_crusher_loot()
+			break
+	//SKYRAT EDIT END
 	if(true_spawn && !(flags_1 & ADMIN_SPAWNED_1))
 		var/tab = "megafauna_kills"
 		if(crusher_kill)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -91,13 +91,6 @@
 	if(crusher_dmg && crusher_loot && crusher_dmg.total_damage >= maxHealth * 0.6)
 		spawn_crusher_loot()
 		crusher_kill = TRUE
-	//SKYRAT EDIT START
-	for(var/mob/living/carbon/human/maybe_ashie in range(7))
-		if(is_species(maybe_ashie, /datum/species/lizard/ashwalker))
-			to_chat(maybe_ashie, span_notice(span_bold("The Necropolis has blessed your kill, dropping its trophy!")))
-			spawn_crusher_loot()
-			break
-	//SKYRAT EDIT END
 	if(true_spawn && !(flags_1 & ADMIN_SPAWNED_1))
 		var/tab = "megafauna_kills"
 		if(crusher_kill)

--- a/modular_skyrat/modules/ashwalkers/code/megafauna/_megafauna.dm
+++ b/modular_skyrat/modules/ashwalkers/code/megafauna/_megafauna.dm
@@ -3,7 +3,7 @@
 	var/ashwalker_harmed = FALSE
 
 /mob/living/simple_animal/hostile/megafauna/attacked_by(obj/item/I, mob/living/user)
-	if(!ashwalker_harmed && is_species(maybe_ashie, /datum/species/lizard/ashwalker))
+	if(!ashwalker_harmed && is_species(user, /datum/species/lizard/ashwalker))
 		ashwalker_harmed = TRUE
 	return ..()
 

--- a/modular_skyrat/modules/ashwalkers/code/megafauna/_megafauna.dm
+++ b/modular_skyrat/modules/ashwalkers/code/megafauna/_megafauna.dm
@@ -1,0 +1,13 @@
+/mob/living/simple_animal/hostile/megafauna
+	/// Has this been harmed by an ashwalker at least once?
+	var/ashwalker_harmed = FALSE
+
+/mob/living/simple_animal/hostile/megafauna/attacked_by(obj/item/I, mob/living/user)
+	if(!ashwalker_harmed && is_species(maybe_ashie, /datum/species/lizard/ashwalker))
+		ashwalker_harmed = TRUE
+	return ..()
+
+/mob/living/simple_animal/hostile/megafauna/death(gibbed, list/force_grant)
+	if(ashwalker_harmed)
+		spawn_crusher_loot()
+	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If there is an ashwalker in the presence of a mega when it dies, it will drop the crusher trophy, regardless of if a crusher was involved or not.

## How This Contributes To The Skyrat Roleplay Experience
Jake was planning a ritual thingy for ashwalkers, and I wanted to add some really rare components, so crusher trophies seemed to fit well. Also, if you're killing megas as an ashie, you probably put more effort in than a crusher miner
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Megafauna will always drop their crusher trophy when killed by ashwalkers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
