### PR TITLE
aribag

### DIFF
--- a/modular_skyrat/modules/window_airbags/code/window_airbag.dm
+++ b/modular_skyrat/modules/window_airbags/code/window_airbag.dm
@@ -36,7 +36,7 @@
 /datum/element/airbag/proc/on_examine(datum/source, mob/user, list/examine_text)
 	SIGNAL_HANDLER
 
-	examine_text += span_warning("It has a blinking red light indicating an aribag is installed, <b>alt+click</b> to disarm.")
+	examine_text += span_warning("It has a blinking red light indicating an airbag is installed. <b>Alt+click</b> to disarm.")
 
 /datum/element/airbag/proc/on_altclick(atom/movable/clicked_atom, mob/living/clicker)
 	SIGNAL_HANDLER


### PR DESCRIPTION
:cl:
spellcheck: Fixed a typo in the airbag element examine, as well as a tiny adjustment to the sentence structure.
/:cl: