### PR TITLE
Sec webbing reskins disable but working this time

### DIFF
--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -109,6 +109,13 @@
 /obj/item/storage/belt/security/webbing
 	uses_advanced_reskins = FALSE
 	unique_reskin = NONE
+	current_skin = "securitywebbing" //Prevents reskinning
+
+/obj/item/storage/belt/security/webbing/peacekeeper //did I mention this codebase is fucking awful
+	current_skin = "peacekeeper_webbing"
+
+/obj/item/storage/belt/security/webbing/peacekeeper/armadyne
+	current_skin = "armadyne_webbing"
 
 ///Enables you to quickdraw weapons from security holsters
 /datum/component/storage/concrete/security/open_storage(mob/user)

--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -108,6 +108,7 @@
 
 /obj/item/storage/belt/security/webbing
 	uses_advanced_reskins = FALSE
+	unique_reskin = NONE
 
 ///Enables you to quickdraw weapons from security holsters
 /datum/component/storage/concrete/security/open_storage(mob/user)


### PR DESCRIPTION
## About The Pull Request
fixes my fix that makes webbings show the secbelt reskins when alt clicked
it's absolute shitcode but garbage in garbage  out I guess

## How This Contributes To The Skyrat Roleplay Experience
I can alt click my webbing again without a fucking radial I don't want

## Changelog
covered in another changelog that was supposed to actually fix it