### PR TITLE
Catnip adjustments

### DIFF
--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -13,7 +13,7 @@
 	growthstages = 5
 	icon_dead = "tea-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/tea/astra)
+	mutatelist = list(/obj/item/seeds/tea/astra, /obj/item/seeds/tea/catnip) // SKYRAT EDIT ADD
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/toxin/teapowder = 0.1)
 
 /obj/item/food/grown/tea

--- a/modular_skyrat/modules/customization/modules/hydroponics/grown/tea_coffee.dm
+++ b/modular_skyrat/modules/customization/modules/hydroponics/grown/tea_coffee.dm
@@ -11,7 +11,7 @@
 	plantname = "Catnip Plant"
 	growthstages = 3
 	product = /obj/item/food/grown/tea/catnip
-	reagents_add = list(/datum/reagent/pax/catnip = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.06, /datum/reagent/toxin/teapowder = 0.3)
+	reagents_add = list(/datum/reagent/pax/catnip = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.05)
 	rarity = 50
 
 /obj/item/food/grown/tea/catnip
@@ -22,4 +22,3 @@
 	filling_color = "#4582B4"
 	grind_results = list(/datum/reagent/pax/catnip = 2, /datum/reagent/water = 1)
 	distill_reagent = /datum/reagent/consumable/pinkmilk //Don't ask, cats speak in poptart
-

--- a/modular_skyrat/modules/customization/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/modular_skyrat/modules/customization/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -41,6 +41,7 @@
 	if(C.mob_biotypes & MOB_ROBOTIC)
 		C.nutrition = min(C.nutrition + 5, NUTRITION_LEVEL_FULL-1)
 	..()
+
 // Catnip
 /datum/reagent/pax/catnip
 	name = "Catnip"
@@ -48,12 +49,16 @@
 	description = "A colourless liquid that makes people more peaceful and felines happier."
 	metabolization_rate = 1.75 * REAGENTS_METABOLISM
 
-/datum/reagent/pax/catnip/on_mob_life(mob/living/carbon/M)
-	if(isfelinid(M) || istajaran(M))
-		if(prob(20))
-			M.emote("nya")
-		if(prob(20))
-			to_chat(M, span_notice("[pick("Headpats feel nice.", "Backrubs would be nice.", "Mew")]"))
-	else
-		to_chat(M, span_notice("[pick("I feel oddly calm.", "I feel relaxed.", "Mew?")]"))
+/datum/mood_event/catnip
+	description = span_nicegreen("That plant has left me feeling great!\n")
+	mood_change = 1
+	timeout = 4 MINUTES
+
+/datum/reagent/pax/catnip/on_mob_metabolize(mob/living/affected_mob)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_ADD_MOOD_EVENT, "catnip", /datum/mood_event/catnip)
+
+/datum/reagent/pax/catnip/on_mob_life(mob/living/carbon/affected_carbon)
+	if(prob(10))
+		affected_carbon.emote(pick("nya", "meow"))
 	..()

--- a/modular_skyrat/modules/modular_vending/code/megaseed.dm
+++ b/modular_skyrat/modules/modular_vending/code/megaseed.dm
@@ -1,7 +1,6 @@
 /obj/machinery/vending/hydroseeds //sneed
-	skyrat_products = list(
+	skyrat_contraband = list(
 		/obj/item/seeds/cocaleaf = 3,
 		/obj/item/seeds/poppy/opiumpoppy = 3,
-		/obj/item/seeds/tea/catnip = 3,
 		/obj/item/seeds/banana/spider_banana = 1,
 	)


### PR DESCRIPTION
## About The Pull Request

- Removes catnip from the seed vendor and to a tea mutation
- Removes the tea powder, as it did toxin damage and didn't really make all too much sense to have anyway
- Very slightly reduces the amount of nutriment
- Removes the slightly random chat messages from on process and gives a small mood boost instead
- Moves some seed vendor items to contraband, they were before but it got adjusted incorrectly
- [ ] make it give drugginess to felinids/tajarans/feline traits

## How This Contributes To The Skyrat Roleplay Experience

It's good to have catnip slightly harder to get, but slightly better once you have it. It should be a somewhat rarer thing IMO.

## Changelog
:cl:
balance: Catnip no longer does toxin damage and gives a mood boost
del: Catnip is no longer in the botany vendor, instead being a mutation of tea
fix: Modular seed vendor contraband is once again contraband
/:cl: