### PR TITLE
[MODULAR] Removes the STG (from guncargo)

### DIFF
--- a/modular_skyrat/modules/gun_cargo/code/armament_datums/armadyne_oldarms.dm
+++ b/modular_skyrat/modules/gun_cargo/code/armament_datums/armadyne_oldarms.dm
@@ -50,8 +50,3 @@
 	item_type = /obj/item/gun/ballistic/automatic/vintorez
 	lower_cost = CARGO_CRATE_VALUE * 12
 	upper_cost = CARGO_CRATE_VALUE * 18
-
-/datum/armament_entry/cargo_gun/oldarms/rifle/stg
-	item_type = /obj/item/gun/ballistic/automatic/stg
-	lower_cost = CARGO_CRATE_VALUE * 24
-	upper_cost = CARGO_CRATE_VALUE * 28


### PR DESCRIPTION


## About The Pull Request

What it says on the tin, removes the STG from guncargo, because, it's functionally just a better version of both the Vintorez and the MK-11, without any of their downsides.

## How This Contributes To The Skyrat Roleplay Experience

We all know what it has done to our people.

## Changelog


:cl:
del: The STG has been banished from guncargo, back into the void it came from.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
