### PR TITLE
Removes Xeno Uncommon.

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -41,7 +41,7 @@
 		/datum/language/selenian,  //SKYRAT EDIT - customization - extra languages
 		/datum/language/gutter,  //SKYRAT EDIT - customization - extra languages
 		/datum/language/zolmach, // SKYRAT EDIT - customization - extra languages
-		/datum/language/xenoknockoff, // SKYRAT EDIT - customization - extra languages
+		/datum/language/xenocommon, // SKYRAT EDIT - customization - extra languages
 		/datum/language/yangyu, // SKYRAT EDIT - customization - extra languages
 		/datum/language/schechi // SKYRAT EDIT - customization - extra languages
 	))

--- a/modular_skyrat/modules/customization/modules/culture/culture/culture_xeno.dm
+++ b/modular_skyrat/modules/customization/modules/culture/culture/culture_xeno.dm
@@ -5,4 +5,4 @@
 	An outsider once described Xenohybrids as 'ancestor worshippers', though a more accurate phrase would be 'fetishization'. \
 	Despite how loathed you are, there's one truth among your kind, you stick together."
 	economic_power = 0
-	required_lang = /datum/language/xenoknockoff
+	required_lang = /datum/language/xenocommon

--- a/modular_skyrat/modules/customization/modules/language/xenoknockoff.dm
+++ b/modular_skyrat/modules/customization/modules/language/xenoknockoff.dm
@@ -1,9 +1,0 @@
-/datum/language/xenoknockoff
-	name = "Xeno Uncommon"
-	desc = "The common tongue of Xenomorph hybrids and cultural attaches."
-	key = "X"
-	syllables = list("sss","sSs","SSS")
-	default_priority = 50
-
-	icon_state = "xeno"
-

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
@@ -34,7 +34,7 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	liked_food = MEAT
-	learnable_languages = list(/datum/language/common, /datum/language/xenoknockoff)
+	learnable_languages = list(/datum/language/common, /datum/language/xenocommon)
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	damage_overlay_type = SPECIES_XENO

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5178,7 +5178,6 @@
 #include "modular_skyrat\modules\customization\modules\language\skrell.dm"
 #include "modular_skyrat\modules\customization\modules\language\spacer.dm"
 #include "modular_skyrat\modules\customization\modules\language\vox.dm"
-#include "modular_skyrat\modules\customization\modules\language\xenoknockoff.dm"
 #include "modular_skyrat\modules\customization\modules\language\zolmach.dm"
 #include "modular_skyrat\modules\customization\modules\mob\dead\new_player\preferences_setup.dm"
 #include "modular_skyrat\modules\customization\modules\mob\dead\new_player\sprite_accessories.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes Xeno uncommon, also known as xenoknockoff, from the game and replaces all references with Xeno Common.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
On Round 5810, a defeated Xenomorph was cornered by HoS Artemis, a xeno hybrid who attempted to engage in Roleplay, on a Roleplay server, and was not able to communicate.  This is completely nonsensical that there should be two xenomorph languages.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Removed Xeno Uncommon.  Xeno common is now selectable in the languages menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
