### PR TITLE
Adds status displays for interlink shuttle

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -3966,7 +3966,7 @@
 /area/centcom/holding/cafedorms)
 "aMI" = (
 /obj/machinery/vending/hydronutrients{
-	products = list(/obj/item/reagent_containers/glass/bottle/nutrient/ez = 50, /obj/item/reagent_containers/glass/bottle/nutrient/l4z = 20, /obj/item/reagent_containers/glass/bottle/nutrient/rh = 10, /obj/item/reagent_containers/spray/pestspray = 30, /obj/item/reagent_containers/syringe = 5, /obj/item/storage/bag/plants = 30, /obj/item/cultivator = 10, /obj/item/shovel/spade = 10, /obj/item/plant_analyzer = 10)
+	products = list(/obj/item/reagent_containers/glass/bottle/nutrient/ez=50,/obj/item/reagent_containers/glass/bottle/nutrient/l4z=20,/obj/item/reagent_containers/glass/bottle/nutrient/rh=10,/obj/item/reagent_containers/spray/pestspray=30,/obj/item/reagent_containers/syringe=5,/obj/item/storage/bag/plants=30,/obj/item/cultivator=10,/obj/item/shovel/spade=10,/obj/item/plant_analyzer=10)
 	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
@@ -4100,13 +4100,13 @@
 /obj/item/storage/box/ingredients/american,
 /obj/item/storage/box/ingredients/exotic,
 /obj/item/reagent_containers/food/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	list_reagents = list(/datum/reagent/consumable/flour=90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
 	},
 /obj/item/reagent_containers/food/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	list_reagents = list(/datum/reagent/consumable/flour=90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
@@ -5686,6 +5686,10 @@
 /obj/machinery/computer/shuttle/arrivals/recall{
 	dir = 4
 	},
+/obj/machinery/status_display/shuttle{
+	pixel_x = -32;
+	shuttle_id = "arrivals_shuttle"
+	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "aZp" = (
@@ -6044,6 +6048,16 @@
 	},
 /turf/open/floor/bamboo,
 /area/centcom/holding/cafedorms)
+"bVB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/status_display/shuttle{
+	shuttle_id = "arrivals_shuttle";
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "bXF" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -7325,12 +7339,12 @@
 /obj/item/reagent_containers/food/condiment/soysauce,
 /obj/item/reagent_containers/food/condiment/sugar,
 /obj/item/reagent_containers/food/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	list_reagents = list(/datum/reagent/consumable/rice=90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
 /obj/item/reagent_containers/food/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	list_reagents = list(/datum/reagent/consumable/rice=90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
@@ -9235,24 +9249,24 @@
 /obj/item/storage/box/ingredients/american,
 /obj/item/storage/box/ingredients/exotic,
 /obj/item/reagent_containers/food/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	list_reagents = list(/datum/reagent/consumable/flour=90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
 	},
 /obj/item/reagent_containers/food/condiment/flour{
-	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	list_reagents = list(/datum/reagent/consumable/flour=90);
 	name = "large flour sack";
 	possible_transfer_amounts = list(1,5,10,15,30,60,90);
 	volume = 90
 	},
 /obj/item/reagent_containers/food/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	list_reagents = list(/datum/reagent/consumable/rice=90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
 /obj/item/reagent_containers/food/condiment/rice{
-	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	list_reagents = list(/datum/reagent/consumable/rice=90);
 	name = "large rice sack";
 	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
 	},
@@ -20841,7 +20855,7 @@ aqG
 aqG
 aqG
 aDg
-aVy
+bVB
 aoN
 tvw
 are

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -5686,10 +5686,6 @@
 /obj/machinery/computer/shuttle/arrivals/recall{
 	dir = 4
 	},
-/obj/machinery/status_display/shuttle{
-	pixel_x = -32;
-	shuttle_id = "arrivals_shuttle"
-	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "aZp" = (
@@ -6048,16 +6044,6 @@
 	},
 /turf/open/floor/bamboo,
 /area/centcom/holding/cafedorms)
-"bVB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/status_display/shuttle{
-	shuttle_id = "arrivals_shuttle";
-	pixel_y = 32
-	},
-/turf/open/floor/iron,
-/area/centcom/interlink)
 "bXF" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -6720,6 +6706,19 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
+/area/centcom/interlink)
+"eRa" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/status_display/shuttle{
+	pixel_x = -32;
+	shuttle_id = "arrivals_shuttle"
+	},
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "eTB" = (
 /obj/structure/railing/corner{
@@ -10208,6 +10207,14 @@
 /obj/structure/flora/bush/sparsegrass,
 /turf/open/misc/asteroid,
 /area/centcom/interlink)
+"rFg" = (
+/obj/effect/turf_decal/trimline/blue/arrow_cw,
+/obj/machinery/status_display/shuttle{
+	shuttle_id = "arrivals_shuttle";
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink)
 "rGP" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
@@ -10394,6 +10401,15 @@
 "shf" = (
 /obj/structure/table/wood/poker,
 /turf/open/floor/eighties,
+/area/centcom/interlink)
+"siH" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/turf/open/floor/iron,
 /area/centcom/interlink)
 "sjJ" = (
 /obj/structure/chair/sofa/right{
@@ -20855,7 +20871,7 @@ aqG
 aqG
 aqG
 aDg
-bVB
+aVy
 aoN
 tvw
 are
@@ -21113,7 +21129,7 @@ aqG
 aqG
 aDg
 aVy
-aoN
+rFg
 tvw
 aEg
 hvQ
@@ -23158,8 +23174,8 @@ poj
 tvw
 aRp
 hvQ
-aHe
-aVm
+siH
+eRa
 aHe
 aiE
 aiE

--- a/_maps/shuttles/skyrat/arrivals_skyrat.dmm
+++ b/_maps/shuttles/skyrat/arrivals_skyrat.dmm
@@ -126,6 +126,16 @@
 	icon_state = "8,4"
 	},
 /area/shuttle/arrival)
+"A" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 1
+	},
+/obj/machinery/status_display/shuttle{
+	pixel_x = 32;
+	shuttle_id = "arrivals_shuttle"
+	},
+/turf/open/floor/iron/shuttle/arrivals,
+/area/shuttle/arrival)
 "B" = (
 /turf/closed/wall/mineral/titanium/shuttle_wall/arrivals{
 	icon_state = "3,0"
@@ -140,6 +150,16 @@
 /turf/closed/wall/mineral/titanium/shuttle_wall/arrivals{
 	icon_state = "12,0"
 	},
+/area/shuttle/arrival)
+"F" = (
+/obj/structure/chair/sofa/bench/left{
+	dir = 1
+	},
+/obj/machinery/status_display/shuttle{
+	pixel_x = -32;
+	shuttle_id = "arrivals_shuttle"
+	},
+/turf/open/floor/iron/shuttle/arrivals,
 /area/shuttle/arrival)
 "G" = (
 /turf/closed/wall/mineral/titanium/shuttle_wall/arrivals{
@@ -275,7 +295,7 @@ B
 Q
 m
 x
-O
+F
 h
 "}
 (6,1,1) = {"
@@ -303,7 +323,7 @@ J
 z
 S
 x
-c
+A
 d
 "}
 (10,1,1) = {"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds shuttle status displays on the interlink shuttle and at the interlink.

![image](https://user-images.githubusercontent.com/1185434/176513077-110dd731-85e7-4736-a6e7-95a658fd8dd4.png)
![image](https://user-images.githubusercontent.com/1185434/176513094-4ad10441-1c15-43d0-8135-c60cdf68e895.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

Seeing interlink status without pressing your snout against the computer with 5 other people.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The interlink shuttle now has status displays.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
