### PR TITLE
[MODULAR] Fix Blueshift capacitor banks not actually being linked

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_lower.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_lower.dmm
@@ -2535,11 +2535,6 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
-"bOL" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/engineering/power_room)
 "bOU" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -12946,7 +12941,6 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Ship Capacitor Banks"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/dark,
 /area/station/engineering/power_room)
@@ -13728,7 +13722,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/evac_maintenance)
 "kWQ" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -15416,8 +15409,12 @@
 	},
 /area/station/engineering/atmos)
 "mpz" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/cable/layer1,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/engineering/power_room)
 "mpG" = (
 /obj/effect/turf_decal/delivery,
@@ -21023,6 +21020,7 @@
 "qCr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/power_room)
 "qCM" = (
@@ -22467,7 +22465,6 @@
 /turf/open/floor/engine/vacuum,
 /area/station/maintenance/disposal/incinerator)
 "rSo" = (
-/obj/structure/cable,
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering - Capacitor banks";
 	name = "engineering camera"
@@ -57323,7 +57320,7 @@ uEa
 ipb
 gZo
 kbY
-iPj
+mpz
 hOV
 uRX
 hOV
@@ -57586,8 +57583,8 @@ wck
 vNL
 vNL
 wck
-bOL
-bOL
+oeC
+oeC
 siE
 lUf
 rYU
@@ -58101,7 +58098,7 @@ tEd
 tEd
 lpJ
 oeC
-bOL
+oeC
 nON
 cui
 uEa
@@ -58357,8 +58354,8 @@ dld
 rCB
 dld
 rSo
-mpz
-mpz
+jsS
+jsS
 krh
 rYU
 rYU

--- a/_maps/map_files/Blueshift/BlueShift_lower.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_lower.dmm
@@ -1833,10 +1833,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"bsT" = (
-/obj/structure/cable/multilayer/connected,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engineering/atmos/port_maint)
 "bsZ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -2994,13 +2990,13 @@
 /obj/effect/turf_decal/stripes{
 	dir = 10
 	},
-/obj/structure/cable/layer1,
 /obj/machinery/power/smes{
 	capacity = 9e+006;
 	charge = 9e+006;
 	input_level = 0;
 	output_level = 25000
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/power_room)
 "ceU" = (
@@ -4499,7 +4495,6 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/power_room)
@@ -6909,12 +6904,6 @@
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"fmO" = (
-/obj/structure/cable/layer1,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/power_room)
 "fmP" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -7383,7 +7372,6 @@
 "fLL" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/layer1,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/power_room)
@@ -9862,7 +9850,6 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/power_room)
 "hPg" = (
@@ -10238,7 +10225,7 @@
 	input_level = 0;
 	output_level = 10000
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/power_room)
 "ifX" = (
@@ -11101,13 +11088,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"iPj" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/cable/layer1,
-/turf/open/floor/iron,
-/area/station/engineering/power_room)
 "iPk" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/bot,
@@ -11532,9 +11512,9 @@
 /area/station/maintenance/evac_maintenance)
 "jgu" = (
 /obj/structure/railing,
-/obj/structure/cable/layer1,
 /obj/structure/rack/shelf,
 /obj/effect/spawner/random/engineering/tool,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/power_room)
 "jgJ" = (
@@ -11837,7 +11817,6 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Ship Capacitor Banks"
 	},
-/obj/structure/cable/layer1,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
@@ -13030,13 +13009,13 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
-/obj/structure/cable/layer1,
 /obj/machinery/power/smes{
 	capacity = 9e+006;
 	charge = 9e+006;
 	input_level = 0;
 	output_level = 40000
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/power_room)
 "kuR" = (
@@ -15412,8 +15391,6 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/structure/cable/layer1,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/power_room)
 "mpG" = (
@@ -16064,13 +16041,13 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/structure/cable/layer1,
 /obj/machinery/power/smes{
 	capacity = 9e+006;
 	charge = 9e+006;
 	input_level = 0;
 	output_level = 40000
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/power_room)
 "mOM" = (
@@ -17910,11 +17887,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
-"odd" = (
-/obj/structure/cable/layer1,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engineering/atmos/port_maint)
 "odq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18427,7 +18399,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "oxH" = (
-/obj/structure/cable/layer1,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/power_room)
@@ -20969,12 +20941,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
-"qzt" = (
-/obj/structure/cable/layer1,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/power_room)
 "qzB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -22108,7 +22074,6 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/power_room)
 "rCD" = (
@@ -22286,7 +22251,6 @@
 /area/station/maintenance/department/engineering/atmos/port_maint)
 "rHF" = (
 /obj/structure/railing,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/power_room)
 "rHV" = (
@@ -24052,7 +24016,7 @@
 	input_level = 0;
 	output_level = 10000
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/power_room)
 "tjW" = (
@@ -24818,7 +24782,6 @@
 /area/station/security/prison/safe)
 "tUg" = (
 /obj/structure/railing/corner,
-/obj/structure/cable/layer1,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/power_room)
@@ -25039,13 +25002,13 @@
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
-/obj/structure/cable/layer1,
 /obj/machinery/power/smes{
 	capacity = 9e+006;
 	charge = 9e+006;
 	input_level = 0;
 	output_level = 25000
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/power_room)
 "uec" = (
@@ -25882,7 +25845,6 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/power_room)
@@ -27449,7 +27411,6 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/power_room)
@@ -27851,7 +27812,6 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/power_room)
 "wcm" = (
@@ -58091,7 +58051,7 @@ uFn
 kiG
 siE
 fLL
-iPj
+mpz
 tEd
 tEd
 tEd
@@ -58344,11 +58304,11 @@ piG
 lce
 xrt
 xeq
-bsT
-odd
+xeq
+xeq
 jvI
-fmO
-qCr
+kbY
+oxH
 rCB
 dld
 rCB
@@ -58604,8 +58564,8 @@ wFG
 xrt
 xrt
 siE
-qzt
-oxH
+qCr
+kbY
 tjK
 tjK
 ifB


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
These seem as if they're intended to be the roundstart power buffer... except they aren't linked to the main powernet at all!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Having roundstart power last longer than 10 minutes is nice, mm?
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Blushift's roundstart power capacitors are now actually linked, actually giving engineering time to setup the SM before blackouts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
