### PR TITLE
Fixes for changelings. Part 3.

### DIFF
--- a/code/__DEFINES/~skyrat_defines/gun.dm
+++ b/code/__DEFINES/~skyrat_defines/gun.dm
@@ -21,3 +21,7 @@
 #define COMPANY_INTEREST_ATTACHMENT 4
 #define COMPANY_INTEREST_AMMO_BULK 4
 #define COMPANY_INTEREST_AMMO 1
+
+// Gun permit states for HUDs
+#define HUD_PERMIT_YES "hud_permit"
+#define HUD_PERMIT_NO "hudfan_no"

--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -178,7 +178,7 @@
 /mob/living/proc/get_quirk_string(medical, category = CAT_QUIRK_ALL) //helper string. gets a string of all the quirks the mob has
 	var/list/dat = list()
 	
-	// SKYRAT EDIT START
+	// SKYRAT EDIT START	( TODO: Move upstream. )
 	// The health analyzer will first check if the target is a changeling, and if they are, load the quirks of the person they're disguising as.
 
 	var/target_quirks = quirks

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -265,7 +265,7 @@ Security HUDs! Basic mode shows only the job.
 	permit_holder.pixel_y = I.Height() - world.icon_size
 	var/permit_icon_state = wear_id?.get_gun_permit_iconstate()
 	if(!permit_icon_state)
-		permit_icon_state = "hudfan_no"
+		permit_icon_state = HUD_PERMIT_NO
 	permit_holder.icon_state = permit_icon_state
 	//SKYRAT EDIT END
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -100,7 +100,7 @@
 
 	var/true_form_death //SKYRAT EDIT ADDITION: The time that the horror form died.
 	
-	/// SKYRAT EDIT START
+	/// SKYRAT EDIT START	( TODO: Move upstream. (Except for some of the quirks in the list.) )
 	///	Keeps track of the currently selected profile.
 	var/datum/changeling_profile/current_profile = null
 	/*	
@@ -495,7 +495,7 @@
 	new_profile.undershirt = target.undershirt
 	new_profile.socks = target.socks
 	
-	// SKYRAT EDIT START
+	// SKYRAT EDIT START	( TODO: Move some of this upstream. )
 	new_profile.underwear_color = target.underwear_color
 	new_profile.undershirt_color = target.undershirt_color
 	new_profile.socks_color = target.socks_color
@@ -745,7 +745,7 @@
 	user.undershirt = chosen_profile.undershirt
 	user.socks = chosen_profile.socks
 	
-	// SKYRAT EDIT START
+	// SKYRAT EDIT START	( TODO: Move some of this upstream. )
 	user.underwear_color = chosen_profile.underwear_color
 	user.undershirt_color = chosen_profile.undershirt_color
 	user.socks_color = chosen_profile.socks_color
@@ -763,7 +763,7 @@
 	user.selected_laugh = new chosen_profile.laugh_type
 	user.age = chosen_profile.age
 	
-	/*
+	/*	
 	 *	Remove old quirks and copy over new ones from the chosen profile.
 	 *
 	 *	Only quirks from the mimicable_quirks_list will be removed and/or copied over.
@@ -899,6 +899,7 @@
 	 *	Usually it's not a major issue: The changeling can just shapeshift again into the same target.
 	 *	The temporary fix is to run transfer_identity and updateappearance twice, effectively updating
 	 *	the changeling's DNA and appearance twice, so that they don't have to shapeshift twice.
+	 *	(Seems to be related to anthro stuff and mutant parts.)
 	 */
 	chosen_dna.transfer_identity(user, TRUE)
 	user.updateappearance(mutcolor_update = TRUE, eyeorgancolor_update = TRUE)
@@ -947,7 +948,7 @@
 	/// ID HUD icon associated with the profile
 	var/id_icon
 	
-	/// SKYRAT EDIT START
+	/// SKYRAT EDIT START	( TODO: Move some of this upstream. )
 	/// The colour of the underwear worn by the profile source.
 	var/underwear_color
 	/// The colour of the undershirt worn by the profile source.
@@ -1017,7 +1018,7 @@
 	new_profile.profile_snapshot = profile_snapshot
 	new_profile.id_icon = id_icon
 	
-	// SKYRAT EDIT START
+	// SKYRAT EDIT START	( TODO: Move some of this upstream. )
 	new_profile.underwear_color = underwear_color
 	new_profile.undershirt_color = undershirt_color
 	new_profile.socks_color = socks_color

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -504,7 +504,7 @@
 	new_profile.age = target.age
 	for(var/datum/quirk/target_quirk in target.quirks)
 		LAZYADD(new_profile.quirks, new target_quirk.type)
