### PR TITLE
Stops mismatching markings from showing up on the dropdowns without "allow mismatched parts" on

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/middleware/limbs_and_markings.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/middleware/limbs_and_markings.dm
@@ -193,6 +193,8 @@
 
 /datum/preference_middleware/limbs_and_markings/get_ui_data(mob/user)
 	var/list/data = list()
+	var/datum/species/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	var/allow_mismatched_parts = preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts)
 	if(!robotic_styles)
 		robotic_styles = list()
 		for(var/style_name in GLOB.robotic_styles_list)
@@ -219,6 +221,12 @@
 			chosen_augment = nice_aug_names[limb][preferences.augments[limbs_to_process[limb]]]
 		else
 			chosen_augment = "None"
+		var/list/choices = GLOB.body_markings_per_limb[limb].Copy()
+		if (!allow_mismatched_parts)
+			for (var/name in choices)
+				var/datum/body_marking/marking = choices[name]
+				if (marking.recommended_species && !(initial(species_type.id) in marking.recommended_species))
+					choices -= name
 		limbs_data += list(list(
 			"slot" = limb,
 			"name" = limbs_to_process[limb],
@@ -228,7 +236,7 @@
 			"aug_choices" = nice_aug_names[limb],
 			"costs" = costs[AUGMENT_CATEGORY_LIMBS],
 			"markings" = list(
-				"marking_choices" = GLOB.body_markings_per_limb[limb],
+				"marking_choices" = choices,
 				"markings_list" = fix_colors_on_markings_to_tgui(preferences.body_markings[limb], limb)
 			),
 		))
@@ -267,10 +275,9 @@
 	data["organs_data"] = organs_data
 
 	var/list/presets = GLOB.body_marking_sets.Copy()
-	if (!preferences.read_preference(/datum/preference/toggle/allow_mismatched_parts))
+	if (!allow_mismatched_parts)
 		for (var/name in presets)
 			var/datum/body_marking_set/BMS = presets[name]
-			var/datum/species/species_type = preferences.read_preference(/datum/preference/choiced/species)
 			if (BMS.recommended_species && !(initial(species_type.id) in BMS.recommended_species))
 				presets -= name
 


### PR DESCRIPTION
## About The Pull Request
Ok, it seems the `recommended_species` variable for markings hasn't been put to use on the tgui menu unlike the homonymous var for presets. This should fix that oversight.

## How This Contributes To The Skyrat Roleplay Experience
Having your lists filled with potentially bad picks isn't a good thing and it deters people from character customization.

## Changelog

:cl:
fix: Stopped mismatching markings from showing up on the dropdowns without "allow mismatched parts" on.
/:cl:
