### PR TITLE
Fixes heels not being properly subtyped

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_shoes.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_shoes.dm
@@ -171,7 +171,7 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 
 /datum/loadout_item/shoes/dominaheels
 	name = "Dominant Heels"
-	item_path = /obj/item/clothing/shoes/dominaheels
+	item_path = /obj/item/clothing/shoes/latex_heels/domina_heels
 
 /datum/loadout_item/shoes/griffin
 	name = "Griffon Boots"

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/erp_belt.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/erp_belt.dm
@@ -74,8 +74,8 @@
 
 						//legs
 						/obj/item/clothing/shoes/latex_socks,
-						/obj/item/clothing/shoes/latexheels,
-						/obj/item/clothing/shoes/dominaheels,
+						/obj/item/clothing/shoes/latex_heels,
+						/obj/item/clothing/shoes/latex_heels/domina_heels,
 
 						//belt
 						/obj/item/clothing/strapon,

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/lewd_shoes.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/lewd_shoes.dm
@@ -1,5 +1,5 @@
 //heels item
-/obj/item/clothing/shoes/latexheels
+/obj/item/clothing/shoes/latex_heels
 	name = "latex heels"
 	desc = "Lace up before use. It's pretty difficult to walk in these."
 	icon_state = "latexheels"
@@ -13,11 +13,11 @@
 	worn_icon_taur_snake = 'modular_skyrat/modules/modular_items/lewd_items/icons/obj/lewd_clothing/lewd_shoes.dmi'
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION|STYLE_TAUR_ALL
 
-/obj/item/clothing/shoes/latexheels/Initialize()
+/obj/item/clothing/shoes/latex_heels/Initialize()
 	. = ..()
 	AddComponent(/datum/component/squeak, list('modular_skyrat/modules/modular_items/lewd_items/sounds/highheel1.ogg' = 1, 'modular_skyrat/modules/modular_items/lewd_items/sounds/highheel2.ogg' = 1), 70)
 
-/obj/item/clothing/shoes/latexheels/dominaheels
+/obj/item/clothing/shoes/latex_heels/dominaheels
 	name = "dominant heels"
 	desc = "A pair of aesthetically pleasing heels."
 	icon_state = "dominaheels"

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_remove_erp_items.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_remove_erp_items.dm
@@ -68,7 +68,7 @@
 	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
 
-/obj/item/clothing/shoes/dominaheels/Initialize()
+/obj/item/clothing/shoes/latex_heels/domina_heels/Initialize()
 	. = ..()
 	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/lustwish.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_structures/lustwish.dm
@@ -82,8 +82,8 @@
 
 					//legs
 					/obj/item/clothing/shoes/latex_socks = 8,
-					/obj/item/clothing/shoes/latexheels = 4,
-					/obj/item/clothing/shoes/dominaheels = 4,
+					/obj/item/clothing/shoes/latex_heels = 4,
+					/obj/item/clothing/shoes/latex_heels/domina_heels = 4,
 					/obj/item/clothing/shoes/jackboots/knee = 3,
 
 					//belt


### PR DESCRIPTION
## About The Pull Request
It took me longer to get on a new branch and to commit than it took me to fix this. C'mon Goof.

## How This Contributes To The Skyrat Roleplay Experience
The domina heels now behave like they were meant to.

## Changelog

:cl: GoldenAlpharex
fix: All heels now behave as intended, and no longer give out error sprites.
/:cl: