### PR TITLE
Fixes lone infiltrator, makes it a light ruleset

### DIFF
--- a/modular_skyrat/modules/Midroundtraitor/code/event.dm
+++ b/modular_skyrat/modules/Midroundtraitor/code/event.dm
@@ -1,11 +1,27 @@
 /datum/dynamic_ruleset/midround/from_ghosts/lone_infiltrator
 	name = "Lone Infiltrator"
 	antag_datum = /datum/antagonist/traitor/infiltrator
-	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
-	antag_flag = ROLE_LONE_INFILTRATOR
-	restricted_roles = list(JOB_CYBORG, JOB_AI, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_DETECTIVE, JOB_HEAD_OF_SECURITY, JOB_CAPTAIN, JOB_CORRECTIONS_OFFICER, JOB_VANGUARD_OPERATIVE, JOB_NT_REP, JOB_BLUESHIELD, JOB_ORDERLY, JOB_BOUNCER, JOB_CUSTOMS_AGENT, JOB_ENGINEERING_GUARD, JOB_SCIENCE_GUARD) //SKYRAT EDIT - Sec_haul
+	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
+	antag_flag = ROLE_TRAITOR // It's basically this anyway
+	restricted_roles = list(JOB_CYBORG,
+							JOB_AI,
+							JOB_SECURITY_OFFICER,
+							JOB_WARDEN,
+							JOB_DETECTIVE,
+							JOB_HEAD_OF_SECURITY,
+							JOB_CAPTAIN,
+							JOB_CORRECTIONS_OFFICER,
+							JOB_VANGUARD_OPERATIVE,
+							JOB_NT_REP,
+							JOB_BLUESHIELD,
+							JOB_ORDERLY,
+							JOB_BOUNCER,
+							JOB_CUSTOMS_AGENT,
+							JOB_ENGINEERING_GUARD,
+							JOB_SCIENCE_GUARD,
+							)
 	required_candidates = 1
-	weight = 5 //Slightly less common than normal midround traitors.
+	weight = 4 //Slightly less common than normal midround traitors.
 	cost = 15 //But also slightly more costly.
 	requirements = list(50,40,30,20,10,10,10,10,10,10)
 	var/list/spawn_locs = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This never actually ran, I think? The pref was never given

Its had its weight reduced to a more reasonable 4 (from 5) and moved to a light ruleset instead of a heavy, since this is effectively a traitor+, not worth a heavy roll.

## How This Contributes To The Skyrat Roleplay Experience
Bugs bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Lone Infiltrator should now run and is a light ruleset, with slightly reduced weight
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
