### PR TITLE
[Blueshift] Small Ordnance QOL

### DIFF
--- a/_maps/map_files/Blueshift/BlueShift_upper.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_upper.dmm
@@ -31532,6 +31532,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint_lesser)
 "kCP" = (
@@ -38476,7 +38477,7 @@
 /obj/machinery/camera/preset/ordnance{
 	dir = 6
 	},
-/turf/open/floor/iron/airless,
+/turf/open/indestructible,
 /area/station/science/ordnance/bomb)
 "mXG" = (
 /obj/structure/cable,
@@ -45024,6 +45025,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint_lesser)
 "pix" = (


### PR DESCRIPTION
## About The Pull Request

- Adds the ordnance access helper to the airlock beneath ordnance. This will allow scientists to easily access the test range of they ever want to.
- Places an indestructable turf to where the bomb sits. This will stop toxins bombs from plopping down onto the second level when the turf is destroyed. 

## How This Contributes To The Skyrat Roleplay Experience

Because scientists should have access to their own range and everyone's sick of their explosives falling and not being read.

## Changelog

:cl:
qol: Indestructable Turf on the ordnance test range. This will stop bombs from dropping to the second level.
qol: Ordnance access added to the exterior airlock beneath ordnance.
/:cl:
