### PR TITLE
Blueshift hydroponics fixes

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -4198,9 +4198,6 @@
 /area/station/common/wrestling/arena)
 "aVs" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Hydroponics"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -4212,6 +4209,9 @@
 	},
 /obj/effect/landmark/navigate_destination,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/door/airlock/hydroponics/glass{
+	name = "Hydroponics"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "aVu" = (
@@ -34819,9 +34819,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "liK" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Hydroponics"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -34831,6 +34828,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/door/airlock/hydroponics{
+	name = "Hydroponics Backroom"
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "liM" = (
@@ -45339,7 +45339,7 @@
 /obj/machinery/door/window/left{
 	dir = 4;
 	name = "Hydroponics Desk";
-	req_access = list("hydroponics","kitchen")
+	req_access = list("hydroponics")
 	},
 /obj/item/folder,
 /obj/item/food/grown/apple,
@@ -52684,9 +52684,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "rod" = (
-/obj/machinery/door/airlock{
-	name = "Hydroponics Test Lab"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -52702,6 +52699,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/door/airlock/hydroponics{
+	name = "Hydroponics Test Lab"
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/upper)
 "ror" = (
@@ -64290,16 +64290,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "vlG" = (
-/obj/machinery/door/airlock{
-	name = "Hydroponics Backroom"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Hydroponics"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/door/airlock/hydroponics{
+	name = "Hydroponics Backroom"
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "vlI" = (
@@ -73773,10 +73770,10 @@
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "yjg" = (
-/obj/item/circuitboard/machine/chem_dispenser/mutagensaltpeter,
 /obj/structure/closet/crate/engineering{
 	name = "Prototype Botanical Plant Nutrient Dispenser"
 	},
+/obj/item/circuitboard/machine/chem_dispenser,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "yjw" = (

--- a/_maps/map_files/Blueshift/BlueShift_middle.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_middle.dmm
@@ -34946,7 +34946,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "llQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden)
 "llU" = (
@@ -48447,7 +48447,7 @@
 	name = "Test Blast Shutters"
 	},
 /obj/machinery/door/airlock/highsecurity{
-	name = "Botany Test Chamber"
+	name = "Hydroponics Test Chamber"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron/dark,
@@ -63450,12 +63450,10 @@
 /area/station/security/warden)
 "uWm" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/vending/hydroseeds{
-	slogan_delay = 700
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/vending/hydroseeds,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},


### PR DESCRIPTION
## About The Pull Request

- Fixes windoor access
- Fixes duplicate door
- Replaces doors with hydroponics-styled ones
- Makes some door names more accurate
- Replaces the botanical chem dispenser in maints behind hydro with a regular one. The botanical one is not really intended for actual gameplay - it not only is kind of overpowered, giving you mostly any chem you could want for botany at the press of a button no actual work required, but it also is not deconstructable. This means you can't even open the panel. So you can't even move it. Once it's built, it's  in that spot forever, no way to deconstruct or otherwise move it. Which is kinda jank.
- replaced most interior rwindows with regular ones, except the test chamber ones
- un-var-edited the seed vendor to have a unique slogan delay (why did it have this??)

## How This Contributes To The Skyrat Roleplay Experience

fixes uhhhhhhhh good

## Changelog
:cl:
fix: Various access/airlock related fixes for Blueshift hydroponics.
fix: The chem dispenser board in maintenance behind Blueshift hydroponics has been replaced with a more functional one.
/:cl: