### PR TITLE
[Non-Modular] Nekomimetic Change

### DIFF
--- a/code/modules/language/nekomimetic.dm
+++ b/code/modules/language/nekomimetic.dm
@@ -1,8 +1,11 @@
 /datum/language/nekomimetic
 	name = "Nekomimetic"
-	desc = "To the casual observer, this langauge is an incomprehensible mess of broken Japanese. To the felinids, it's somehow comprehensible."
+	//ORIGINAL: desc = "To the casual observer, this langauge is an incomprehensible mess of broken Japanese. To the felinids, it's somehow comprehensible."
+	desc = "Cat vocalizations, categorized by their acoustic qualities, are quite complicated; both linguistically and emotionally. While this mess of an array of sounds may come off as utter nonsense to outsiders, to felines, it's quite comprehensible."
 	key = "f"
 	space_chance = 70
+	//ORIGINAL:
+	/*
 	syllables = list(
 		"neko", "nyan", "mimi", "moe", "mofu", "fuwa", "kyaa", "kawaii", "poka", "munya",
 		"puni", "munyu", "ufufu", "uhuhu", "icha", "doki", "kyun", "kusu", "nya", "nyaa",
@@ -10,5 +13,13 @@
 		"sou", "baka", "chan", "san", "kun", "mahou", "yatta", "suki", "usagi", "domo", "ori",
 		"uwa", "zaazaa", "shiku", "puru", "ira", "heto", "etto"
 	)
+	*/
+	//SKYRAT EDIT BEGIN: Less Meme Nekomimetic
+    syllables = list("mao", "cht", "skr", "mew", "maw", "sss", "hss", "mouw", "reow", "meow", "krr", "cht-cht",
+        "nya", "chrp", "chipt", "baou", "reeaow", "aaahou", "mrp", "mrrp", "ragh", "mro", "mra", "mrro", "mrra",
+        "kra", "mi", "chur", "eech", "ara", "ch", "chrp", "tr", "trll", "chrr", "kit", "nnaeu", "yoa", "nny",
+		"turr", "uuou", "merr", "ynn", "orrd", "ssu"
+	)
+	//SKYRAT EDIT END
 	icon_state = "neko"
 	default_priority = 90

--- a/code/modules/language/nekomimetic.dm
+++ b/code/modules/language/nekomimetic.dm
@@ -15,9 +15,9 @@
 	)
 	*/
 	//SKYRAT EDIT BEGIN: Less Meme Nekomimetic
-    syllables = list("mao", "cht", "skr", "mew", "maw", "sss", "hss", "mouw", "reow", "meow", "krr", "cht-cht",
-        "nya", "chrp", "chipt", "baou", "reeaow", "aaahou", "mrp", "mrrp", "ragh", "mro", "mra", "mrro", "mrra",
-        "kra", "mi", "chur", "eech", "ara", "ch", "chrp", "tr", "trll", "chrr", "kit", "nnaeu", "yoa", "nny",
+	syllables = list("mao", "cht", "skr", "mew", "maw", "sss", "hss", "mouw", "reow", "meow", "krr", "cht-cht",
+		"nya", "chrp", "chipt", "baou", "reeaow", "aaahou", "mrp", "mrrp", "ragh", "mro", "mra", "mrro", "mrra",
+		"kra", "mi", "chur", "eech", "ara", "ch", "chrp", "tr", "trll", "chrr", "kit", "nnaeu", "yoa", "nny",
 		"turr", "uuou", "merr", "ynn", "orrd", "ssu"
 	)
 	//SKYRAT EDIT END


### PR DESCRIPTION
## About The Pull Request
To make the language less of a meme, I've replaced the syllables in there with ones that aren't weebspeak. Instead, cat sounds.
![image](https://user-images.githubusercontent.com/12636964/176069230-11051078-df63-48d2-9271-35d6ad1db9e6.png)
As you can see this is moderately painful to read so I'm instadrafting this so I can get a better syllable list together.

## How This Contributes To The Skyrat Roleplay Experience
1) it's a language entirely designed around being funny rather than being immersive
2) it has made 100x less sense ever since we added Yangyu because it means that speakers of actual real Japanese cannot understand speakers of 'about 14 japanese words and all of them are anime shit'.
3) it is straining at the immersion to have people say stuff like 'she has a nekomimetic accent' or 'when he signs in nekomimetic' considering it is, again, abt 14 japanese words and they're all weeb buzzwords.
4) this has wider applicability for feline species at large.

## Changelog
:cl:
add: Nekomimetic has been replaced with actual cat sounds.
/:cl:
