### PR TITLE
Fixes drifting contractor greentext

### DIFF
--- a/modular_skyrat/modules/contractor/code/datums/midround/antag_datum.dm
+++ b/modular_skyrat/modules/contractor/code/datums/midround/antag_datum.dm
@@ -25,7 +25,9 @@
 	equip_guy()
 
 /datum/antagonist/contractor/proc/forge_objectives()
-	objectives += new/datum/objective/contractor_total
+	var/datum/objective/contractor_total/contract_objectives = new
+	contract_objectives.owner = owner
+	objectives += contract_objectives
 
 /datum/antagonist/contractor/roundend_report()
 	var/list/report = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Their owner never got assigned

## How This Contributes To The Skyrat Roleplay Experience
Muh greentext

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Drifting Contractor now can greentext again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
