### PR TITLE
Wild West Meat Grinder is now guaranteed to kill you

### DIFF
--- a/code/modules/awaymissions/mission_code/wildwest.dm
+++ b/code/modules/awaymissions/mission_code/wildwest.dm
@@ -124,7 +124,7 @@
 	anchored = TRUE
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blobpod"
-	var/triggered = 0
+	var/triggered = FALSE
 
 /obj/effect/meatgrinder/Initialize(mapload)
 	. = ..()
@@ -138,21 +138,21 @@
 	Bumped(AM)
 
 /obj/effect/meatgrinder/Bumped(atom/movable/AM)
-
 	if(triggered)
 		return
 	if(!ishuman(AM))
+		to_chat(AM, span_notice("You feel as if you aren't valid sacrifice..."))
 		return
 
-	var/mob/living/carbon/human/M = AM
+	var/mob/living/carbon/human/human_atom = AM
 
-	if(M.stat != DEAD && M.ckey)
-		visible_message(span_warning("[M] triggered [src]!"))
-		triggered = 1
-
-		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
+	if(human_atom.stat != DEAD && human_atom.ckey && human_atom.client)
+		visible_message(span_warning("[human_atom] triggers [src], vaporizing them instantly as it explodes!"))
+		triggered = TRUE
+		human_atom.dust(just_ash = TRUE, drop_items = FALSE, force = TRUE)
+		var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
+		sparks.set_up(3, 1, src)
+		sparks.start()
 		explosion(src, devastation_range = 1, explosion_cause = src)
 		qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This thing used to just explode you (read: deals like... 35 brute, which is nothing), which doesn't always kill. Now it explodes *and* dusts you

## How This Contributes To The Skyrat Roleplay Experience
This thing blocks a literal immortality granter and the whole point is that it needs to be uncheesable, to require the RR of someone to get immorality for someone else

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Wild West's meat grinder now dusts the first person to touch it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