-	if(target.wear_id?.get_gun_permit_iconstate()=="hud_permit")
+	if(target.wear_id?.get_gun_permit_iconstate() == "hud_permit")
 		new_profile.gun_permit = TRUE
 	//SKYRAT EDIT END
 	

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -82,7 +82,7 @@
 	var/static/list/slot2type = list(
 		"head" = /obj/item/clothing/head/changeling,
 		"wear_mask" = /obj/item/clothing/mask/changeling,
-		"wear_neck" = /obj/item/changeling, // SKYRAT EDIT
+		"wear_neck" = /obj/item/changeling, // SKYRAT EDIT	( TODO: Move upstream. )
 		"back" = /obj/item/changeling,
 		"wear_suit" = /obj/item/clothing/suit/changeling,
 		"w_uniform" = /obj/item/clothing/under/changeling,
@@ -534,7 +534,7 @@
 	// Grab the target's sechut icon.
 	new_profile.id_icon = target.wear_id?.get_sechud_job_icon_state()
 
-	var/list/slots = list("head", "wear_mask", "wear_neck", "back", "wear_suit", "w_uniform", "shoes", "belt", "gloves", "glasses", "ears", "wear_id", "s_store") // SKYRAT EDIT
+	var/list/slots = list("head", "wear_mask", "wear_neck", "back", "wear_suit", "w_uniform", "shoes", "belt", "gloves", "glasses", "ears", "wear_id", "s_store") // SKYRAT EDIT	( TODO: Move upstream. )
 	for(var/slot in slots)
 		if(!(slot in target.vars))
 			continue
@@ -574,7 +574,7 @@
 
 	if(!first_profile)
 		first_profile = new_profile
-		current_profile = first_profile  // SKYRAT EDIT
+		current_profile = first_profile  // SKYRAT EDIT	( TODO: Move upstream. )
 
 	stored_profiles += new_profile
 	absorbed_count++
@@ -726,7 +726,7 @@
 	var/static/list/slot2slot = list(
 		"head" = ITEM_SLOT_HEAD,
 		"wear_mask" = ITEM_SLOT_MASK,
-		"wear_neck" = ITEM_SLOT_NECK, // SKYRAT EDIT
+		"wear_neck" = ITEM_SLOT_NECK, // SKYRAT EDIT	( TODO: Move upstream. )
 		"back" = ITEM_SLOT_BACK,
 		"wear_suit" = ITEM_SLOT_OCLOTHING,
 		"w_uniform" = ITEM_SLOT_ICLOTHING,

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -101,7 +101,7 @@
 	var/true_form_death //SKYRAT EDIT ADDITION: The time that the horror form died.
 	
 	// SKYRAT EDIT START
-	var/datum/changeling_profile/current_profile
+	var/datum/changeling_profile/current_profile = null
 	var/list/mimicable_quirks_list = list(
 		"Bad Touch",
 		"Sensitive Snout",

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -505,8 +505,14 @@
 	new_profile.grad_style = LAZYLISTDUPLICATE(target.grad_style)
 	new_profile.grad_color = LAZYLISTDUPLICATE(target.grad_color)
 	new_profile.physique = target.physique
-	new_profile.scream_type = target.selected_scream.type
-	new_profile.laugh_type = target.selected_laugh.type
+	if(target.selected_scream)
+		new_profile.scream_type = target.selected_scream.type
+	else
+		new_profile.scream_type = /datum/scream_type/human
+	if(target.selected_laugh)
+		new_profile.laugh_type = target.selected_laugh.type
+	else
+		new_profile.laugh_type = /datum/laugh_type/human
 	new_profile.age = target.age
 	// Grab the target's quirks.
 	for(var/datum/quirk/target_quirk in target.quirks)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -100,8 +100,14 @@
 
 	var/true_form_death //SKYRAT EDIT ADDITION: The time that the horror form died.
 	
-	// SKYRAT EDIT START
+	/// SKYRAT EDIT START
+	///	Keeps track of the currently selected profile.
 	var/datum/changeling_profile/current_profile = null
+	/*	
+	 *	Static list of the quirks that you can gain/lose depending on who you shapeshift into.
+	 *	It'd be easiest to just get all of your target's quirks, but it wouldn't make sense for
+	 *	quirks like pacifist, brain tumor or paraplegic.
+	 */
 	var/list/mimicable_quirks_list = list(
 		"Bad Touch",
 		"Sensitive Snout",
@@ -502,11 +508,13 @@
 	new_profile.scream_type = target.selected_scream.type
 	new_profile.laugh_type = target.selected_laugh.type
 	new_profile.age = target.age
+	// Grab the target's quirks.
 	for(var/datum/quirk/target_quirk in target.quirks)
 		LAZYADD(new_profile.quirks, new target_quirk.type)
+	// Grab the target's gun permit.
 	if(target.wear_id?.get_gun_permit_iconstate() == "hud_permit")
 		new_profile.gun_permit = TRUE
-	//SKYRAT EDIT END
+	// SKYRAT EDIT END
 	
 	// Grab skillchips they have
 	new_profile.skillchips = target.clone_skillchip_list(TRUE)
@@ -544,6 +552,7 @@
 		new_profile.exists_list[slot] = 1
 		
 		// SKYRAT EDIT START
+		// Grabs variation flags and digi/teshari/vox icons for items/clothes.
 		new_profile.worn_icon_digi_list[slot] = clothing_item.worn_icon_digi
 		new_profile.worn_icon_teshari_list[slot] = clothing_item.worn_icon_teshari
 		new_profile.worn_icon_vox_list[slot] = clothing_item.worn_icon_vox
@@ -746,13 +755,25 @@
 	user.grad_style = LAZYLISTDUPLICATE(chosen_profile.grad_style)
 	user.grad_color = LAZYLISTDUPLICATE(chosen_profile.grad_color)
 	user.physique = chosen_profile.physique
+	// Delete user's scream and laugh.
 	qdel(user.selected_scream)
 	qdel(user.selected_laugh)
+	// Make a new scream and laugh of the selected types.
 	user.selected_scream = new chosen_profile.scream_type
 	user.selected_laugh = new chosen_profile.laugh_type
 	user.age = chosen_profile.age
 	
-	// Only certain quirks will be copied, to avoid making the changeling blind or wheelchair-bound when they can simply pretend to have these quirks.
+	/*
+	 *	Remove old quirks and copy over new ones from the chosen profile.
+	 *
+	 *	Only quirks from the mimicable_quirks_list will be removed and/or copied over.
+	 *	Copying all quirks would be easier as well as making it harder to distinguish
+	 *	the changeling from crew, but it would act as a major debuff with quirks like
+	 *	blind, paraplegic or brain tumor.
+	 *	TODO: Maybe add a toggle feature, allowing the changeling to switch between
+	 *	"mimicable" quirks and the full set of their target's quirks? That way they could
+	 *	make it harder for others to distinguish them when inspected up close.
+	 */
 	
 	for(var/datum/quirk/target_quirk in user.quirks)
 		for(var/mimicable_quirk in mimicable_quirks_list)
@@ -872,6 +893,13 @@
 	user.regenerate_icons()
 	
 	// SKYRAT EDIT START
+	/*
+	 *	When shapeshifting, sometimes the transform would not go all the way through,
+	 *	giving the changeling a mixed appearance of what they looked like and what they shapeshifted into.
+	 *	Usually it's not a major issue: The changeling can just shapeshift again into the same target.
+	 *	The temporary fix is to run transfer_identity and updateappearance twice, effectively updating
+	 *	the changeling's DNA and appearance twice, so that they don't have to shapeshift twice.
+	 */
 	chosen_dna.transfer_identity(user, TRUE)
 	user.updateappearance(mutcolor_update = TRUE, eyeorgancolor_update = TRUE)
 	user.regenerate_icons()
@@ -920,23 +948,41 @@
 	var/id_icon
 	
 	/// SKYRAT EDIT START
+	/// The colour of the underwear worn by the profile source.
 	var/underwear_color
+	/// The colour of the undershirt worn by the profile source.
 	var/undershirt_color
+	/// The colour of the socks worn by the profile source.
 	var/socks_color
+	/// The colour of the left eye of the profile source.
 	var/eye_color_left
+	/// The colour of the right eye of the profile source.
 	var/eye_color_right
+	/// Whether the profile source had emissive eyes.
 	var/emissive_eyes
+	/// The hair and facial hair gradient styles of the profile source.
 	var/list/grad_style = list("None", "None")
+	/// The hair and facial hair gradient colours of the profile source.
 	var/list/grad_color = list(null, null)
+	/// The body type (male/female) of the profile source.
 	var/physique
+	/// Digitigrade icons of the items/clothes worn by the profile source.
 	var/list/worn_icon_digi_list = list()
+	/// Teshari icons of the items/clothes worn by the profile source.
 	var/list/worn_icon_teshari_list = list()
+	/// Vox icons of the items/clothes worn by the profile source.
 	var/list/worn_icon_vox_list = list()
+	/// Variation flags of the items/clothes worn by the profile source.
 	var/list/supports_variations_flags_list = list()
+	/// The typepath of the selected_scream used by the profile source.
 	var/scream_type
+	/// The typepath of the selected_laugh used by the profile source.
 	var/laugh_type
+	/// The age of the profile source.
 	var/age
+	/// The quirks of the profile source.
 	var/list/quirks = list()
+	/// Whether the profile source displayed a gun permit icon when looked at with a sechud.
 	var/gun_permit
 	/// SKYRAT EDIT END
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -101,7 +101,7 @@
 	var/true_form_death //SKYRAT EDIT ADDITION: The time that the horror form died.
 	
 	// SKYRAT EDIT START
-	var/datum/changeling_profile/current_profile = null
+	var/datum/changeling_profile/current_profile
 	var/list/mimicable_quirks_list = list(
 		"Bad Touch",
 		"Sensitive Snout",
@@ -504,6 +504,8 @@
 	new_profile.age = target.age
 	for(var/datum/quirk/target_quirk in target.quirks)
 		LAZYADD(new_profile.quirks, new target_quirk.type)
+	if(target.wear_id?.get_gun_permit_iconstate()=="hud_permit")
+		new_profile.gun_permit = TRUE
 	//SKYRAT EDIT END
 	
 	// Grab skillchips they have
@@ -855,6 +857,7 @@
 		if(istype(new_flesh_item, /obj/item/changeling/id) && chosen_profile.id_icon)
 			var/obj/item/changeling/id/flesh_id = new_flesh_item
 			flesh_id.hud_icon = chosen_profile.id_icon
+			flesh_id.gun_permit = chosen_profile.gun_permit  // SKYRAT EDIT
 
 		if(equip)
 			user.equip_to_slot_or_del(new_flesh_item, slot2slot[slot])
@@ -934,6 +937,7 @@
 	var/laugh_type
 	var/age
 	var/list/quirks = list()
+	var/gun_permit
 	/// SKYRAT EDIT END
 
 /datum/changeling_profile/Destroy()
@@ -985,6 +989,7 @@
 	new_profile.laugh_type = laugh_type
 	new_profile.age = age
 	new_profile.quirks = quirks.Copy()
+	new_profile.gun_permit = gun_permit
 	// SKYRAT EDIT END
 
 /datum/antagonist/changeling/roundend_report()

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -29,7 +29,7 @@
 	changeling.purchased_powers -= src
 	Remove(user)
 	
-	// SKYRAT EDIT START
+	// SKYRAT EDIT START	( TODO: Move upstream. )
 	var/datum/dna/chosen_dna = chosen_prof.dna
 	var/datum/species/chosen_species = chosen_dna.species
 	user.humanize(chosen_species)

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -11,15 +11,9 @@
 		to_chat(user, span_notice("We must exit the pipes before we can transform back!"))
 		return FALSE
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
-	var/list/names = list()
-	for(var/datum/changeling_profile/prof in changeling.stored_profiles)
-		names += "[prof.name]"
-
-	var/chosen_name = tgui_input_list(user, "Target DNA", "Transformation", sort_list(names))
-	if(isnull(chosen_name))
-		return
-
-	var/datum/changeling_profile/chosen_prof = changeling.get_dna(chosen_name)
+	
+	var/datum/changeling_profile/chosen_prof = changeling.select_dna()  // SKYRAT EDIT (Surely the radial menu is better than a list?)
+	
 	if(!chosen_prof)
 		return
 	if(!user || user.notransform)
@@ -34,7 +28,8 @@
 	var/datum/species/chosen_species = chosen_dna.species
 	user.humanize(chosen_species)
 
-	changeling.transform(user, chosen_prof)
+	if(LAZYACCESS(chosen_dna.features, 14) == 1)
+		changeling.transform(user, chosen_prof)
 	user.regenerate_icons()
 	return TRUE
 	// SKYRAT EDIT END

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -29,7 +29,7 @@
 	changeling.purchased_powers -= src
 	Remove(user)
 	
-	// SKYRAT EDIT START	( TODO: Move upstream. )
+	// SKYRAT EDIT START
 	var/datum/dna/chosen_dna = chosen_prof.dna
 	var/datum/species/chosen_species = chosen_dna.species
 	user.humanize(chosen_species)

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -33,7 +33,7 @@
 	var/datum/dna/chosen_dna = chosen_prof.dna
 	var/datum/species/chosen_species = chosen_dna.species
 	user.humanize(chosen_species)
-	
+
 	changeling.transform(user, chosen_prof)
 	user.regenerate_icons()
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -11,9 +11,15 @@
 		to_chat(user, span_notice("We must exit the pipes before we can transform back!"))
 		return FALSE
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
-	
-	var/datum/changeling_profile/chosen_prof = changeling.select_dna()  // SKYRAT EDIT (Surely the radial menu is better than a list?)
-	
+	var/list/names = list()
+	for(var/datum/changeling_profile/prof in changeling.stored_profiles)
+		names += "[prof.name]"
+
+	var/chosen_name = tgui_input_list(user, "Target DNA", "Transformation", sort_list(names))
+	if(isnull(chosen_name))
+		return
+
+	var/datum/changeling_profile/chosen_prof = changeling.get_dna(chosen_name)
 	if(!chosen_prof)
 		return
 	if(!user || user.notransform)

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -33,9 +33,8 @@
 	var/datum/dna/chosen_dna = chosen_prof.dna
 	var/datum/species/chosen_species = chosen_dna.species
 	user.humanize(chosen_species)
-
-	if(LAZYACCESS(chosen_dna.features, 14) == 1)
-		changeling.transform(user, chosen_prof)
+	
+	changeling.transform(user, chosen_prof)
 	user.regenerate_icons()
 	return TRUE
 	// SKYRAT EDIT END

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -15,6 +15,11 @@
 	..()
 
 	// SKYRAT EDIT START
+	/*
+	 *	We need to clear most of the skyrat customisation stuff before changing into a monkey
+	 *	because changing species does not automatically clear these and you'll create an abomination
+	 *	if you try to continue without doing so.
+	 */
 	var/datum/dna/current_dna = user.dna
 	for(var/key in current_dna.mutant_bodyparts)
 		LAZYSET(current_dna.mutant_bodyparts, key, "None")
@@ -24,7 +29,6 @@
 		LAZYREMOVE(current_dna.features, "legs")
 	LAZYSET(current_dna.features, "body_size", 1)
 	current_dna.update_body_size()
-	user.transform = list(1, 0, 0, 0, 1, 0)
 	// SKYRAT EDIT END
 
 	user.monkeyize()
@@ -34,7 +38,8 @@
 	changeling.purchased_powers += human_form_ability
 	changeling.purchased_powers -= src
 	
-	// SKYRAT EDIT START
+	// SKYRAT EDIT START	( TODO: Move upstream. )
+	// Drops all flesh disguise items after monkeyizing, because they don't drop automatically like real clothing.
 	for(var/slot in changeling.slot2type)
 		if(istype(user.vars[slot], changeling.slot2type[slot]))
 			qdel(user.vars[slot])

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -20,10 +20,11 @@
 		LAZYSET(current_dna.mutant_bodyparts, key, "None")
 	for(var/key in current_dna.body_markings)
 		LAZYSET(current_dna.body_markings, key, null)
-	if(current_dna.features["body_size"])
-		LAZYSET(current_dna.features, "body_size", 1)
 	if(current_dna.features["legs"])
 		LAZYREMOVE(current_dna.features, "legs")
+	LAZYSET(current_dna.features, "body_size", 1)
+	current_dna.update_body_size()
+	user.transform = list(1, 0, 0, 0, 1, 0)
 	// SKYRAT EDIT END
 
 	user.monkeyize()

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -145,7 +145,7 @@
 	..()
 	changeling.transform(user, chosen_prof)
 	
-	// SKYRAT EDIT START
+	// SKYRAT EDIT START	( TODO: Move upstream. )
 	var/mob/dum = user.tgui.dummy_holder
 	dum.name = chosen_prof.name
 	for(var/obj/item/item in dum)

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -113,6 +113,7 @@
 	var/icon/cached_flat_icon
 	/// HUD job icon of the ID
 	var/hud_icon
+	/// Gun permit of the ID (TRUE or FALSE, it either has one or it doesn't).
 	var/gun_permit // SKYRAT EDIT
 
 /obj/item/changeling/id/equipped(mob/user, slot, initial)

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -113,6 +113,7 @@
 	var/icon/cached_flat_icon
 	/// HUD job icon of the ID
 	var/hud_icon
+	var/gun_permit // SKYRAT EDIT
 
 /obj/item/changeling/id/equipped(mob/user, slot, initial)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -69,8 +69,9 @@
 		qdel(src)
 
 /obj/item/organ/internal/body_egg/changeling_egg/proc/Pop()
-	// SKYRAT EDIT START
+	// SKYRAT EDIT START	( TODO: Move some of this upstream. )
 	var/mob/living/carbon/human/species/monkey/spawned_monkey = new(owner)
+	// Need to clear the skyrat customisation stuff before transforming into a monkey, otherwise an abomination is created.
 	var/datum/dna/current_dna = spawned_monkey.dna
 	for(var/key in current_dna.mutant_bodyparts)
 		LAZYSET(current_dna.mutant_bodyparts, key, "None")
@@ -100,7 +101,7 @@
 		if(changeling_datum.can_absorb_dna(owner))
 			changeling_datum.add_new_profile(owner)
 
-		// SKYRAT EDIT START
+		// SKYRAT EDIT START	( TODO: Move upstream. )
 		var/datum/action/changeling/humanform/hf = new()
 		changeling_datum.purchased_powers += hf
 		hf.Grant(origin.current)

--- a/modular_skyrat/modules/gun_cargo/code/objects/access.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/access.dm
@@ -3,13 +3,13 @@
 	if(istype(src, /obj/item/changeling/id))
 		var/obj/item/changeling/id/changeling_card = src
 		if(changeling_card.gun_permit)
-			return "hud_permit"
-		return "hudfan_no"
+			return HUD_PERMIT_YES
+		return HUD_PERMIT_NO
 
 	var/obj/item/card/id/id_card = GetID()
 	
 	if(!id_card)
-		return "hudfan_no"
+		return HUD_PERMIT_NO
 	if(ACCESS_WEAPONS in id_card.GetAccess())
-		return "hud_permit"
-	return "hudfan_no"
+		return HUD_PERMIT_YES
+	return HUD_PERMIT_NO

--- a/modular_skyrat/modules/gun_cargo/code/objects/access.dm
+++ b/modular_skyrat/modules/gun_cargo/code/objects/access.dm
@@ -1,6 +1,13 @@
 /obj/item/proc/get_gun_permit_iconstate()
-	var/obj/item/card/id/id_card = GetID()
 
+	if(istype(src, /obj/item/changeling/id))
+		var/obj/item/changeling/id/changeling_card = src
+		if(changeling_card.gun_permit)
+			return "hud_permit"
+		return "hudfan_no"
+
+	var/obj/item/card/id/id_card = GetID()
+	
 	if(!id_card)
 		return "hudfan_no"
 	if(ACCESS_WEAPONS in id_card.GetAccess())


### PR DESCRIPTION
## About The Pull Request
[A further continuation on #14190.](https://github.com/Skyrat-SS13/Skyrat-tg/pull/14190)

Current flesh ID's are able to trick sechuds by displaying an occupation icon. Still, they **cannot** display a gun permit icon. It does not matter if either you or your target actually have a gun permit, a flesh ID just won't display it.

**Security won't mix up an assistant with a changeling, if the assistant has a gun permit: It functions partly like a mindshield.**

Of course, that wasn't intended, right? So boom, let's make flesh ID's copy the target's gun permit.

## Changelog

**Changeling profiles now store the target's gun permit status.**
This does not give your flesh ID any sort of access, it only tricks sechuds into displaying a gun permit.

**Lesser form now resets your body size correctly before monkeyizing you.**
Forgot to add _/update_body_size()._ This prevents the user from becoming a monkey with an irregular body size.

**Added a fair bit of comments to the changes I've made here and in my previous PRs, as per request.**
Also, I acknowledge that there's a lot that I should have put upstream. Initially I wanted to keep everything here because most of the issues I was working with were solely related to shapeshifting as anthros. I'm now moving what I can to /tg/.
https://github.com/tgstation/tgstation/pull/68117

**Added two defines for gun permit states, as per request.**
```
#define HUD_PERMIT_YES "hud_permit"
#define HUD_PERMIT_NO "hudfan_no"
```

:cl:
fix: Shapeshifting now updates your flesh ID's gun permit sechud icon.
fix: Lesser form resets your body size before monkeyizing.
/:cl: