### PR TITLE
Updates /update_body_size() to compensate for a player's rotation.

### DIFF
--- a/modular_skyrat/modules/customization/datums/dna.dm
+++ b/modular_skyrat/modules/customization/datums/dna.dm
@@ -180,7 +180,20 @@ GLOBAL_LIST_EMPTY(total_uf_len_by_block)
 	//We update the translation to make sure our character doesn't go out of the southern bounds of the tile
 	var/translate = ((change_multiplier-1) * 32)/2
 	holder.transform = holder.transform.Scale(change_multiplier)
-	holder.transform = holder.transform.Translate(0, translate)
+	// Check user's rotation before updating their translation, f.e. whether they're laying down or hanging upside down
+	var/translate_x = 0
+	var/translate_y = 0
+	if(holder.transform.a > 0)
+		translate_y = translate
+	else if(holder.transform.d > 0)
+		translate_x = -translate
+	else if(holder.transform.b > 0)
+		translate_x = translate
+	else if(holder.transform.a < 0)
+		translate_y = -translate
+	else
+		return
+	holder.transform = holder.transform.Translate(translate_x, translate_y)
 	holder.maptext_height = 32 * features["body_size"] // Adjust runechat height
 	current_body_size = features["body_size"]
 

--- a/modular_skyrat/modules/customization/datums/dna.dm
+++ b/modular_skyrat/modules/customization/datums/dna.dm
@@ -180,19 +180,9 @@ GLOBAL_LIST_EMPTY(total_uf_len_by_block)
 	//We update the translation to make sure our character doesn't go out of the southern bounds of the tile
 	var/translate = ((change_multiplier-1) * 32)/2
 	holder.transform = holder.transform.Scale(change_multiplier)
-	// Check user's rotation before updating their translation, f.e. whether they're laying down or hanging upside down
-	var/translate_x = 0
-	var/translate_y = 0
-	if(holder.transform.a > 0)
-		translate_y = translate
-	else if(holder.transform.d > 0)
-		translate_x = -translate
-	else if(holder.transform.b > 0)
-		translate_x = translate
-	else if(holder.transform.a < 0)
-		translate_y = -translate
-	else
-		return
+	// Splits the updated translation into X and Y based on the user's rotation.
+	var/translate_x = translate * ( holder.transform.b / features["body_size"] )
+	var/translate_y = translate * ( holder.transform.e / features["body_size"] )
 	holder.transform = holder.transform.Translate(translate_x, translate_y)
 	holder.maptext_height = 32 * features["body_size"] // Adjust runechat height
 	current_body_size = features["body_size"]


### PR DESCRIPTION
## About The Pull Request
Running _/datum/dna/proc/update_body_size()_ on someone who's laying down breaks their sprite **if** their body size changes. This is especially noticable if a changeling lays down and shapeshifts into someone who's smaller or bigger than them.

The reason is that updating someone's size includes moving their sprite a few pixels:
`//We update the translation to make sure our character doesn't go out of the southern bounds of the tile`
`var/translate = ((change_multiplier-1) * 32)/2`
`holder.transform = holder.transform.Scale(change_multiplier)`
`holder.transform = holder.transform.Translate(0, translate)`

The code here does not compensate for when the player is laying down or hanging upside down, in which case it will change the translation in the wrong direction, causing the player's sprite to go semi-permanently off-center until their transform matrix gets corrected manually, presumably by an admin.

I added some code and changed _Translate(0, translate)_ to _Translate(translate_x, translate_y)._

## Changelog

**_/update_body_size()_ now compensates for a player's rotation.**
It now splits _translate_ into _translate_x_ and _translate_y_ with appropriate values based on _transform.b, transform.e_ and _features["body_size"]._

:cl:
fix: Updates /update_body_size() to compensate for a player's rotation.
/:cl: