### PR TITLE
[NON-MODULAR] Progtot value tweaks (fewer TC, lower final objective costs.)

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -233,7 +233,7 @@ GLOBAL_LIST_INIT(ai_employers, list(
 // Progression traitor defines
 
 /// How many telecrystals a normal traitor starts with
-#define TELECRYSTALS_DEFAULT 35 //SKYRAT EDIT CHANGE
+#define TELECRYSTALS_DEFAULT 20
 /// How many telecrystals mapper/admin only "precharged" uplink implant
 #define TELECRYSTALS_PRELOADED_IMPLANT 10
 /// The normal cost of an uplink implant; used for calcuating how many

--- a/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
@@ -12,7 +12,7 @@
 	abstract_type = /datum/traitor_objective/final
 	progression_minimum = 140 MINUTES
 
-	var/progression_points_in_objectives = 75 MINUTES //skyrat edit: original value 20 MINUTES
+	var/progression_points_in_objectives = 60 MINUTES //skyrat edit: original value 20 MINUTES
 
 /// Determines if this final objective can be taken. Should be put into every final objective's generate function.
 /datum/traitor_objective/final/proc/can_take_final_objective()

--- a/code/modules/uplink/uplink_devices.dm
+++ b/code/modules/uplink/uplink_devices.dm
@@ -24,8 +24,7 @@
 	/// See [`code/__DEFINES/uplink.dm`]
 	var/uplink_flag = UPLINK_TRAITORS
 
-///obj/item/uplink/Initialize(mapload, owner, tc_amount = 20) //ORIGINAL
-/obj/item/uplink/Initialize(mapload, owner, tc_amount = 35) //SKYRAT EDIT CHANGE
+/obj/item/uplink/Initialize(mapload, owner, tc_amount = 20)
 	. = ..()
 	AddComponent(/datum/component/uplink, owner, FALSE, TRUE, uplink_flag, tc_amount)
 


### PR DESCRIPTION
## About The Pull Request

Reduces progtot starting tc to 20 (/tg/ baseline) and reduces the completed objective cost of unlocking final objectives again. 

## How This Contributes To The Skyrat Roleplay Experience

Because our rounds are long enough that the time constraint from passive rep gain doesn't meaningfully limit the power spikes offered by our broader gear availability, this PR reduces the starting TC for traitors to a level originally balanced for /tg/ - 20TC. 

You should actually have to do things to unlock the dominant gear and gear combinations made available to traitors here. Having combos like three implants + CQC available from the starting gun has meant them showing up in many if not most loadouts even for traitors who do very little towards their objectives. What this means is that when they do something, pursuing their objectives or not, traitors on SR spike to a power-level rendered flatout unattainable to progression traitors on /tg/ - and often only act at a point in the round where dynamic has had time to introduce other significant threats already. 

In the presence of spicier dynamic with more alternative antagonists (and hopefully more heavy rulesets as time goes on,) traitors don't need to start with 35 TC - there are plans on /tg/ to move dynamic numbers towards more midround traitors anyway (https://github.com/tgstation/tgstation/pull/67823). If somebody rolling traitor needs access to gear to do something uniquely cool while not first doing other lower-bore progtot things (using other, more novel, lower-bore progtot gear combinations,) it can probably be justified with an OpFor (instead of requiring an opfor for all uplink access as suggested in other PRs - reducing relative admin overhead.) 

This PR also lowers the final objective cost in completed objective rep once again (75->60.) 
#14189 has reduced an issue present on /tg/ where, with shorter round-times, the high requirements and diminishing returns for objectives meant final objectives were often soft-locked even for very successful progression traitors. 

Our round times are not nearly so short, and we don't necessarily want them to be. However, we should want progtots to be able to have some meaningful impact on the round in the course of doing their objectives. The ones that really do this are final objectives. Even initially lowering the cost for final objectives has only meant a very rare handful of people have gotten access to them. This takes it a bit further. This change still requires that a traitor be largely active and successful throughout a round to unlock a final objective. All final objectives have a leadup to their spawning and some way of telegraphing threat when they're set off. 

While still keeping the rep cost higher than /tg/ - reducing it a bit further should help compensate for the reduction in TC traitors get here by giving them an earlier 'in' to pursuing an ultimate end goal that gets everybody involved. This in my mind is much preferable and more engaging than having them go around hitting the fifth head office of the day at two hours into the round; getting a final objective to begin with is also more likely to be a genuine challenge in the absence of 15 TC of extra gear's advantage for them starting off. 

## Changelog

:cl:
balance: Traitors no longer get 35 TC starting in their uplinks; instead, traitors start with the regular 20TC. 
balance: Final objectives can now appear after completing 60 rep worth of objectives (and having a total of 140 rep.)
/:cl:
